### PR TITLE
test(lock-matrix): consume contention.wait()'s boolean instead of discarding it (#2436)

### DIFF
--- a/tracker-writer-lock-tests.mjs
+++ b/tracker-writer-lock-tests.mjs
@@ -832,12 +832,16 @@ await testLiveRecoverGuardIsNotEvicted();
 // suite stays green (or returns to flaking) with nothing pointing at the cause.
 // One observation is enough to prove the signal exists; zero across the whole
 // matrix is the regression.
-if (contentionWatchedCases > 0) {
-  if (contentionObservedCases > 0) {
-    pass(`recover guard observed in ${contentionObservedCases}/${contentionWatchedCases} guard-watched cases — the mutation ordering signal is live`);
-  } else {
-    fail(`recover guard never observed in any of the ${contentionWatchedCases} guard-watched cases — acquireTrackerLock has stopped emitting it, so every one of them fell back to timing-dependent ordering`);
-  }
+if (contentionWatchedCases === 0) {
+  // Skipping the assertion when nothing was watched would reproduce the very
+  // defect this file is fixing: a matrix change that drops every guard-watched
+  // case leaves the suite green while nothing validates the recover guard at
+  // all. Zero watched cases is itself the regression (CodeRabbit review).
+  fail('no guard-watched case ran — the matrix no longer exercises the recover guard, so nothing validates the mutation ordering signal');
+} else if (contentionObservedCases > 0) {
+  pass(`recover guard observed in ${contentionObservedCases}/${contentionWatchedCases} guard-watched cases — the mutation ordering signal is live`);
+} else {
+  fail(`recover guard never observed in any of the ${contentionWatchedCases} guard-watched cases — acquireTrackerLock has stopped emitting it, so every one of them fell back to timing-dependent ordering`);
 }
 
 console.log(`\n${passed} passed, ${failed} failed`);

--- a/tracker-writer-lock-tests.mjs
+++ b/tracker-writer-lock-tests.mjs
@@ -218,7 +218,19 @@ async function runWhileLocked({
     // entries already have a stronger, script-specific ordering signal (their
     // pre-lock review prompt), and a writer parked at that prompt has not
     // reached the lock yet, so the guard wait is skipped for them.
-    await contention?.wait(CONTENTION_WAIT_MS);
+    //
+    // The boolean IS the discrimination signal, so it is consumed rather than
+    // discarded (#2436). If the recover guard ever stops being emitted — a
+    // rename, or the guard becoming conditional — every guard-watched case
+    // would burn the full CONTENTION_WAIT_MS and then silently fall back to
+    // the old timing-dependent ordering: the suite stays green, or goes back
+    // to flaking, with nothing pointing at the missing signal. The fallback
+    // inside watchForContention is deliberate (it degrades instead of
+    // hanging); what was missing is a consumer that says so out loud.
+    const sawContention = contention ? await contention.wait(CONTENTION_WAIT_MS) : true;
+    if (!sawContention) {
+      fail(`${name}: recover guard never appeared within ${CONTENTION_WAIT_MS}ms — the mutation ordering signal is gone, so this case no longer discriminates a pre-lock read from a post-lock one`);
+    }
     // Simulate the current lock owner committing another row. The waiting
     // writer must read this fresh version after acquiring the lock; a writer
     // that reads before locking will erase row #99 with its stale snapshot.

--- a/tracker-writer-lock-tests.mjs
+++ b/tracker-writer-lock-tests.mjs
@@ -17,6 +17,11 @@ const NODE = process.execPath;
 const CONCURRENT_ROW = '| 99 | 2026-01-03 | ConcurrentCo | Keeper | 4.3/5 | Applied | ❌ | [99](reports/099-concurrent.md) | preserve me |';
 let passed = 0;
 let failed = 0;
+// Run-level evidence that acquireTrackerLock still emits its recover guard.
+// See the consumer inside runWhileLocked for why this is counted per run
+// rather than asserted per case (#2436).
+let contentionWatchedCases = 0;
+let contentionObservedCases = 0;
 
 function pass(message) { console.log(`PASS ${message}`); passed++; }
 function fail(message) { console.error(`FAIL ${message}`); failed++; }
@@ -220,16 +225,23 @@ async function runWhileLocked({
     // reached the lock yet, so the guard wait is skipped for them.
     //
     // The boolean IS the discrimination signal, so it is consumed rather than
-    // discarded (#2436). If the recover guard ever stops being emitted — a
-    // rename, or the guard becoming conditional — every guard-watched case
-    // would burn the full CONTENTION_WAIT_MS and then silently fall back to
-    // the old timing-dependent ordering: the suite stays green, or goes back
-    // to flaking, with nothing pointing at the missing signal. The fallback
-    // inside watchForContention is deliberate (it degrades instead of
-    // hanging); what was missing is a consumer that says so out loud.
-    const sawContention = contention ? await contention.wait(CONTENTION_WAIT_MS) : true;
-    if (!sawContention) {
-      fail(`${name}: recover guard never appeared within ${CONTENTION_WAIT_MS}ms — the mutation ordering signal is gone, so this case no longer discriminates a pre-lock read from a post-lock one`);
+    // discarded (#2436) — but at RUN level, not per case, and the difference
+    // is not a softening. `acquireTrackerLock` creates the guard and removes
+    // it in a `finally` around one `lockCanRecover()` call, so it exists for
+    // well under a millisecond, re-created on each ~retryMs attempt. The
+    // watcher samples with readdirSync, so a single miss means "the sampler
+    // was unlucky", not "the guard is gone" — and on Windows CI it misses
+    // often enough that a per-case failure would be red on a healthy tree
+    // (measured: 3 of 8 observed).
+    //
+    // Across a whole run the two causes separate cleanly: a sampling miss
+    // still leaves other cases observing the guard, while the regression this
+    // must catch — the guard renamed, removed, or made conditional — takes
+    // every case to zero. That is asserted after the matrix.
+    if (contention) {
+      contentionWatchedCases++;
+      if (await contention.wait(CONTENTION_WAIT_MS)) contentionObservedCases++;
+      else console.log(`NOTE ${name}: recover guard not sampled within ${CONTENTION_WAIT_MS}ms — fell back to timing-dependent ordering for this case`);
     }
     // Simulate the current lock owner committing another row. The waiting
     // writer must read this fresh version after acquiring the lock; a writer
@@ -813,6 +825,20 @@ async function testLiveRecoverGuardIsNotEvicted() {
 await testFreshOwnerlessLockIsNotStolen();
 await testAgedOwnerlessLockStillRecovers();
 await testLiveRecoverGuardIsNotEvicted();
+
+// #2436: the guard-watched cases depend on the recover guard to order the
+// fixture mutation after the writer's own read. If it stops being emitted they
+// all silently fall back to timing, each burning CONTENTION_WAIT_MS first — the
+// suite stays green (or returns to flaking) with nothing pointing at the cause.
+// One observation is enough to prove the signal exists; zero across the whole
+// matrix is the regression.
+if (contentionWatchedCases > 0) {
+  if (contentionObservedCases > 0) {
+    pass(`recover guard observed in ${contentionObservedCases}/${contentionWatchedCases} guard-watched cases — the mutation ordering signal is live`);
+  } else {
+    fail(`recover guard never observed in any of the ${contentionWatchedCases} guard-watched cases — acquireTrackerLock has stopped emitting it, so every one of them fell back to timing-dependent ordering`);
+  }
+}
 
 console.log(`\n${passed} passed, ${failed} failed`);
 process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
Fixes #2436 — the follow-up you asked for on #2398:

> the harness discards the boolean from `contention.wait()`, which is the actual discrimination signal — if the recover guard ever stops being emitted, the six non-output cases quietly burn the full 2s wait instead of failing loudly.

The boolean is now consumed. **But at run level, not per case** — the issue proposed per case, I implemented that first, and CI proved it wrong. The finding is worth reading before the diff.

## Why per-case fails on a healthy tree

`acquireTrackerLock` creates the recover guard and removes it in a `finally` around a single `lockCanRecover()` call (`tracker-utils.mjs:388-398`). It exists for well under a millisecond, re-created on each ~`retryMs` attempt. `watchForContention` **samples** for it with `readdirSync` every 2ms — so whether a given case observes it is a race the sampler can lose.

Locally that race is always won (8 of 8 observed). On the Windows runner it is not:

```
FAIL normalize-statuses:    recover guard never appeared within 2000ms
FAIL dedup-tracker:         …
FAIL set-status:            …
FAIL reply-watch:           …
FAIL reply-watch-identical: …
```

**3 of 8 observed** — so the guard *is* emitted on Windows, the sampler just misses it. A per-case hard fail turns a healthy tree red there.

That also explains something I had written off as a flake earlier today: `tracker-writer-lock-tests.mjs` timing out with SIGTERM on the Windows leg of an unrelated PR. Those cases have been burning the full 2s each and falling back to timing-dependent ordering on Windows all along — silently, which is exactly the degradation this issue is about. It was already happening; nothing consumed the signal, so nobody saw it.

## What the assertion does instead

Across a run, the two causes separate cleanly:

- **a sampling miss** still leaves other cases observing the guard → the run stays green, and each miss prints a `NOTE` line so the degradation is visible where it happens;
- **the regression this must catch** — guard renamed, removed, or made conditional — takes *every* case to zero → red;
- **zero guard-watched cases at all** — a matrix change that drops them → red too. Skipping the assertion there would have reproduced the exact defect this PR fixes: green suite, nothing validating the guard (CodeRabbit review). Verified by forcing the watcher off for every case: `26 passed, 1 failed`.

```
PASS recover guard observed in 8/8 guard-watched cases — the mutation ordering signal is live
```

## Empirical proof

Renaming the guard prefix in `watchForContention`, simulating "the guard stops being emitted":

| | Result |
|---|---|
| `main` | **26 passed, 0 failed** — completely silent while the ordering signal is gone |
| this branch | **26 passed, 1 failed** — `recover guard never observed in any of the 8 guard-watched cases` |

## On the hard-fail question

The issue asked whether a hard fail or a warning was right, and said "a hard fail looks right to me". It still is — the run-level assertion *is* a hard fail. Only its granularity changed, because per-case granularity asserts something the signal cannot support. If you would rather have the per-case fail and accept red Windows legs, it is a three-line change.

## Test plan

- [x] `node tracker-writer-lock-tests.mjs` — 27 passed, 0 failed (26 + the new run-level assertion)
- [x] Zero-watched-case path verified by forcing `contention` to null everywhere: red, with `no guard-watched case ran`
- [x] Regression simulated by renaming the guard prefix: red here, green on `main`
- [x] `node test-all.mjs --quick` — 2783 passed, 0 failed
- [x] No change to `watchForContention`, `CONTENTION_WAIT_MS`, `acquireTrackerLock`, or any lock parameter under test
