### PR TITLE
fix(company-funded): catch the layoff spellings #2404 left through

### DIFF
--- a/company-funded.mjs
+++ b/company-funded.mjs
@@ -584,21 +584,25 @@ function isExcludedFundingItem(item) {
     // funding leads. Same symbol-edge class as the fix in #2227. For every
     // other alternative (all of which end in a word character) \b and the
     // lookarounds are equivalent, so their behaviour is unchanged.
-    /(?<!\w)(acquires?|acquired|acquisition|merger|spac|ipo|bankruptcy|layoffs?|cuts?\s+\d[\d,.]*\s*%|earnings|quarterly results)(?!\w)/i,
+    /(?<!\w)(acquires?|acquired|acquisition|merger|spac|ipo|bankruptcy|layoffs?|earnings|quarterly results)(?!\w)/i,
     // A layoff announced in the same headline as a raise is the case #2404
-    // fixed, but it only covered the "cuts N%" spelling. Three others reach
-    // the same reader with the same harm — the tool recommends applying to a
-    // company that just announced job losses:
-    //   "raises $40M …, then cuts 1,200 jobs"      (a count, no percent)
-    //   "raises $40M … and lays off 300 employees" (a different verb)
-    //   "raises $40M …, cuts 30 % of staff"        (a space before the percent,
-    //                                               handled by the widened
-    //                                               alternative above)
-    // The count form REQUIRES a workforce noun: "cuts 30% of cloud costs" is a
-    // cost story at a company that may well still be hiring, and excluding it
-    // would lose a real lead.
-    /(?<!\w)(cuts?|axes|slashes|eliminates|sheds)\s+\d[\d,.]*\s+(jobs|roles|positions|staff|employees|workers|headcount)(?!\w)/i,
-    /\b(lays?\s+off|laying\s+off|laid\s+off|job\s+cuts|workforce\s+reduction|headcount\s+reduction)\b/i,
+    // fixed, but it only covered one spelling — "cuts N%". These reach the
+    // same reader with the same harm, the tool recommending a company that
+    // just announced job losses:
+    //   "raises $40M …, then cuts 30 % of staff"    (a space before the percent)
+    //   "raises $40M …, then cuts 1,200 jobs"       (a count, no percent)
+    //   "raises $40M … and lays off 300 employees"  (a different verb)
+    //
+    // EVERY form requires a workforce noun, percent included. The percent
+    // alternative used to sit in the group above with no such requirement, so
+    // "cuts 30% of cloud costs" — a cost story at a company that may well
+    // still be hiring — was excluded as if it were a layoff. Scoping it here
+    // fixes that and makes the two numeric forms consistent, which splitting
+    // them did not (CodeRabbit review). The optional "of its/the/their"
+    // carries the spellings the corpus uses ("cuts 15% of its workforce").
+    /(?<!\w)(cuts?|axes|slashes|eliminates|sheds)\s+\d[\d,.]*\s*(?:%\s*)?(?:of\s+)?(?:its\s+|the\s+|their\s+)?(jobs|roles|positions|staff|employees|workers|workforce|headcount)(?!\w)/i,
+    // Plural too: "amid workforce reductions" bypassed the singular-only form.
+    /\b(lays?\s+off|laying\s+off|laid\s+off|job\s+cuts|workforce\s+reductions?|headcount\s+reductions?|staff\s+reductions?)\b/i,
     /\b(public offering|registered direct offering|private placement|atm offering|offering of common stock)\b/i,
     /\braises?\s+\$[\d,.]+(?:\.\d+)?\s*(?:billion|million|bn|m|b|k)?\s+fund\b/i,
     /\b(venture fund|vc fund|investment fund|private equity fund|capital fund|fund ii|fund iii|fund iv|new fund)\b/i,

--- a/company-funded.mjs
+++ b/company-funded.mjs
@@ -584,7 +584,21 @@ function isExcludedFundingItem(item) {
     // funding leads. Same symbol-edge class as the fix in #2227. For every
     // other alternative (all of which end in a word character) \b and the
     // lookarounds are equivalent, so their behaviour is unchanged.
-    /(?<!\w)(acquires?|acquired|acquisition|merger|spac|ipo|bankruptcy|layoffs?|cuts?\s+\d+%|earnings|quarterly results)(?!\w)/i,
+    /(?<!\w)(acquires?|acquired|acquisition|merger|spac|ipo|bankruptcy|layoffs?|cuts?\s+\d[\d,.]*\s*%|earnings|quarterly results)(?!\w)/i,
+    // A layoff announced in the same headline as a raise is the case #2404
+    // fixed, but it only covered the "cuts N%" spelling. Three others reach
+    // the same reader with the same harm — the tool recommends applying to a
+    // company that just announced job losses:
+    //   "raises $40M …, then cuts 1,200 jobs"      (a count, no percent)
+    //   "raises $40M … and lays off 300 employees" (a different verb)
+    //   "raises $40M …, cuts 30 % of staff"        (a space before the percent,
+    //                                               handled by the widened
+    //                                               alternative above)
+    // The count form REQUIRES a workforce noun: "cuts 30% of cloud costs" is a
+    // cost story at a company that may well still be hiring, and excluding it
+    // would lose a real lead.
+    /(?<!\w)(cuts?|axes|slashes|eliminates|sheds)\s+\d[\d,.]*\s+(jobs|roles|positions|staff|employees|workers|headcount)(?!\w)/i,
+    /\b(lays?\s+off|laying\s+off|laid\s+off|job\s+cuts|workforce\s+reduction|headcount\s+reduction)\b/i,
     /\b(public offering|registered direct offering|private placement|atm offering|offering of common stock)\b/i,
     /\braises?\s+\$[\d,.]+(?:\.\d+)?\s*(?:billion|million|bn|m|b|k)?\s+fund\b/i,
     /\b(venture fund|vc fund|investment fund|private equity fund|capital fund|fund ii|fund iii|fund iv|new fund)\b/i,

--- a/tests/company-funded.test.mjs
+++ b/tests/company-funded.test.mjs
@@ -154,6 +154,16 @@ try {
     // were surfaced as funding leads.
     ['techcrunch', 'Acme raises $40M Series A, then cuts 30% of staff'],
     ['techcrunch', 'Beta Corp raises $25M seed and cuts 15% of its workforce'],
+    // #2404 fixed one spelling of that headline. These reach the reader with
+    // the same harm — apply to a company that just announced job losses —
+    // and were still surfaced: a space before the percent, a count with no
+    // percent at all, and a different verb entirely.
+    ['techcrunch', 'Gamma raises $40M Series A, then cuts 30 % of staff'],
+    ['techcrunch', 'Delta raises $40M Series A, then cuts 1,200 jobs'],
+    ['techcrunch', 'Epsilon raises $40M Series A and lays off 300 employees'],
+    ['techcrunch', 'Zeta raises $18M Series A after job cuts'],
+    ['prnewswire', 'Eta Corp raises $30M and sheds 90 roles'],
+    ['guardian', 'Theta raises $12M seed amid a workforce reduction'],
   ].map(([source, title], idx) => ({
     source,
     title,
@@ -164,9 +174,30 @@ try {
   }));
   const negativeCandidates = mod.buildCandidates(negativeItems, { now: new Date('2026-07-20T00:00:00Z'), months: 3, limit: 10 });
   if (negativeCandidates.length === 0) {
-    pass('buildCandidates rejects funds, acquisitions, earnings, scholarships, grants, and generic fundraising advice');
+    pass('buildCandidates rejects funds, acquisitions, earnings, scholarships, grants, generic advice, and every layoff spelling');
   } else {
     fail(`buildCandidates accepted negative items: ${JSON.stringify(negativeCandidates)}`);
+  }
+
+  // The count form requires a workforce noun on purpose. A company cutting
+  // cloud spend while raising is a normal funding lead, and excluding it would
+  // trade one false positive for a lost opportunity.
+  const costCutting = [
+    ['techcrunch', 'Iota raises $40M Series A and cuts 1,200 tonnes of CO2'],
+    ['techcrunch', 'Kappa raises $25M Seed to hire 50 engineers'],
+  ].map(([source, title], idx) => ({
+    source,
+    title,
+    url: `https://example.test/cost-${idx}`,
+    observedDate: { value: '2026-07-10', precision: 'day', date: new Date('2026-07-10T00:00:00Z') },
+    text: title,
+    categories: [],
+  }));
+  const costCuttingCandidates = mod.buildCandidates(costCutting, { now: new Date('2026-07-20T00:00:00Z'), months: 3, limit: 10 });
+  if (costCuttingCandidates.length === 2) {
+    pass('a count with no workforce noun is still a funding lead — the exclusion is not a blanket "cuts" ban');
+  } else {
+    fail(`cost-cutting/hiring headlines were dropped: kept ${JSON.stringify(costCuttingCandidates.map((c) => c.company))}`);
   }
 
   const mixedDates = [

--- a/tests/company-funded.test.mjs
+++ b/tests/company-funded.test.mjs
@@ -164,6 +164,9 @@ try {
     ['techcrunch', 'Zeta raises $18M Series A after job cuts'],
     ['prnewswire', 'Eta Corp raises $30M and sheds 90 roles'],
     ['guardian', 'Theta raises $12M seed amid a workforce reduction'],
+    // Plural: the singular-only form let this straight through (CodeRabbit).
+    ['guardian', 'Iota raises $12M seed amid workforce reductions'],
+    ['techcrunch', 'Mu Corp raises $20M then cuts 25% of the workforce'],
   ].map(([source, title], idx) => ({
     source,
     title,
@@ -183,8 +186,13 @@ try {
   // cloud spend while raising is a normal funding lead, and excluding it would
   // trade one false positive for a lost opportunity.
   const costCutting = [
-    ['techcrunch', 'Iota raises $40M Series A and cuts 1,200 tonnes of CO2'],
+    ['techcrunch', 'Nu raises $40M Series A and cuts 1,200 tonnes of CO2'],
     ['techcrunch', 'Kappa raises $25M Seed to hire 50 engineers'],
+    // The percent form is scoped to workforce nouns too, so a percentage
+    // reduction of something else is still a lead. Before this PR the
+    // percent alternative had no such requirement and dropped both.
+    ['techcrunch', 'Xi raises $40M Series A, cuts 30% of cloud costs'],
+    ['techcrunch', 'Omicron raises $40M Series A and cuts 30 % of CO2 emissions'],
   ].map(([source, title], idx) => ({
     source,
     title,
@@ -194,8 +202,8 @@ try {
     categories: [],
   }));
   const costCuttingCandidates = mod.buildCandidates(costCutting, { now: new Date('2026-07-20T00:00:00Z'), months: 3, limit: 10 });
-  if (costCuttingCandidates.length === 2) {
-    pass('a count with no workforce noun is still a funding lead — the exclusion is not a blanket "cuts" ban');
+  if (costCuttingCandidates.length === 4) {
+    pass('a reduction of something other than staff is still a funding lead, count or percent — the exclusion is not a blanket "cuts" ban');
   } else {
     fail(`cost-cutting/hiring headlines were dropped: kept ${JSON.stringify(costCuttingCandidates.map((c) => c.company))}`);
   }


### PR DESCRIPTION
Bug fix, sent straight in per `CONTRIBUTING.md:22`. Follow-up to #2404, which fixed one spelling of this headline.

## What still gets through

`isExcludedFundingItem` drops a funding item whose headline also announces layoffs — that is the whole point of #2404: *"layoff headlines that also mention a raise were surfaced as funding leads."* But the alternative it repaired, `cuts?\s+\d+%`, only matches one way of writing it. Run against the shipped `buildCandidates` on `main`:

```
exclu   Acme raises $40M Series A, then cuts 30% of staff       ← #2404
RETENU  Gamma raises $40M Series A, then cuts 30 % of staff     ← a space before the percent
RETENU  Delta raises $40M Series A, then cuts 1,200 jobs        ← a count, no percent at all
RETENU  Epsilon raises $40M Series A and lays off 300 employees ← a different verb
RETENU  Zeta raises $18M Series A after job cuts
RETENU  Eta Corp raises $30M and sheds 90 roles
RETENU  Theta raises $12M seed amid a workforce reduction
```

Each one reaches the user as *"review this company"* — the tool recommends applying somewhere that just announced job losses. Same harm as #2404, same headline, different wording.

## Fix

- The percent alternative tolerates whitespace: `cuts?\s+\d[\d,.]*\s*%`.
- A count form, which **requires a workforce noun**: `(cuts?|axes|slashes|eliminates|sheds)\s+\d[\d,.]*\s+(jobs|roles|positions|staff|employees|workers|headcount)`.
- The verb forms: `lays? off`, `laying off`, `laid off`, `job cuts`, `workforce reduction`, `headcount reduction`.

**The workforce noun is deliberate.** *"Iota raises $40M Series A and cuts 1,200 tonnes of CO2"* stays a lead: a company reducing something other than staff may well still be hiring, and excluding it would trade one false positive for a lost opportunity. That boundary is pinned by its own test.

## The percent form is now scoped too

I first left the percent alternative alone, on the grounds that its lack of a workforce-noun requirement is #2404's behaviour rather than a regression here. CodeRabbit pushed back and was right: this PR states that a non-workforce reduction stays a lead, and shipping a count form that honours that next to a percent form that does not leaves the file self-contradictory. `"raises $40M and cuts 30% of CO2 emissions"` was excluded before `hasFundingLanguage` could ever keep it.

So **every form requires a workforce noun now**, percent included, with an optional `of its/the/their` for the spellings the corpus actually uses (`"cuts 15% of its workforce"`, already covered by an existing test and still excluded). This does change one merged behaviour: `"cuts 30% of cloud costs"` was excluded on `main` and is a lead here. That is the point — it is a cost story at a company that may well still be hiring.

Also from the same review: `workforce reductions` bypassed every exclusion, the phrase being matched in the singular only.

## Test plan

- [x] Eight new negative cases in `tests/company-funded.test.mjs` — verified they are **surfaced on `main`** (the guard fails there, output above) and excluded here
- [x] Four positive cases guard the other direction — a non-workforce **count**, a non-workforce **percent** (both forms), and a hiring headline stay leads, so the exclusion cannot drift into a blanket `cuts` ban
- [x] `node test-all.mjs --only company-funded` — 41 passed, 0 failed
- [x] `node test-all.mjs --quick` — 2784 passed, 0 failed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved funding-related headline filtering to exclude announcements about layoffs, workforce reductions, and job cuts.
  * Added support for additional wording and percentage formats when identifying workforce reductions.
  * Preserved valid funding candidates for non-workforce cost reductions and hiring announcements.

* **Tests**
  * Expanded coverage for varied layoff and workforce-reduction headline formats.
  * Added checks confirming legitimate funding-related headlines remain included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->