### PR TITLE
tests(web): move web's hand-enumerated suites to a glob-discovered layout

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,14 @@ node test-all.mjs --only providers/themuse   # Run just one provider's test(s)
 `tests/providers/{name}.test.mjs` — it's auto-discovered (`tests/**/*.test.mjs`),
 no registration needed. Do not add a section to `test-all.mjs` for this.
 
+**Adding a test for the web app:** web suites live under `web/tests/`, mirroring
+the tested module's path below `web/src/` (`src/lib/clean-chips.mjs` →
+`tests/lib/clean-chips.test.mjs`), named `{module}.test.mjs`. `web/`'s own
+`npm test` glob-discovers them, so no registration is needed there either — but
+keep them out of `web/src/` (Next.js scans that tree) and write them as `.mjs`,
+since there is no TypeScript loader for `node --test`. `web/README.md` has the
+detail; `tests/web-test-layout.test.mjs` enforces it on every PR.
+
 **`--only` is a dev convenience, not a PR gate:** it runs *only* the discovered
 `tests/` files matching the given substring and skips every inline core
 section (syntax, scripts, dashboard, data contract, personal data, paths,

--- a/tests/README.md
+++ b/tests/README.md
@@ -24,6 +24,18 @@ Node.js (`tests/helpers.mjs`).
   scripts. Note: standalone `*.test.mjs` files in the repo root are run by
   `test-all.mjs`'s inline script list, not by this directory's discovery.
 
+**Web tests do not live here.** `web/` runs its own `npm test` over
+`web/tests/**/*.test.mjs` (see [../web/README.md](../web/README.md)); this
+directory is for the core. The two suites also differ in style on purpose: web
+suites use `node:test`, while suites here use the `pass`/`fail` helpers because
+this suite must run on a bare clone with no framework — "not even `node:test`"
+(#1440). Don't carry either style across the boundary.
+
+The one exception to the split is a guard *about* web's layout —
+`web-test-layout.test.mjs` lives here on purpose, because `web-ci.yml` is
+informative by design and never blocks a merge, while `test-all.mjs` runs on
+every PR as a required check.
+
 ## Running
 
 ```bash

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -196,12 +196,17 @@ export function fileExists(path) { return existsSync(join(ROOT, path)); }
  * level, so the result is identical on every run and every OS — the same
  * property test-all.mjs's own `tests/` discovery relies on (#1440).
  *
+ * A missing `dir` yields `[]` rather than throwing, so the caller reports its
+ * own contract failure (e.g. "discovery is empty") instead of the run dying
+ * mid-traversal with an ENOENT that says nothing about what was expected.
+ *
  * @param {string} dir - Absolute directory to walk.
  * @param {RegExp} match - Tested against each entry's basename.
  * @param {Set<string>} [skipDirs] - Directory names never descended into.
  * @returns {string[]} Absolute paths, parents before children.
  */
 export function walkFiles(dir, match, skipDirs = new Set()) {
+  if (!existsSync(dir)) return [];
   const out = [];
   const entries = readdirSync(dir, { withFileTypes: true })
     .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -2,7 +2,7 @@
 // Moved verbatim from test-all.mjs (issue #1440); no framework by design:
 // the suite must run on a fresh clone with only Node.
 import { execFileSync } from 'child_process';
-import { existsSync } from 'fs';
+import { existsSync, readdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -188,6 +188,33 @@ export function formatRunFailure(maxChars = 2000) {
  * @returns {boolean} True when the file exists.
  */
 export function fileExists(path) { return existsSync(join(ROOT, path)); }
+
+/**
+ * Recursively collect files under `dir` whose basename matches `match`.
+ *
+ * Deterministic by construction: entries are sorted lexicographically at every
+ * level, so the result is identical on every run and every OS — the same
+ * property test-all.mjs's own `tests/` discovery relies on (#1440).
+ *
+ * @param {string} dir - Absolute directory to walk.
+ * @param {RegExp} match - Tested against each entry's basename.
+ * @param {Set<string>} [skipDirs] - Directory names never descended into.
+ * @returns {string[]} Absolute paths, parents before children.
+ */
+export function walkFiles(dir, match, skipDirs = new Set()) {
+  const out = [];
+  const entries = readdirSync(dir, { withFileTypes: true })
+    .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!skipDirs.has(entry.name)) out.push(...walkFiles(full, match, skipDirs));
+    } else if (match.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
 
 let bashCache = null;
 

--- a/tests/web-test-layout.test.mjs
+++ b/tests/web-test-layout.test.mjs
@@ -1,0 +1,220 @@
+// tests/web-test-layout.test.mjs — freezes web/'s test DISCOVERY contract (#2360).
+//
+// web/ used to carry two conventions at once: suites under web/tests/ plus two
+// hand-enumerated at the web root, listed by name in web/package.json's `test`
+// script. A suite missing from that list never ran and `npm test` still exited
+// 0. #1440, the parent issue, named that failure mode directly — "the runner
+// should also fail hard if the glob matches zero files, so a path typo can't
+// silently turn CI green" — and removed it from the root suite. web/ kept it,
+// and it nearly cost two suites for real during #2182, where either side of a
+// package.json conflict would have dropped them with CI green.
+//
+// This guard lives in the ROOT suite, not web/tests/, deliberately:
+//   1. .github/workflows/test.yml runs test-all.mjs on every PR with no paths
+//      filter and is a required check. web-ci.yml is informative by design —
+//      "a red here never blocks a core merge" — so it cannot be the enforcer.
+//   2. A guard inside web/tests/ would be discovered by the very glob it
+//      validates: if the glob breaks, the guard silently stops running too.
+// Same reach-into-web/ pattern as test-all.mjs's 55.3c/55.3d freezes (#2369).
+//
+// ONE responsibility: web/'s suites must be reachable by what `npm test`
+// actually runs. Every assertion below is a facet of that — including the
+// engines floor, which is checked because a glob operand is unrunnable below
+// Node 22, not as general Node policy.
+//
+// It asserts PROPERTIES, not a frozen script string, so a legitimate
+// restructure is not blocked.
+import { pass, fail, ROOT, walkFiles } from './helpers.mjs';
+import { join, relative, sep } from 'path';
+import { readFileSync, existsSync } from 'fs';
+
+console.log('\nweb/ test discovery contract (#2360)');
+
+const WEB = join(ROOT, 'web');
+const WEB_PKG = join(WEB, 'package.json');
+
+// `node --test` only expands CLI globs from Node 22 on: 18.19.1 and 20.11.1
+// both print "Could not find '<pattern>'", run 0 tests and exit 1 (measured).
+// So a glob-discovered suite is only actually runnable at >= 22 — this is the
+// binding constraint on web/'s engines floor. next@16.2's own >=20.9.0 is a
+// separate, lower one and does NOT satisfy discovery.
+const GLOB_FLOOR = [22, 0, 0];
+
+/**
+ * Run one scenario in isolation.
+ *
+ * Each case gets its own try/catch so a throw in one cannot collapse the rest
+ * into a single unexplained failure (PIT — every case stands alone, in any
+ * order). A guard that cannot inspect the tree must be loud, never a silent
+ * pass — the same stance as test-all.mjs's SYSTEM_PATHS coverage probe.
+ *
+ * @param {string} label - What this scenario checks, used in the error path.
+ * @param {() => void} body - The When/Then; calls pass() or fail() itself.
+ * @returns {void}
+ */
+function scenario(label, body) {
+  try {
+    body();
+  } catch (err) {
+    fail(`could not verify ${label} (#2360): ${err.message}`);
+  }
+}
+
+/**
+ * Translate a `node --test` glob operand into an anchored matcher.
+ *
+ * Supports exactly the two constructs `node --test` expands — `**` spanning
+ * separators (and matching zero segments, so `tests/**\/*.test.mjs` reaches
+ * `tests/x.test.mjs`) and `*` within one segment. Anything else in a pattern
+ * is out of contract: it is treated literally, which fails closed by reporting
+ * suites as unreachable rather than waving them through.
+ *
+ * @param {string} pattern - A glob operand from the `test` script.
+ * @returns {RegExp} Matcher for web-relative, `/`-separated paths.
+ */
+function globToRegExp(pattern) {
+  let out = '';
+  for (let i = 0; i < pattern.length; i++) {
+    const c = pattern[i];
+    if (c !== '*') {
+      out += c.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
+    } else if (pattern[i + 1] === '*') {
+      out += '.*';
+      i++;
+      if (pattern[i + 1] === '/') i++;
+    } else {
+      out += '[^/]*';
+    }
+  }
+  return new RegExp(`^${out}$`);
+}
+
+/**
+ * Lowest Node version an `engines` range admits, as [major, minor, patch].
+ *
+ * Accepts the partial forms package.json ranges use in practice — `>=22`,
+ * `>=22.0`, `^22.0.0`, `22.x` — defaulting absent components to 0. A compound
+ * range like `>=20 <23` yields its first version, which is the floor.
+ *
+ * @param {string} range - An `engines.node` value.
+ * @returns {number[]|null} [major, minor, patch], or null if none found.
+ */
+function floorOf(range) {
+  const m = range.match(/(\d+)(?:\.(\d+))?(?:\.(\d+))?/);
+  return m ? [Number(m[1]), Number(m[2] ?? 0), Number(m[3] ?? 0)] : null;
+}
+
+// web/ is NOT in update-system.mjs's SYSTEM_PATHS but tests/ is, so this file
+// ships to end users whose checkout has no web/ at all. The invariant is
+// conditional ("if web/ exists, its suites are reachable") and vacuously true
+// there — but say so out loud rather than skipping in silence.
+if (!existsSync(WEB_PKG)) {
+  pass('web/ is not present in this checkout — discovery contract not applicable');
+} else {
+  // ── Given: what is on disk, and what web/package.json claims to run ──
+
+  // Anything a contributor would reasonably expect to be run: the sanctioned
+  // {module}.test.{ext} and the legacy test-{module}.{ext}. Non-.mjs
+  // extensions are caught on purpose — `node --test` cannot run a .ts suite
+  // without a loader, so one would sit in the tree looking like coverage and
+  // never execute.
+  const TEST_FILE = /(?:\.test\.(?:mjs|js|ts|tsx)|^test-.*\.(?:mjs|js|ts|tsx))$/;
+  // node_modules matters for speed, not just noise: a populated
+  // web/node_modules is ~400 MB (see test-all.mjs's copy-exclusion note).
+  const SKIP_DIRS = new Set(['node_modules', '.next', '.git', 'out', 'dist', 'coverage']);
+
+  const found = walkFiles(WEB, TEST_FILE, SKIP_DIRS)
+    .map((p) => relative(WEB, p).split(sep).join('/'));
+
+  const pkg = JSON.parse(readFileSync(WEB_PKG, 'utf8'));
+  const script = pkg.scripts?.test ?? '';
+  // Tokenize respecting quotes, then keep only path-shaped operands. Shape, not
+  // position, decides what counts — so a flag value like `--test-reporter spec`
+  // and any command prefix are both excluded without hardcoding an argv index.
+  const operands = (script.match(/"[^"]*"|'[^']*'|\S+/g) ?? [])
+    .map((t) => t.replace(/^["']|["']$/g, ''))
+    .filter((t) => !t.startsWith('-'))
+    .filter((t) => /\.(mjs|js|ts|tsx)$/.test(t) || t.includes('*'));
+  const patterns = operands.filter((t) => t.includes('*'));
+  const enumerated = operands.filter((t) => !t.includes('*'));
+
+  const misplaced = found.filter((p) => !p.startsWith('tests/') || !p.endsWith('.test.mjs'));
+
+  // ── Every suite sits where the glob can see it, under the right name ──
+  scenario('where web suites live', () => {
+    if (misplaced.length === 0) {
+      pass(`all ${found.length} web suites live under web/tests/ as {module}.test.mjs`);
+    } else {
+      fail(`web suites outside the discovered layout (#2360): ${misplaced.join(', ')}`
+        + ' — web tests live at web/tests/{dir}/{module}.test.mjs mirroring web/src/,'
+        + " and must end in .test.mjs for `npm test`'s glob to run them");
+    }
+  });
+
+  // ── The script discovers by pattern; it never lists suites by name ──
+  scenario('that the test script names no suites', () => {
+    if (enumerated.length === 0) {
+      pass('web/package.json test script enumerates no suites by name');
+    } else {
+      fail(`web/package.json test script names suites explicitly (#2360): ${enumerated.join(', ')}`
+        + ' — a suite missing from a hand-maintained list never runs and `npm test` still exits 0;'
+        + ' rely on the tests/**/*.test.mjs glob instead');
+    }
+  });
+
+  scenario('that the test script declares a pattern', () => {
+    if (patterns.length > 0) {
+      pass(`web test script discovers by pattern (${patterns.join(', ')})`);
+    } else {
+      fail('web/package.json test script declares no glob pattern (#2360)'
+        + ' — expected something like: node --test "tests/**/*.test.mjs"');
+    }
+  });
+
+  // ── A pattern that matches nothing exits 0 (#1440's zero-match rule) ──
+  // Verified on Node 22: `node --test "zzz/**/*.test.mjs"` exits 0 with zero
+  // tests run. A missing literal path exits 1, so THIS is the silent case.
+  scenario('that web discovery is non-empty', () => {
+    if (found.length > 0) {
+      pass(`web test discovery is non-empty (${found.length} suites on disk)`);
+    } else {
+      fail('no web test suites found under web/ (#2360, #1440) — an empty glob exits 0,'
+        + ' so zero web coverage would look identical to a green run');
+    }
+  });
+
+  // ── ...and the declared pattern actually reaches each one ──
+  scenario('that the declared glob reaches every suite', () => {
+    const patternMatchers = patterns.map(globToRegExp);
+    const unreachable = found.filter(
+      (p) => !misplaced.includes(p) && !patternMatchers.some((re) => re.test(p)));
+    if (unreachable.length === 0) {
+      pass('every web suite on disk is matched by the declared glob');
+    } else {
+      fail(`web suites the declared glob cannot reach (#2360): ${unreachable.join(', ')}`
+        + ` — pattern(s) ${patterns.join(', ')} run, but these files do not match,`
+        + ' so they are dead weight that looks like coverage');
+    }
+  });
+
+  // ── The declared glob must be runnable on the declared engines floor ──
+  scenario("that web's engines floor can run a glob", () => {
+    const engines = pkg.engines?.node ?? '';
+    const declaredFloor = floorOf(engines);
+    const required = GLOB_FLOOR.join('.');
+    if (!declaredFloor) {
+      fail(`web/package.json declares no engines.node floor (#2360, got ${JSON.stringify(engines)})`
+        + ` — its test script discovers by glob, which needs >=${required}`);
+      return;
+    }
+    const [dMajor, dMinor, dPatch] = declaredFloor;
+    const [rMajor, rMinor, rPatch] = GLOB_FLOOR;
+    const order = (dMajor - rMajor) || (dMinor - rMinor) || (dPatch - rPatch);
+    if (order >= 0) {
+      pass(`web engines.node ${engines} can run the declared glob (>= ${required})`);
+    } else {
+      fail(`web engines.node ${engines} is below >=${required} (#2360) — \`node --test\``
+        + ' does not expand CLI globs there, so `npm test` would find 0 suites and exit 1');
+    }
+  });
+}

--- a/tests/web-test-layout.test.mjs
+++ b/tests/web-test-layout.test.mjs
@@ -90,17 +90,25 @@ function globToRegExp(pattern) {
 }
 
 /**
- * Lowest Node version an `engines` range admits, as [major, minor, patch].
+ * Lowest Node version an `engines` range provably admits, as [major, minor, patch].
  *
- * Accepts the partial forms package.json ranges use in practice — `>=22`,
- * `>=22.0`, `^22.0.0`, `22.x` — defaulting absent components to 0. A compound
- * range like `>=20 <23` yields its first version, which is the floor.
+ * Deliberately narrow: one `>=` lower bound, optionally followed by upper-bound
+ * constraints (`>=22 <25` is fine — an upper bound never admits an older Node).
+ * Partial versions are accepted (`>=22`, `>=22.0`), absent components read as 0.
+ *
+ * Everything else returns null and is reported as unverifiable rather than
+ * guessed at, because guessing silently blesses a Node that cannot run the
+ * suite: `^22.0.0 || >=20.0.0` admits 20, `^24 || ^20` admits 20, and
+ * `<=23.0.0` sets no lower bound at all. Evaluating those properly means a
+ * semver range evaluator, which is far more machinery than this one invariant
+ * justifies — and `tests/` must stay dependency-free (it runs on a bare clone).
  *
  * @param {string} range - An `engines.node` value.
- * @returns {number[]|null} [major, minor, patch], or null if none found.
+ * @returns {number[]|null} [major, minor, patch], or null if not provable.
  */
 function floorOf(range) {
-  const m = range.match(/(\d+)(?:\.(\d+))?(?:\.(\d+))?/);
+  if (range.includes('||')) return null;
+  const m = range.trim().match(/^>=\s*(\d+)(?:\.(\d+))?(?:\.(\d+))?/);
   return m ? [Number(m[1]), Number(m[2] ?? 0), Number(m[3] ?? 0)] : null;
 }
 
@@ -203,8 +211,10 @@ if (!existsSync(WEB_PKG)) {
     const declaredFloor = floorOf(engines);
     const required = GLOB_FLOOR.join('.');
     if (!declaredFloor) {
-      fail(`web/package.json declares no engines.node floor (#2360, got ${JSON.stringify(engines)})`
-        + ` — its test script discovers by glob, which needs >=${required}`);
+      fail(`web/package.json declares no verifiable engines.node floor (#2360, got ${JSON.stringify(engines)})`
+        + ` — its test script discovers by glob, which needs >=${required}. State it as a single`
+        + ` \`>=<version>\` lower bound (an upper bound may follow); \`||\` alternatives are refused`
+        + ' because they can admit an older Node than the first term suggests');
       return;
     }
     const [dMajor, dMinor, dPatch] = declaredFloor;

--- a/tests/web-test-layout.test.mjs
+++ b/tests/web-test-layout.test.mjs
@@ -92,24 +92,46 @@ function globToRegExp(pattern) {
 /**
  * Lowest Node version an `engines` range provably admits, as [major, minor, patch].
  *
- * Deliberately narrow: one `>=` lower bound, optionally followed by upper-bound
- * constraints (`>=22 <25` is fine — an upper bound never admits an older Node).
- * Partial versions are accepted (`>=22`, `>=22.0`), absent components read as 0.
+ * Validates the WHOLE range against one deliberately narrow grammar:
+ * whitespace-separated comparators, each `>=`/`<=`/`<` followed by a 1-to-3
+ * component version, with exactly one `>=` lower bound. Every upper bound must
+ * leave that bound satisfiable, so `>=22 <25` and `>=22 <=22` are accepted
+ * while `>=22.0.0 <20.0.0` and `>=22.0.0 <22.0.0` are not.
  *
- * Everything else returns null and is reported as unverifiable rather than
- * guessed at, because guessing silently blesses a Node that cannot run the
- * suite: `^22.0.0 || >=20.0.0` admits 20, `^24 || ^20` admits 20, and
- * `<=23.0.0` sets no lower bound at all. Evaluating those properly means a
- * semver range evaluator, which is far more machinery than this one invariant
- * justifies — and `tests/` must stay dependency-free (it runs on a bare clone).
+ * Anything outside the grammar returns null and is reported as unverifiable
+ * rather than guessed at, because guessing silently blesses a Node that cannot
+ * run the suite. Refused, with the reason: `^22.0.0 || >=20.0.0` and
+ * `^24 || ^20` (unions admitting 20), `<=23.0.0` (no lower bound at all),
+ * `>=22.0.0 garbage` (trailing junk), `^22.0.0` / `22.x` (caret and x-range
+ * semantics this guard does not parse).
+ *
+ * Evaluating the full npm range grammar properly needs a semver evaluator.
+ * `semver` is not a dependency of this repo and is not installed, Node ships no
+ * built-in equivalent, and `tests/` must stay dependency-free — it ships to end
+ * users via SYSTEM_PATHS and #1440 requires the suite to run on a bare clone.
+ * So the burden is inverted: prove the floor or refuse the range.
  *
  * @param {string} range - An `engines.node` value.
  * @returns {number[]|null} [major, minor, patch], or null if not provable.
  */
 function floorOf(range) {
-  if (range.includes('||')) return null;
-  const m = range.trim().match(/^>=\s*(\d+)(?:\.(\d+))?(?:\.(\d+))?/);
-  return m ? [Number(m[1]), Number(m[2] ?? 0), Number(m[3] ?? 0)] : null;
+  const terms = range.trim().split(/\s+/).filter(Boolean);
+  const parsed = [];
+  for (const term of terms) {
+    const m = term.match(/^(>=|<=|<)(\d+)(?:\.(\d+))?(?:\.(\d+))?$/);
+    if (!m) return null;   // unknown operator, `||`, caret/x-range, or junk
+    parsed.push({ op: m[1], version: [Number(m[2]), Number(m[3] ?? 0), Number(m[4] ?? 0)] });
+  }
+  const lowerBounds = parsed.filter((t) => t.op === '>=');
+  if (lowerBounds.length !== 1) return null;
+  const floor = lowerBounds[0].version;
+  const order = (a, b) => (a[0] - b[0]) || (a[1] - b[1]) || (a[2] - b[2]);
+  for (const { op, version } of parsed) {
+    // An upper bound at or below the floor makes the range unsatisfiable.
+    if (op === '<' && order(version, floor) <= 0) return null;
+    if (op === '<=' && order(version, floor) < 0) return null;
+  }
+  return floor;
 }
 
 // web/ is NOT in update-system.mjs's SYSTEM_PATHS but tests/ is, so this file
@@ -202,6 +224,35 @@ if (!existsSync(WEB_PKG)) {
       fail(`web suites the declared glob cannot reach (#2360): ${unreachable.join(', ')}`
         + ` — pattern(s) ${patterns.join(', ')} run, but these files do not match,`
         + ' so they are dead weight that looks like coverage');
+    }
+  });
+
+  // ── The floor parser itself, so a subtle range can't slip past ──
+  // Regression table for the #2468 review: every entry here once passed, or
+  // could plausibly be written by hand, and each would bless a Node that
+  // cannot run the suite.
+  scenario('that floorOf only accepts provable floors', () => {
+    const PROVABLE = ['>=22', '>=22.0', '>=22.0.0', '>=22 <25', '>=22 <=22'];
+    const REFUSED = [
+      '^22.0.0 || >=20.0.0',  // union — admits Node 20
+      '^24 || ^20',           // union — admits Node 20
+      '<=23.0.0',             // no lower bound at all
+      '>=22.0.0 <20.0.0',     // unsatisfiable
+      '>=22.0.0 <22.0.0',     // unsatisfiable
+      '>=22.0.0 garbage',     // trailing junk
+      '>=22 >=24',            // two lower bounds — ambiguous
+      '^22.0.0',              // caret semantics, not parsed here
+      '22.x',                 // x-range semantics, not parsed here
+      '',                     // absent
+    ];
+    const wrong = [
+      ...PROVABLE.filter((r) => floorOf(r) === null).map((r) => `${JSON.stringify(r)} should be provable`),
+      ...REFUSED.filter((r) => floorOf(r) !== null).map((r) => `${JSON.stringify(r)} should be refused`),
+    ];
+    if (wrong.length === 0) {
+      pass(`floorOf accepts ${PROVABLE.length} provable floors, refuses ${REFUSED.length} unprovable ranges`);
+    } else {
+      fail(`floorOf misjudged engines ranges (#2360): ${wrong.join('; ')}`);
     }
   });
 

--- a/web/README.md
+++ b/web/README.md
@@ -46,9 +46,43 @@ Open http://localhost:3000. The app reads the career-ops checkout it lives in
 
 ```bash
 npm run dev          # dev server (Turbopack)
+npm test             # unit suites (node --test, no framework)
 npx tsc --noEmit     # typecheck
 npm run build        # production build
 ```
 
 Set `CAREER_OPS_ROOT=/path/to/checkout` in `web/.env.local` to point the app at
 a different career-ops directory (useful for testing against sample data).
+
+### Tests
+
+Suites live in `web/tests/`, mirroring the path of what they test under
+`web/src/` — so `src/lib/clean-chips.mjs` is tested by
+`tests/lib/clean-chips.test.mjs`. Name the file `{module}.test.mjs`.
+
+`npm test` discovers them with a glob (`tests/**/*.test.mjs`), so a new suite
+needs **no registration** — just add the file. **Requires Node ≥ 22**: earlier
+versions don't expand CLI globs for `node --test`, so `npm test` prints
+`Could not find '…'`, runs nothing and exits 1. Hence `engines.node` in
+`web/package.json` — a higher floor than `next` itself asks for.
+
+Three constraints follow from all this:
+
+- **Keep tests out of `src/`.** `src/` is the Next.js app's own tree, scanned by
+  `next build`'s file tracing and `tsc --noEmit`; test files there entangle
+  fixtures with build and route conventions.
+- **Use `.mjs`, not `.ts`.** There is no test framework and no TypeScript loader
+  by design — `node --test` cannot run a `.ts` suite, so one would look like
+  coverage and never execute. Extract the logic under test into a plain `.mjs`
+  module (the pattern `src/lib/pdf-paths.mjs` and `src/lib/pdf-render.mjs`
+  already follow) and import it from the test.
+- **Web suites use `node:test`; core suites don't.** Here you write
+  `import { test } from "node:test"` with `node:assert/strict`. The root
+  `tests/` suite deliberately uses neither — it has its own `pass`/`fail`
+  helpers, because [#1440](https://github.com/santifer/career-ops/issues/1440)
+  requires the core suite to run on a bare clone with "no framework, not even
+  `node:test`". Don't carry either style across the boundary.
+
+`tests/web-test-layout.test.mjs` in the **root** suite enforces all of the above
+on every PR, including that `npm test` never goes back to listing suites by name
+([#2360](https://github.com/santifer/career-ops/issues/2360)).

--- a/web/README.md
+++ b/web/README.md
@@ -11,7 +11,7 @@ database, no server. If you never run it, nothing about your CLI workflow change
 
 ## Quick start
 
-Requires Node 20+.
+Requires Node 22+ (see [Tests](#tests) — `npm test`'s glob discovery needs it).
 
 ```bash
 cd web

--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,10 @@
     "build": "next build",
     "start": "next start",
     "typecheck": "tsc --noEmit",
-    "test": "node --test \"tests/**/*.test.mjs\" test-stream-parse.mjs test-act-envelope.mjs"
+    "test": "node --test \"tests/**/*.test.mjs\""
+  },
+  "engines": {
+    "node": ">=22.0.0"
   },
   "dependencies": {
     "@paper-design/shaders-react": "^0.0.78",

--- a/web/src/lib/act-envelope.mjs
+++ b/web/src/lib/act-envelope.mjs
@@ -1,6 +1,7 @@
 // Pure JS helper for the assistant console's <<act:ID {json}>> envelope parser
 // (assistant-console.tsx). No TypeScript types so it can be imported by both the
-// component and test-act-envelope.mjs (which can't import .tsx without a runner).
+// component and tests/lib/act-envelope.test.mjs (which can't import .tsx
+// without a runner).
 //
 // parseEnvelopes only hides an incomplete envelope once the opener regex
 // `<<act:([a-zA-Z]+)[ \t]+` fully matches — i.e. `<<act:`, the id letters, AND

--- a/web/src/lib/stream-parse.mjs
+++ b/web/src/lib/stream-parse.mjs
@@ -1,9 +1,10 @@
 // Pure JS helper for the AI-search <<offer:>> stream parser — no TypeScript
 // types so it can be imported directly by both explore-ai.ts (which uses it)
-// and test-stream-parse.mjs (which can't import .ts without a runner). This is
-// the single source of truth for the "how much of a possibly-split opener do we
-// hold back?" logic — the load-bearing part of never dropping an offer whose
-// `<<offer:` marker straddles a stream chunk boundary (#2290).
+// and tests/lib/stream-parse.test.mjs (which can't import .ts without a
+// runner). This is the single source of truth for the "how much of a
+// possibly-split opener do we hold back?" logic — the load-bearing part of
+// never dropping an offer whose `<<offer:` marker straddles a stream chunk
+// boundary (#2290).
 
 /**
  * Length of the trailing run of `buf` that is a proper prefix of `opener` —

--- a/web/tests/lib/act-envelope.test.mjs
+++ b/web/tests/lib/act-envelope.test.mjs
@@ -2,11 +2,11 @@
 // Imports directly from act-envelope.mjs (the single source of truth) so the
 // test and production code can never drift.
 //
-// Run:  node --test test-act-envelope.mjs
+// Run:  node --test tests/lib/act-envelope.test.mjs
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { pendingActOpenerStart } from "./src/lib/act-envelope.mjs";
+import { pendingActOpenerStart } from "../../src/lib/act-envelope.mjs";
 
 test("every trailing partial opener is caught as the stream builds `<<act:navigate `", () => {
   // Char-by-char up to (but not including) the space the regex requires: each

--- a/web/tests/lib/stream-parse.test.mjs
+++ b/web/tests/lib/stream-parse.test.mjs
@@ -2,11 +2,11 @@
 // Imports directly from stream-parse.mjs (the single source of truth) so the
 // test and production code can never drift out of sync.
 //
-// Run:  node --test test-stream-parse.mjs
+// Run:  node --test tests/lib/stream-parse.test.mjs
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { pendingOpenerLen } from "./src/lib/stream-parse.mjs";
+import { pendingOpenerLen } from "../../src/lib/stream-parse.mjs";
 
 const OPEN = "<<offer:";
 


### PR DESCRIPTION
## What does this PR do?

Moves `web/`'s two remaining hand-enumerated test suites into the glob-discovered `web/tests/` layout, collapses `web/package.json`'s `test` script to a plain glob, and adds a root-suite guard so the convention can't drift back. Since #2182 already merged, this is the reduced branch of #2360's own Sequencing note.

## Related issue

Closes #2360

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / translation
- [x] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---

## Two deliberate deviations from the issue

### 1. The `engines` floor is `>=22.0.0`, not `next`'s `>=20.9.0`

The issue's "One floor to pin down" paragraph predicts that an old Node "could end up with a `test` script that matches nothing and **passes**." Measured, that premise is inverted:

| Scenario | Result |
|---|---|
| Node 18.19.1 / 20.11.1, glob operand | `Could not find '<pattern>'` — 0 tests, **exit 1** (loud) |
| Node 22.15.1, glob operand | 60 tests, exit 0 |
| Any Node, glob that expands but matches nothing | 0 tests, **exit 0** (silent) |

So an unsupported-glob Node fails *loudly*; the genuinely silent case is a glob that matches nothing. Two consequences:

- The floor is set from **what the glob needs** (≥ 22), not from `next@16.2`'s `>=20.9.0`. Declaring 20.9 would bless a range where `web/`'s entire suite cannot run at all. Node 22 is also Active LTS, and CI already runs 24.
- The silent case is what the guard asserts, which is exactly #1440's stated rule: *"the runner should also fail hard if the glob matches zero files, so a path typo can't silently turn CI green."*

### 2. A guard test, in the root suite

Not on the issue's 4-bullet checklist — added because an unwritten, unenforced convention is what let `web/` drift into two conventions in the first place. `tests/web-test-layout.test.mjs` asserts *properties*, not a frozen script string, so a legitimate restructure isn't blocked:

- every web suite lives under `web/tests/` as `{module}.test.mjs` (a `.ts` suite is flagged too — `node --test` can't run one without a loader, so it would look like coverage and never execute)
- the `test` script names no suites explicitly, and does declare a pattern
- discovery is **non-empty**, and the declared pattern actually reaches every suite on disk
- the declared `engines` floor can actually run a glob

**It lives in `tests/`, not `web/tests/`, deliberately:** `test.yml` runs `test-all.mjs` on every PR with no paths filter and is a required check, while `web-ci.yml` is informative by design ("a red here never blocks a core merge"); and a guard inside `web/tests/` would be discovered by the very glob it validates, so if the glob broke the guard would stop running too. Same reach-into-`web/` pattern as `test-all.mjs`'s 55.3c/55.3d freezes (#2369).

## Deliberately out of scope

- **The `test/` (singular) orphans.** `test/profile-photo.test.mjs` and `test/zh-minimal-template.test.mjs` are in `SYSTEM_PATHS` but executed by nothing — a live recurrence of #1624, which wired six root suites in but not these two. Confirmed still broken; left alone because the issue author said they'd file it separately.
- **Repo-wide layout enforcement.** The guard is `web/`-only. A repo-wide version would need a grandfathered allowlist for ~19 root-level colocated suites plus the `test/` dir — conventions #2360 explicitly scoped out.
- **Partial de-duplication.** `walkFiles()` is extracted to `tests/helpers.mjs` and used by the guard, but `test-all.mjs`'s own private `discoverTests` is left as-is: it's load-bearing for 104 suites and rewiring it is outside this issue's blast radius. Flagging so it doesn't read as an oversight.

## Verification

- `cd web && npm test` → **60/60, identical to the pre-change baseline** (the load-bearing check: a dropped suite is invisible, which is the whole point of the issue)
- 11 negative scenarios each confirmed to fire, so the guard isn't decorative: misplaced suite, `.ts` suite, legacy `test-*.mjs`, enumeration reintroduced, glob pointed at the wrong tree, no glob at all, engines below floor, engines absent, plus partial-version forms (`>=22`, `22.x`) accepted and `web/` absent handled as not-applicable
- The guard loads on Node 18, so it respects the root `package.json`'s `>=18` floor and stays safe for end users (`tests/` ships via `SYSTEM_PATHS`; `web/` does not)
- `npx tsc --noEmit` and `npm run build` clean. After a rebuild, `web/.next/server/**/*.nft.json` no longer lists the moved files — they were previously pulled into Next's build file tracing, which is concrete support for Option A over Option B
- `node test-all.mjs --quick` → green, with the 6 new assertions from the guard


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for web test placement, naming, discovery, and execution.
  * Clarified testing conventions, Node.js requirements, and source/test separation.

* **Tests**
  * Added automated checks enforcing web test layout and discovery rules.
  * Added a reusable recursive file-discovery helper.

* **Chores**
  * Updated web tests to use automatic discovery.
  * Raised the web test requirement to Node.js 22 or newer.
  * Updated test references and related inline documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->