### PR TITLE
fix: resolve the PDF manifest from the tracker, not the install dir

### DIFF
--- a/find.mjs
+++ b/find.mjs
@@ -28,6 +28,7 @@ import { readFileSync, existsSync } from 'fs';
 import { dirname, resolve } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
+import { resolvePdfIndexPath } from './tracker-utils.mjs';
 import { roleFuzzyMatch } from './role-matcher.mjs';
 
 const ROOT = dirname(fileURLToPath(import.meta.url));
@@ -143,7 +144,9 @@ function main() {
   }
   const rows = parseTrackerRows(readFileSync(trackerPath, 'utf-8'));
 
-  const manifestPath = resolve(ROOT, 'data', 'pdf-index.tsv');
+  // Derived from the tracker resolved just above, not from ROOT: a redirected
+  // CAREER_OPS_TRACKER must not be searched against this install's manifest (#2471).
+  const manifestPath = resolvePdfIndexPath(trackerPath);
   const pdfIndex = existsSync(manifestPath)
     ? parsePdfIndex(readFileSync(manifestPath, 'utf-8'))
     : new Map();

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -22,7 +22,7 @@ import { normalizeReportLink as normalizeLink } from './tracker-links.mjs';
 import { roleFuzzyMatch } from './role-matcher.mjs';
 import { parsePdfIndex } from './find.mjs';
 import { LEGACY_COLMAP, detectColumns, resolveScoreStatus, normalizeVia, SEPARATOR_ROW_RE } from './tracker-parse.mjs';
-import { resolveTrackerPath, trackerLockDirFor, acquireTrackerLock, writeFileAtomic, normalizeCompany, cell } from './tracker-utils.mjs';
+import { resolveTrackerPath, resolveWorkspaceRoot, resolvePdfIndexPath, trackerLockDirFor, acquireTrackerLock, writeFileAtomic, normalizeCompany, cell } from './tracker-utils.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 // Support both layouts: data/applications.md (boilerplate) and applications.md
@@ -78,8 +78,10 @@ const TRACKER_LOCK_DIR = trackerLockDirFor(APPS_FILE);
 
 // The reports/ dir sits at the repo root, which is the tracker's parent in the
 // data/ layout (data/applications.md) and the tracker's own dir at root layout.
-const REPORTS_ROOT = basename(TRACKER_DIR) === 'data' ? dirname(TRACKER_DIR) : TRACKER_DIR;
-const PDF_INDEX_FILE = join(REPORTS_ROOT, 'data', 'pdf-index.tsv');
+// Shared with sync-pdf-flags.mjs so the two agree on where a workspace's
+// siblings live — they disagreed before #2471.
+const REPORTS_ROOT = resolveWorkspaceRoot(APPS_FILE);
+const PDF_INDEX_FILE = resolvePdfIndexPath(APPS_FILE);
 
 /**
  * Normalize report links before writing them into the tracker file.

--- a/sync-pdf-flags.mjs
+++ b/sync-pdf-flags.mjs
@@ -17,11 +17,13 @@ import { readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { extractTrackerReportNumbers, resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
-import { rebuildRow, resolveTrackerPath, openTrackerTransaction } from './tracker-utils.mjs';
+import { rebuildRow, resolveTrackerPath, resolvePdfIndexPath, openTrackerTransaction } from './tracker-utils.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const APPS_FILE = resolveTrackerPath(CAREER_OPS);
-const PDF_MANIFEST = process.env.CAREER_OPS_PDF_INDEX || join(CAREER_OPS, 'data', 'pdf-index.tsv');
+// Derived from the TRACKER, not from this script's location, so a redirected
+// CAREER_OPS_TRACKER moves the whole workspace together (#2471).
+const PDF_MANIFEST = resolvePdfIndexPath(APPS_FILE);
 
 const flags = { dryRun: false, json: false };
 for (const arg of process.argv.slice(2)) {

--- a/tests/pdf-index-path.test.mjs
+++ b/tests/pdf-index-path.test.mjs
@@ -72,16 +72,21 @@ withPdfIndexEnv('/elsewhere/custom-index.tsv', () => {
 });
 
 // THE REGRESSION (#2471). Given a tracker redirected into an isolated
-// workspace, When resolving the manifest with no override, Then the result must
-// live inside that workspace and never in the career-ops install directory —
-// otherwise an isolated run reads real user data.
+// workspace, When resolving the manifest with no override, Then it must be that
+// workspace's own manifest — never the career-ops install directory's, which is
+// how an isolated run came to read real user data.
+//
+// Asserted as exact equality rather than a prefix match: a prefix would also
+// accept a wrong filename or a nested path inside the workspace.
 withPdfIndexEnv(undefined, () => {
   const isolatedWorkspace = join('/tmp', 'career-ops-fixture');
   const resolved = resolvePdfIndexPath(join(isolatedWorkspace, 'data', 'applications.md'));
-  const installManifest = join(process.cwd(), 'data', 'pdf-index.tsv');
-  if (resolved.startsWith(isolatedWorkspace) && resolved !== installManifest) {
-    pass('a redirected tracker never resolves to the install directory\'s manifest');
+  const expected = join(isolatedWorkspace, 'data', 'pdf-index.tsv');
+  if (resolved === expected) {
+    pass('a redirected tracker resolves its own workspace manifest, not the install directory\'s');
   } else {
-    fail(`#2471 regression: isolated tracker resolved to ${resolved}`);
+    const installManifest = join(process.cwd(), 'data', 'pdf-index.tsv');
+    const leaked = resolved === installManifest ? " — that is the install directory's manifest" : '';
+    fail(`#2471 regression: expected ${expected}, got ${resolved}${leaked}`);
   }
 });

--- a/tests/pdf-index-path.test.mjs
+++ b/tests/pdf-index-path.test.mjs
@@ -28,28 +28,35 @@ function withPdfIndexEnv(value, body) {
   }
 }
 
+// Both sides of every path assertion are built with join(), so the separator
+// matches on Windows too (the suite runs on windows-latest). Deliberately NOT
+// resolve(): resolve() resolves against cwd and so prepends the current drive
+// on Windows, while resolveWorkspaceRoot() derives its answer with dirname(),
+// which never drive-qualifies — `C:\ws` vs `\ws` would fail there.
+const WORKSPACE = join('/ws');
+
 // Given a tracker in the data/ layout, When resolving its workspace root,
 // Then it is the tracker's grandparent (where reports/ and data/ live).
 {
-  const root = resolveWorkspaceRoot(join('/ws', 'data', 'applications.md'));
-  if (root === '/ws') pass('data/ layout: workspace root is the tracker\'s parent directory');
-  else fail(`data/ layout: expected /ws, got ${root}`);
+  const root = resolveWorkspaceRoot(join(WORKSPACE, 'data', 'applications.md'));
+  if (root === WORKSPACE) pass('data/ layout: workspace root is the tracker\'s parent directory');
+  else fail(`data/ layout: expected ${WORKSPACE}, got ${root}`);
 }
 
 // Given a tracker in the root layout, When resolving its workspace root,
 // Then it is the tracker's own directory.
 {
-  const root = resolveWorkspaceRoot(join('/ws', 'applications.md'));
-  if (root === '/ws') pass('root layout: workspace root is the tracker\'s own directory');
-  else fail(`root layout: expected /ws, got ${root}`);
+  const root = resolveWorkspaceRoot(join(WORKSPACE, 'applications.md'));
+  if (root === WORKSPACE) pass('root layout: workspace root is the tracker\'s own directory');
+  else fail(`root layout: expected ${WORKSPACE}, got ${root}`);
 }
 
 // Given no override, When resolving the manifest for a tracker,
 // Then it sits under that tracker's workspace in both layouts.
 withPdfIndexEnv(undefined, () => {
-  const fromData = resolvePdfIndexPath(join('/ws', 'data', 'applications.md'));
-  const fromRoot = resolvePdfIndexPath(join('/ws', 'applications.md'));
-  const expected = join('/ws', 'data', 'pdf-index.tsv');
+  const fromData = resolvePdfIndexPath(join(WORKSPACE, 'data', 'applications.md'));
+  const fromRoot = resolvePdfIndexPath(join(WORKSPACE, 'applications.md'));
+  const expected = join(WORKSPACE, 'data', 'pdf-index.tsv');
   if (fromData === expected && fromRoot === expected) {
     pass('manifest resolves under the tracker\'s workspace in both layouts');
   } else {
@@ -69,10 +76,10 @@ withPdfIndexEnv('/elsewhere/custom-index.tsv', () => {
 // live inside that workspace and never in the career-ops install directory —
 // otherwise an isolated run reads real user data.
 withPdfIndexEnv(undefined, () => {
-  const isolated = join('/tmp', 'career-ops-fixture', 'data', 'applications.md');
-  const resolved = resolvePdfIndexPath(isolated);
+  const isolatedWorkspace = join('/tmp', 'career-ops-fixture');
+  const resolved = resolvePdfIndexPath(join(isolatedWorkspace, 'data', 'applications.md'));
   const installManifest = join(process.cwd(), 'data', 'pdf-index.tsv');
-  if (resolved.startsWith(join('/tmp', 'career-ops-fixture')) && resolved !== installManifest) {
+  if (resolved.startsWith(isolatedWorkspace) && resolved !== installManifest) {
     pass('a redirected tracker never resolves to the install directory\'s manifest');
   } else {
     fail(`#2471 regression: isolated tracker resolved to ${resolved}`);

--- a/tests/pdf-index-path.test.mjs
+++ b/tests/pdf-index-path.test.mjs
@@ -1,0 +1,80 @@
+// tests/pdf-index-path.test.mjs — the PDF manifest must follow the tracker (#2471).
+//
+// sync-pdf-flags.mjs and find.mjs used to resolve data/pdf-index.tsv from their
+// own install directory while resolving the tracker through CAREER_OPS_TRACKER.
+// Redirecting the tracker therefore reconciled one workspace's rows against
+// another workspace's manifest: the merge-tracker suite read the developer's
+// real manifest and flipped an isolated fixture's PDF cells, so `node
+// test-all.mjs` failed locally for anyone who had ever generated a PDF while
+// staying green in CI (data/ is gitignored).
+import { pass, fail } from './helpers.mjs';
+import { join } from 'path';
+import { resolveWorkspaceRoot, resolvePdfIndexPath } from '../tracker-utils.mjs';
+
+console.log('\nPDF manifest follows the tracker (#2471)');
+
+// Env is process-wide and discovered suites run in-process, so every mutation
+// is restored — a leaked CAREER_OPS_PDF_INDEX would silently retarget later
+// suites (PIT: each case must stand alone, in any order).
+function withPdfIndexEnv(value, body) {
+  const previous = process.env.CAREER_OPS_PDF_INDEX;
+  if (value === undefined) delete process.env.CAREER_OPS_PDF_INDEX;
+  else process.env.CAREER_OPS_PDF_INDEX = value;
+  try {
+    return body();
+  } finally {
+    if (previous === undefined) delete process.env.CAREER_OPS_PDF_INDEX;
+    else process.env.CAREER_OPS_PDF_INDEX = previous;
+  }
+}
+
+// Given a tracker in the data/ layout, When resolving its workspace root,
+// Then it is the tracker's grandparent (where reports/ and data/ live).
+{
+  const root = resolveWorkspaceRoot(join('/ws', 'data', 'applications.md'));
+  if (root === '/ws') pass('data/ layout: workspace root is the tracker\'s parent directory');
+  else fail(`data/ layout: expected /ws, got ${root}`);
+}
+
+// Given a tracker in the root layout, When resolving its workspace root,
+// Then it is the tracker's own directory.
+{
+  const root = resolveWorkspaceRoot(join('/ws', 'applications.md'));
+  if (root === '/ws') pass('root layout: workspace root is the tracker\'s own directory');
+  else fail(`root layout: expected /ws, got ${root}`);
+}
+
+// Given no override, When resolving the manifest for a tracker,
+// Then it sits under that tracker's workspace in both layouts.
+withPdfIndexEnv(undefined, () => {
+  const fromData = resolvePdfIndexPath(join('/ws', 'data', 'applications.md'));
+  const fromRoot = resolvePdfIndexPath(join('/ws', 'applications.md'));
+  const expected = join('/ws', 'data', 'pdf-index.tsv');
+  if (fromData === expected && fromRoot === expected) {
+    pass('manifest resolves under the tracker\'s workspace in both layouts');
+  } else {
+    fail(`manifest path wrong: data-layout=${fromData} root-layout=${fromRoot} expected=${expected}`);
+  }
+});
+
+// Given CAREER_OPS_PDF_INDEX, When resolving, Then the override wins outright.
+withPdfIndexEnv('/elsewhere/custom-index.tsv', () => {
+  const resolved = resolvePdfIndexPath(join('/ws', 'data', 'applications.md'));
+  if (resolved === '/elsewhere/custom-index.tsv') pass('CAREER_OPS_PDF_INDEX overrides the derived path');
+  else fail(`override ignored: got ${resolved}`);
+});
+
+// THE REGRESSION (#2471). Given a tracker redirected into an isolated
+// workspace, When resolving the manifest with no override, Then the result must
+// live inside that workspace and never in the career-ops install directory —
+// otherwise an isolated run reads real user data.
+withPdfIndexEnv(undefined, () => {
+  const isolated = join('/tmp', 'career-ops-fixture', 'data', 'applications.md');
+  const resolved = resolvePdfIndexPath(isolated);
+  const installManifest = join(process.cwd(), 'data', 'pdf-index.tsv');
+  if (resolved.startsWith(join('/tmp', 'career-ops-fixture')) && resolved !== installManifest) {
+    pass('a redirected tracker never resolves to the install directory\'s manifest');
+  } else {
+    fail(`#2471 regression: isolated tracker resolved to ${resolved}`);
+  }
+});

--- a/tracker-utils.mjs
+++ b/tracker-utils.mjs
@@ -94,6 +94,45 @@ export function resolveTrackerPath(rootDir) {
 }
 
 /**
+ * Resolve the workspace root that owns a tracker, i.e. where `reports/` and
+ * `data/` sit: the tracker's parent in the `data/applications.md` layout, and
+ * the tracker's own directory in the root `applications.md` layout.
+ *
+ * Derive sibling paths from THIS rather than from a script's own location, so
+ * that pointing `CAREER_OPS_TRACKER` at another workspace moves the whole set
+ * together. A script that mixes the two (tracker from the env, manifest from
+ * its own directory) reads one workspace and writes another — which is how the
+ * merge-tracker suite came to read a developer's real `data/pdf-index.tsv`
+ * while writing an isolated temp tracker.
+ *
+ * @param {string} trackerPath - Tracker path, typically from resolveTrackerPath().
+ * @returns {string} Absolute workspace root directory.
+ */
+export function resolveWorkspaceRoot(trackerPath) {
+  const trackerDir = dirname(trackerPath);
+  return basename(trackerDir) === 'data' ? dirname(trackerDir) : trackerDir;
+}
+
+/**
+ * Resolve the PDF manifest (`data/pdf-index.tsv`) for the workspace that owns
+ * a tracker. `CAREER_OPS_PDF_INDEX` overrides it explicitly.
+ *
+ * One definition for every reader, because the manifest path was previously
+ * rebuilt from a literal in each script — and each picked its own base
+ * directory, so `merge-tracker.mjs` derived it from the tracker while
+ * `sync-pdf-flags.mjs` and `find.mjs` used their own install directory. Scripts
+ * that resolve the tracker from `CAREER_OPS_TRACKER` then read one workspace's
+ * manifest against another's tracker (#2471).
+ *
+ * @param {string} trackerPath - Tracker path, typically from resolveTrackerPath().
+ * @returns {string} Absolute path to the PDF manifest.
+ */
+export function resolvePdfIndexPath(trackerPath) {
+  return process.env.CAREER_OPS_PDF_INDEX
+    || join(resolveWorkspaceRoot(trackerPath), 'data', 'pdf-index.tsv');
+}
+
+/**
  * Convert the tracker path into one stable absolute spelling before hashing it.
  *
  * Equivalent tracker paths can be written in multiple ways, such as a relative


### PR DESCRIPTION
## What does this PR do?

`sync-pdf-flags.mjs` and `find.mjs` resolved the PDF manifest from their own install directory while resolving the tracker from `CAREER_OPS_TRACKER`, so a redirected tracker was reconciled against the *wrong workspace's* manifest. All three tracker-coupled readers now derive it from the tracker via one shared helper.

## Related issue

Closes #2471

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---

## The bug, measured

`merge-tracker.mjs:819` spawns `sync-pdf-flags.mjs`. The #912 test isolates the tracker and additions dir into a temp workspace, but cannot isolate a manifest it does not know exists, so the child read the real `data/pdf-index.tsv` and flipped the fixture's PDF cells ❌→✅:

```
before: 📊 Summary: 2 PDF flags synced   → both fixture rows ✅ (assertions fail)
after:  📊 Summary: 0 PDF flags synced   → both fixture rows ❌ (as asserted)
```

`node test-all.mjs --quick` went from **2 failed** to **0 failed** on a checkout with generated PDFs. CI never saw it — `data/` is gitignored, so CI has no manifest to leak.

## Two things the issue did not cover

- **`find.mjs` had the identical bug** (tracker from env at line 138, manifest from `ROOT` at line 146). Same fix applied — searching a redirected tracker no longer annotates it with this install's PDFs.
- **The path literal was rebuilt in every reader.** `join(..., 'data', 'pdf-index.tsv')` appeared in each, each picking its own base directory — which is *why* they could disagree. `resolvePdfIndexPath()` now owns the location and the `CAREER_OPS_PDF_INDEX` override; `merge-tracker.mjs`'s already-correct copy uses it too, so the two cannot drift apart again.

## Behaviour notes

- **No change for normal use:** a tracker at `<repo>/data/applications.md` resolves to today's manifest path. Verified with `sync-pdf-flags --dry-run` and `find.mjs` against a real workspace.
- **One intentional change:** `merge-tracker.mjs` now honours `CAREER_OPS_PDF_INDEX`, which it previously ignored. Having one reader honour an override and another not is the same class of inconsistency this fixes.

## Deliberately out of scope

- **`generate-pdf.mjs:378`** writes the manifest from `__dirname` and has no tracker awareness, so a redirected tracker still gets its PDFs recorded against the install directory. Real, but a writer-side design question rather than this asymmetry.
- **`outcome.mjs:201`** derives `repoRoot` as `dirname(trackerDir)` unconditionally, which is wrong for the root `applications.md` layout — a *different* defect with its own blast radius. Can file it separately.
- **Docs:** no `.md` documents any `CAREER_OPS_*` variable — not `CAREER_OPS_TRACKER` either — so documenting only this one would be inconsistent. The resolver's JSDoc covers the override; a full env reference belongs in its own docs PR.

## Verification

- New `tests/pdf-index-path.test.mjs` (5 assertions, auto-discovered): both tracker layouts, the override, and a named #2471 regression asserting a redirected tracker never resolves to the install directory's manifest. Confirmed it fails against the pre-fix behaviour.
- The existing #1429 test still passes, proving the manifest is still found when it legitimately exists in the workspace — the fix isolates without disabling.
- `node test-all.mjs --quick` → 2789 passed, 0 failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected PDF manifest resolution when using redirected tracker locations.
  * Ensured workspace, reports, and PDF index paths consistently resolve from the configured tracker.
  * Preserved support for explicit PDF index path overrides.

* **Tests**
  * Added coverage for root-level and data-directory tracker layouts, custom overrides, and redirected tracker scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->