### PR TITLE
fix(merge-tracker): collapse placeholder Notes to the re-eval marker (#2483)

### DIFF
--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -275,8 +275,14 @@ function companiesMatch(a, b) {
  */
 function mergeNotes(existingNotes, addition, oldScore, newScore) {
   // Trailing period trimmed only so the '. ' join does not produce '..'; no
-  // other character of the existing text is touched.
-  const prev = String(existingNotes ?? '').trim().replace(/\s*\.\s*$/, '');
+  // other character of the existing text is touched. The tracker's "no data"
+  // sentinels (the looksLikeScoreCell set minus the score-only DUP) count as
+  // empty here: a placeholder cell collapses to the marker instead of gaining
+  // a `—. ` separator the row never had (#2483).
+  const prevRaw = String(existingNotes ?? '').trim();
+  const prev = ['—', '-', 'N/A'].includes(prevRaw)
+    ? ''
+    : prevRaw.replace(/\s*\.\s*$/, '');
   const incoming = String(addition.notes ?? '').trim();
   const marker = `Re-eval ${addition.date} (${oldScore}→${newScore})`;
   // Re-running the same evaluation would otherwise repeat its own text; the

--- a/tests/merge-tracker.test.mjs
+++ b/tests/merge-tracker.test.mjs
@@ -282,6 +282,31 @@ try {
   fail(`merge-tracker Notes-preservation tests crashed: ${e.message}`);
 }
 
+// ── #2483: placeholder Notes collapse to the marker, not gain a separator ───
+// mergeNotes() only collapsed empty/whitespace/bare-period cells. The tracker's
+// own "no data" sentinels (`—` / `-` / `N/A` — the looksLikeScoreCell set minus
+// the score-only DUP) stayed truthy after the trim, so a placeholder row came
+// out of a score upgrade as `—. Re-eval …`, a separator the row never had.
+console.log('\nmerge-tracker.mjs — placeholder Notes collapse on upgrade (#2483)');
+try {
+  for (const ph of ['—', '-', 'N/A']) {
+    const row =
+      '| 1 | 2026-01-01 | Acme | Staff Data Platform Engineer | 4.0/5 | Evaluated | ❌ | ' +
+      `[1](reports/001-acme-2026-01-01.md) | ${ph} |\n`;
+    const upgraded = runMergeDetailed({
+      '001-acme.tsv': '1\t2026-03-01\tAcme\tStaff Data Platform Engineer\tEvaluated\t4.7/5\t❌\t[1](reports/001-acme-2026-01-01.md)\tre-scored after JD refresh\n',
+    }, { rows: row });
+    const notes = (dataRows(upgraded.tracker)[0] || '').split('|').map(c => c.trim())[9] ?? '';
+    if (notes === 'Re-eval 2026-03-01 (4→4.7): re-scored after JD refresh') {
+      pass(`placeholder Notes "${ph}" collapses to the marker alone`);
+    } else {
+      fail(`placeholder "${ph}" leaked into the merged Notes: "${notes}"`);
+    }
+  }
+} catch (e) {
+  fail(`merge-tracker placeholder-notes tests crashed: ${e.message}`);
+}
+
 // ── #2394: a tracker with no separator row dropped everything, silently ─────
 // The insert point comes from SEPARATOR_ROW_RE. With no match, insertIdx
 // stayed -1, the splice was skipped with no else, and the run went on to write


### PR DESCRIPTION
Closes #2483. Follow-up to #2392 / #2399, covering the placeholder case that fix missed.

A Notes cell holding one of the tracker's "no data" sentinels (`—`, `-`, `N/A`) was still truthy after `mergeNotes()` trimmed it, so a score upgrade joined it like real text:

```
before:  —
after:   —. Re-eval 2026-03-01 (4→4.7): re-scored after JD refresh
```

The row gained a `—. ` separator it never had. This was raised explicitly in the #2392 thread and is the one ask from that comment the merged fix did not cover.

## Fix

One conditional in `mergeNotes()`: when the trimmed existing cell is exactly `—`, `-`, or `N/A`, treat it as empty so the cell collapses to the marker alone. The set mirrors `looksLikeScoreCell` (tracker-parse.mjs, #1799) minus the score-only `DUP`; it is the same convention merge-tracker itself writes into empty Via and Location cells, so a user hand-writing it into Notes is ordinary. Matching is exact and case-sensitive, same as the score-cell check, so a real note that merely starts with a dash is untouched.

## Tests

One new block in `tests/merge-tracker.test.mjs`: each of the three sentinels is seeded as the full Notes cell, upgraded 4.0→4.7, and the merged cell must equal the marker plus the new note exactly, with nothing leaked in front. All three fail on main (`"—. Re-eval …"`) and pass with the fix. Full suite: 2869 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Notes now correctly replace placeholder values such as “—”, “-”, and “N/A” when adding re-evaluation updates.
  * Existing meaningful notes continue to be preserved while being cleaned up consistently.

* **Tests**
  * Added regression coverage to verify placeholder notes are removed from updated entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->