### PR TITLE
fix(providers): route softgarden and radancy through the shared entity decoder

### DIFF
--- a/providers/radancy.mjs
+++ b/providers/radancy.mjs
@@ -1,5 +1,6 @@
 // @ts-check
 /** @typedef {import('./_types.js').Provider} Provider */
+import { decodeEntities } from './_html-entities.mjs';
 
 // Radancy (TalentBrew) provider — the career sites Radancy hosts for large
 // employers (careers.munichre.com and its ERGO brands, plus many others). The
@@ -64,23 +65,6 @@ const PAGE_DELAY_MS = 150; // polite pacing — full walks are >100 sequential r
 // Page size for the JSON fragment transport. 100 is honored live by both known
 // legacy tenants (UHG, Kaiser); the HTML page hard-codes 15.
 const FRAGMENT_RECORDS_PER_PAGE = 100;
-
-// Minimal HTML entity decoder — mirrors the other HTML-scraping providers.
-const NAMED_ENTITIES = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ' };
-/** @param {string} s */
-function decodeEntities(s) {
-  return s.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (m, body) => {
-    if (body[0] === '#') {
-      const code = body[1] === 'x' || body[1] === 'X' ? parseInt(body.slice(2), 16) : parseInt(body.slice(1), 10);
-      // String.fromCodePoint throws RangeError outside 0..0x10FFFF or on a lone
-      // surrogate half — a malformed/adversarial entity must degrade to the
-      // original text, never crash the whole parse.
-      const valid = Number.isFinite(code) && code >= 0 && code <= 0x10ffff && !(code >= 0xd800 && code <= 0xdfff);
-      return valid ? String.fromCodePoint(code) : m;
-    }
-    return NAMED_ENTITIES[body.toLowerCase()] ?? m;
-  });
-}
 
 /** @param {string} s */
 function clean(s) {

--- a/providers/softgarden.mjs
+++ b/providers/softgarden.mjs
@@ -1,5 +1,6 @@
 // @ts-check
 /** @typedef {import('./_types.js').Provider} Provider */
+import { decodeEntities } from './_html-entities.mjs';
 
 // softgarden provider — the hosted job widgets at
 // https://{tenant}.softgarden.io/{lang}/widgets/jobs (e.g. RENK:
@@ -24,20 +25,6 @@
 // slashes M/D/YY) — same heuristic as the successfactors CSB parser.
 
 const MAX_JOBS = 1000; // cap postings taken from one widget page
-
-// Minimal HTML entity decoder — titles carry named (&amp;) and numeric
-// (&#252; / &#xfc;) entities. Mirrors successfactors.mjs / dassault.mjs.
-const NAMED_ENTITIES = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ' };
-/** @param {string} s */
-function decodeEntities(s) {
-  return s.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (m, body) => {
-    if (body[0] === '#') {
-      const code = body[1] === 'x' || body[1] === 'X' ? parseInt(body.slice(2), 16) : parseInt(body.slice(1), 10);
-      return Number.isInteger(code) && code >= 0 && code <= 0x10ffff ? String.fromCodePoint(code) : m;
-    }
-    return NAMED_ENTITIES[body.toLowerCase()] ?? m;
-  });
-}
 
 /** @param {string} s */
 function clean(s) {

--- a/tests/providers/softgarden.test.mjs
+++ b/tests/providers/softgarden.test.mjs
@@ -55,6 +55,23 @@ try {
     fail('softgarden.parseWidget() should return [] without cards');
   }
 
+  // decodeEntities (exercised via parseWidget) — the private copy this provider
+  // used to carry guarded the fromCodePoint range but NOT lone surrogate halves,
+  // so `&#xD800;` decoded into an ill-formed UTF-16 string that then travelled
+  // into titles. It also matched hex and decimal with one "#x?[0-9a-fA-F]+"
+  // alternative, so `&#1a2;` silently parsed as codepoint 1 and dropped "a2".
+  // Routing through the shared guarded decoder degrades all three to literal
+  // text while still decoding valid entities.
+  {
+    const badTitle = 'Overflow &#99999999; Surrogate &#xD800; Mixed &#1a2; Valid &#252; &amp;';
+    let badRows, badThrew = null;
+    try { badRows = parseWidget('<html>' + sgCard('333', badTitle, ['Berlin']) + '</html>', 'https://renk-group.softgarden.io/de/widgets/jobs'); } catch (e) { badThrew = e; }
+    const expected = 'Overflow &#99999999; Surrogate &#xD800; Mixed &#1a2; Valid ü &';
+    if (badThrew) fail(`softgarden.parseWidget() threw ${badThrew.name} on a malformed numeric entity: ${badThrew.message}`);
+    else if (badRows.length === 1 && badRows[0].title === expected) pass('softgarden.parseWidget() degrades out-of-range / lone-surrogate / mixed-radix entities to literal text while still decoding valid ones');
+    else fail(`softgarden.parseWidget() malformed-entity handling wrong: ${JSON.stringify(badRows?.[0]?.title)}`);
+  }
+
   // fetch — single widget request, jobs normalized.
   const sgCtx = { fetchText: async () => sgHtml };
   const sgJobs = await softgarden.fetch({ name: 'Renk', api: 'https://renk-group.softgarden.io/de/widgets/jobs' }, sgCtx);


### PR DESCRIPTION
## Summary

Follow-up to the review on #1639, which asked for the two remaining private `decodeEntities` copies to be folded into the shared helper. `providers/_html-entities.mjs` says it exists so "the guard can't diverge again" — with `softgarden` and `radancy` still carrying their own copies, that wasn't true yet. After this PR no private `decodeEntities` remains under `providers/`.

The two migrations are not equivalent in weight:

**`softgarden` — correctness fix.** Its copy guarded the `fromCodePoint` range but not lone surrogate halves, and matched hex and decimal in a single `#x?[0-9a-fA-F]+` alternative. On real markup:

| Entity | Before | After |
|---|---|---|
| `&#xD800;` | a lone surrogate — ill-formed UTF-16 in the job title | `&#xD800;` (literal) |
| `&#1a2;` | parsed as decimal `1`, silently dropping `a2` | `&#1a2;` (literal) |
| `&#252;` / `&amp;` | `ü` / `&` | unchanged |

Neither case throws, so this is not the `RangeError` crash #1639 targeted — it is bad output rather than a dead scan. The ill-formed string is the more interesting one, since it travels into anything that later serializes or compares the title.

**`radancy` — pure de-duplication.** Its copy already had the correct range *and* surrogate guard, so behavior is unchanged; its existing malformed-entity regression test passes untouched.

## Test plan

- New regression test in `tests/providers/softgarden.test.mjs` puts out-of-range, lone-surrogate and mixed-radix entities in one title and asserts valid entities (`&#252;`, `&amp;`) still decode alongside them.
- Confirmed the new test **fails against the pre-migration decoder** (old output: `"Surrogate \ud800 Mixed "`), so it pins the fix instead of restating current behavior.
- `node test-all.mjs` — 2917 passed, 0 failed.
- Named-entity parity checked before swapping: both providers' local `NAMED_ENTITIES` maps were byte-identical to the shared one, so there is no repeat of the extra `&#8226;` mapping that `avature` carried in #1639.

## Notes

Branched fresh off current `main` rather than rebasing #1639's branch, which sat ~1000 commits back. This PR contains only the two migrations and the test — the shared module and the other four providers are already on `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML entity handling when processing provider content.
  * Malformed numeric entities now remain as literal text instead of causing errors.
  * Valid numeric and named entities continue to decode correctly.

* **Tests**
  * Added coverage for malformed, valid, and mixed-format HTML entities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->