### PR TITLE
fix(tests): isolate tracker-columns fixtures from the real reports/ directory

### DIFF
--- a/tracker-columns-tests.mjs
+++ b/tracker-columns-tests.mjs
@@ -48,6 +48,9 @@ function runScript(script, args, sandbox) {
     CAREER_OPS_TRACKER: sandbox.tracker,
     CAREER_OPS_ADDITIONS: sandbox.additions,
     CAREER_OPS_TRACKER_LOCK: sandbox.lock,
+    // Pinned for the same reason as the tracker: keep the fixture isolated from
+    // the real reports/ dir. See makeSandbox.
+    ...(sandbox.reports ? { CAREER_OPS_REPORTS: sandbox.reports } : {}),
   };
   try {
     const stdout = execFileSync(NODE, [join(ROOT, script), ...args], {
@@ -75,12 +78,21 @@ function makeSandbox(trackerContent, additions = {}) {
   const tracker = join(dir, 'applications.md');
   const additionsDir = join(dir, 'tracker-additions');
   const lock = join(dir, 'lock');
+  // An empty reports dir belongs in the sandbox alongside the tracker. Without
+  // it verify-pipeline scans the REAL reports/ dir and emits one "Orphan report"
+  // warning per report not referenced by this fixture's tracker -- 213 of them
+  // at 256 reports. That made Test 2 slow enough to trip its own 30s timeout
+  // under full-suite load, failing ~2 runs in 5 as "tracker-columns-tests.mjs
+  // crashed" while passing 8/8 in isolation. Same fixture bug as the #1704 block
+  // in test-all.mjs (see PATCHES.md patch 10).
+  const reportsDir = join(dir, 'reports');
   mkdirSync(additionsDir, { recursive: true });
+  mkdirSync(reportsDir, { recursive: true });
   writeFileSync(tracker, trackerContent);
   for (const [name, content] of Object.entries(additions)) {
     writeFileSync(join(additionsDir, name), content);
   }
-  return { dir, tracker, additions: additionsDir, lock };
+  return { dir, tracker, additions: additionsDir, lock, reports: reportsDir };
 }
 
 // Pin scan.mjs's extra dedupe sources inside the sandbox. The module-level


### PR DESCRIPTION
## The bug

`makeSandbox` in `tracker-columns-tests.mjs` builds an isolated tracker and additions dir — but not an isolated `reports/`. So the `verify-pipeline` child it spawns scans the **real** `reports/` directory.

On a clean checkout that costs nothing, because `reports/` is empty. On a populated install it does: every report not referenced by the fixture's tiny tracker emits an "Orphan report" warning, so the child's output scales with the *user's history* instead of with the fixture. Test 2 then starts tripping its own 30s timeout under full-suite load.

It surfaces as:

```
❌ tracker-columns-tests.mjs crashed
```

with no assertion text — and intermittently, which makes it read like flakiness in the tracker writer lock rather than a fixture-isolation problem.

## Measurement

Against an install with **311 reports**, 8 consecutive runs each:

| | result |
|---|---|
| `upstream/main` | **3 of 8 runs failed** — 2, 4 and 1 assertions respectively |
| with this fix | **0 of 8 runs failed** |

The *varying* failure count is the tell: load- and timing-dependent, not a deterministic assertion problem. Wall time also drops (2.59s → 2.29s) since the child stops walking hundreds of unrelated files.

## The fix

Exactly what `test-all.mjs` already does for the same class of bug — put an empty `reports/` inside the sandbox and pin `CAREER_OPS_REPORTS` to it, so the spawned child sees the fixture and nothing else. 13 lines, no behaviour change to what is being asserted.

## Why this survived

**CI cannot see it.** CI checks out a repo with no reports, so the sandbox leak costs nothing there. It only appears once someone has a real history — which means it is invisible to the automation and visible only to the people actually using the tool. That asymmetry is why I thought it was worth writing up rather than just carrying locally.

Found while running the suite on a fork with ~300 evaluations. Happy to adjust the shape if you'd rather `makeSandbox` return the dir differently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved test execution reliability by isolating reports directory to prevent verification tests from scanning real repository data, eliminating timeout issues during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->