### PR TITLE
docs(workday): correct the stale ctx.sinceMs caller note after #2418

### DIFF
--- a/providers/workday.mjs
+++ b/providers/workday.mjs
@@ -314,11 +314,17 @@ export default {
     // (a full-directory scan can hit this on dozens of tenants).
     //
     // "raise max_pages" only applies when `entry` is a real portals.yml
-    // tracked_companies entry (scan.mjs, sinceMs === null). scan-ats-full.mjs's
-    // reverse scan (the only caller that sets ctx.sinceMs) synthesizes entries
-    // from the external dataset — there's no portal entry to edit, and no
-    // fixed cap can guarantee full coverage of an unbounded company
-    // directory anyway, so there's nothing else to suggest.
+    // tracked_companies entry — there is something to edit. scan-ats-full.mjs's
+    // reverse scan synthesizes entries from the external dataset, so there's no
+    // portal entry to point at, and no fixed cap can guarantee full coverage of
+    // an unbounded company directory anyway; nothing else to suggest there.
+    //
+    // The branch below keys on `sinceMs === null` as a proxy for that
+    // distinction. Since #2418 the proxy is no longer exact: `scan.mjs --since`
+    // also sets ctx.sinceMs, so those runs take the else branch and get the
+    // terser message even though they DO have a portals.yml entry to raise.
+    // Harmless (the cap is still surfaced, just without the suggestion) but
+    // worth knowing before trusting the proxy — see #2495.
     if (stopReason === 'cap') {
       const jobsSummary = `${jobs.length}${total !== null ? ` of ${total}` : ''} jobs`;
       if (sinceMs === null) {


### PR DESCRIPTION
Follow-up from the #2418 merge review — the first of the two items you raised, @santifer. Comment only, no behavior change.

### What was stale

The cap-warning comment in `providers/workday.mjs` said `scan-ats-full.mjs`'s reverse scan was **"the only caller that sets `ctx.sinceMs`"**. Since #2418 that is no longer true: `scan.mjs` sets it whenever `--since` is passed (`scan.mjs:2158`).

It also implied `sinceMs === null` cleanly separates *"has a `portals.yml` entry to edit"* from *"synthesized entry, nothing to suggest"*. It no longer does — a `scan.mjs --since` run has a real `tracked_companies` entry but takes the else branch, so it gets the terser `truncated at N pages` line instead of `raise max_pages on this entry for more`.

### What it says now

Intent first, then the proxy and its gap:

```js
// "raise max_pages" only applies when `entry` is a real portals.yml
// tracked_companies entry — there is something to edit. scan-ats-full.mjs's
// reverse scan synthesizes entries from the external dataset, so there's no
// portal entry to point at, ...
//
// The branch below keys on `sinceMs === null` as a proxy for that
// distinction. Since #2418 the proxy is no longer exact: `scan.mjs --since`
// also sets ctx.sinceMs, so those runs take the else branch and get the
// terser message even though they DO have a portals.yml entry to raise.
// Harmless (the cap is still surfaced, just without the suggestion) but
// worth knowing before trusting the proxy — see #2495.
```

I chose to **name the seam rather than smooth it over**. A comment that reads cleanly while describing behavior that no longer holds is worse than one that says plainly where the proxy stops being exact — that is what cost a reader here in the first place.

### Scope

Comment only. Whether the branch should key on entry provenance instead of `sinceMs` is the second item from your review and is filed separately as **#2495**, per your note about leading with an issue rather than a PR. Happy to implement whichever shape you prefer there, or to leave the proxy as-is now that it is documented.

Branched off `50c1c28`. `node --check` passes; no logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation for pagination truncation warnings.
  * Documented how scan date filters affect the interpretation of scan results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->