### PR TITLE
fix(cv): pair _EMPTY fallbacks with their block so mixed rows stay aligned

### DIFF
--- a/build-cv-html.mjs
+++ b/build-cv-html.mjs
@@ -209,21 +209,35 @@ function parsePartial(source) {
   // can remove them verbatim from the entry zone in step 3, without needing any
   // broad HTML-comment regex (which would trigger CodeQL).
   const definitionStrings = [];
+  // Collect every definition first. The _EMPTY fallbacks are resolved in a
+  // second pass because a fallback may be defined before the block it belongs
+  // to, and pairing needs to know which block names exist.
+  const definitions = new Map();
   let m;
   while ((m = blockRe.exec(entryZone)) !== null) {
     const name = m[1];
     const content = m[2];
     if (name === 'ENTRY') continue; // skip the sentinel itself
     definitionStrings.push(m[0]); // full match, e.g. <!--FOO-->bar<!--/FOO-->
-    // EMPTY variants are the absent-field fallback (e.g. <!--ORG_EMPTY-->).
-    if (name.endsWith('_EMPTY')) {
-      const base = name.slice(0, -6);
-      const existing = blocks.get(base) || { present: '', absent: '' };
-      blocks.set(base, { ...existing, absent: content });
-    } else {
-      const existing = blocks.get(name) || { present: '', absent: '' };
-      blocks.set(name, { ...existing, present: content });
-    }
+    definitions.set(name, content);
+  }
+
+  const EMPTY_SUFFIX = '_EMPTY';
+  for (const [name, content] of definitions) {
+    if (name.endsWith(EMPTY_SUFFIX)) continue;
+    const existing = blocks.get(name) || { present: '', absent: '' };
+    blocks.set(name, { ...existing, present: content });
+  }
+  // An EMPTY variant is the absent-field fallback for a sibling block, and the
+  // renderer looks it up under the block's own name. Both spellings pair to the
+  // same block: <!--ORG_EMPTY--> and <!--ORG_BLOCK_EMPTY--> attach to ORG_BLOCK.
+  // Falling back to the bare stem keeps a FOO_EMPTY/FOO pair working.
+  for (const [name, content] of definitions) {
+    if (!name.endsWith(EMPTY_SUFFIX)) continue;
+    const stem = name.slice(0, -EMPTY_SUFFIX.length);
+    const base = definitions.has(`${stem}_BLOCK`) ? `${stem}_BLOCK` : stem;
+    const existing = blocks.get(base) || { present: '', absent: '' };
+    blocks.set(base, { ...existing, absent: content });
   }
 
   // Step 3: build the entry template by removing the captured block *definitions*

--- a/build-cv-html.mjs
+++ b/build-cv-html.mjs
@@ -459,8 +459,8 @@ function buildCertifications(entries, partial) {
   const { entryTemplate, blocks } = partial;
   return entries.filter(Boolean).map(e => {
     const blockValues = new Map([
-      // Certifications use EMPTY variants so that absent fields still emit an
-      // empty <span> for table-cell alignment — not a bare removal.
+      // An absent field resolves to the partial's _EMPTY fallback, emitting an
+      // empty <span> for table-cell alignment rather than being removed.
       ['ORG_BLOCK',  { value: escapeHtml(e.org || ''),  present: Boolean(e.org) }],
       ['YEAR_BLOCK', { value: escapeHtml(e.year || ''), present: Boolean(e.year) }],
     ]);
@@ -493,8 +493,8 @@ function buildAwards(entries, partial) {
   const { entryTemplate, blocks } = partial;
   return entries.filter(Boolean).map(e => {
     const blockValues = new Map([
-      // As with certifications, absent fields still emit an empty <span> so the
-      // table cells stay aligned across rows.
+      // As with certifications, an absent field resolves to the partial's
+      // _EMPTY fallback so the table cells stay aligned across rows.
       ['ORG_BLOCK',  { value: escapeHtml(e.org || ''),  present: Boolean(e.org) }],
       ['YEAR_BLOCK', { value: escapeHtml(e.year || ''), present: Boolean(e.year) }],
     ]);

--- a/tests/cv-partial-empty-fallbacks.test.mjs
+++ b/tests/cv-partial-empty-fallbacks.test.mjs
@@ -1,0 +1,116 @@
+// tests/cv-partial-empty-fallbacks.test.mjs — the _EMPTY fallbacks in the
+// certifications and awards partials must actually render (#2486).
+//
+// Both partials define <!--ORG_EMPTY--> / <!--YEAR_EMPTY--> so a row missing an
+// org or a year still emits an empty <span> and the columns stay aligned.
+// parsePartial resolved the fallback name by stripping _EMPTY, which keyed it
+// under ORG instead of ORG_BLOCK where the renderer looks, so the fallback was
+// collected and then never used: a mixed-row CV rendered rows with two spans
+// next to rows with three, and the columns drifted.
+//
+// End-to-end through the real builder and the shipped partials on purpose.
+// build-cv-html.mjs exports nothing, and the bug lived in the seam between the
+// partial's block names and the builder's lookup — a unit test of either half
+// alone would have passed.
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { pass, fail, run, NODE, ROOT, lastRunFailure } from './helpers.mjs';
+
+console.log('\nbuild-cv-html.mjs — partial _EMPTY fallbacks render for mixed rows');
+
+const PAYLOAD = {
+  lang: 'en',
+  page_format: 'letter',
+  candidate: { name: 'Mixed Rows', email: 'mixed@example.com' },
+  summary: 'Summary.',
+  competencies: ['Competency'],
+  experience: [{ company: 'Corp', role: 'Engineer', dates: '2024 - Present', bullets: ['Did a thing'] }],
+  certifications: [
+    { title: 'Cert both', org: 'Issuer', year: '2024' },
+    { title: 'Cert no org', year: '2023' },
+    { title: 'Cert no year', org: 'Issuer' },
+    { title: 'Cert neither' },
+  ],
+  awards: [
+    { title: 'Award both', org: 'Body', year: '2022' },
+    { title: 'Award no org', year: '2021' },
+    { title: 'Award no year', org: 'Body' },
+  ],
+  // A block with no _EMPTY sibling: absent must render nothing at all. This is
+  // the other half of the same switch, and it shares the parsePartial change.
+  skills: [
+    { category: 'Languages', items: ['JavaScript'] },
+    { items: ['Uncategorized skill'] },
+  ],
+};
+
+// Every row must carry both spans, present-or-empty, so each section renders a
+// constant number of cells per row. That is the alignment property; asserting
+// the exact markup also pins which variant was chosen.
+const EXPECTED = {
+  cert: [
+    ['Cert both', '<span class="cert-org">Issuer</span>', '<span class="cert-year">2024</span>'],
+    ['Cert no org', '<span class="cert-org"></span>', '<span class="cert-year">2023</span>'],
+    ['Cert no year', '<span class="cert-org">Issuer</span>', '<span class="cert-year"></span>'],
+    ['Cert neither', '<span class="cert-org"></span>', '<span class="cert-year"></span>'],
+  ],
+  award: [
+    ['Award both', '<span class="award-org">Body</span>', '<span class="award-year">2022</span>'],
+    ['Award no org', '<span class="award-org"></span>', '<span class="award-year">2021</span>'],
+    ['Award no year', '<span class="award-org">Body</span>', '<span class="award-year"></span>'],
+  ],
+};
+
+const dir = mkdtempSync(join(tmpdir(), 'cv-2486-'));
+try {
+  const input = join(dir, 'mixed.json');
+  const output = join(dir, 'mixed.html');
+  writeFileSync(input, JSON.stringify(PAYLOAD));
+
+  // Default template, so the shipped templates/sections/ partials are the ones
+  // under test rather than a fixture copy.
+  const built = run(NODE, [join(ROOT, 'build-cv-html.mjs'), input, output]);
+  if (built === null) {
+    const f = lastRunFailure();
+    fail(`build-cv-html.mjs crashed (exit ${f?.status}) — ${(f?.stderr || '').trim().split('\n').pop()}`);
+  } else {
+    const html = readFileSync(output, 'utf-8');
+
+    for (const [kind, rows] of Object.entries(EXPECTED)) {
+      const found = [...html.matchAll(new RegExp(`<div class="${kind}-item">([\\s\\S]*?)</div>`, 'g'))]
+        .map(m => m[1].replace(/\s+/g, ' ').trim());
+
+      if (found.length !== rows.length) {
+        fail(`${kind}: expected ${rows.length} rows, found ${found.length}`);
+        continue;
+      }
+
+      rows.forEach(([title, org, year], i) => {
+        const row = found[i];
+        const expected = `<span class="${kind}-title">${title}</span> ${org} ${year}`;
+        if (row === expected) pass(`${kind}: ${title} renders both cells`);
+        else fail(`${kind}: ${title} — expected \`${expected}\`, got \`${row}\``);
+      });
+
+      // The alignment property itself, independent of the markup above: every
+      // row carries the same number of spans.
+      const counts = new Set(found.map(row => (row.match(/<span/g) || []).length));
+      if (counts.size === 1) pass(`${kind}: every row has the same cell count (${[...counts][0]})`);
+      else fail(`${kind}: rows have differing cell counts (${[...counts].sort().join(', ')}) — columns misalign`);
+    }
+
+    // skills.html defines CATEGORY_BLOCK with no _EMPTY sibling, so an absent
+    // category must collapse to nothing rather than to an empty label. Guards
+    // the shared present/absent switch this fix reaches through.
+    const skillRows = [...html.matchAll(/<div class="skill-item">([\s\S]*?)<\/div>/g)]
+      .map(m => m[1].replace(/\s+/g, ' ').trim());
+    const labelled = '<span class="skill-category">Languages: </span>JavaScript';
+    if (skillRows[0] === labelled) pass('skills: a category renders its label');
+    else fail(`skills: expected \`${labelled}\`, got \`${skillRows[0]}\``);
+    if (skillRows[1] === 'Uncategorized skill') pass('skills: no category renders no label');
+    else fail(`skills: expected a bare row, got \`${skillRows[1]}\``);
+  }
+} finally {
+  try { rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+}

--- a/tests/cv-partial-empty-fallbacks.test.mjs
+++ b/tests/cv-partial-empty-fallbacks.test.mjs
@@ -12,7 +12,7 @@
 // build-cv-html.mjs exports nothing, and the bug lived in the seam between the
 // partial's block names and the builder's lookup — a unit test of either half
 // alone would have passed.
-import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'fs';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, cpSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { pass, fail, run, NODE, ROOT, lastRunFailure } from './helpers.mjs';
@@ -63,47 +63,90 @@ const EXPECTED = {
 };
 
 const dir = mkdtempSync(join(tmpdir(), 'cv-2486-'));
-try {
+
+// Build the payload through the given template and return the HTML, or null
+// when the build failed (already reported).
+function build(label, templateArg) {
   const input = join(dir, 'mixed.json');
-  const output = join(dir, 'mixed.html');
+  const output = join(dir, `${label}.html`);
   writeFileSync(input, JSON.stringify(PAYLOAD));
 
+  const args = [join(ROOT, 'build-cv-html.mjs'), input, output];
+  if (templateArg) args.push(templateArg);
+
+  if (run(NODE, args) === null) {
+    const f = lastRunFailure();
+    fail(`${label}: build-cv-html.mjs crashed (exit ${f?.status}) - ${(f?.stderr || '').trim().split('\n').pop()}`);
+    return null;
+  }
+  // A zero exit with no file would otherwise surface as a bare ENOENT.
+  if (!existsSync(output)) {
+    fail(`${label}: build-cv-html.mjs exited 0 but wrote no output file`);
+    return null;
+  }
+  return readFileSync(output, 'utf-8');
+}
+
+// Assert the alignment property and the exact chosen variant for every row.
+function checkRows(label, html) {
+  for (const [kind, rows] of Object.entries(EXPECTED)) {
+    const found = [...html.matchAll(new RegExp(`<div class="${kind}-item">([\\s\\S]*?)</div>`, 'g'))]
+      .map(m => m[1].replace(/\s+/g, ' ').trim());
+
+    if (found.length !== rows.length) {
+      fail(`${label} ${kind}: expected ${rows.length} rows, found ${found.length}`);
+      continue;
+    }
+
+    rows.forEach(([title, org, year], i) => {
+      const row = found[i];
+      const expected = `<span class="${kind}-title">${title}</span> ${org} ${year}`;
+      if (row === expected) pass(`${label} ${kind}: ${title} renders both cells`);
+      else fail(`${label} ${kind}: ${title} - expected \`${expected}\`, got \`${row}\``);
+    });
+
+    // The alignment property itself, independent of the markup above: every
+    // row carries the same number of spans.
+    const counts = new Set(found.map(row => (row.match(/<span/g) || []).length));
+    if (counts.size === 1) pass(`${label} ${kind}: every row has the same cell count (${[...counts][0]})`);
+    else fail(`${label} ${kind}: rows have differing cell counts (${[...counts].sort().join(', ')}) - columns misalign`);
+  }
+}
+
+// A template pack whose fallbacks use the block-suffixed spelling. The issue
+// offered renaming the fallbacks to ORG_BLOCK_EMPTY/YEAR_BLOCK_EMPTY as the
+// alternative fix; parsePartial accepts both, so a pack that took that route
+// renders identically to the shipped one. Only the two partials under test are
+// rewritten, so the spelling is the single variable.
+function blockSuffixedTemplate() {
+  const packDir = join(dir, 'pack');
+  cpSync(join(ROOT, 'templates'), packDir, { recursive: true });
+
+  for (const [section, prefix] of [['certifications', 'cert'], ['awards', 'award']]) {
+    const file = join(packDir, 'sections', `${section}.html`);
+    const renamed = readFileSync(file, 'utf-8')
+      .replaceAll('ORG_EMPTY', 'ORG_BLOCK_EMPTY')
+      .replaceAll('YEAR_EMPTY', 'YEAR_BLOCK_EMPTY');
+    if (!renamed.includes(`<!--ORG_BLOCK_EMPTY--><span class="${prefix}-org">`)) {
+      fail(`${section}.html no longer defines the ORG_EMPTY fallback this fixture renames`);
+    }
+    writeFileSync(file, renamed);
+  }
+
+  return join(packDir, 'cv-template.html');
+}
+
+try {
   // Default template, so the shipped templates/sections/ partials are the ones
   // under test rather than a fixture copy.
-  const built = run(NODE, [join(ROOT, 'build-cv-html.mjs'), input, output]);
-  if (built === null) {
-    const f = lastRunFailure();
-    fail(`build-cv-html.mjs crashed (exit ${f?.status}) — ${(f?.stderr || '').trim().split('\n').pop()}`);
-  } else {
-    const html = readFileSync(output, 'utf-8');
-
-    for (const [kind, rows] of Object.entries(EXPECTED)) {
-      const found = [...html.matchAll(new RegExp(`<div class="${kind}-item">([\\s\\S]*?)</div>`, 'g'))]
-        .map(m => m[1].replace(/\s+/g, ' ').trim());
-
-      if (found.length !== rows.length) {
-        fail(`${kind}: expected ${rows.length} rows, found ${found.length}`);
-        continue;
-      }
-
-      rows.forEach(([title, org, year], i) => {
-        const row = found[i];
-        const expected = `<span class="${kind}-title">${title}</span> ${org} ${year}`;
-        if (row === expected) pass(`${kind}: ${title} renders both cells`);
-        else fail(`${kind}: ${title} — expected \`${expected}\`, got \`${row}\``);
-      });
-
-      // The alignment property itself, independent of the markup above: every
-      // row carries the same number of spans.
-      const counts = new Set(found.map(row => (row.match(/<span/g) || []).length));
-      if (counts.size === 1) pass(`${kind}: every row has the same cell count (${[...counts][0]})`);
-      else fail(`${kind}: rows have differing cell counts (${[...counts].sort().join(', ')}) — columns misalign`);
-    }
+  const shipped = build('shipped', null);
+  if (shipped) {
+    checkRows('shipped:', shipped);
 
     // skills.html defines CATEGORY_BLOCK with no _EMPTY sibling, so an absent
     // category must collapse to nothing rather than to an empty label. Guards
     // the shared present/absent switch this fix reaches through.
-    const skillRows = [...html.matchAll(/<div class="skill-item">([\s\S]*?)<\/div>/g)]
+    const skillRows = [...shipped.matchAll(/<div class="skill-item">([\s\S]*?)<\/div>/g)]
       .map(m => m[1].replace(/\s+/g, ' ').trim());
     const labelled = '<span class="skill-category">Languages: </span>JavaScript';
     if (skillRows[0] === labelled) pass('skills: a category renders its label');
@@ -111,6 +154,9 @@ try {
     if (skillRows[1] === 'Uncategorized skill') pass('skills: no category renders no label');
     else fail(`skills: expected a bare row, got \`${skillRows[1]}\``);
   }
+
+  const suffixed = build('block-suffixed', blockSuffixedTemplate());
+  if (suffixed) checkRows('_BLOCK_EMPTY:', suffixed);
 } finally {
   try { rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
 }

--- a/tests/cv-partial-empty-fallbacks.test.mjs
+++ b/tests/cv-partial-empty-fallbacks.test.mjs
@@ -127,8 +127,10 @@ function blockSuffixedTemplate() {
     const renamed = readFileSync(file, 'utf-8')
       .replaceAll('ORG_EMPTY', 'ORG_BLOCK_EMPTY')
       .replaceAll('YEAR_EMPTY', 'YEAR_BLOCK_EMPTY');
-    if (!renamed.includes(`<!--ORG_BLOCK_EMPTY--><span class="${prefix}-org">`)) {
-      fail(`${section}.html no longer defines the ORG_EMPTY fallback this fixture renames`);
+    for (const [field, cell] of [['ORG', 'org'], ['YEAR', 'year']]) {
+      if (!renamed.includes(`<!--${field}_BLOCK_EMPTY--><span class="${prefix}-${cell}">`)) {
+        fail(`${section}.html no longer defines the ${field}_EMPTY fallback this fixture renames`);
+      }
     }
     writeFileSync(file, renamed);
   }


### PR DESCRIPTION
Fixes #2486.

`parsePartial` resolved an `_EMPTY` fallback by stripping the suffix, so `<!--ORG_EMPTY-->` was filed under `ORG` while `fillEntry` looks the fallback up under `ORG_BLOCK`. The definition was collected and then never used, so a certification or award row missing an org or a year emitted nothing where the empty `<span>` belonged.

Before, on a CV with mixed rows:

```
<span class="cert-title">Cert both</span> <span class="cert-org">Issuer</span> <span class="cert-year">2024</span>
<span class="cert-title">Cert no org</span> <span class="cert-year">2023</span>
<span class="cert-title">Cert no year</span> <span class="cert-org">Issuer</span>
<span class="cert-title">Cert neither</span>
```

After:

```
<span class="cert-title">Cert both</span> <span class="cert-org">Issuer</span> <span class="cert-year">2024</span>
<span class="cert-title">Cert no org</span> <span class="cert-org"></span> <span class="cert-year">2023</span>
<span class="cert-title">Cert no year</span> <span class="cert-org">Issuer</span> <span class="cert-year"></span>
<span class="cert-title">Cert neither</span> <span class="cert-org"></span> <span class="cert-year"></span>
```

### Which of the two fixes, and why

The issue offered either renaming the fallbacks in both partials or teaching `parsePartial` the current suffix. This takes the parser.

Both partial headers say "Template packs: edit tag names, class names, and field order freely inside the ENTRY zone". Any pack that copied the shipped `ORG_EMPTY` naming would keep parsing fine after a rename and silently stop emitting its fallback, which is the same invisible misalignment this issue is about, just moved onto pack authors. Fixing the parser repairs every existing pack, including ones outside this repo.

The pairing is resolved in a second pass over the collected definitions, because a fallback can be defined before the block it belongs to. `ORG_EMPTY` and `ORG_BLOCK_EMPTY` both attach to `ORG_BLOCK`, and the bare stem stays as a fallback so a `FOO_EMPTY` / `FOO` pair keeps working. Every conditional in every shipped partial is named `<FIELD>_BLOCK`, so there was no ambiguity to resolve.

### Testing

`tests/cv-partial-empty-fallbacks.test.mjs` (auto-discovered, `pass`/`fail` from `helpers.mjs`, no `process.exit`). It runs the real builder against the shipped `templates/sections/` partials with a mixed-rows payload, then asserts the exact markup of each row plus the alignment property itself: every row in a section carries the same number of cells. The shipped partials are the primary subject rather than a fixture copy; a fixture pack appears only to cover the second fallback spelling, described below.

End to end rather than a unit test because `build-cv-html.mjs` exports nothing, and the bug lived in the seam between the partial's block names and the builder's lookup. A unit test of either half alone would have passed.

```
$ node test-all.mjs --quick     # this branch
📊 Results: 2936 passed, 0 failed, 1 warnings

$ node test-all.mjs --quick     # main, for comparison
📊 Results: 2916 passed, 0 failed, 1 warnings
```

Exactly the 20 new assertions. The single warning is the pre-existing `cv-sync-check.mjs exited with error (expected without user data)` on both.

`test:cv-visual` needs `pdftotext`, which I do not have locally, so instead I rendered the same payload through the builder at the parent commit and at this one and diffed the HTML: byte-identical, since the only change to `build-cv-html.mjs` in the second commit is comment text.

Each assertion was checked by reverting the behaviour it covers and confirming the intended test goes red:

| Sabotage | Test result |
|---|---|
| restore the pre-fix stem lookup (the reported bug) | 7 failures across both sections |
| always use the present variant, ignoring `present` | 1 failure, on the skills row |
| always pair to `<stem>_BLOCK`, dropping the bare-stem fallback | 7 failures, all in the `_BLOCK_EMPTY` pack, shipped partials still green |

One correction while I am here: I tried a further sabotage, dropping the merge with the existing entry in the present-variant pass, and it is **not** caught. That one is behaviour-equivalent rather than a gap: the second pass writes `absent` afterwards, so overwriting only differs if a single block name is defined twice as a non-`_EMPTY` definition, which no partial does.

The second sabotage is why the test also covers skills. For certifications and awards, the present variant filled with an empty value renders byte-identically to the `_EMPTY` fallback, so no assertion on those two sections can tell the two implementations apart. `skills.html` defines `CATEGORY_BLOCK` with no `_EMPTY` sibling, so an absent category must collapse to nothing, and that sabotage renders a visible stray `<span class="skill-category">: </span>`. It also guards the shared `parsePartial` path this change reaches for every other section.

### Second commit, from review

Three things, none of them changing the fix.

**Both fallback spellings are now covered.** The parser accepts `ORG_EMPTY` and `ORG_BLOCK_EMPTY`, but only the shipped spelling had a test. The suite now builds the same payload a second time through a template pack that took the rename route the issue offered as the alternative, copying `templates/` and rewriting only those two partials so the spelling is the single variable. That pack is what the third sabotage row above catches, and it is the case the "fix the parser, not the partials" argument rests on, so it was worth pinning.

**The builder comments now name the mechanism** rather than restating the promise, which covers the third acceptance criterion directly instead of leaving it implied by the fix.

**A zero exit that wrote no output now fails with a message** instead of a bare `ENOENT` from `readFileSync`. Worth saying plainly: I could not construct a case that reaches this branch, because `writeAndReport` stats the file it just wrote, so a missing output already exits non-zero and lands in the crash branch. It is defensive only, and no test distinguishes it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering of conditional CV sections when organization or year information is missing.
  * Added support for standard and block-specific empty fallbacks.
  * Ensured sections without configured fallbacks remain hidden when data is unavailable.

* **Tests**
  * Added end-to-end coverage for certification and award fallback rendering.
  * Verified generated markup and consistent output formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->