### PR TITLE
fix(scan-ats-full): `--since -5` silently scanned nothing and called it a clean run

### DIFF
--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -256,7 +256,7 @@ function parseArgs(argv) {
     return kv ? kv.split('=').slice(1).join('=') : null;
   };
   // Validated by the SAME parser scan.mjs uses, so one flag name cannot mean
-  // two different things (#2492). `Number(...) || 3` silently swallowed every
+  // two different things (#2498). `Number(...) || 3` silently swallowed every
   // malformed operand: `--since abc` and `--since 0` became 3 while the user
   // believed they had scanned the window they typed; `--since -5` put the
   // cutoff in the FUTURE so nothing was ever eligible, which reads exactly like

--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -43,7 +43,7 @@ import lever from './providers/lever.mjs';
 import ashby from './providers/ashby.mjs';
 import workday from './providers/workday.mjs';
 import icims from './providers/icims.mjs';
-import { buildTitleFilter, buildLocationFilter, buildContentFilter, matchedTitleKeywords, loadSeenUrls, normalizeUrlForDedup, appendToPipeline, appendToScanHistory, loadBlacklist } from './scan.mjs';
+import { buildTitleFilter, buildLocationFilter, buildContentFilter, matchedTitleKeywords, loadSeenUrls, normalizeUrlForDedup, appendToPipeline, appendToScanHistory, loadBlacklist, parseSinceDays } from './scan.mjs';
 import { SEED_SOURCES, toPortalEntry } from './seeds/vc-portfolios.mjs';
 import { normalizeCompany } from './tracker-utils.mjs';
 
@@ -255,7 +255,20 @@ function parseArgs(argv) {
     const kv = args.find(a => a.startsWith(flag + '='));
     return kv ? kv.split('=').slice(1).join('=') : null;
   };
-  const sinceDays = Number(valueOf('--since')) || 3;
+  // Validated by the SAME parser scan.mjs uses, so one flag name cannot mean
+  // two different things (#2492). `Number(...) || 3` silently swallowed every
+  // malformed operand: `--since abc` and `--since 0` became 3 while the user
+  // believed they had scanned the window they typed; `--since -5` put the
+  // cutoff in the FUTURE so nothing was ever eligible, which reads exactly like
+  // "no new postings"; `--since 1e400` became Infinity → an -Infinity cutoff,
+  // i.e. no window at all. Only the DEFAULT stays local: absent --since means
+  // 3 days here, where scan.mjs means no bound.
+  const sinceArg = parseSinceDays(args);
+  if (sinceArg.error) {
+    console.error(`Error: ${sinceArg.error}`);
+    process.exit(1);
+  }
+  const sinceDays = sinceArg.days ?? 3;
   const limit = Number(valueOf('--limit')) || Infinity;
   const atsArg = valueOf('--ats');
   // --seeds: optional comma-separated VC portfolio sources (e.g. yc,a16z).

--- a/scan.mjs
+++ b/scan.mjs
@@ -324,6 +324,55 @@ export function buildPostingAgeFilter(maxAgeDays, now = Date.now()) {
 // provider early-stop hint. Kept as one function so they cannot drift.
 
 /**
+ * Parse and validate `--since <days>` from an argv slice.
+ *
+ * Shared by scan.mjs and scan-ats-full.mjs so ONE flag name cannot mean two
+ * different things. scan-ats-full.mjs used `Number(valueOf('--since')) || 3`,
+ * which silently swallowed every malformed operand: `--since abc` and
+ * `--since 0` both became 3 (the user believes they scanned the window they
+ * typed), `--since -5` produced a cutoff in the FUTURE so nothing was ever
+ * eligible (indistinguishable from "no new postings"), and `--since 1e400`
+ * became Infinity → an -Infinity cutoff, i.e. no window at all (#2492).
+ *
+ * Returns the day count, or null when the flag is absent — the DEFAULT is the
+ * caller's to choose (scan.mjs: no bound; scan-ats-full.mjs: 3 days), only the
+ * validation is shared. `error` is a ready-to-print message; callers print and
+ * exit rather than this throwing, so both CLIs fail the same way.
+ *
+ * @param {string[]} args - argv slice.
+ * @returns {{days: number|null, error: string|null}}
+ */
+export function parseSinceDays(args) {
+  // Every occurrence is collected, not just the first match of either form:
+  // picking one and ignoring the rest means `--since=7 --since` succeeds while
+  // an occurrence with no value goes unread.
+  const occurrences = args.filter((a) => a === '--since' || a.startsWith('--since='));
+  if (occurrences.length > 1) {
+    return { days: null, error: `--since given ${occurrences.length} times; pass it once` };
+  }
+  if (occurrences.length === 0) return { days: null, error: null };
+  const occ = occurrences[0];
+  const next = args[args.indexOf('--since') + 1];
+  const raw = occ.startsWith('--since=')
+    ? occ.slice('--since='.length)
+    : (next != null && !next.startsWith('--') ? next : null);
+  const n = raw == null || raw === '' ? NaN : Number(raw);
+  // Number.isFinite also rejects Infinity and 1e309, which pass a bare `> 0`
+  // test and would yield an -Infinity cutoff (i.e. silently no window).
+  if (!Number.isFinite(n) || n <= 0) {
+    return { days: null, error: `--since expects a positive number of days, got ${raw == null || raw === '' ? '(no value)' : `"${raw}"`}` };
+  }
+  // Finite and positive is not enough: 1e300 days lands outside the ±8.64e15ms
+  // range a Date can represent, so the derived cutoff is an Invalid Date and
+  // toISOString() throws. Reject it here rather than let it surface as an
+  // unhandled "Invalid time value" mid-scan.
+  if (Number.isNaN(new Date(Date.now() - n * 86_400_000).getTime())) {
+    return { days: null, error: `--since ${raw} is too large to express as a date` };
+  }
+  return { days: n, error: null };
+}
+
+/**
  * Collapse --posted-after and --since into a single absolute lower bound.
  *
  * @param {string|null} postedAfter - YYYY-MM-DD from --posted-after, or null.
@@ -1954,42 +2003,15 @@ async function main() {
   // built a bare makeHttpCtx(), so every Workday tenant paginated to its
   // max_pages cap on every run however stale the deep pages were.
   //
-  // Flag presence is tracked separately from its operand. `--since` with no
-  // value, `--since=`, and `--since --posted-after X` must all fail rather than
-  // silently degrade to "no window", which would look like a fast scan that
-  // simply found less — indistinguishable from success. Number.isFinite also
-  // rejects Infinity and 1e309, which pass a bare `> 0` test and would yield an
-  // -Infinity cutoff.
-  // Every occurrence is collected, not just the first match of either form:
-  // picking one and ignoring the rest means `--since=7 --since` succeeds while
-  // an occurrence with no value goes unread.
-  const sinceOccurrences = args.filter((a) => a === '--since' || a.startsWith('--since='));
-  if (sinceOccurrences.length > 1) {
-    console.error(`Error: --since given ${sinceOccurrences.length} times; pass it once`);
+  // Flag presence, operand validity, duplicate occurrences and the
+  // out-of-Date-range case are all handled by the SHARED parseSinceDays(), so
+  // scan-ats-full.mjs cannot disagree about what --since means (#2492).
+  const since = parseSinceDays(args);
+  if (since.error) {
+    console.error(`Error: ${since.error}`);
     process.exit(1);
   }
-  let sinceDays = null;
-  if (sinceOccurrences.length === 1) {
-    const occ = sinceOccurrences[0];
-    const next = args[args.indexOf('--since') + 1];
-    const raw = occ.startsWith('--since=')
-      ? occ.slice('--since='.length)
-      : (next != null && !next.startsWith('--') ? next : null);
-    const n = raw == null || raw === '' ? NaN : Number(raw);
-    if (!Number.isFinite(n) || n <= 0) {
-      console.error(`Error: --since expects a positive number of days, got ${raw == null || raw === '' ? '(no value)' : `"${raw}"`}`);
-      process.exit(1);
-    }
-    // Finite and positive is not enough: 1e300 days lands outside the ±8.64e15ms
-    // range a Date can represent, so the derived cutoff is an Invalid Date and
-    // toISOString() throws. Reject it here rather than let it surface as an
-    // unhandled "Invalid time value" mid-scan.
-    if (Number.isNaN(new Date(Date.now() - n * 86_400_000).getTime())) {
-      console.error(`Error: --since ${raw} is too large to express as a date`);
-      process.exit(1);
-    }
-    sinceDays = n;
-  }
+  const sinceDays = since.days;
 
   const effectiveAfter = resolveEffectiveAfter(postedAfter, sinceDays);
 

--- a/scan.mjs
+++ b/scan.mjs
@@ -332,7 +332,7 @@ export function buildPostingAgeFilter(maxAgeDays, now = Date.now()) {
  * `--since 0` both became 3 (the user believes they scanned the window they
  * typed), `--since -5` produced a cutoff in the FUTURE so nothing was ever
  * eligible (indistinguishable from "no new postings"), and `--since 1e400`
- * became Infinity → an -Infinity cutoff, i.e. no window at all (#2492).
+ * became Infinity → an -Infinity cutoff, i.e. no window at all (#2498).
  *
  * Returns the day count, or null when the flag is absent — the DEFAULT is the
  * caller's to choose (scan.mjs: no bound; scan-ats-full.mjs: 3 days), only the
@@ -2005,7 +2005,7 @@ async function main() {
   //
   // Flag presence, operand validity, duplicate occurrences and the
   // out-of-Date-range case are all handled by the SHARED parseSinceDays(), so
-  // scan-ats-full.mjs cannot disagree about what --since means (#2492).
+  // scan-ats-full.mjs cannot disagree about what --since means (#2498).
   const since = parseSinceDays(args);
   if (since.error) {
     console.error(`Error: ${since.error}`);

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5047,6 +5047,7 @@ try {
     buildPostedDateFilter,
     resolveEffectiveAfter,
     resolveEarlyStopMs,
+    parseSinceDays,
     buildVisaFilter,
     buildCountryEligibilityFilter,
     shouldDedupScanHistoryRow,
@@ -5131,6 +5132,50 @@ try {
     pass('--since resolves to an absolute lower bound; the newest active bound wins');
   } else {
     fail('effective posted-after bound is not the newest of --posted-after and --since');
+  }
+
+  // ── --since means the SAME thing in both scanners (#2492) ──────────────
+  // scan-ats-full.mjs parsed it as `Number(valueOf('--since')) || 3`, which
+  // swallowed every malformed operand: `abc`/`0` silently became 3 (the user
+  // believes they scanned the window they typed), `-5` produced a cutoff in the
+  // FUTURE so nothing was ever eligible (reads exactly like "no new postings"),
+  // and `1e400` became Infinity → an -Infinity cutoff, i.e. no window at all.
+  // Both CLIs now share parseSinceDays, so the flag cannot mean two things.
+  {
+    const bad = [
+      [['--since', 'abc'], 'a non-numeric operand'],
+      [['--since', '-5'], 'a negative day count'],
+      [['--since', '0'], 'a zero day count'],
+      [['--since', '1e400'], 'Infinity'],
+      [['--since', '1e300'], 'a count outside the representable Date range'],
+      [['--since'], 'a missing operand'],
+      [['--since', '--posted-after', '2026-01-01'], 'an operand that is really the next flag'],
+      [['--since=7', '--since'], 'duplicate occurrences'],
+    ];
+    const leaked = bad.filter(([args]) => parseSinceDays(args).error === null);
+    if (leaked.length === 0) {
+      pass('parseSinceDays rejects every malformed --since operand instead of coercing it (#2492)');
+    } else {
+      fail(`parseSinceDays accepted malformed --since: ${JSON.stringify(leaked.map(([a]) => a))}`);
+    }
+    const good =
+      parseSinceDays(['--since', '7']).days === 7 &&
+      parseSinceDays(['--since=7']).days === 7 &&
+      // Absent is NOT an error — the default is the caller's to choose
+      // (scan.mjs: no bound; scan-ats-full.mjs: 3 days).
+      parseSinceDays([]).days === null && parseSinceDays([]).error === null;
+    if (good) {
+      pass('parseSinceDays accepts both spellings and leaves the default to the caller (#2492)');
+    } else {
+      fail('parseSinceDays mishandled a valid --since or the absent case');
+    }
+    // Source-level: neither scanner may re-introduce a private coercion.
+    const atsSrc = readFileSync(join(ROOT, 'scan-ats-full.mjs'), 'utf-8');
+    if (/parseSinceDays\(/.test(atsSrc) && !/Number\(valueOf\('--since'\)\)/.test(atsSrc)) {
+      pass('scan-ats-full.mjs derives --since from the shared parser, not its own Number() coercion (#2492)');
+    } else {
+      fail('scan-ats-full.mjs parses --since itself again — the two scanners can disagree (#2492)');
+    }
   }
 
   if (

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5134,7 +5134,7 @@ try {
     fail('effective posted-after bound is not the newest of --posted-after and --since');
   }
 
-  // ── --since means the SAME thing in both scanners (#2492) ──────────────
+  // ── --since means the SAME thing in both scanners (#2498) ──────────────
   // scan-ats-full.mjs parsed it as `Number(valueOf('--since')) || 3`, which
   // swallowed every malformed operand: `abc`/`0` silently became 3 (the user
   // believes they scanned the window they typed), `-5` produced a cutoff in the
@@ -5154,7 +5154,7 @@ try {
     ];
     const leaked = bad.filter(([args]) => parseSinceDays(args).error === null);
     if (leaked.length === 0) {
-      pass('parseSinceDays rejects every malformed --since operand instead of coercing it (#2492)');
+      pass('parseSinceDays rejects every malformed --since operand instead of coercing it (#2498)');
     } else {
       fail(`parseSinceDays accepted malformed --since: ${JSON.stringify(leaked.map(([a]) => a))}`);
     }
@@ -5165,16 +5165,16 @@ try {
       // (scan.mjs: no bound; scan-ats-full.mjs: 3 days).
       parseSinceDays([]).days === null && parseSinceDays([]).error === null;
     if (good) {
-      pass('parseSinceDays accepts both spellings and leaves the default to the caller (#2492)');
+      pass('parseSinceDays accepts both spellings and leaves the default to the caller (#2498)');
     } else {
       fail('parseSinceDays mishandled a valid --since or the absent case');
     }
     // Source-level: neither scanner may re-introduce a private coercion.
     const atsSrc = readFileSync(join(ROOT, 'scan-ats-full.mjs'), 'utf-8');
     if (/parseSinceDays\(/.test(atsSrc) && !/Number\(valueOf\('--since'\)\)/.test(atsSrc)) {
-      pass('scan-ats-full.mjs derives --since from the shared parser, not its own Number() coercion (#2492)');
+      pass('scan-ats-full.mjs derives --since from the shared parser, not its own Number() coercion (#2498)');
     } else {
-      fail('scan-ats-full.mjs parses --since itself again — the two scanners can disagree (#2492)');
+      fail('scan-ats-full.mjs parses --since itself again — the two scanners can disagree (#2498)');
     }
   }
 


### PR DESCRIPTION
Closes #2498.

#2477 landed a strictly-validated `--since` in `scan.mjs`, with the stated intent:

> Matches `scan-ats-full.mjs`, which has always treated `--since` as a filter; **one flag name should not mean two different things.**

`scan-ats-full.mjs` doesn't match it. It parses `Number(valueOf('--since')) || 3`, with no later validation:

| input | `sinceDays` | effect |
|---|---|---|
| `--since abc` | **3** | typo swallowed — user believes they scanned what they typed |
| `--since 0` | **3** | same |
| `--since -5` | **-5** | cutoff in the **FUTURE** → nothing ever eligible |
| `--since 1e400` | **Infinity** | cutoff `-Infinity` → **no window at all** |

`--since -5` is the sharp one: a future cutoff makes every posting older than it, so the sweep finds nothing and reports a clean run — indistinguishable from "no new postings", on the flag that decides what the sweep looks at. `1e400` is the mirror image: ask for a bound, silently get none. The bad `cutoffMs` is persisted into the `--resume` checkpoint too.

`scan.mjs` already rejects all four, and its own comment names the trap:

> `Number.isFinite` also rejects Infinity and 1e309, which pass a bare `> 0` test and would yield an -Infinity cutoff.

## Fix

Extracted that validation as an exported `parseSinceDays(args)` and pointed **both** scanners at it. `scan-ats-full.mjs` already imports from `scan.mjs`, so this **shares** rather than copies — the flag can't drift into meaning two things again.

Only the *default* stays per-script, since they legitimately differ: absent `--since` is 3 days in `scan-ats-full.mjs`, no bound in `scan.mjs`. The helper returns `days: null, error: null` when absent and lets each caller choose.

After:

```
--since abc    Error: --since expects a positive number of days, got "abc"
--since -5     Error: --since expects a positive number of days, got "-5"
--since 0      Error: --since expects a positive number of days, got "0"
--since 1e400  Error: --since expects a positive number of days, got "1e400"
--since 7      accepted, proceeds normally
```

`scan.mjs`'s own behaviour is unchanged — verified across all 11 cases (both spellings, duplicates, missing operand, operand-is-next-flag, out-of-Date-range).

## Note

Sharing also brings `scan-ats-full.mjs` two guards it lacked: duplicate-occurrence rejection (`--since=7 --since`) and the out-of-Date-range check (`1e300`). Both were already `scan.mjs` behaviour; I've called them out rather than let them ride in unmentioned.

## Tests

Eight malformed operands must all be rejected, both spellings accepted, the absent case left to the caller — plus a source-level assertion that `scan-ats-full.mjs` doesn't re-introduce a private `Number()` coercion.

`node test-all.mjs --quick` → **2917 passed, 0 failed**.

3 commits (extract → fix → tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for the `--since` option.
  * Invalid, missing, duplicate, non-positive, non-finite, and out-of-range values now produce clear errors.
  * Preserved the default date range when `--since` is omitted.
  * Standardized `--since` handling across scanning commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->