### PR TITLE
fix(lock-matrix): the contention signal is unobservable on Windows, not absent

### DIFF
--- a/tracker-writer-lock-tests.mjs
+++ b/tracker-writer-lock-tests.mjs
@@ -840,6 +840,16 @@ if (contentionWatchedCases === 0) {
   fail('no guard-watched case ran — the matrix no longer exercises the recover guard, so nothing validates the mutation ordering signal');
 } else if (contentionObservedCases > 0) {
   pass(`recover guard observed in ${contentionObservedCases}/${contentionWatchedCases} guard-watched cases — the mutation ordering signal is live`);
+} else if (process.platform === 'win32') {
+  // The signal is SAMPLED: acquireTrackerLock removes the guard in a `finally`
+  // around one lockCanRecover() call, so it exists for well under a
+  // millisecond, and the watcher looks for it with readdirSync. On Windows
+  // that sampling is unreliable enough to miss every window in a run — one CI
+  // leg observed 3 of 8, another 0 of 8 on the same commit — so failing here
+  // reports the sampler's luck, not the guard's existence, and turns a healthy
+  // tree red at random. Reported, not enforced, on this platform.
+  console.log(`NOTE recover guard not sampled in any of the ${contentionWatchedCases} guard-watched cases on win32 — the ordering signal could not be observed here; the assertion is enforced on platforms where sampling is reliable`);
+  passed++;
 } else {
   fail(`recover guard never observed in any of the ${contentionWatchedCases} guard-watched cases — acquireTrackerLock has stopped emitting it, so every one of them fell back to timing-dependent ordering`);
 }


### PR DESCRIPTION
Fixes a flake **I introduced** in #2451, merged this morning. Sent straight in per `CONTRIBUTING.md:22`.

## What happened

#2451 made the run-level contention assertion a hard failure when no guard-watched case observes the recover guard. On Windows that fails a healthy tree at random.

Two CI legs on the same commit, same code:

| Run | Observed | Result |
|---|---|---|
| PR #2451's own leg | 3 of 8 | green |
| PR #2459's leg, on current `main` | **0 of 8** | **red** — `recover guard never observed in any of the 8 guard-watched cases` |

Six other PRs rebased on that same `main` are green on Windows, so this is not a systematic break — it is a roughly one-in-seven flake, which is worse: a red that means nothing is how a red that means something stops being read.

## Why it flakes there and not elsewhere

The signal is **sampled**, not delivered. `acquireTrackerLock` creates the recover guard and removes it in a `finally` around a single `lockCanRecover()` call (`tracker-utils.mjs:388-398`) — it exists for well under a millisecond, re-created on each ~`retryMs` attempt. `watchForContention` looks for it with `readdirSync` every 2ms.

On Linux and macOS that race is won consistently (8 of 8 locally). On the Windows runner — slower directory reads, coarser scheduling — it can miss every window in a whole run. Failing there reports the sampler's luck, not whether the guard exists.

## Change

The assertion is **enforced where sampling is reliable, reported as a `NOTE` on `win32`**:

```
NOTE recover guard not sampled in any of the 8 guard-watched cases on win32 — the
     ordering signal could not be observed here; the assertion is enforced on
     platforms where sampling is reliable
```

This does not weaken the regression #2451 exists to catch: if `acquireTrackerLock` stops emitting the guard, the Linux and macOS legs go red, and CI requires all three. It stops claiming a verdict on a platform where the harness cannot see the thing it is judging.

## Test plan

- [x] `node tracker-writer-lock-tests.mjs` — 27 passed, 0 failed (guard observed 8 of 8 locally)
- [x] Simulated the failing Windows path — guard prefix renamed **and** the `win32` branch forced on: prints the `NOTE`, suite stays green
- [x] Non-win32 still fails closed: same rename without the platform override → `26 passed, 1 failed`
- [x] `node test-all.mjs --quick` — 2916 passed, 0 failed

## The honest version

I chose the run-level assertion in #2451 precisely because per-case failing was already flaky on Windows, and I measured 3 of 8 there. I read that as "the run always observes at least one" without checking whether the distribution could reach zero. It can. This is the correction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows test reporting for recovery checks when no guard sample is observed.
  * Windows cases now pass with an informational note in this scenario, while other platforms retain their existing validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->