### PR TITLE
fix(fingerprint): a Russian and a Chinese employer counted as the same company, hiding cross-listings

### DIFF
--- a/fingerprint-core.mjs
+++ b/fingerprint-core.mjs
@@ -19,6 +19,7 @@
  */
 
 import { createHash } from 'crypto';
+import { normalizeTextKey } from './tracker-parse.mjs';
 
 /** Descriptions shorter than this (after normalization) carry too little
  * signal to distinguish real matches from boilerplate — skip them. */
@@ -166,10 +167,22 @@ function maxDistanceFor(threshold) {
   return 64;
 }
 
-/** Company key for "different employer" checks — same normalization family as
- * the tracker tooling (lowercase alphanumerics). */
+/**
+ * Company key for "different employer" checks.
+ *
+ * Delegates to the shared normalizeTextKey() (#2393/#2445) rather than the
+ * `[a-z0-9]` strip it used to carry. That strip DELETED every non-Latin name,
+ * so アクメ株式会社, グロベックス合同会社 and Яндекс all keyed to '' and compared
+ * equal — and because findCrossListings() SKIPS same-key pairs as re-posts,
+ * an identical posting shared between two genuinely different non-Latin
+ * employers was silently never reported as a cross-listing. The Latin
+ * equivalent was reported normally (#2500).
+ *
+ * The key keeps combining marks, so Devanagari/Arabic names differing only in
+ * matras stay distinct rather than collapsing into one "employer".
+ */
 function companyKey(name) {
-  return String(name ?? '').toLowerCase().replace(/[^a-z0-9]/g, '');
+  return normalizeTextKey(String(name ?? ''));
 }
 
 /**

--- a/tests/fingerprint-core.test.mjs
+++ b/tests/fingerprint-core.test.mjs
@@ -275,3 +275,36 @@ try {
 } catch (e) {
   fail(`fingerprint-core popcount equivalence tests crashed: ${e.stack || e.message}`);
 }
+
+// ── non-Latin employers are DIFFERENT employers (#2500) ──────────────────
+// companyKey used an [a-z0-9] strip, so every non-Latin name keyed to '' and
+// compared equal. findCrossListings skips same-key pairs as re-posts, so an
+// identical posting shared between two genuinely different non-Latin employers
+// was silently never reported — while the Latin equivalent was reported fine.
+{
+  const { findCrossListings, fingerprintText } = await import(pathToFileURL(join(ROOT, 'fingerprint-core.mjs')).href);
+  const jd = 'Senior backend engineer working on distributed payment platforms. You will design and operate high throughput services, own reliability, and mentor other engineers across the payments organisation. Experience with Go, Kubernetes and event driven systems is expected for this role.';
+  const f = fingerprintText(jd);
+  const today = new Date('2026-08-04T00:00:00Z');
+  const offer = (company) => ({ url: 'https://x.test/1', company, title: 'Backend Engineer', fingerprint: f });
+  const histRow = (company) => ({ url: 'https://y.test/2', company, title: 'Backend Engineer', fingerprint: f, dateStr: '2026-08-01' });
+  const found = (a, b) => findCrossListings([offer(a)], [histRow(b)], { today }).length;
+
+  const differentEmployers = [
+    ['アクメ株式会社', 'グロベックス合同会社'],
+    ['Яндекс', '北京字节跳动'],
+    ['कंपनी', 'कपनी'], // differ only in combining marks
+  ];
+  if (differentEmployers.every(([a, b]) => found(a, b) === 1)) {
+    pass('cross-listings between two different non-Latin employers are detected (#2500)');
+  } else {
+    fail('a shared posting between different non-Latin employers was skipped as a same-company re-post');
+  }
+  // The same-company skip must survive: a non-Latin employer re-posting its own
+  // listing is a re-post, not a cross-listing.
+  if (found('Acme Inc', 'Acme Inc') === 0 && found('アクメ株式会社', 'アクメ株式会社') === 0) {
+    pass('same-employer pairs are still skipped as re-posts, Latin and non-Latin alike (#2500)');
+  } else {
+    fail('same-employer pair was reported as a cross-listing');
+  }
+}


### PR DESCRIPTION
Closes #2501.

`companyKey()` in `fingerprint-core.mjs` stripped `[^a-z0-9]`, so every non-Latin company name keyed to `''` and compared equal. `findCrossListings()` skips same-key pairs:

```js
if (cand.key === offerCompany) continue; // re-post, not cross-listing
```

…so two genuinely different non-Latin employers looked like one, and a shared posting between them was **silently never reported**.

Reproduced with one identical JD posted by two companies:

```
                                      BEFORE   AFTER
two Latin companies                      1       1
two DIFFERENT non-Latin companies        0       1     ← was silently skipped
Russian vs Chinese company               0       1
Devanagari differing only in matras      —       1
```

Same root cause as #2429, opposite symptom: there an empty key caused a false *merge*, here a false *skip*. Both quietly do less for anyone tracking employers in the ja/ko/zh/zh-TW/ru/ua/ar/hi markets `modes/` ships.

## Fix

Delegate to the shared `normalizeTextKey()` (#2393/#2445) — the key every grouping consumer is meant to share — instead of a private strip. It keeps combining marks too, so Devanagari/Arabic names differing only in matras stay distinct rather than collapsing into one "employer".

## Tests

Three different-employer pairs must each detect the shared posting, **and** same-employer pairs must still be skipped as re-posts — Latin and non-Latin alike, so the fix can't be read as just disabling the skip.

One note: `tests/fingerprint-core.test.mjs` inlines a verbatim reference copy of the pre-#2381 implementation, including its own old `companyKey`. I deliberately left it untouched — the file says its whole value is being the code that shipped. The differential corpus is Latin-only, so it still agrees; if non-Latin fixtures are ever added there, the reference is the side that should be understood as stale.

`node tests/fingerprint-core.test.mjs` → all green (incl. the 153-match differential corpus). `node test-all.mjs --quick` → **2916 passed, 0 failed**.

2 commits (fix + test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of non-Latin employer names to prevent distinct names from being incorrectly merged into the same identifier.
  * Fixed cross-listing detection for employer names with combining marks.

* **Tests**
  * Added regression tests for non-Latin employer name handling in cross-listing detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->