### PR TITLE
feat(cv): strip the Core Competencies section when the payload has no entries

### DIFF
--- a/cv-sections-core.mjs
+++ b/cv-sections-core.mjs
@@ -1,12 +1,14 @@
 // Shared optional-section stripping for the CV builders (build-cv-html.mjs,
 // build-cv-latex.mjs).
 //
-// Projects, education, certifications, and awards are the genuinely optional
-// CV sections: a candidate's projects are often already covered under Work
-// Experience, not every candidate has a degree, not every application carries a
-// certification worth listing, and most candidates have no award to name. The
-// templates wrap all four unconditionally, so a payload with no entries renders
-// a bare section header with nothing under it. The builders'
+// Core competencies, projects, education, certifications, and awards are the
+// genuinely optional CV sections: a competency tag row is often redundant with
+// the summary and experience bullets that prove the same claims, a candidate's
+// projects are often already covered under Work Experience, not every
+// candidate has a degree, not every application carries a certification worth
+// listing, and most candidates have no award to name. The templates wrap all
+// five unconditionally, so a payload with no entries renders a bare section
+// header with nothing under it. The builders' buildCompetencies()/
 // buildProjects()/buildEducation()/buildCertifications()/buildAwards()
 // correctly return '' — nothing removes the surrounding wrapper, which is what
 // this module does.
@@ -40,6 +42,7 @@ const TEX_BOUNDARY = String.raw`(?=%{4,}\s|$)`;
 
 const PATTERNS = {
   html: {
+    competencies: new RegExp(String.raw`<!--\s+CORE COMPETENCIES\s+-->[\s\S]*?` + HTML_BOUNDARY),
     projects: new RegExp(String.raw`<!--\s+PROJECTS\s+-->[\s\S]*?` + HTML_BOUNDARY),
     education: new RegExp(String.raw`<!--\s+EDUCATION\s+-->[\s\S]*?` + HTML_BOUNDARY),
     certifications: new RegExp(String.raw`<!--\s+CERTIFICATIONS\s+-->[\s\S]*?` + HTML_BOUNDARY),
@@ -52,7 +55,7 @@ const PATTERNS = {
   },
 };
 
-export const OPTIONAL_SECTIONS = ['projects', 'education', 'certifications', 'awards'];
+export const OPTIONAL_SECTIONS = ['competencies', 'projects', 'education', 'certifications', 'awards'];
 
 export function isEmptySection(payload, section) {
   const entries = payload?.[section];

--- a/tests/cv-optional-sections.test.mjs
+++ b/tests/cv-optional-sections.test.mjs
@@ -1,6 +1,7 @@
-// tests/cv-optional-sections.test.mjs — the optional CV sections (projects,
-// education, certifications, awards) must vanish entirely when they have no
-// entries, rather than rendering a bare section header with nothing under it.
+// tests/cv-optional-sections.test.mjs — the optional CV sections
+// (competencies, projects, education, certifications, awards) must vanish
+// entirely when they have no entries, rather than rendering a bare section
+// header with nothing under it.
 //
 // #1879 fixed this for projects; education is the same bug (not every
 // candidate has a degree). Certifications was fixed once directly in
@@ -8,7 +9,10 @@
 // shared module (only projects/education made the cut) — the v1.22.0
 // auto-update shipped that regression. Awards (#2220) is optional by
 // construction: most candidates have none, so it ships hidden-when-empty from
-// the start rather than being retrofitted. All four are delimited by marker
+// the start rather than being retrofitted. Core competencies is optional the
+// same way: the tag row is often redundant with the summary and experience
+// bullets, so payloads legitimately omit it — and like certifications it has
+// no LaTeX marker, so it is html-only. All five are delimited by marker
 // matching rather than parsed, so the boundary pattern is the whole
 // correctness story — see the header comment in cv-sections-core.mjs for the
 // failure modes exercised here.
@@ -19,8 +23,9 @@ import { stripEmptySections } from '../cv-sections-core.mjs';
 
 console.log('\ncv-sections-core.mjs — optional sections leave no bare header');
 
-const EMPTY = { projects: [], education: [], certifications: [], awards: [] };
+const EMPTY = { competencies: [], projects: [], education: [], certifications: [], awards: [] };
 const FULL = {
+  competencies: ['Tag'],
   projects: [{ name: 'P' }],
   education: [{ degree: 'D' }],
   certifications: [{ title: 'C' }],
@@ -36,12 +41,12 @@ function check(label, actual, expected) {
 // Assert against the shipped templates so a template edit that renames or
 // reorders a marker fails here instead of silently reviving the bare header.
 const TEMPLATES = [
-  { file: 'templates/cv-template.html', format: 'html', after: 'SKILLS', hasCertifications: true },
-  { file: 'templates/resume-template.html', format: 'html', after: 'SKILLS', hasCertifications: false },
-  { file: 'templates/cv-template.tex', format: 'tex', after: 'Technical Skills', hasCertifications: false },
+  { file: 'templates/cv-template.html', format: 'html', after: 'SKILLS', hasCertifications: true, hasCompetencies: true },
+  { file: 'templates/resume-template.html', format: 'html', after: 'SKILLS', hasCertifications: false, hasCompetencies: true },
+  { file: 'templates/cv-template.tex', format: 'tex', after: 'Technical Skills', hasCertifications: false, hasCompetencies: false },
 ];
 
-for (const { file, format, after, hasCertifications } of TEMPLATES) {
+for (const { file, format, after, hasCertifications, hasCompetencies } of TEMPLATES) {
   const template = readFileSync(join(ROOT, file), 'utf-8');
   const name = file.split('/').pop();
 
@@ -49,12 +54,16 @@ for (const { file, format, after, hasCertifications } of TEMPLATES) {
   const projectsMarker = format === 'html' ? '<!-- PROJECTS -->' : 'PROJECTS  %';
   const educationMarker = format === 'html' ? '<!-- EDUCATION -->' : 'Education  %';
   const certificationsMarker = '<!-- CERTIFICATIONS -->'; // html-only; no LaTeX Certifications section exists
+  const competenciesMarker = '<!-- CORE COMPETENCIES -->'; // html-only; no LaTeX Competencies section exists
   const awardsMarker = format === 'html' ? '<!-- AWARDS -->' : 'AWARDS  %';
 
   check(`${name}: empty payload removes the projects block`, stripped.includes(projectsMarker), false);
   check(`${name}: empty payload removes the education block`, stripped.includes(educationMarker), false);
   if (hasCertifications) {
     check(`${name}: empty payload removes the certifications block`, stripped.includes(certificationsMarker), false);
+  }
+  if (hasCompetencies) {
+    check(`${name}: empty payload removes the competencies block`, stripped.includes(competenciesMarker), false);
   }
   check(`${name}: empty payload removes the awards block`, stripped.includes(awardsMarker), false);
   check(`${name}: the section after awards survives`, stripped.includes(after), true);
@@ -69,6 +78,9 @@ for (const { file, format, after, hasCertifications } of TEMPLATES) {
   check(`${name}: empty education alone keeps projects`, onlyEdu.includes(projectsMarker), true);
   check(`${name}: empty education alone drops education`, onlyEdu.includes(educationMarker), false);
   check(`${name}: empty education alone keeps awards`, onlyEdu.includes(awardsMarker), true);
+  if (hasCompetencies) {
+    check(`${name}: empty education alone keeps competencies`, onlyEdu.includes(competenciesMarker), true);
+  }
   if (hasCertifications) {
     check(`${name}: empty education alone keeps certifications`, onlyEdu.includes(certificationsMarker), true);
 
@@ -89,6 +101,19 @@ for (const { file, format, after, hasCertifications } of TEMPLATES) {
   check(`${name}: empty awards alone keeps the section after it`, onlyAwards.includes(after), true);
   if (hasCertifications) {
     check(`${name}: empty awards alone keeps certifications`, onlyAwards.includes(certificationsMarker), true);
+  }
+
+  // Competencies empty on its own: it is first among the optional sections,
+  // sitting between Professional Summary and Work Experience, so a boundary
+  // slip here would swallow the entire experience section rather than a
+  // trailing one.
+  if (hasCompetencies) {
+    const onlyComp = stripEmptySections(template, { ...FULL, competencies: [] }, format);
+    check(`${name}: empty competencies alone drops competencies`, onlyComp.includes(competenciesMarker), false);
+    check(`${name}: empty competencies alone keeps the work-experience marker`, onlyComp.includes('<!-- WORK EXPERIENCE -->'), true);
+    check(`${name}: empty competencies alone keeps {{EXPERIENCE}}`, onlyComp.includes('{{EXPERIENCE}}'), true);
+    check(`${name}: empty competencies alone keeps projects`, onlyComp.includes(projectsMarker), true);
+    check(`${name}: empty competencies alone keeps awards`, onlyComp.includes(awardsMarker), true);
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

Adds Core Competencies to the shared optional-section stripping (`cv-sections-core.mjs`), so an empty/absent `competencies` payload removes the section instead of rendering a bare "Core Competencies" header. Same mechanism as projects/education/certifications/awards; HTML-only like certifications (no LaTeX marker exists in `cv-template.tex`).

Test coverage extended in `tests/cv-optional-sections.test.mjs`: competencies joins the payload matrix (`hasCompetencies` per template), plus a competencies-empty-alone case — competencies is *first* among the optional sections, sitting between Professional Summary and Work Experience, so a boundary slip here would swallow the experience section rather than a trailing one. The new checks assert `<!-- WORK EXPERIENCE -->` and `{{EXPERIENCE}}` survive the strip.

## Related issue

Closes #2509

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty Core Competencies sections are now automatically removed from CVs.
  * Other populated sections, including work experience and projects, remain unaffected when competencies are empty.

* **Tests**
  * Expanded coverage for CVs with empty, populated, and mixed optional sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->