### PR TITLE
feat(cover): optional letter.signature sign-off block

### DIFF
--- a/generate-cover-letter.mjs
+++ b/generate-cover-letter.mjs
@@ -118,6 +118,26 @@ function buildFootnotesBlock(footnotes) {
   return `<div class="footnotes">\n${lines}\n  </div>`;
 }
 
+/**
+ * Build the optional sign-off block: a valediction over the signing name.
+ *
+ * Accepts either a plain string (used verbatim as the valediction) or an
+ * object `{ valediction, name }`. `name` defaults to the candidate name so a
+ * payload can set only the valediction. Returns "" when unset, which keeps
+ * every pre-existing payload rendering byte-identical.
+ */
+function buildSignatureBlock(signature, candidateName) {
+  if (!signature) return "";
+  const isObject = typeof signature === "object" && signature !== null;
+  const valediction = isObject ? signature.valediction : signature;
+  const name = (isObject ? signature.name : "") || candidateName || "";
+  if (!valediction && !name) return "";
+  // Each value is escaped independently; the <br> separator is template markup
+  // emitted between them, never injected into escaped content.
+  const lines = [valediction, name].filter(Boolean).map(escapeHtml);
+  return `<p class="signature">${lines.join("<br>")}</p>`;
+}
+
 // Resolve the cover-letter template through the shared resolver so a
 // `cover_letter.template` profile default, an explicit `payload.template`, and
 // installed template packs are all honored. Any resolver failure (no profile,
@@ -152,6 +172,12 @@ export function buildHtml(payload, templatePath) {
     : "";
   const problemsBlock = letter.problems_section ? `<p>${escapeHtml(letter.problems_section)}</p>` : "";
 
+  // Optional sign-off (e.g. valediction "Sincerely," over the signing name).
+  // Omitted -> no signature, preserving behavior for payloads that don't set it.
+  // The name falls back to the candidate name so a payload can set only the
+  // valediction. The <br> is emitted around escaped values, never inside one.
+  const signatureBlock = buildSignatureBlock(letter.signature, candidate.name);
+
   const replacements = {
     "{{NAME}}": escapeHtml(candidate.name),
     "{{CONTACT_LINE}}": buildContactLine(candidate),
@@ -165,6 +191,7 @@ export function buildHtml(payload, templatePath) {
     "{{PROBLEMS_BLOCK}}": problemsBlock,
     "{{CLOSING_BLOCK}}": closingBlock,
     "{{LANGUAGE_CLOSING_BLOCK}}": languageClosingBlock,
+    "{{SIGNATURE_BLOCK}}": signatureBlock,
     "{{FOOTNOTES_BLOCK}}": buildFootnotesBlock(letter.footnotes),
   };
 

--- a/templates/cover-letter-template.html
+++ b/templates/cover-letter-template.html
@@ -115,6 +115,11 @@
     margin-bottom: 8pt;
   }
 
+  .signature {
+    margin-top: 12pt;
+    margin-bottom: 8pt;
+  }
+
   .footnotes {
     margin-top: 10pt;
     padding-top: 4pt;
@@ -147,6 +152,7 @@
   {{PROBLEMS_BLOCK}}
   {{CLOSING_BLOCK}}
   {{LANGUAGE_CLOSING_BLOCK}}
+  {{SIGNATURE_BLOCK}}
   {{FOOTNOTES_BLOCK}}
 </body>
 </html>

--- a/tests/cover-letter-signature.test.mjs
+++ b/tests/cover-letter-signature.test.mjs
@@ -1,0 +1,84 @@
+// tests/cover-letter-signature.test.mjs — the optional cover-letter sign-off
+// block (`letter.signature`): a valediction rendered over the signing name.
+//
+// The key is optional and additive: a payload that does not set it must render
+// byte-identical to before the feature existed, so every pre-existing payload
+// is untouched. The value is either a plain string (used as the valediction,
+// name defaulting to the candidate) or `{ valediction, name }`. Both lines are
+// HTML-escaped independently; the <br> separator is template markup emitted
+// between them, never injected into escaped content.
+import { join } from 'path';
+import { pass, fail, ROOT } from './helpers.mjs';
+import { buildHtml } from '../generate-cover-letter.mjs';
+
+console.log('\nCover letter signature block');
+
+// The shipped base template, passed explicitly so an installed template pack
+// or profile default cannot redirect resolution mid-test.
+const TEMPLATE = join(ROOT, 'templates', 'cover-letter-template.html');
+
+const basePayload = {
+  candidate: { name: 'Jane Doe' },
+  letter: {
+    role_title: 'Head of Applied AI',
+    opening: 'CLOSING_MARKER opening sentence.',
+    profile_intro: 'Profile intro.',
+  },
+};
+
+function render(signature) {
+  const letter = { ...basePayload.letter };
+  if (signature !== undefined) letter.signature = signature;
+  return buildHtml({ ...basePayload, letter }, TEMPLATE);
+}
+
+function check(label, actual, expected) {
+  if (actual === expected) pass(label);
+  else fail(`${label} — expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+// --- Backward compatibility: unset key changes nothing ----------------------
+const withoutSignature = render(undefined);
+check('unset signature renders no signature markup',
+  withoutSignature.includes('class="signature"'), false);
+check('unset signature leaves no {{SIGNATURE_BLOCK}} token behind',
+  withoutSignature.includes('{{SIGNATURE_BLOCK}}'), false);
+
+// null and empty string are as unset as an absent key — a payload generator
+// that emits `"signature": null` must not change the output.
+check('null signature renders byte-identical to an absent key',
+  render(null) === withoutSignature, true);
+check('empty-string signature renders byte-identical to an absent key',
+  render('') === withoutSignature, true);
+
+// --- String form: valediction over the candidate name -----------------------
+const stringForm = render('Sincerely,');
+check('string signature renders the valediction over the candidate name',
+  stringForm.includes('<p class="signature">Sincerely,<br>Jane Doe</p>'), true);
+
+// The sign-off belongs at the end of the letter, after the body text.
+const sigIdx = stringForm.indexOf('class="signature"');
+const openingIdx = stringForm.indexOf('CLOSING_MARKER');
+check('signature block renders after the letter body',
+  sigIdx !== -1 && openingIdx !== -1 && sigIdx > openingIdx, true);
+
+// --- Object form ------------------------------------------------------------
+check('object signature renders its own valediction and name',
+  render({ valediction: 'Best regards,', name: 'J. Doe, PhD' })
+    .includes('<p class="signature">Best regards,<br>J. Doe, PhD</p>'), true);
+
+check('object signature without a name falls back to the candidate name',
+  render({ valediction: 'Kind regards,' })
+    .includes('<p class="signature">Kind regards,<br>Jane Doe</p>'), true);
+
+check('object signature with only a name renders the name alone',
+  render({ name: 'J. Doe' }).includes('<p class="signature">J. Doe</p>'), true);
+
+// --- Escaping ---------------------------------------------------------------
+// Both lines pass through escapeHtml; only the <br> the template emits between
+// them may survive as markup.
+const escaped = render({ valediction: 'With <3 & "thanks",', name: "O'Brien <script>" });
+check('valediction and name are HTML-escaped',
+  escaped.includes('With &lt;3 &amp; &quot;thanks&quot;,<br>O&#39;Brien &lt;script&gt;'), true);
+check('unescaped payload markup never reaches the output',
+  escaped.includes('<script>'), false);


### PR DESCRIPTION
## What does this PR do?

Adds an optional `letter.signature` payload key to the cover-letter builder, rendering a sign-off block (valediction over the signing name) at the end of the letter. Accepts a plain string (`"Sincerely,"` → valediction over the candidate name) or `{ valediction, name }` with an explicit signing name; `name` defaults to `candidate.name`. An unset/null/empty key renders byte-identical output, so every pre-existing payload is untouched.

Both lines are HTML-escaped independently; the `<br>` separator is template markup emitted between them, never injected into escaped content.

New discovered test suite `tests/cover-letter-signature.test.mjs` (11 assertions): backward compatibility (unset/null/`""` byte-identical, no leftover `{{SIGNATURE_BLOCK}}` token), string form, object form incl. name fallback and name-only, block position after the letter body, and escaping (`<script>` in payload never reaches output).

## Related issue

Closes #2510

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional signatures to generated cover letters.
  * Supports custom valedictions and names, with automatic fallback to the candidate’s name.
  * Signature content is safely escaped and omitted when not provided.
  * Added signature formatting and placement below the letter body.

* **Bug Fixes**
  * Preserved existing output when no signature is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->