### PR TITLE
fix(invite-match): every non-Latin company returned zero candidates — the script was inert in 8 shipped locales

### DIFF
--- a/invite-match.mjs
+++ b/invite-match.mjs
@@ -108,10 +108,20 @@ const GENERIC_DESCRIPTORS = [
  */
 export function normalizeCompanyName(name) {
   let key = String(name ?? '')
+    // NFKC before folding so full-width and half-width spellings of the same
+    // name compare equal, matching the shared normalizeTextKey() contract.
+    .normalize('NFKC')
     .toLowerCase()
     .replace(/\([^)]*\)/g, ' ')
     .replace(/&/g, ' and ')
-    .replace(/[^a-z0-9 ]/g, ' ')
+    // Letters and digits of ANY script, not just [a-z0-9]: the Latin-only
+    // class DELETED every non-Latin name, so アクメ株式会社 and Яндекс both
+    // produced '' — and matchInvite() bails on an empty key, so pasting an
+    // invite from any company in the ja/ko/zh/zh-TW/ru/ua/ar/hi markets that
+    // modes/ ships returned ZERO candidates even when the row was right
+    // there. Combining marks are kept for the same reason normalizeTextKey
+    // keeps them: Indic matras have no precomposed form (#2517).
+    .replace(/[^\p{L}\p{M}\p{N} ]/gu, ' ')
     .replace(/\s+/g, ' ')
     .trim();
 
@@ -443,28 +453,6 @@ function runSelfTest() {
   check(normalizeCompanyName('Acme (Example Group)') === 'acme', 'drops parenthetical branding');
   check(normalizeCompanyName('Acme & Co') === normalizeCompanyName('Acme and Co'), '"&" normalizes the same as "and"');
   check(normalizeCompanyName('  ACME   ') === 'acme', 'trims and lowercases whitespace-padded input');
-
-  // --- companySimilarity ---
-  check(companySimilarity('acme', 'acme') === 1, 'identical strings score 1');
-  check(companySimilarity('acme example', 'acme') > 0.5, 'substring containment scores high');
-  check(companySimilarity('acme', 'globex') === 0, 'unrelated names score 0');
-  check(companySimilarity('', 'acme') === 0, 'empty string never matches');
-
-  // --- extractCompany ---
-  check(extractCompany('Company: Example Industries\nRole: Analyst') === 'Example Industries', 'extracts from "Company:" line');
-  check(extractCompany('Schedule Your Phone Screen – Acme Opportunity') === 'Acme', 'extracts from generic "Schedule Your Phone Screen" subject');
-  check(extractCompany('Looking forward to interviewing with Example Corp for the role.') === 'Example Corp', 'extracts from "interviewing with X" phrasing');
-  check(extractCompany('no company signal here at all') === null, 'returns null when nothing plausible is found');
-
-  // --- extractDate ---
-  check(extractDate('Interview scheduled for 2026-07-09 at 4pm') === '2026-07-09', 'extracts ISO date');
-  check(extractDate('See you on July 9, 2026') === '2026-07-09', 'extracts named-month date');
-  check(extractDate('no date mentioned') === null, 'returns null when no date is present');
-
-  // --- extractReqId ---
-  check(extractReqId('Req ID: R260013984') === 'R260013984', 'extracts "Req ID:" token');
-  check(extractReqId('Job ID: 43683') === '43683', 'extracts "Job ID:" token');
-  check(extractReqId('no id here') === null, 'returns null when no req-like token is present');
 
   // --- extractPlatform ---
   check(extractPlatform('Join via Zoom: https://us02web.zoom.us/j/1234567890') === 'Zoom', 'detects Zoom from a zoom.us URL');

--- a/invite-match.mjs
+++ b/invite-match.mjs
@@ -454,6 +454,48 @@ function runSelfTest() {
   check(normalizeCompanyName('Acme & Co') === normalizeCompanyName('Acme and Co'), '"&" normalizes the same as "and"');
   check(normalizeCompanyName('  ACME   ') === 'acme', 'trims and lowercases whitespace-padded input');
 
+  // Non-Latin company names must survive the fold (#2517). The Latin-only
+  // [a-z0-9] class deleted them entirely, so every one keyed to '' and
+  // matchInvite's `if (!targetKey) return []` bailed — pasting an invite from
+  // any company in the ja/ko/zh/zh-TW/ru/ua/ar/hi markets modes/ ships
+  // returned ZERO candidates even when the row was right there.
+  check(normalizeCompanyName('アクメ株式会社') === 'アクメ株式会社', 'a Japanese company name survives normalization');
+  check(normalizeCompanyName('Яндекс') === 'яндекс', 'a Cyrillic company name survives normalization and case-folds');
+  check(normalizeCompanyName('北京字节跳动') !== normalizeCompanyName('アクメ株式会社'), 'two different non-Latin companies keep distinct keys');
+  check(normalizeCompanyName('ＡＣＭＥ') === normalizeCompanyName('ACME'), 'NFKC folds full-width to half-width');
+  {
+    const rows = [
+      { num: 1, company: 'アクメ株式会社', role: 'エンジニア', status: 'Applied', notes: '' },
+      { num: 2, company: 'Acme Inc', role: 'Engineer', status: 'Applied', notes: '' },
+    ];
+    const jp = matchInvite({ company: 'アクメ株式会社' }, rows);
+    check(jp.length === 1 && jp[0].appNumber === 1, 'an invite from a non-Latin company matches its own tracker row');
+    const latin = matchInvite({ company: 'Acme Inc' }, rows);
+    check(latin.length === 1 && latin[0].appNumber === 2, 'the Latin path still matches its own row, unchanged');
+  }
+
+  // --- companySimilarity ---
+  check(companySimilarity('acme', 'acme') === 1, 'identical strings score 1');
+  check(companySimilarity('acme example', 'acme') > 0.5, 'substring containment scores high');
+  check(companySimilarity('acme', 'globex') === 0, 'unrelated names score 0');
+  check(companySimilarity('', 'acme') === 0, 'empty string never matches');
+
+  // --- extractCompany ---
+  check(extractCompany('Company: Example Industries\nRole: Analyst') === 'Example Industries', 'extracts from "Company:" line');
+  check(extractCompany('Schedule Your Phone Screen – Acme Opportunity') === 'Acme', 'extracts from generic "Schedule Your Phone Screen" subject');
+  check(extractCompany('Looking forward to interviewing with Example Corp for the role.') === 'Example Corp', 'extracts from "interviewing with X" phrasing');
+  check(extractCompany('no company signal here at all') === null, 'returns null when nothing plausible is found');
+
+  // --- extractDate ---
+  check(extractDate('Interview scheduled for 2026-07-09 at 4pm') === '2026-07-09', 'extracts ISO date');
+  check(extractDate('See you on July 9, 2026') === '2026-07-09', 'extracts named-month date');
+  check(extractDate('no date mentioned') === null, 'returns null when no date is present');
+
+  // --- extractReqId ---
+  check(extractReqId('Req ID: R260013984') === 'R260013984', 'extracts "Req ID:" token');
+  check(extractReqId('Job ID: 43683') === '43683', 'extracts "Job ID:" token');
+  check(extractReqId('no id here') === null, 'returns null when no req-like token is present');
+
   // --- extractPlatform ---
   check(extractPlatform('Join via Zoom: https://us02web.zoom.us/j/1234567890') === 'Zoom', 'detects Zoom from a zoom.us URL');
   check(extractPlatform('Join Microsoft Teams Meeting: https://teams.microsoft.com/l/meetup-join/xyz') === 'Microsoft Teams', 'detects Microsoft Teams from a teams.microsoft.com URL');

--- a/invite-match.mjs
+++ b/invite-match.mjs
@@ -463,6 +463,14 @@ function runSelfTest() {
   check(normalizeCompanyName('Яндекс') === 'яндекс', 'a Cyrillic company name survives normalization and case-folds');
   check(normalizeCompanyName('北京字节跳动') !== normalizeCompanyName('アクメ株式会社'), 'two different non-Latin companies keep distinct keys');
   check(normalizeCompanyName('ＡＣＭＥ') === normalizeCompanyName('ACME'), 'NFKC folds full-width to half-width');
+  // The rest of the shipped non-Latin markets, so coverage isn't just ja/ru.
+  check(normalizeCompanyName('삼성전자') === '삼성전자', 'a Korean company name survives normalization');
+  check(normalizeCompanyName('Київстар') === 'київстар', 'a Ukrainian company name survives normalization and case-folds');
+  check(normalizeCompanyName('شركة النور') === 'شركة النور', 'an Arabic company name survives normalization, spaces intact');
+  check(normalizeCompanyName('हिन्दी टेक') === 'हिन्दी टेक', 'a Devanagari name survives normalization');
+  // The actual \p{M} invariant: names differing ONLY in combining marks must
+  // stay distinct. A mark-stripping fold would collapse these into one company.
+  check(normalizeCompanyName('कंपनी') !== normalizeCompanyName('कपनी'), 'Devanagari names differing only in matras keep distinct keys');
   {
     const rows = [
       { num: 1, company: 'アクメ株式会社', role: 'エンジニア', status: 'Applied', notes: '' },


### PR DESCRIPTION
Closes #2517.

`normalizeCompanyName()` stripped to `[a-z0-9 ]`, deleting every non-Latin company name entirely. `matchInvite()` bails on the resulting empty key:

```js
const targetKey = normalizeCompanyName(signals.company);
if (!targetKey) return [];
```

So pasting an interview invite from any company written in a non-Latin script returned **zero candidates even when its own tracker row was present**:

```
tracker: [ アクメ株式会社 , Acme Inc ]

                        BEFORE   AFTER
invite "アクメ株式会社"      0        1     ← its own row was right there
invite "Acme Inc"           1        1
```

`modes/` ships ja, ko, zh, zh-TW, ru, ua, ar and hi. In all of them this script wasn't degraded, it was **inert** — and it failed by reporting "no match", which a user reads as *"you never applied there"* rather than *"I can't read this name"*.

Third symptom of the root cause behind #2429 (empty key → false **merge**) and #2501 (empty key → false **skip**). Here it's a total miss.

## Fix

Script-preserving character class (`\p{L}\p{M}\p{N}` + space) with NFKC first, matching the shared `normalizeTextKey()` contract. Marks are kept for the same reason it keeps them: Indic matras have no precomposed form.

**Deliberately not delegating to `normalizeTextKey()` wholesale.** This function is stricter on purpose — it strips legal suffixes and keeps spaces so `companySimilarity()` can do token overlap — and its own docstring explains why it differs from the tracker key. Only the character class was wrong.

Latin behaviour is unchanged: `Acme Corp.` and `Acme Technologies Inc.` still both key to `acme`. Full-width `ＡＣＭＥ` now folds to `acme`, which it previously did not — a small consistency gain I'm flagging rather than letting ride.

## Tests

Six assertions covering both scripts and the end-to-end match, plus the Latin path staying put.

`invite-match --self-test` → **54 passed, 0 failed** · `invite-match.test.mjs` → 27/0 · `detect-reposts` (the other `normalizeCompanyName` consumer) → 8/0 and 233/0 · `node test-all.mjs --quick` → **2973 passed, 0 failed**.

2 commits (fix + test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved company-name matching for international names across different writing systems.
  - Added support for full-width characters and combining marks.
  - Prevented distinct company names from being incorrectly treated as identical.
  - Improved matching accuracy against tracker records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->