### PR TITLE
fix(arbeitsagentur): move to the v6 Jobsuche API

### DIFF
--- a/providers/arbeitsagentur.mjs
+++ b/providers/arbeitsagentur.mjs
@@ -20,21 +20,23 @@
 //       size: 100               # results per keyword (1–100, default 100)
 //       remoteNationwide: true  # also run a nationwide pass keeping remote-eligible hits
 //       remoteMatch: filter     # how that pass detects remote (default 'title'):
-//                               #   'filter' — server-side `homeoffice=nv_true` query + pagination, then one
-//                               #              detail call per hit to confirm `homeofficetyp: VOLLSTAENDIG`
-//                               #              (nv_true alone also returns hybrid roles). Recommended.
+//                               #   'filter' — server-side `homeoffice=nv_true` query + pagination to narrow
+//                               #              the set, then the same title check as 'title'. Recommended:
+//                               #              same standard of proof, applied to a far better candidate set.
+//                               #              (v4 confirmed `homeofficetyp: VOLLSTAENDIG` per hit via the
+//                               #              detail endpoint; v6 no longer serves it to this key — #2494.)
 //                               #   'title'  — regex on the job title only (cheap; misses body-level remote)
 //                               #   'off'    — skip the remote pass entirely
 //       remoteMaxPages: 10      # 'filter' mode: max pages to paginate (size each); default 1
 //     enabled: true
 
-const API_URL = 'https://rest.arbeitsagentur.de/jobboerse/jobsuche-service/pc/v4/jobs';
+// v6. The v4 search and detail endpoints both 404 as of 2026-08-04 (#2494);
+// v5 does too. v6 keeps every query parameter this provider sends
+// (was/wo/umkreis/veroeffentlichtseit/angebotsart/homeoffice/page/size) but
+// renames the response fields — see normalizeJob().
+const API_URL = 'https://rest.arbeitsagentur.de/jobboerse/jobsuche-service/pc/v6/jobs';
 const API_KEY = 'jobboerse-jobsuche'; // public client key the arbeitsagentur.de UI uses
 const DETAIL_BASE = 'https://www.arbeitsagentur.de/jobsuche/jobdetail/';
-const DETAIL_API = 'https://rest.arbeitsagentur.de/jobboerse/jobsuche-service/pc/v4/jobdetails/';
-// Verify in small batches so a wide remote pass can't fire hundreds of detail
-// requests at once.
-const VERIFY_BATCH = 5;
 const REMOTE_RE = /(remote|homeoffice|home[-\s]?office|ortsunabh|deutschlandweit|bundesweit|100\s*%|full[-\s]?remote|fully remote)/i;
 
 // Clamp a runtime integer into [min, max], falling back to `def` for NaN, so a
@@ -69,74 +71,71 @@ export function parseArbeitsagenturConfig(entry) {
 }
 
 /**
- * Assembles a human-readable location from the API's `arbeitsort` object. Most
+ * Assembles a human-readable location from v6's `stellenlokationen` array. Most
  * postings are in Germany; only a non-DE country is appended so the downstream
  * location_filter can act on it.
- * @param {any} arbeitsort
+ *
+ * v4 exposed a single `arbeitsort` object whose `region` was a display name, so
+ * it was joined onto the city. v6 nests the address one level deeper and its
+ * `region` is an uppercase federal-state enum (`BADEN_WUERTTEMBERG`), which
+ * would only add noise to a string the commute filter has to match — so the
+ * city stands alone. A posting may list several locations; the downstream shape
+ * is one string, so the first is used, as v4's single field effectively was.
+ * @param {any} lokationen
  */
-export function buildLocation(arbeitsort) {
-  if (!arbeitsort || typeof arbeitsort !== 'object') return '';
-  const loc = [arbeitsort.ort, arbeitsort.region].filter(Boolean).join(', ');
-  const land = arbeitsort.land;
-  if (land && !/deutschland|germany/i.test(land)) return loc ? `${loc}, ${land}` : land;
+export function buildLocation(lokationen) {
+  if (!Array.isArray(lokationen)) return '';
+  const adresse = lokationen[0] && lokationen[0].adresse;
+  if (!adresse || typeof adresse !== 'object') return '';
+  const loc = String(adresse.ort || '').trim();
+  const land = adresse.land;
+  if (land && !/deutschland|germany/i.test(land)) return loc ? `${loc}, ${land}` : String(land);
   return loc;
 }
 
 /**
  * Normalizes one raw Arbeitsagentur posting into a Job plus its `refnr` (kept
  * for dedup, stripped before the provider returns). Returns null when the
- * posting lacks a usable refnr or title.
+ * posting lacks a usable reference number or title.
+ *
+ * v6 renamed every field this reads — `refnr` → `referenznummer`, `titel` →
+ * `stellenangebotsTitel`, `arbeitgeber` → `firma`, `arbeitsort` →
+ * `stellenlokationen[]` (#2494). The public job-detail page still resolves by
+ * reference number, so the outgoing URL is unchanged.
  * @param {any} job
  * @returns {({title: string, url: string, company: string, location: string, refnr: string}) | null}
  */
 export function normalizeJob(job) {
-  const refnr = job && job.refnr;
-  const title = String((job && job.titel) || '').trim();
+  const refnr = job && job.referenznummer;
+  const title = String((job && job.stellenangebotsTitel) || '').trim();
   if (!refnr || !title) return null;
   return {
     title,
     url: DETAIL_BASE + encodeURIComponent(String(refnr)),
-    company: String((job && job.arbeitgeber) || '').trim(),
-    location: buildLocation(job && job.arbeitsort),
+    company: String((job && job.firma) || '').trim(),
+    location: buildLocation(job && job.stellenlokationen),
     refnr: String(refnr),
   };
 }
 
-/**
- * Confirms which of `jobs` are advertised as fully remote.
- *
- * The search response carries no home-office field, and the `homeoffice=nv_true`
- * query only means "home office is possible" — it also matches
- * `homeofficetyp: NACH_VEREINBARUNG` ("nach Absprache"), i.e. an office-anchored
- * hybrid role. Only the detail endpoint exposes `homeofficetyp`, so each
- * candidate is checked there before it may claim to be nationwide-remote.
- *
- * Fails closed: a posting whose lookup errors stays untagged, keeping its real
- * city so the downstream location_filter still applies.
- *
- * @param {Array<{refnr: string}>} jobs
- * @param {{ fetchJson: (url: string, opts?: object) => Promise<any> }} ctx
- * @returns {Promise<Set<string>>} refnrs confirmed `VOLLSTAENDIG`
- */
-export async function verifyFullyRemote(jobs, ctx) {
-  const confirmed = new Set();
-  for (let i = 0; i < jobs.length; i += VERIFY_BATCH) {
-    const batch = jobs.slice(i, i + VERIFY_BATCH);
-    await Promise.all(batch.map(async (job) => {
-      try {
-        const json = await ctx.fetchJson(DETAIL_API + Buffer.from(job.refnr).toString('base64'), {
-          headers: { 'X-API-Key': API_KEY, accept: 'application/json' },
-          redirect: 'error',
-          timeoutMs: 12_000,
-        });
-        if (String((json && json.homeofficetyp) || '') === 'VOLLSTAENDIG') confirmed.add(job.refnr);
-      } catch {
-        // Unverifiable → not confirmed. Never tag on optimism.
-      }
-    }));
-  }
-  return confirmed;
-}
+// What `remoteMatch: 'filter'` lost in the v6 move, and why it still exists.
+//
+// v4 proved a role was fully remote by reading `homeofficetyp: VOLLSTAENDIG`
+// from the detail endpoint, because the `homeoffice=nv_true` query alone also
+// returns `NACH_VEREINBARUNG` ("nach Absprache") — an office-anchored hybrid.
+// That proof is gone: v6's detail endpoint answers 403 to this public client
+// key, and the only home-office field on a v6 search hit is the boolean
+// `homeofficemoeglich`, which is exactly what nv_true already filtered on (a
+// sampled nv_true page was 100% `true`). A boolean that cannot separate
+// fully-remote from hybrid is not evidence.
+//
+// So 'filter' keeps the half that still works — the server-side query narrows
+// the candidate set far better than a nationwide sweep — and falls back to the
+// posting's own title for the proof, the same standard 'title' mode uses. A
+// candidate whose title makes no remote claim keeps its real city, which is the
+// fail-closed behaviour an unverifiable lookup had in v4: the `Deutschlandweit
+// (Homeoffice)` marker exempts a job from the commute location_filter, so
+// tagging on nv_true alone would smuggle every hybrid past it.
 
 /** @type {Provider} */
 export default {
@@ -170,7 +169,7 @@ export default {
         redirect: 'error',
         timeoutMs: 12_000,
       });
-      return Array.isArray(json && json.stellenangebote) ? json.stellenangebote : [];
+      return Array.isArray(json && json.ergebnisliste) ? json.ergebnisliste : [];
     };
 
     const byRef = new Map();
@@ -191,7 +190,9 @@ export default {
       }
       // Pass B (optional): a nationwide pass for remote roles hosted at a far HQ
       // (which the radius pass misses). Detection is config-driven via `remoteMatch`:
-      //   'filter' — server-side `homeoffice=nv_true` query + pagination (every hit is remote)
+      //   'filter' — server-side `homeoffice=nv_true` query + pagination, narrowing
+      //              the candidate set; the title still has to claim remote (see
+      //              the note on what v6 took away, above)
       //   'title'  — keep only nationwide hits whose title matches the remote regex
       // Its failure must NOT discard the primary results already fetched above.
       let wide = [];
@@ -200,7 +201,7 @@ export default {
           if (remoteMatch === 'filter') {
             // Server-side home-office filter: collect the candidates. `nv_true` only
             // means "home office is possible", so these are not yet known to be
-            // remote — verifyFullyRemote() confirms each below before tagging.
+            // remote — the title check below is what decides.
             for (let page = 1; page <= remoteMaxPages; page++) {
               const res = await fetchKeyword(kw, { homeoffice: 'nv_true', page: String(page) });
               wide.push(...res);
@@ -208,7 +209,7 @@ export default {
             }
           } else { // 'title'
             const nationwide = await fetchKeyword(kw);
-            wide = nationwide.filter(j => REMOTE_RE.test(String((j && j.titel) || '')));
+            wide = nationwide.filter(j => REMOTE_RE.test(String((j && j.stellenangebotsTitel) || '')));
           }
         } catch (err) {
           errors.push(`"${kw}" (remote pass): ${(err && err.message) || err}`);
@@ -225,12 +226,11 @@ export default {
       // smuggles an office-anchored hybrid past the distance check, so it may
       // only be applied on evidence:
       //   'title'  — the posting's own title claims remote; take it at face value.
-      //   'filter' — `homeoffice=nv_true` only means "home office possible" and
-      //              also returns NACH_VEREINBARUNG (hybrid) roles, so each
-      //              candidate's `homeofficetyp` is confirmed via the detail
-      //              endpoint. Unconfirmed ones keep their real city.
-      // Dedup by refnr before verifying: paginating a live index can return the same
-      // posting on two pages, and each duplicate would otherwise cost its own detail request.
+      //   'filter' — `homeoffice=nv_true` narrowed the set but only means "home
+      //              office possible", so the title is what proves it. Hits that
+      //              make no such claim keep their real city.
+      // Dedup by refnr first: paginating a live index can return the same posting
+      // on two pages.
       const wideJobs = [...new Map(
         wide
           .map(normalizeJob)
@@ -238,11 +238,8 @@ export default {
           .filter(job => !byRef.has(job.refnr))
           .map(job => [job.refnr, job]),
       ).values()];
-      const fullyRemote = remoteMatch === 'filter' && wideJobs.length
-        ? await verifyFullyRemote(wideJobs, ctx)
-        : null; // null = mode needs no per-job proof
       for (const job of wideJobs) {
-        if (!fullyRemote || fullyRemote.has(job.refnr)) {
+        if (remoteMatch !== 'filter' || REMOTE_RE.test(job.title)) {
           job.location = job.location ? `${job.location} · Deutschlandweit (Homeoffice)` : 'Deutschlandweit (Homeoffice)';
         }
         if (!byRef.has(job.refnr)) byRef.set(job.refnr, job);

--- a/providers/vdab.mjs
+++ b/providers/vdab.mjs
@@ -58,7 +58,8 @@ const DETAIL_BASE = 'https://www.vdab.be/vindeenjob/vacatures/';
 const KEY_RE = /vej-key-monitor","([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})"/i;
 const BUNDLE_RE = /https:\/\/www\.vdab\.be\/webapps\/vindeenjob\/main-[\w-]+\.js/;
 // Batch detail calls so a large detailLimit can't fire dozens of concurrent
-// requests at once (mirrors arbeitsagentur.mjs's VERIFY_BATCH).
+// requests at once. (arbeitsagentur.mjs had the same guard until its detail
+// endpoint stopped answering and the lookups went away entirely — #2494.)
 const DETAIL_BATCH = 5;
 // Real-scan safety cap (mirrors workday.mjs's DEFAULT_MAX_PAGES pattern):
 // fetchKeyword() otherwise only stops on a short page, trusting VDAB's

--- a/tests/providers/arbeitsagentur.test.mjs
+++ b/tests/providers/arbeitsagentur.test.mjs
@@ -1,9 +1,24 @@
 // tests/providers/arbeitsagentur.test.mjs — moved verbatim from test-all.mjs (#1440).
+// Fixtures follow the v6 search shape (#2494): the response list is
+// `ergebnisliste`, and a posting carries `referenznummer` /
+// `stellenangebotsTitel` / `firma` / `stellenlokationen[]`.
 import { pass, fail, ROOT } from '../helpers.mjs';
 import { join } from 'path';
 import { pathToFileURL } from 'url';
 
 console.log('\nProvider — arbeitsagentur');
+
+/** One posting in the v6 search shape. */
+const v6 = (referenznummer, stellenangebotsTitel, ort, extra = {}) => ({
+  referenznummer,
+  stellenangebotsTitel,
+  firma: 'Co',
+  stellenlokationen: [{ adresse: { ort, region: 'BERLIN', land: 'DEUTSCHLAND' } }],
+  ...extra,
+});
+
+/** A v6 search response. */
+const page = (...jobs) => ({ ergebnisliste: jobs });
 
 try {
   const arbeitsagenturModule = await import(pathToFileURL(join(ROOT, 'providers/arbeitsagentur.mjs')).href);
@@ -36,58 +51,76 @@ try {
     fail(`parseArbeitsagenturConfig sanitized = ${JSON.stringify(cfg)}`);
   }
 
-  // buildLocation — ort/region join, non-DE country appended, DE omitted
-  if (buildLocation({ ort: 'Berlin', region: 'Berlin', land: 'Deutschland' }) === 'Berlin, Berlin') {
-    pass('buildLocation joins ort/region and omits Germany');
+  // buildLocation — reads the first entry of the v6 `stellenlokationen` array.
+  // v6's `region` is an uppercase federal-state enum (BADEN_WUERTTEMBERG), not a
+  // display name, so it is deliberately dropped rather than joined onto the city.
+  if (buildLocation([{ adresse: { ort: 'Berlin', region: 'BERLIN', land: 'DEUTSCHLAND' } }]) === 'Berlin') {
+    pass('buildLocation takes the city and omits Germany and the region enum');
   } else {
-    fail(`buildLocation DE = ${JSON.stringify(buildLocation({ ort: 'Berlin', region: 'Berlin', land: 'Deutschland' }))}`);
+    fail(`buildLocation DE = ${JSON.stringify(buildLocation([{ adresse: { ort: 'Berlin', region: 'BERLIN', land: 'DEUTSCHLAND' } }]))}`);
   }
-  if (buildLocation({ ort: 'Wien', land: 'Österreich' }) === 'Wien, Österreich') {
-    pass('buildLocation appends non-DE country');
+  if (buildLocation([{ adresse: { ort: 'Wien', land: 'OESTERREICH' } }]) === 'Wien, OESTERREICH') {
+    pass('buildLocation appends a non-German country');
   } else {
-    fail(`buildLocation non-DE = ${JSON.stringify(buildLocation({ ort: 'Wien', land: 'Österreich' }))}`);
+    fail(`buildLocation non-DE = ${JSON.stringify(buildLocation([{ adresse: { ort: 'Wien', land: 'OESTERREICH' } }]))}`);
   }
-  if (buildLocation(null) === '' && buildLocation('x') === '') pass('buildLocation returns "" for missing/garbage input');
-  else fail('buildLocation should return "" for missing/garbage input');
+  // 11% of a sampled page carried more than one location; the downstream shape is
+  // a single string, so the first is used — matching v4's single `arbeitsort`.
+  if (buildLocation([{ adresse: { ort: 'Hamburg', land: 'DEUTSCHLAND' } }, { adresse: { ort: 'Bremen' } }]) === 'Hamburg') {
+    pass('buildLocation uses the first of several locations');
+  } else {
+    fail(`buildLocation multi = ${JSON.stringify(buildLocation([{ adresse: { ort: 'Hamburg' } }, { adresse: { ort: 'Bremen' } }]))}`);
+  }
+  if (buildLocation(null) === '' && buildLocation('x') === '' && buildLocation([]) === '' && buildLocation([{}]) === '') {
+    pass('buildLocation returns "" for missing/garbage input');
+  } else {
+    fail('buildLocation should return "" for missing/garbage input');
+  }
 
-  // normalizeJob — happy path encodes refnr into the detail URL
-  const norm = normalizeJob({ refnr: '10000-123/4 X', titel: '  ML Engineer  ', arbeitgeber: ' ACME ', arbeitsort: { ort: 'Berlin' } });
+  // normalizeJob — happy path encodes the reference number into the detail URL
+  const norm = normalizeJob(v6('10000-123/4 X', '  ML Engineer  ', 'Berlin', { firma: ' ACME ' }));
   if (norm && norm.title === 'ML Engineer' && norm.company === 'ACME'
       && norm.url === 'https://www.arbeitsagentur.de/jobsuche/jobdetail/' + encodeURIComponent('10000-123/4 X')
       && norm.refnr === '10000-123/4 X') {
-    pass('normalizeJob trims fields and URL-encodes refnr');
+    pass('normalizeJob trims fields and URL-encodes the reference number');
   } else {
     fail(`normalizeJob = ${JSON.stringify(norm)}`);
   }
-  if (normalizeJob({ titel: 'No refnr' }) === null && normalizeJob({ refnr: 'x', titel: '' }) === null) {
-    pass('normalizeJob returns null without a refnr or title');
+  if (normalizeJob({ stellenangebotsTitel: 'No refnr' }) === null && normalizeJob({ referenznummer: 'x', stellenangebotsTitel: '' }) === null) {
+    pass('normalizeJob returns null without a reference number or title');
   } else {
-    fail('normalizeJob should return null when refnr or title is missing');
+    fail('normalizeJob should return null when the reference number or title is missing');
   }
 
   // fetch() — nationwide single-keyword pass, dedup across keywords, header sent
   let sentApiKey = null;
+  let sentUrl = null;
   const mkCtx = (byWas) => ({
     fetchJson: async (url, opts) => {
       sentApiKey = opts?.headers?.['X-API-Key'] ?? sentApiKey;
+      sentUrl = url;
       const was = new URL(url).searchParams.get('was');
-      return { stellenangebote: byWas[was] || [] };
+      return page(...(byWas[was] || []));
     },
   });
   const fetched = await aa.fetch(
     { name: 'AA', arbeitsagentur: { keywords: ['ML', 'NLP'] } },
     mkCtx({
-      ML: [{ refnr: 'A', titel: 'ML Engineer', arbeitgeber: 'Co', arbeitsort: { ort: 'Berlin' } }],
+      ML: [v6('A', 'ML Engineer', 'Berlin')],
       NLP: [
-        { refnr: 'A', titel: 'ML Engineer', arbeitgeber: 'Co', arbeitsort: { ort: 'Berlin' } }, // dup refnr
-        { refnr: 'B', titel: 'NLP Scientist', arbeitgeber: 'Co', arbeitsort: { ort: 'Köln' } },
+        v6('A', 'ML Engineer', 'Berlin'), // dup reference number
+        v6('B', 'NLP Scientist', 'Köln'),
       ],
     }),
   );
-  if (fetched.length === 2 && !('refnr' in fetched[0])) pass('aa.fetch() dedups by refnr and strips refnr from output');
+  if (fetched.length === 2 && !('refnr' in fetched[0])) pass('aa.fetch() dedups by reference number and strips it from output');
   else fail(`aa.fetch() returned ${JSON.stringify(fetched)}`);
   if (sentApiKey === 'jobboerse-jobsuche') pass('aa.fetch() sends the X-API-Key header');
   else fail(`aa.fetch() X-API-Key = ${JSON.stringify(sentApiKey)}`);
+  // The v4 path is gone (404 as of 2026-08-04, #2494); pin the version so a
+  // silent revert can't reintroduce a dead endpoint.
+  if (sentUrl && sentUrl.includes('/pc/v6/jobs')) pass('aa.fetch() queries the v6 jobs endpoint');
+  else fail(`aa.fetch() endpoint = ${JSON.stringify(sentUrl)}`);
 
   // fetch() — remoteNationwide pass keeps only remote-titled wide hits
   let calls = 0;
@@ -99,11 +132,8 @@ try {
         const hasWo = new URL(url).searchParams.has('wo');
         // Pass A (wo set) → local hit; Pass B (no wo) → one remote-titled, one not.
         return hasWo
-          ? { stellenangebote: [{ refnr: 'L', titel: 'ML Engineer', arbeitgeber: 'Co', arbeitsort: { ort: 'Berlin' } }] }
-          : { stellenangebote: [
-              { refnr: 'R', titel: 'ML Engineer (Remote)', arbeitgeber: 'Co', arbeitsort: { ort: 'Hamburg' } },
-              { refnr: 'X', titel: 'Onsite ML Engineer', arbeitgeber: 'Co', arbeitsort: { ort: 'Hamburg' } },
-            ] };
+          ? page(v6('L', 'ML Engineer', 'Berlin'))
+          : page(v6('R', 'ML Engineer (Remote)', 'Hamburg'), v6('X', 'Onsite ML Engineer', 'Hamburg'));
       },
     },
   );
@@ -127,37 +157,28 @@ try {
     fail(`parseArbeitsagenturConfig remote defaults = ${JSON.stringify({ m: rdef.remoteMatch, p: rdef.remoteMaxPages })}`);
   }
 
-  // fetch() — remoteMatch:'filter' uses server-side homeoffice filter, paginates, and tags
-  // only the candidates the detail endpoint confirms as homeofficetyp VOLLSTAENDIG.
-  // `homeoffice=nv_true` also returns NACH_VEREINBARUNG (office-anchored hybrid) roles,
-  // which must keep their real city so the commute location_filter still drops them.
+  // fetch() — remoteMatch:'filter' narrows server-side with homeoffice=nv_true and
+  // paginates, but still requires the posting's own title to claim remote before
+  // tagging it. v6 exposes only a boolean `homeofficemoeglich`, which is exactly
+  // what nv_true already filtered on, so it cannot separate a fully-remote role
+  // from an office-anchored hybrid (#2494). Tagging on nv_true alone would smuggle
+  // hybrids past the commute filter, so unproven candidates keep their real city.
   let usedHomeoffice = false;
   const pagesSeen = new Set();
-  const detailsSeen = [];
-  // R1 München = genuinely remote; R2 Stuttgart = hybrid "nach Absprache"; R3 Köln = lookup fails.
-  const HOMEOFFICETYP = { R1: 'VOLLSTAENDIG', R2: 'NACH_VEREINBARUNG' };
   const filterFetched = await aa.fetch(
     { name: 'AA', arbeitsagentur: { keywords: ['ML'], wo: 'Berlin', remoteNationwide: true, remoteMatch: 'filter', remoteMaxPages: 5, size: 2 } },
     {
       fetchJson: async (url) => {
-        if (url.includes('/jobdetails/')) {
-          const refnr = Buffer.from(url.split('/jobdetails/')[1], 'base64').toString();
-          detailsSeen.push(refnr);
-          if (!(refnr in HOMEOFFICETYP)) throw new Error('HTTP 404'); // unverifiable → must stay untagged
-          return { homeofficetyp: HOMEOFFICETYP[refnr] };
-        }
         const sp = new URL(url).searchParams;
-        if (sp.has('wo')) {
-          return { stellenangebote: [{ refnr: 'L', titel: 'ML Engineer', arbeitgeber: 'Co', arbeitsort: { ort: 'Berlin' } }] };
-        }
+        if (sp.has('wo')) return page(v6('L', 'ML Engineer', 'Berlin'));
         usedHomeoffice = usedHomeoffice || sp.get('homeoffice') === 'nv_true';
         pagesSeen.add(sp.get('page'));
         return Number(sp.get('page')) === 1
-          ? { stellenangebote: [ // full page (== size) → pagination continues
-              { refnr: 'R1', titel: 'ML Engineer', arbeitgeber: 'Co', arbeitsort: { ort: 'München' } },
-              { refnr: 'R2', titel: 'ML Scientist', arbeitgeber: 'Co', arbeitsort: { ort: 'Stuttgart' } },
-            ] }
-          : { stellenangebote: [{ refnr: 'R3', titel: 'NLP Engineer', arbeitgeber: 'Co', arbeitsort: { ort: 'Köln' } }] }; // short → stop
+          ? page( // full page (== size) → pagination continues
+              v6('R1', 'ML Engineer — 100% Remote', 'München', { homeofficemoeglich: true }),
+              v6('R2', 'ML Scientist', 'Stuttgart', { homeofficemoeglich: true }),
+            )
+          : page(v6('R3', 'NLP Engineer (Homeoffice)', 'Köln', { homeofficemoeglich: true })); // short → stop
       },
     },
   );
@@ -166,70 +187,47 @@ try {
   const koeln = filterFetched.find(j => j.url.endsWith('R3'));
   const TAG = /Deutschlandweit \(Homeoffice\)/;
   if (usedHomeoffice && pagesSeen.has('1') && pagesSeen.has('2') && munich && TAG.test(munich.location)) {
-    pass('aa.fetch() remoteMatch:filter sends homeoffice=nv_true, paginates, and tags confirmed VOLLSTAENDIG roles');
+    pass('aa.fetch() remoteMatch:filter sends homeoffice=nv_true, paginates, and tags titles that claim remote');
   } else {
     fail(`aa.fetch() filter mode = ${JSON.stringify({ usedHomeoffice, pages: [...pagesSeen], munichLoc: munich?.location })}`);
   }
   if (stuttgart && !TAG.test(stuttgart.location) && stuttgart.location === 'Stuttgart') {
-    pass('aa.fetch() does not tag NACH_VEREINBARUNG (hybrid) roles as nationwide remote');
+    pass('aa.fetch() leaves a nv_true hit untagged when its title does not claim remote (hybrid stays commute-filtered)');
   } else {
-    fail(`aa.fetch() NACH_VEREINBARUNG role = ${JSON.stringify({ loc: stuttgart?.location })}`);
+    fail(`aa.fetch() unproven nv_true hit = ${JSON.stringify({ loc: stuttgart?.location })}`);
   }
-  if (koeln && !TAG.test(koeln.location) && koeln.location === 'Köln') {
-    pass('aa.fetch() leaves a posting untagged when the homeofficetyp lookup fails');
+  if (koeln && TAG.test(koeln.location)) {
+    pass('aa.fetch() tags remote-titled hits found on later pages');
   } else {
-    fail(`aa.fetch() unverifiable role = ${JSON.stringify({ loc: koeln?.location })}`);
+    fail(`aa.fetch() later-page remote hit = ${JSON.stringify({ loc: koeln?.location })}`);
   }
-  if (detailsSeen.length === 3 && ['R1', 'R2', 'R3'].every(r => detailsSeen.includes(r))) {
-    pass('aa.fetch() verifies homeofficetyp once per remote candidate');
+  // The boolean must never be treated as proof on its own: every fixture above
+  // carries homeofficemoeglich:true, and R2 still has to stay untagged.
+  if (stuttgart && stuttgart.location === 'Stuttgart') {
+    pass('aa.fetch() never tags on homeofficemoeglich alone');
   } else {
-    fail(`aa.fetch() detail lookups = ${JSON.stringify(detailsSeen)}`);
+    fail(`aa.fetch() tagged on the boolean alone: ${JSON.stringify({ loc: stuttgart?.location })}`);
   }
 
-  // fetch() — the detail lookups must stay batched (VERIFY_BATCH = 5). With more
-  // candidates than one batch, peak in-flight requests must never exceed the cap,
-  // and a duplicate refnr across pagination pages must not cost a second lookup.
-  // Both would pass silently under an unbounded Promise.all / an un-deduped list.
-  let inFlight = 0;
-  let peakInFlight = 0;
-  const detailCalls = [];
+  // fetch() — a duplicate reference number across pagination pages is kept once.
   const wideRefs = ['W1', 'W2', 'W3', 'W4', 'W5', 'W6', 'W7'];
   const batchFetched = await aa.fetch(
     { name: 'AA', arbeitsagentur: { keywords: ['ML'], wo: 'Berlin', remoteNationwide: true, remoteMatch: 'filter', remoteMaxPages: 5, size: 7 } },
     {
       fetchJson: async (url) => {
-        if (url.includes('/jobdetails/')) {
-          const refnr = Buffer.from(url.split('/jobdetails/')[1], 'base64').toString();
-          detailCalls.push(refnr);
-          inFlight++;
-          peakInFlight = Math.max(peakInFlight, inFlight);
-          await new Promise(r => setTimeout(r, 5)); // hold the slot so overlap is observable
-          inFlight--;
-          return { homeofficetyp: 'VOLLSTAENDIG' };
-        }
         const sp = new URL(url).searchParams;
-        if (sp.has('wo')) return { stellenangebote: [] };
+        if (sp.has('wo')) return page();
         // Page 1 is full (== size) so pagination continues; W1 repeats on page 2.
         return Number(sp.get('page')) === 1
-          ? { stellenangebote: wideRefs.map(r => ({ refnr: r, titel: 'ML Engineer', arbeitgeber: 'Co', arbeitsort: { ort: 'München' } })) }
-          : { stellenangebote: [{ refnr: 'W1', titel: 'ML Engineer', arbeitgeber: 'Co', arbeitsort: { ort: 'München' } }] };
+          ? page(...wideRefs.map(r => v6(r, 'ML Engineer (Remote)', 'München')))
+          : page(v6('W1', 'ML Engineer (Remote)', 'München'));
       },
     },
   );
-  if (peakInFlight > 0 && peakInFlight <= 5) {
-    pass(`aa.fetch() caps concurrent homeofficetyp lookups at VERIFY_BATCH (peak ${peakInFlight})`);
+  if (batchFetched.length === wideRefs.length && batchFetched.every(j => TAG.test(j.location))) {
+    pass('aa.fetch() keeps each duplicated reference number once and tags every proven candidate');
   } else {
-    fail(`aa.fetch() peak in-flight detail requests = ${peakInFlight} (expected 1..5)`);
-  }
-  if (detailCalls.length === wideRefs.length && new Set(detailCalls).size === wideRefs.length) {
-    pass('aa.fetch() verifies each duplicated refnr only once');
-  } else {
-    fail(`aa.fetch() detail calls = ${detailCalls.length} (${JSON.stringify(detailCalls)}), expected ${wideRefs.length} unique`);
-  }
-  if (batchFetched.length === wideRefs.length && batchFetched.every(j => /Deutschlandweit \(Homeoffice\)/.test(j.location))) {
-    pass('aa.fetch() tags every confirmed VOLLSTAENDIG candidate across batches');
-  } else {
-    fail(`aa.fetch() batched tagging = ${JSON.stringify(batchFetched.map(j => j.location))}`);
+    fail(`aa.fetch() paginated tagging = ${JSON.stringify(batchFetched.map(j => j.location))}`);
   }
 
   // fetch() — no keywords throws; total outage throws (not silent)
@@ -254,7 +252,7 @@ try {
       { name: 'AA', arbeitsagentur: { keywords: ['OK', 'BAD'] } },
       { fetchJson: async (url) => {
           if (new URL(url).searchParams.get('was') === 'BAD') throw new Error('HTTP 503');
-          return { stellenangebote: [] }; // OK answers, just empty
+          return page(); // OK answers, just empty
         } },
     );
   } catch { partialThrew = true; }
@@ -269,9 +267,7 @@ try {
     { name: 'AA', arbeitsagentur: { keywords: ['ML'], wo: 'Berlin', remoteNationwide: true } },
     { fetchJson: async (url) => {
         // Pass A (wo set) returns a job; Pass B (no wo) throws.
-        if (new URL(url).searchParams.has('wo')) {
-          return { stellenangebote: [{ refnr: 'L', titel: 'ML Engineer', arbeitgeber: 'Co', arbeitsort: { ort: 'Berlin' } }] };
-        }
+        if (new URL(url).searchParams.has('wo')) return page(v6('L', 'ML Engineer', 'Berlin'));
         throw new Error('HTTP 503');
       } },
   );
@@ -284,4 +280,3 @@ try {
 } catch (e) {
   fail(`arbeitsagentur provider tests crashed: ${e.message}`);
 }
-


### PR DESCRIPTION
## What does this PR do?

Moves the Arbeitsagentur provider from the withdrawn v4 Jobsuche API to v6, remapping the renamed response fields. Also narrows `remoteMatch: 'filter'`, whose per-candidate proof no longer exists in v6 — see the trade-off below, it is the one judgement call here.

## Related issue

Fixes #2494

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## The query side is fine; the response side is not

@gowrishacv's report stops at v5, so the first thing worth adding is that **v6 answers**:

| endpoint | status |
|---|---|
| `/pc/v4/jobs` | 404 |
| `/pc/v4/app/jobs` | 404 |
| `/pc/v5/app/jobs` | 404 |
| **`/pc/v6/jobs`** | **200** |

v6 accepts every parameter this provider already sends — `was`, `wo`, `umkreis`, `veroeffentlichtseit`, `angebotsart`, `homeoffice`, `page`, `size` — all 200. So the query builder is untouched.

The response shape changed:

| v4 | v6 |
|---|---|
| `stellenangebote[]` | `ergebnisliste[]` |
| `refnr` | `referenznummer` |
| `titel` | `stellenangebotsTitel` |
| `arbeitgeber` | `firma` |
| `arbeitsort` (object) | `stellenlokationen[]` → `[0].adresse` |

The public job-detail page still resolves by reference number, so outgoing URLs are unchanged.

**One deliberate behaviour change in the location string:** v4's `region` was a display name and was joined onto the city (`Berlin, Berlin`). In v6 it is an uppercase federal-state enum, so the same join yields `Stuttgart, BADEN_WUERTTEMBERG` — noise in a string `scan.mjs`'s commute filter has to match. The city now stands alone. Postings can carry several locations (11 of 100 in a sampled page); the first is used, as v4's single field effectively was.

## The trade-off: `remoteMatch: 'filter'` lost its proof

This is the part I'd most like your read on.

`'filter'` used to query `homeoffice=nv_true` and then confirm each hit's `homeofficetyp: VOLLSTAENDIG` through the detail endpoint — because `nv_true` alone also returns `NACH_VEREINBARUNG`, an office-anchored hybrid. In v6 that proof is unavailable:

- the detail endpoint answers **403** to this public client key (`/pc/v6/jobdetails/<refnr>`), and v4's is 404;
- the only home-office field on a v6 search hit is the boolean `homeofficemoeglich`, which is exactly what `nv_true` filtered on — **a sampled `nv_true` page came back 100% `true`**. It cannot separate fully-remote from hybrid.

Rather than tag on the boolean, `'filter'` now keeps the server-side narrowing and applies **the same title check `'title'` mode uses**. A candidate whose title makes no remote claim keeps its real city — the same fail-closed outcome an unverifiable lookup had in v4. That matters because the `Deutschlandweit (Homeoffice)` marker exempts a job from the commute filter, so tagging on `nv_true` alone would smuggle every hybrid past it, which is the exact defect #1981 fixed.

Net effect: `'filter'` is now `'title'` applied to a better candidate set, not a stronger standard of proof. If you'd rather it hard-fail, or fall back to `'title'` with a warning, or be removed until an authenticated detail route is available, say which and I'll change it — I picked the option that keeps existing `portals.yml` configs working without weakening the tagging rule.

## Validation

- `node test-all.mjs` → **2974 passed, 0 failed** (2 pre-existing environment warnings: no user data, no Playwright browser).
- Provider tests rewritten onto v6 fixtures, including a case pinning `/pc/v6/jobs` in the request URL so a silent revert can't reintroduce a dead endpoint, and one asserting an `homeofficemoeglich: true` hit still goes untagged when its title makes no remote claim.
- The detail-batching tests went with the lookups they covered; the dedup-across-pagination case they also exercised is kept.
- **End-to-end against the live API** (`keywords: ['Machine Learning Engineer'], wo: Berlin, umkreis: 50, remoteMatch: 'filter'`):

```
total: 10
  Data Engineer* / Machine Learning Engineer*
    inovex GmbH | Berlin
    https://www.arbeitsagentur.de/jobsuche/jobdetail/16752-r5446-S
  Machine Learning Engineer (all genders)
    Parship | Berlin
    https://www.arbeitsagentur.de/jobsuche/jobdetail/13644-308449-S
  Principal Machine Learning Scientist (alle Geschlechter)
    Bayer AG Pharmaceuticals | Berlin
    https://www.arbeitsagentur.de/jobsuche/jobdetail/12708-1575645-1-S
tagged nationwide-remote: 0
```

Real titles, employers, cities and resolvable detail URLs. `tagged 0` is the conservative path working as intended — none of that batch's `nv_true` candidates claimed remote in the title.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fix — exempt, and #2494 exists)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (system layer only: `providers/`, `tests/`)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

<sub>One unrelated line: `providers/vdab.mjs`'s batching comment cross-referenced `arbeitsagentur.mjs`'s `VERIFY_BATCH`, which this PR deletes. Reworded so it doesn't point at something that no longer exists.</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated Arbeitsagentur job listings to use the latest API format.
  * Improved display of job titles, companies, reference numbers, and locations.
  * Enhanced search result handling, pagination, and duplicate prevention.
  * Remote-job filtering now requires a remote-work indication in the job title; other listings retain their actual location.
* **Documentation**
  * Updated configuration guidance to reflect the latest Arbeitsagentur API behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->