### PR TITLE
feat(providers): add join.com SSR __NEXT_DATA__ parser

### DIFF
--- a/docs/SUPPORTED_JOB_BOARDS.md
+++ b/docs/SUPPORTED_JOB_BOARDS.md
@@ -38,6 +38,7 @@ are shared helpers and are not loaded as providers.
 | Jobicy | API | Reads the board-wide `https://jobicy.com/api/v2/remote-jobs?count=50` JSON feed (remote-jobs aggregator). Configure with `provider: jobicy` in a `job_boards:` entry. |
 | Jobspresso | RSS | Reads the public WordPress `https://jobspresso.co/?feed=job_feed` XML job feed and parses it in-process. Configure with `provider: jobspresso` in a `job_boards:` entry. |
 | Jobstreet / SEEK | API | Uses the public SEEK chalice-search JSON API for Jobstreet and SEEK sites. Configure explicitly with `provider: jobstreet`. |
+| join.com | Parser | Auto-detects `join.com/companies/<slug>` careers URLs and parses the `__NEXT_DATA__` JSON embedded in the server-rendered HTML (no separate API). Paginates `?page=N` up to the page's own reported `pagination.pageCount`. |
 | JustJoin.it | API | Auto-detects `justjoin.it/job-offers/...` URLs and reads the public `justjoin.it/api/candidate-api/offers` API (Polish/EU tech board); paginates up to `max_pages` (default 50). |
 | Landing.jobs | API | Reads the board-wide `https://landing.jobs/api/v1/jobs` JSON feed (tech, Europe). Configure with `provider: landingjobs`; company is derived from the posting URL slug. |
 | LaraJobs | RSS | Reads the board-wide `https://larajobs.com/feed` RSS feed (Laravel / PHP jobs) and parses it in-process. Configure with `provider: larajobs`; company and location come from the feed's `job:` namespace. |

--- a/docs/SUPPORTED_JOB_BOARDS.md
+++ b/docs/SUPPORTED_JOB_BOARDS.md
@@ -38,7 +38,7 @@ are shared helpers and are not loaded as providers.
 | Jobicy | API | Reads the board-wide `https://jobicy.com/api/v2/remote-jobs?count=50` JSON feed (remote-jobs aggregator). Configure with `provider: jobicy` in a `job_boards:` entry. |
 | Jobspresso | RSS | Reads the public WordPress `https://jobspresso.co/?feed=job_feed` XML job feed and parses it in-process. Configure with `provider: jobspresso` in a `job_boards:` entry. |
 | Jobstreet / SEEK | API | Uses the public SEEK chalice-search JSON API for Jobstreet and SEEK sites. Configure explicitly with `provider: jobstreet`. |
-| join.com | Parser | Auto-detects `join.com/companies/<slug>` careers URLs and parses the `__NEXT_DATA__` JSON embedded in the server-rendered HTML (no separate API). Paginates `?page=N` up to the page's own reported `pagination.pageCount`. |
+| join.com | Parser | Auto-detects `join.com/companies/<slug>` careers URLs and parses the `__NEXT_DATA__` JSON embedded in the server-rendered HTML (no separate API). Paginates `?page=N` up to `max_pages` (default 50), warning if a tenant's postings exceed the cap. |
 | JustJoin.it | API | Auto-detects `justjoin.it/job-offers/...` URLs and reads the public `justjoin.it/api/candidate-api/offers` API (Polish/EU tech board); paginates up to `max_pages` (default 50). |
 | Landing.jobs | API | Reads the board-wide `https://landing.jobs/api/v1/jobs` JSON feed (tech, Europe). Configure with `provider: landingjobs`; company is derived from the posting URL slug. |
 | LaraJobs | RSS | Reads the board-wide `https://larajobs.com/feed` RSS feed (Laravel / PHP jobs) and parses it in-process. Configure with `provider: larajobs`; company and location come from the feed's `job:` namespace. |

--- a/providers/join.mjs
+++ b/providers/join.mjs
@@ -5,6 +5,24 @@
 // Auto-detects from careers_url matching join.com/companies/<slug>.
 // No API key needed — data is SSR-rendered in the page HTML.
 
+// Safety cap on pagination — applied regardless of what the page's own
+// __NEXT_DATA__ reports as pagination.pageCount, so a board that grows (or a
+// payload that reports a wrong pageCount) can't drive this into an unbounded
+// fetch loop; nothing wraps the provider call with a timeout of its own.
+// Every known tenant is a single company's careers page, so 50 pages is
+// generous headroom; override with `max_pages` on the portal entry for a
+// tenant that genuinely exceeds it.
+const DEFAULT_MAX_PAGES = 50;
+// Hard ceiling even for an explicit override.
+const MAX_PAGES_CAP = 200;
+
+/** Resolve the page cap: a positive integer `max_pages` on the entry, capped. */
+function resolveMaxPages(entry) {
+  const v = entry?.max_pages;
+  if (Number.isInteger(v) && v > 0) return Math.min(v, MAX_PAGES_CAP);
+  return DEFAULT_MAX_PAGES;
+}
+
 export function extractSlug(url) {
   let parsed;
   try { parsed = new URL(url || ''); } catch { return null; }
@@ -50,10 +68,14 @@ export default {
     // Honor a context page cap — verify-portals' liveness probe sets
     // `ctx.maxPages: 1` so it only needs to know a board is live, not its
     // full count (mirrors providers/workday.mjs). No effect on real scans,
-    // which don't set ctx.maxPages.
+    // which don't set ctx.maxPages. Kept separate from `maxPages` below so
+    // the "raise max_pages" warning only fires when the entry-level cap is
+    // what actually truncated the board, not the health-check probe.
     const ctxMaxPages = Number(ctx?.maxPages);
     const ctxCap = ctxMaxPages > 0 ? ctxMaxPages : Infinity;
-    const pageCount = Math.min(state.jobs?.pagination?.pageCount || 0, ctxCap);
+    const reportedPageCount = state.jobs?.pagination?.pageCount || 0;
+    const maxPages = resolveMaxPages(entry);
+    const pageCount = Math.min(reportedPageCount, maxPages, ctxCap);
     for (let page = 2; page <= pageCount; page++) {
       const html = await ctx.fetchText(`${baseUrl}?page=${page}`, { redirect: 'error' });
       const data = extractNextData(html);
@@ -62,6 +84,9 @@ export default {
       const pageItems = pageState.jobs?.items;
       if (!Array.isArray(pageItems)) throw new Error('join: __NEXT_DATA__ not found or unexpected structure');
       allItems.push(...pageItems);
+    }
+    if (pageCount === maxPages && reportedPageCount > maxPages && ctxCap === Infinity) {
+      console.error(`⚠️  join: ${entry.name} truncated at max_pages=${maxPages} of ${reportedPageCount} reported pages — raise max_pages on this entry for more`);
     }
 
     const companySlug = state.company?.domain || slug;

--- a/providers/join.mjs
+++ b/providers/join.mjs
@@ -1,0 +1,75 @@
+// @ts-check
+/** @typedef {import('./_types.js').Provider} Provider */
+
+// join.com provider — reads jobs from Next.js __NEXT_DATA__ embedded in HTML.
+// Auto-detects from careers_url matching join.com/companies/<slug>.
+// No API key needed — data is SSR-rendered in the page HTML.
+
+export function extractSlug(url) {
+  let parsed;
+  try { parsed = new URL(url || ''); } catch { return null; }
+  if (parsed.hostname.toLowerCase() !== 'join.com') return null;
+  const match = parsed.pathname.match(/^\/companies\/([^/?#]+)/);
+  return match?.[1] || null;
+}
+
+export function extractNextData(html) {
+  if (typeof html !== 'string') return null;
+  const match = html.match(/<script[^>]+__NEXT_DATA__[^>]*>([\s\S]*?)<\/script>/);
+  if (!match) return null;
+  try { return JSON.parse(match[1]); } catch { return null; }
+}
+
+/** @type {Provider} */
+export default {
+  id: 'join',
+
+  detect(entry) {
+    return extractSlug(entry.careers_url) ? { url: entry.careers_url } : null;
+  },
+
+  async fetch(entry, ctx) {
+    const slug = extractSlug(entry.careers_url);
+    if (!slug) throw new Error('join: cannot extract slug from careers_url');
+
+    const baseUrl = `https://join.com/companies/${slug}`;
+    const allItems = [];
+
+    // redirect:'error' prevents SSRF via server-side redirects; baseUrl is
+    // always reconstructed as https://join.com/... so the host is pinned
+    // regardless of the original careers_url.
+    const firstHtml = await ctx.fetchText(baseUrl, { redirect: 'error' });
+    const firstData = extractNextData(firstHtml);
+    const state = firstData?.props?.pageProps?.initialState;
+    if (!state) throw new Error('join: __NEXT_DATA__ not found or unexpected structure');
+
+    const firstJobs = state.jobs?.items;
+    if (!Array.isArray(firstJobs)) throw new Error('join: __NEXT_DATA__ not found or unexpected structure');
+    allItems.push(...firstJobs);
+
+    // Honor a context page cap — verify-portals' liveness probe sets
+    // `ctx.maxPages: 1` so it only needs to know a board is live, not its
+    // full count (mirrors providers/workday.mjs). No effect on real scans,
+    // which don't set ctx.maxPages.
+    const ctxMaxPages = Number(ctx?.maxPages);
+    const ctxCap = ctxMaxPages > 0 ? ctxMaxPages : Infinity;
+    const pageCount = Math.min(state.jobs?.pagination?.pageCount || 0, ctxCap);
+    for (let page = 2; page <= pageCount; page++) {
+      const html = await ctx.fetchText(`${baseUrl}?page=${page}`, { redirect: 'error' });
+      const data = extractNextData(html);
+      const pageState = data?.props?.pageProps?.initialState;
+      if (!pageState) throw new Error('join: __NEXT_DATA__ not found or unexpected structure');
+      const pageItems = pageState.jobs?.items;
+      if (!Array.isArray(pageItems)) throw new Error('join: __NEXT_DATA__ not found or unexpected structure');
+      allItems.push(...pageItems);
+    }
+
+    const companySlug = state.company?.domain || slug;
+    return allItems.map(j => ({
+      title: j.title || '',
+      url: `https://join.com/companies/${companySlug}/jobs/${j.idParam}`,
+      company: entry.name,
+      location: j.city?.cityName || '',
+    }));
+  },
+};

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -636,6 +636,7 @@ search_queries:
 #                   (Oracle Recruiting Cloud / Fusion CX — JPMorgan, Oracle, BNY, Amex, Honeywell; siteNumber
 #                   auto-derived from the URL, override with provider: oraclecloud + siteNumber: / optional locationId:)
 #   gem             jobs.gem.com/<boardId>
+#   join            join.com/companies/<slug>  (SSR __NEXT_DATA__ parse, no separate API)
 #
 # When the public careers URL is a branded custom domain (e.g.
 # careers.adyen.com), set `provider: smartrecruiters` explicitly to
@@ -746,6 +747,13 @@ search_queries:
 #   # division path is required; one of:
 #   # it, engineering, marketing, sales, hr, logistics, finances, other
 #   careers_url: https://solid.jobs/public-api/offers/engineering
+#   enabled: true
+#
+# - name: Example join.com Co
+#   # join.com career page. Auto-detects any join.com/companies/<slug> URL and
+#   # parses the __NEXT_DATA__ JSON embedded in the server-rendered HTML — no
+#   # separate API. Pagination follows the page's own reported pageCount.
+#   careers_url: https://join.com/companies/exampleco
 #   enabled: true
 #
 # -- Job boards / aggregators (no careers_url; set provider: explicitly) --

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -752,8 +752,11 @@ search_queries:
 # - name: Example join.com Co
 #   # join.com career page. Auto-detects any join.com/companies/<slug> URL and
 #   # parses the __NEXT_DATA__ JSON embedded in the server-rendered HTML — no
-#   # separate API. Pagination follows the page's own reported pageCount.
+#   # separate API.
 #   careers_url: https://join.com/companies/exampleco
+#   max_pages: 50           # optional page cap (default 50, max 200) — raise it
+#                            # for a tenant with 50+ pages of postings (a warning
+#                            # is logged if the cap truncates real results)
 #   enabled: true
 #
 # -- Job boards / aggregators (no careers_url; set provider: explicitly) --

--- a/tests/providers/join.test.mjs
+++ b/tests/providers/join.test.mjs
@@ -1,0 +1,190 @@
+// tests/providers/join.test.mjs — join.com __NEXT_DATA__ SSR parser.
+import { pass, fail, ROOT } from '../helpers.mjs';
+import { join as joinPath } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nProvider — join (join.com __NEXT_DATA__ SSR parser)');
+try {
+  const joinModule = await import(pathToFileURL(joinPath(ROOT, 'providers/join.mjs')).href);
+  const joinProvider = joinModule.default;
+  const { extractSlug, extractNextData } = joinModule;
+
+  if (joinProvider.id === 'join') pass('join.id is "join"');
+  else fail(`join.id is ${JSON.stringify(joinProvider.id)}`);
+
+  // extractSlug — anchored to the literal join.com host and /companies/<slug> path.
+  if (extractSlug('https://join.com/companies/acme-corp') === 'acme-corp') {
+    pass('join.extractSlug() extracts the slug from join.com/companies/<slug>');
+  } else {
+    fail(`join.extractSlug() wrong: ${JSON.stringify(extractSlug('https://join.com/companies/acme-corp'))}`);
+  }
+  if (extractSlug('https://join.com.evil.com/companies/acme-corp') === null && extractSlug('https://evil.com/join.com/companies/acme-corp') === null) {
+    pass('join.extractSlug() rejects spoofed hosts (not the literal join.com hostname)');
+  } else {
+    fail('join.extractSlug() should reject spoofed hosts');
+  }
+  if (extractSlug('not a url') === null && extractSlug(undefined) === null) pass('join.extractSlug() returns null for invalid/missing input');
+  else fail('join.extractSlug() should return null for invalid/missing input');
+
+  // detect() — auto-detects from a valid join.com careers_url.
+  const hit = joinProvider.detect({ careers_url: 'https://join.com/companies/acme-corp' });
+  if (hit && hit.url === 'https://join.com/companies/acme-corp') pass('join.detect() resolves a join.com careers_url');
+  else fail(`join.detect() wrong: ${JSON.stringify(hit)}`);
+  if (joinProvider.detect({ careers_url: 'https://example.com/careers' }) === null) pass('join.detect() returns null for non-join.com URLs');
+  else fail('join.detect() should return null for non-join.com URLs');
+
+  // extractNextData — pulls and parses the __NEXT_DATA__ JSON blob.
+  const nextDataHtml = (jobs, pageCount) =>
+    `<html><body><script id="__NEXT_DATA__" type="application/json">${JSON.stringify({
+      props: { pageProps: { initialState: { company: { domain: 'acme-corp' }, jobs: { items: jobs, pagination: { pageCount } } } } },
+    })}</script></body></html>`;
+  const data = extractNextData(nextDataHtml([{ title: 'X', idParam: '1', city: { cityName: 'Berlin' } }], 1));
+  if (data?.props?.pageProps?.initialState?.jobs?.items?.length === 1) pass('join.extractNextData() parses the embedded __NEXT_DATA__ JSON');
+  else fail(`join.extractNextData() wrong: ${JSON.stringify(data)}`);
+  if (extractNextData('<html>no script here</html>') === null) pass('join.extractNextData() returns null when the script tag is absent');
+  else fail('join.extractNextData() should return null without a __NEXT_DATA__ script');
+  if (extractNextData('<html><script id="__NEXT_DATA__">not json</script></html>') === null) {
+    pass('join.extractNextData() returns null on malformed JSON');
+  } else {
+    fail('join.extractNextData() should return null on malformed JSON');
+  }
+  if (extractNextData(undefined) === null && extractNextData(null) === null && extractNextData(42) === null) {
+    pass('join.extractNextData() returns null for non-string input instead of throwing');
+  } else {
+    fail('join.extractNextData() should return null for non-string input');
+  }
+
+  // fetch() — single page, maps items to the normalized job shape.
+  const entry = { name: 'Acme', careers_url: 'https://join.com/companies/acme-corp' };
+  let singleCalls = 0;
+  const singleCtx = {
+    fetchText: async () => {
+      singleCalls++;
+      return nextDataHtml([{ title: 'Senior AI Engineer', idParam: 'abc123', city: { cityName: 'Remote' } }], 1);
+    },
+  };
+  const singleJobs = await joinProvider.fetch(entry, singleCtx);
+  if (
+    singleCalls === 1 &&
+    singleJobs.length === 1 &&
+    singleJobs[0].title === 'Senior AI Engineer' &&
+    singleJobs[0].url === 'https://join.com/companies/acme-corp/jobs/abc123' &&
+    singleJobs[0].location === 'Remote'
+  ) {
+    pass('join.fetch() maps a single page of items to the normalized job shape');
+  } else {
+    fail(`join.fetch() single-page wrong: ${JSON.stringify(singleJobs)} after ${singleCalls} calls`);
+  }
+
+  // fetch() — paginates via ?page=N while pageCount > 1.
+  const pages = [nextDataHtml([{ title: 'Job 1', idParam: '1', city: {} }], 2), nextDataHtml([{ title: 'Job 2', idParam: '2', city: {} }], 2)];
+  let pagedCalls = 0;
+  const seenUrls = [];
+  const pagedCtx = {
+    fetchText: async (url) => {
+      seenUrls.push(url);
+      return pages[pagedCalls++];
+    },
+  };
+  const pagedJobs = await joinProvider.fetch(entry, pagedCtx);
+  if (pagedJobs.length === 2 && pagedCalls === 2 && seenUrls[1] === 'https://join.com/companies/acme-corp?page=2') {
+    pass('join.fetch() paginates via ?page=N while pagination.pageCount > 1');
+  } else {
+    fail(`join.fetch() pagination wrong: ${JSON.stringify(seenUrls)}, ${pagedJobs.length} jobs`);
+  }
+
+  // fetch() — passes redirect:'error' on every request (SSRF hardening).
+  let redirectCalls = [];
+  let redirectPagedCalls = 0;
+  const redirectCtx = {
+    fetchText: async (url, opts) => {
+      redirectCalls.push(opts?.redirect);
+      return pages[redirectPagedCalls++];
+    },
+  };
+  await joinProvider.fetch(entry, redirectCtx);
+  if (redirectCalls.length === 2 && redirectCalls.every((r) => r === 'error')) {
+    pass('join.fetch() passes redirect:"error" on the first request and every paginated request');
+  } else {
+    fail(`join.fetch() redirect opts wrong: ${JSON.stringify(redirectCalls)}`);
+  }
+
+  // fetch() — honors ctx.maxPages (verify-portals' liveness probe passes 1)
+  // so a health check never crawls a tenant's full multi-page board.
+  let cappedCalls = 0;
+  const cappedCtx = {
+    maxPages: 1,
+    fetchText: async () => {
+      cappedCalls++;
+      return nextDataHtml([{ title: 'Job 1', idParam: '1', city: {} }], 2);
+    },
+  };
+  const cappedJobs = await joinProvider.fetch(entry, cappedCtx);
+  if (cappedCalls === 1 && cappedJobs.length === 1) {
+    pass('join.fetch() honors ctx.maxPages and stops after the first page even when pageCount is higher');
+  } else {
+    fail(`join.fetch() ctx.maxPages wrong: calls=${cappedCalls}, jobs=${cappedJobs.length}`);
+  }
+
+  // fetch() — missing/unexpected __NEXT_DATA__ structure throws instead of
+  // silently returning an empty list (so a scan doesn't mistake a parse
+  // failure for a genuinely empty board).
+  let throwErrored = false;
+  try {
+    await joinProvider.fetch(entry, { fetchText: async () => '<html>no next data</html>' });
+  } catch {
+    throwErrored = true;
+  }
+  if (throwErrored) pass('join.fetch() throws when __NEXT_DATA__ is missing or has an unexpected shape');
+  else fail('join.fetch() should throw on missing/unexpected __NEXT_DATA__');
+
+  // fetch() — a valid first page followed by a broken second page must throw,
+  // not silently treat the second page as empty (that would mask a parse
+  // failure as a genuinely short board).
+  const brokenPagePages = [nextDataHtml([{ title: 'Job 1', idParam: '1', city: {} }], 2), '<html>no next data on page 2</html>'];
+  let brokenPageCalls = 0;
+  const brokenPageCtx = { fetchText: async () => brokenPagePages[brokenPageCalls++] };
+  let brokenPageErrored = false;
+  try {
+    await joinProvider.fetch(entry, brokenPageCtx);
+  } catch {
+    brokenPageErrored = true;
+  }
+  if (brokenPageErrored) pass('join.fetch() throws when a paginated (non-first) page has missing/unexpected __NEXT_DATA__');
+  else fail('join.fetch() should throw when a later page has missing/unexpected __NEXT_DATA__, not swallow it as empty');
+
+  // fetch() — jobs.items present but not an array (first page) must throw,
+  // not silently spread garbage or crash with a raw TypeError.
+  let nonArrayFirstPageErrored = false;
+  try {
+    await joinProvider.fetch(entry, { fetchText: async () => nextDataHtml({ not: 'an array' }, 1) });
+  } catch {
+    nonArrayFirstPageErrored = true;
+  }
+  if (nonArrayFirstPageErrored) pass('join.fetch() throws when the first page\'s jobs.items is not an array');
+  else fail('join.fetch() should throw when the first page\'s jobs.items is not an array');
+
+  // fetch() — same check on a later page.
+  const nonArrayPagePages = [nextDataHtml([{ title: 'Job 1', idParam: '1', city: {} }], 2), nextDataHtml({ not: 'an array' }, 2)];
+  let nonArrayPageCalls = 0;
+  let nonArrayPageErrored = false;
+  try {
+    await joinProvider.fetch(entry, { fetchText: async () => nonArrayPagePages[nonArrayPageCalls++] });
+  } catch {
+    nonArrayPageErrored = true;
+  }
+  if (nonArrayPageErrored) pass('join.fetch() throws when a paginated (non-first) page\'s jobs.items is not an array');
+  else fail('join.fetch() should throw when a later page\'s jobs.items is not an array');
+
+  // fetch() — careers_url that fails extractSlug() throws before any request.
+  let slugErrored = false;
+  try {
+    await joinProvider.fetch({ name: 'Acme', careers_url: 'https://example.com/careers' }, { fetchText: async () => { throw new Error('should not be called'); } });
+  } catch {
+    slugErrored = true;
+  }
+  if (slugErrored) pass('join.fetch() throws when careers_url is not a join.com URL');
+  else fail('join.fetch() should throw when the slug cannot be extracted');
+} catch (e) {
+  fail(`join provider tests crashed: ${e.message}`);
+}

--- a/tests/providers/join.test.mjs
+++ b/tests/providers/join.test.mjs
@@ -126,6 +126,52 @@ try {
     fail(`join.fetch() ctx.maxPages wrong: calls=${cappedCalls}, jobs=${cappedJobs.length}`);
   }
 
+  // fetch() — DEFAULT_MAX_PAGES caps pagination even when the page's own
+  // reported pagination.pageCount is far higher, and warns about it. Applies
+  // regardless of ctx.maxPages (unset here), unlike the health-check cap.
+  let bigBoardCalls = 0;
+  const bigBoardCtx = {
+    fetchText: async () => {
+      bigBoardCalls++;
+      return nextDataHtml([{ title: `Job ${bigBoardCalls}`, idParam: String(bigBoardCalls), city: {} }], 9999);
+    },
+  };
+  const bigBoardWarnings = [];
+  const realConsoleError = console.error;
+  console.error = (...args) => bigBoardWarnings.push(args.join(' '));
+  let bigBoardJobs;
+  try {
+    bigBoardJobs = await joinProvider.fetch(entry, bigBoardCtx);
+  } finally {
+    console.error = realConsoleError;
+  }
+  if (bigBoardCalls === 50 && bigBoardJobs.length === 50) {
+    pass('join.fetch() caps pagination at DEFAULT_MAX_PAGES=50 even when pagination.pageCount reports far more');
+  } else {
+    fail(`join.fetch() DEFAULT_MAX_PAGES cap wrong: calls=${bigBoardCalls}, jobs=${bigBoardJobs?.length}`);
+  }
+  if (bigBoardWarnings.some((w) => w.includes('truncated at max_pages=50'))) {
+    pass('join.fetch() warns when DEFAULT_MAX_PAGES truncates the board');
+  } else {
+    fail(`join.fetch() truncation warning missing; captured = ${JSON.stringify(bigBoardWarnings)}`);
+  }
+
+  // fetch() — entry.max_pages overrides the default, clamped at MAX_PAGES_CAP.
+  let overrideCalls = 0;
+  const overrideCtx = {
+    fetchText: async () => {
+      overrideCalls++;
+      return nextDataHtml([{ title: `Job ${overrideCalls}`, idParam: String(overrideCalls), city: {} }], 9999);
+    },
+  };
+  const overrideEntry = { name: 'Acme', careers_url: 'https://join.com/companies/acme-corp', max_pages: 3 };
+  const overrideJobs = await joinProvider.fetch(overrideEntry, overrideCtx);
+  if (overrideCalls === 3 && overrideJobs.length === 3) {
+    pass('join.fetch() honors entry.max_pages as an override on the default cap');
+  } else {
+    fail(`join.fetch() entry.max_pages override wrong: calls=${overrideCalls}, jobs=${overrideJobs?.length}`);
+  }
+
   // fetch() — missing/unexpected __NEXT_DATA__ structure throws instead of
   // silently returning an empty list (so a scan doesn't mistake a parse
   // failure for a genuinely empty board).


### PR DESCRIPTION
## Summary
- Adds a `join.com` scanner provider: auto-detects `join.com/companies/<slug>` careers URLs and reads jobs from the Next.js `__NEXT_DATA__` blob embedded in the server-rendered HTML (no public API exists for this board).
- Follows the `workday.mjs` `ctx.maxPages` pagination pattern and pins every request to the literal `join.com` host with `redirect:'error'` (SSRF hardening — no allowlist needed since the URL is rebuilt from a fixed string, not passed through from config).
- Documents the provider in `docs/SUPPORTED_JOB_BOARDS.md` and `templates/portals.example.yml` (URL pattern + copy-paste example stanza).

## Test plan
- [x] `node test-all.mjs --only providers/join` — 19/19 pass (slug extraction, spoofed-host rejection, `detect()`, pagination, SSRF hardening, `ctx.maxPages`, defensive throw on missing/malformed `__NEXT_DATA__`, non-string input, and non-array `jobs.items` on both the first and a later page)
- [x] `node test-all.mjs` — full suite green (2993 passed, 0 failed)
- [x] Verified the provider auto-registers via `providers/_registry.mjs` with no duplicate-id or load errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Join.com job boards, including automatic detection of company career pages and paginated job listings.
  * Expanded auto-detection and setup examples for scanning Join.com pages.

* **Bug Fixes**
  * Improved handling of invalid URLs, missing page data, and malformed content with clearer failures.
  * Added safeguards for redirects and page limits during job fetching.

* **Tests**
  * Added coverage for detection, parsing, pagination, error handling, and crash reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
