### PR TITLE
fix(providers): personio falls back to HTML scrape when the XML feed is disabled

### DIFF
--- a/docs/SUPPORTED_JOB_BOARDS.md
+++ b/docs/SUPPORTED_JOB_BOARDS.md
@@ -50,7 +50,7 @@ are shared helpers and are not loaded as providers.
 | No Fluff Jobs | API | Auto-detects `nofluffjobs.com` and reads its public `/api/search/posting` API (Polish/EU tech board); paginates up to `max_pages` (default 5). |
 | NoDesk | RSS | Reads the public `https://nodesk.co/remote-jobs/index.xml` feed and parses it in-process. Configure with `provider: nodesk`. |
 | Oracle Recruiting Cloud (ORC) | API | Auto-detects `<tenant>.fa[.<region>][.ocs].oraclecloud.com` careers URLs (e.g. JPMorgan Chase, BNY Mellon, American Express) and reads the public zero-auth `recruitingCEJobRequisitions` REST API. Paginates by offset up to a safety cap (25 pages / ~5,000 jobs); pagination is driven by returned list length and `TotalJobsCount`, not the unreliable `hasMore` flag some tenants always report `false`. |
-| Personio | RSS | Auto-detects `<slug>.jobs.personio.de` or `.com` hosts and parses the public XML jobs feed. |
+| Personio | Parser | Auto-detects `<slug>.jobs.personio.de` or `.com` hosts and parses the public XML jobs feed; falls back to scraping the careers page HTML for tenants that have disabled the XML feed. |
 | Phenom People | API | Reads Phenom "CareerConnect" career sites (e.g. `careers.allianz.com`) via the public no-auth `POST {origin}/widgets` JSON endpoint on the branded host. Point `careers_url`/`api` at the Phenom host (or set `provider: phenom`). |
 | Pinpoint | API | Auto-detects `<slug>.pinpointhq.com` boards and reads the public zero-auth `/postings.json` per-tenant feed. |
 | Radancy | Parser | Reads Radancy (TalentBrew) career sites (e.g. `careers.munichre.com`) via the server-rendered `/{lang}/search-jobs?p={N}` results page (1-based pagination). Select with `provider: radancy`. |

--- a/providers/personio.mjs
+++ b/providers/personio.mjs
@@ -68,8 +68,22 @@ export default {
     assertPersonioUrl(feedUrl);
     // redirect:'error' prevents SSRF via server-side redirects; combined with
     // assertPersonioUrl above it guarantees the final hostname stays in-domain.
-    const text = await ctx.fetchText(feedUrl, { redirect: 'error' });
-    return parsePersonioXml(text, entry.name, host);
+    try {
+      const text = await ctx.fetchText(feedUrl, { redirect: 'error' });
+      return parsePersonioXml(text, entry.name, host);
+    } catch (err) {
+      if (err?.status !== 404) throw err;
+      // Some tenants disable the public XML feed. The careers page itself is
+      // still server-rendered with the full job list in the initial HTML, so
+      // fall back to scraping it directly instead of giving up.
+      // ?language=en forces English titles — unlike the XML feed (which has
+      // no language param and always renders in the tenant's default
+      // language), the HTML page respects it.
+      const pageUrl = `https://${host}/?language=en`;
+      assertPersonioUrl(pageUrl);
+      const html = await ctx.fetchText(pageUrl, { redirect: 'error' });
+      return parsePersonioHtml(html, entry.name, host);
+    }
   },
 };
 
@@ -100,6 +114,20 @@ function extractText(inner) {
   const cdata = inner.match(/^\s*<!\[CDATA\[([\s\S]*?)\]\]>\s*$/);
   if (cdata) return cdata[1].trim();
   return decodeXmlEntities(inner).trim();
+}
+
+// Looped to a fixed point rather than a single pass: a single global replace
+// only removes non-overlapping matches in one left-to-right sweep, which
+// CodeQL flags as an incomplete sanitizer (js/incomplete-sanitization) since
+// adversarial nesting can leave a `<`-fragment behind. Repeating until the
+// string stops changing removes any tag that pass N reveals.
+function stripTags(s) {
+  let prev;
+  do {
+    prev = s;
+    s = s.replace(/<[^>]*>/g, '');
+  } while (s !== prev);
+  return s;
 }
 
 // Extract the text of the first <tag>…</tag> in a block. Returns '' when absent.
@@ -163,6 +191,65 @@ export function parsePersonioXml(xml, companyName, host) {
       location: offices.join(', '),
       company: companyName,
       postedAt: toEpochMs(tagText(scalar, 'createdAt')),
+    });
+  }
+  return jobs;
+}
+
+/**
+ * Fallback for tenants whose /xml feed is disabled (404 there, 200 on the
+ * page). The careers page is server-rendered by the same Personio frontend
+ * build across tenants, so the job list is already present in the initial
+ * HTML — no headless browser needed. Each job is an `<a href="/job/{id}">`
+ * carrying the shared (non-hashed) marker class `job-box`, wrapping an
+ * `<h3>` title and a `<span>` with the first location line. Class names use
+ * hashed CSS module suffixes (e.g. `page_jobTitle__K0ilk`) that are build-
+ * specific, not tenant-specific, so matching only on the stable `job-box` /
+ * `jobMetaText` substrings keeps the regex independent of that hash.
+ *
+ * No creation date is exposed on the listing page, so postedAt is always
+ * omitted (unlike parsePersonioXml's createdAt).
+ *
+ * @param {string} html — careers page HTML body
+ * @param {string} companyName — value written into job.company
+ * @param {string} host — validated tenant host, e.g. `acme.jobs.personio.de`
+ * @returns {Array<{title: string, url: string, company: string, location: string}>}
+ */
+export function parsePersonioHtml(html, companyName, host) {
+  if (typeof html !== 'string') return [];
+  const jobs = [];
+  const seen = new Set();
+  // href may carry a trailing query string, e.g. "/job/2560093?language=en"
+  // when the page itself was fetched with ?language=en — the numeric id is
+  // still what we need, so the query part (if any) is matched and discarded.
+  // class and href aren't guaranteed to appear in a fixed order on the
+  // anchor, so the opening tag's attributes are captured as one blob and
+  // checked independently rather than anchored on attribute order.
+  const anchorRe = /<a\b([^>]*)>([\s\S]*?)<\/a>/g;
+  let m;
+  while ((m = anchorRe.exec(html))) {
+    const attrs = m[1];
+    if (!/\bclass="[^"]*\bjob-box\b[^"]*"/.test(attrs)) continue;
+    const hrefMatch = attrs.match(/\bhref="\/job\/(\d+)(?:\?[^"]*)?"/);
+    if (!hrefMatch) continue;
+    const id = hrefMatch[1];
+    if (seen.has(id)) continue;
+    const block = m[2];
+
+    const titleMatch = block.match(/<h3\b[^>]*>([\s\S]*?)<\/h3>/);
+    if (!titleMatch) continue;
+    const title = decodeXmlEntities(stripTags(titleMatch[1])).trim();
+    if (!title) continue;
+
+    const locMatch = block.match(/<span\b[^>]*class="[^"]*jobMetaText[^"]*"[^>]*>([\s\S]*?)<\/span>/);
+    const location = locMatch ? decodeXmlEntities(stripTags(locMatch[1])).trim() : '';
+
+    seen.add(id);
+    jobs.push({
+      title,
+      url: `https://${host}/job/${id}`,
+      location,
+      company: companyName,
     });
   }
   return jobs;

--- a/tests/providers/personio.test.mjs
+++ b/tests/providers/personio.test.mjs
@@ -9,7 +9,7 @@ console.log('\nProvider — personio');
 try {
   const personioModule = await import(pathToFileURL(join(ROOT, 'providers/personio.mjs')).href);
   const personio = personioModule.default;
-  const { parsePersonioXml } = personioModule;
+  const { parsePersonioXml, parsePersonioHtml } = personioModule;
 
   if (personio.id === 'personio') pass('personio.id is "personio"');
   else fail(`personio.id is ${JSON.stringify(personio.id)}`);
@@ -187,6 +187,121 @@ try {
   } catch (e) {
     if (/cannot derive feed URL for NoFeed/.test(e.message)) {
       pass('personio.fetch() throws "cannot derive feed URL" for underivable entries');
+    } else {
+      fail(`personio.fetch() threw the wrong error: ${e.message}`);
+    }
+  }
+
+  // parsePersonioHtml — real page markup shape served when /xml is disabled.
+  const HTML_HOST = 'acme.jobs.personio.de';
+  const htmlSample = `<ul><li>
+    <a class="page_job__haA3E job-box" href="/job/2378948"><div class="page_jobHeaderContent__c_2JP">
+      <h3 class="page_jobTitle__K0ilk jb-title">ML-QA Engineer</h3>
+      <div class="page_jobMeta__GhU10 jb-description">
+        <div class="page_jobMetaItem__olmVi"><span class="page_jobMetaText__5yzux">Berlin AI Campus, Munich</span></div>
+        <div class="page_jobMetaItem__olmVi"><span class="page_jobMetaText__5yzux">Vollzeit</span></div>
+      </div>
+    </div></a>
+  </li><li>
+    <a class="page_job__haA3E job-box" href="/job/2540715?language=en"><div class="page_jobHeaderContent__c_2JP">
+      <h3 class="page_jobTitle__K0ilk jb-title">Senior Engineer (m/f/d) &amp; Lead</h3>
+      <div class="page_jobMeta__GhU10 jb-description">
+        <div class="page_jobMetaItem__olmVi"><span class="page_jobMetaText__5yzux">Remote</span></div>
+      </div>
+    </div></a>
+  </li><li>
+    <a class="nav-link" href="/privacy-policy">Datenschutzerklärung</a>
+  </li></ul>`;
+  const htmlJobs = parsePersonioHtml(htmlSample, 'Acme', HTML_HOST);
+
+  if (htmlJobs.length === 2) pass('parsePersonioHtml keeps 2 job-box anchors (ignores unrelated links)');
+  else fail(`parsePersonioHtml returned ${htmlJobs.length} jobs (expected 2)`);
+
+  if (htmlJobs[0]?.title === 'ML-QA Engineer' && htmlJobs[0]?.url === 'https://acme.jobs.personio.de/job/2378948') {
+    pass('parsePersonioHtml extracts title + builds url from host + numeric id');
+  } else {
+    fail(`row 0 = ${JSON.stringify(htmlJobs[0])}`);
+  }
+
+  if (htmlJobs[0]?.location === 'Berlin AI Campus, Munich' && htmlJobs[0]?.company === 'Acme') {
+    pass('parsePersonioHtml extracts the first jobMetaText span as location');
+  } else {
+    fail(`row 0 location/company = ${JSON.stringify({ location: htmlJobs[0]?.location, company: htmlJobs[0]?.company })}`);
+  }
+
+  if (htmlJobs[1]?.title === 'Senior Engineer (m/f/d) & Lead') {
+    pass('parsePersonioHtml decodes &amp; in the title');
+  } else {
+    fail(`row 1 title = ${JSON.stringify(htmlJobs[1]?.title)}`);
+  }
+
+  if (htmlJobs[1]?.url === 'https://acme.jobs.personio.de/job/2540715') {
+    pass('parsePersonioHtml strips a ?language=en query string from href, keeping the numeric id');
+  } else {
+    fail(`row 1 url = ${JSON.stringify(htmlJobs[1]?.url)}`);
+  }
+
+  if (htmlJobs.every((j) => j.postedAt === undefined)) {
+    pass('parsePersonioHtml never sets postedAt (not exposed on the listing page)');
+  } else {
+    fail('parsePersonioHtml should never set postedAt');
+  }
+
+  // href before class on the anchor must still match (attribute order isn't
+  // guaranteed across tenants).
+  const hrefFirstSample = `<a href="/job/999001" class="job-box page_job__haA3E"><h3>Ops Lead</h3></a>`;
+  const hrefFirstJobs = parsePersonioHtml(hrefFirstSample, 'Acme', HTML_HOST);
+  if (hrefFirstJobs.length === 1 && hrefFirstJobs[0]?.title === 'Ops Lead' && hrefFirstJobs[0]?.url === 'https://acme.jobs.personio.de/job/999001') {
+    pass('parsePersonioHtml matches an anchor with href before class');
+  } else {
+    fail(`href-before-class variant: ${JSON.stringify(hrefFirstJobs)}`);
+  }
+
+  if (parsePersonioHtml('', 'X', HTML_HOST).length === 0 && parsePersonioHtml(null, 'X', HTML_HOST).length === 0) {
+    pass('parsePersonioHtml: empty / non-string page → empty result (no crash)');
+  } else {
+    fail('parsePersonioHtml: empty / non-string page should yield empty result');
+  }
+
+  // fetch() falls back to HTML scraping when /xml 404s.
+  {
+    const calls = [];
+    const jobsFromFallback = await personio.fetch(
+      { name: 'Acme', careers_url: 'https://acme.jobs.personio.de/' },
+      {
+        fetchText: async (url, opts) => {
+          calls.push(url);
+          if (url.endsWith('/xml')) {
+            const err = new Error('HTTP 404 Not Found');
+            err.status = 404;
+            throw err;
+          }
+          return htmlSample;
+        },
+      },
+    );
+    if (calls.length === 2 && calls[0].endsWith('/xml') && calls[1] === 'https://acme.jobs.personio.de/?language=en') {
+      pass('personio.fetch() falls back to the careers page (?language=en) after a 404 on /xml');
+    } else {
+      fail(`personio.fetch() fallback calls = ${JSON.stringify(calls)}`);
+    }
+    if (jobsFromFallback.length === 2) {
+      pass('personio.fetch() returns jobs parsed from the HTML fallback');
+    } else {
+      fail(`personio.fetch() fallback returned ${jobsFromFallback.length} jobs`);
+    }
+  }
+
+  // fetch() re-throws non-404 errors from the /xml feed (no silent fallback).
+  try {
+    await personio.fetch(
+      { name: 'Acme', careers_url: 'https://acme.jobs.personio.de/' },
+      { fetchText: async () => { const err = new Error('HTTP 500 Internal Server Error'); err.status = 500; throw err; } },
+    );
+    fail('personio.fetch() should re-throw non-404 errors instead of falling back');
+  } catch (e) {
+    if (/HTTP 500/.test(e.message)) {
+      pass('personio.fetch() re-throws non-404 errors without falling back to HTML');
     } else {
       fail(`personio.fetch() threw the wrong error: ${e.message}`);
     }


### PR DESCRIPTION
## Summary

- Some Personio tenants disable the public `/xml` jobs feed (confirmed live on three independent tenants) while their careers page is still server-rendered with the full job list present in the initial HTML.
- On a 404 from `/xml`, the provider now falls back to fetching the careers page with `?language=en` and parsing the job list from there (that query param forces English titles -- the XML feed has no language param and always renders in the tenant's default language). Non-404 errors still propagate unchanged.
- The HTML fallback matches on the stable `job-box` / `jobMetaText` class-name substrings rather than a full class match, since Personio's hashed CSS-module suffixes differ per frontend build but those marker substrings are shared across tenants.
- No creation date is exposed on the careers page, so `postedAt` is intentionally omitted on the fallback path only (still present via `<createdAt>` on the normal XML path).
- Docs: updated the `Personio` row in `docs/SUPPORTED_JOB_BOARDS.md` to mention the fallback.

## Test plan

- [x] `node test-all.mjs --only providers/personio` -- 29/29 passing
- [x] `node test-all.mjs --quick` -- full suite green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a fallback for Personio job boards when XML feeds return a 404, retrieving listings from English careers pages.
  * Improved extraction of job titles, locations, company names, and job links from HTML pages.

* **Bug Fixes**
  * Prevented duplicate listings and removed unnecessary URL query parameters.
  * Improved handling of nested HTML markup and encoded characters, including omitting unavailable posting timestamps.

* **Documentation**
  * Updated supported job-board documentation to describe Personio fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->