### PR TITLE
docs(i18n): add the Portuguese interview README (#2426)

### DIFF
--- a/modes/pt/interview/README.md
+++ b/modes/pt/interview/README.md
@@ -1,0 +1,33 @@
+# Competências para entrevista
+
+Um conjunto de competências reutilizáveis para preparar uma entrevista de ponta a ponta.
+
+## Competências
+
+| Competência | Arquivo | Quando usar |
+|---|---|---|
+| Planejador de preparação | `plan.md` | Dada uma descrição da vaga e a data da entrevista, monta um plano de preparação estruturado e dividido em blocos de tempo |
+| Entrevistador de simulação | `practice.md` | Conduz perguntas de entrevista simulada com feedback estruturado |
+| Debrief pós-entrevista | `debrief.md` | Após uma entrevista real, fecha lacunas e atualiza a question bank |
+
+## Competências relacionadas (na pasta `modes/` acima)
+
+| Competência | Arquivo | Quando usar |
+|---|---|---|
+| Pesquisa sobre a empresa | `../../interview-prep.md` | Pesquisa uma empresa e uma vaga específicas antes da entrevista |
+
+## Convenções de arquivos
+
+Estas competências pressupõem que os arquivos abaixo existam (padrões do career-ops):
+
+| Arquivo | Finalidade |
+|---|---|
+| `cv.md` | CV do candidato — fonte de verdade para experiência e pontos de prova |
+| `article-digest.md` | Pontos de prova condensados do portfolio (opcional) |
+| `config/profile.yml` | Perfil do candidato — vagas-alvo, remuneração, narrativa |
+| `modes/_profile.md` | Arquétipos, narrativa e deal-breakers do candidato |
+| `interview-prep/story-bank.md` | Histórias STAR+R acumuladas |
+| `interview-prep/question-bank.md` | Question bank com rastreamento de lacunas (criada no primeiro uso) |
+| `interview-prep/interview-prep-guide.md` | Princípios gerais de entrevista (opcional) |
+| `interview-prep/{company}-{role}.md` | Arquivo de preparação específico da vaga |
+| `interview-prep/retracted-claims.md` | Alegações que o candidato rejeitou como indefensáveis — barreira rígida na simulação e no debrief (formato: `**"[claim]"** ([context]). Reason: [one-line reason + correct framing if applicable].`) |

--- a/modes/pt/interview/README.md
+++ b/modes/pt/interview/README.md
@@ -8,7 +8,7 @@ Um conjunto de competências reutilizáveis para preparar uma entrevista de pont
 |---|---|---|
 | Planejador de preparação | `plan.md` | Dada uma descrição da vaga e a data da entrevista, monta um plano de preparação estruturado e dividido em blocos de tempo |
 | Entrevistador de simulação | `practice.md` | Conduz perguntas de entrevista simulada com feedback estruturado |
-| Debrief pós-entrevista | `debrief.md` | Após uma entrevista real, fecha lacunas e atualiza a question bank |
+| Debrief pós-entrevista | `debrief.md` | Após uma entrevista real, fecha lacunas e atualiza o banco de perguntas |
 
 ## Competências relacionadas (na pasta `modes/` acima)
 
@@ -27,7 +27,7 @@ Estas competências pressupõem que os arquivos abaixo existam (padrões do care
 | `config/profile.yml` | Perfil do candidato — vagas-alvo, remuneração, narrativa |
 | `modes/_profile.md` | Arquétipos, narrativa e deal-breakers do candidato |
 | `interview-prep/story-bank.md` | Histórias STAR+R acumuladas |
-| `interview-prep/question-bank.md` | Question bank com rastreamento de lacunas (criada no primeiro uso) |
+| `interview-prep/question-bank.md` | Banco de perguntas com rastreamento de lacunas (criado no primeiro uso) |
 | `interview-prep/interview-prep-guide.md` | Princípios gerais de entrevista (opcional) |
 | `interview-prep/{company}-{role}.md` | Arquivo de preparação específico da vaga |
 | `interview-prep/retracted-claims.md` | Alegações que o candidato rejeitou como indefensáveis — barreira rígida na simulação e no debrief (formato: `**"[claim]"** ([context]). Reason: [one-line reason + correct framing if applicable].`) |


### PR DESCRIPTION
## What does this PR do?

Adds `modes/pt/interview/README.md`, the folder index for the Portuguese interview skills. Mirrors `modes/fr/interview/README.md` (#2450) and `modes/it/interview/README.md` (#2335); `plan.md`, `practice.md` and `debrief.md` already existed in `modes/pt/interview/`.

## Related issue

Part of #2426, `pt` (pt-BR) only, per the one-language-per-PR rule.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] Translations are exempt from issue-first (CONTRIBUTING.md line 22); claimed `pt` in the issue comment before starting
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (new file in the system layer, no user-layer file touched)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156) (translation work named directly in #2426)

## Test plan

- [x] `node test-all.mjs` - 2970 passed, 0 failed, 4 warnings (same as the baseline without this file; warnings are environment-only, no Go compiler and no browser here)
- [x] `node test-all.mjs --quick` (matches the CI job, `.github/workflows/test.yml:39`) - 2970 passed, 0 failed, 3 warnings
- [x] Structural parity with `modes/interview/README.md` checked programmatically: same 4 headings in the same order, same 19 table rows across the 3 blocks, same 15 backticked tokens in the same positions

## Notes

Native pt-BR speaker, and pt-BR is the language I use career-ops in (stated in the issue comment claiming `pt`).

Two deliberate deviations from the English original, both matching the fr/it precedent:

- `../interview-prep.md` becomes `../../interview-prep.md`: the translated README sits one level deeper, under `modes/pt/interview/`.
- The `retracted-claims.md` format string stays in English, matching `modes/pt/interview/practice.md:104` and `debrief.md:197`, which already carry that string in English.

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Portuguese interview-preparation documentation covering reusable competencies, related company research, usage guidance, and career-operations file conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->