### PR TITLE
chore(gitignore): ignore .idea/, .vscode/, and .mcp.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,10 @@ data/model-blacklist.json
 *.mov
 *.mp4
 
+# IDE-specific local config
+.idea/
+.vscode/
+
 # CLI-specific local config
 .claude/settings.local.json
 .claude/memory/
@@ -103,6 +107,10 @@ data/model-blacklist.json
 .opencode/memory/
 # OpenCode project config (often holds personal MCP/model/per-machine prefs).
 opencode.json
+# Claude Code project-level MCP server config — commonly ends up holding
+# personal server credentials (e.g. a plugin's API token) once a user adds
+# an MCP server, same risk class as .env.
+.mcp.json
 career-dashboard
 career-dashboard.exe
 package-lock.json


### PR DESCRIPTION
## Summary

- `.idea/` and `.vscode/` (JetBrains / VS Code project folders) aren't ignored at all currently — standard editor clutter with no reason to ever be tracked.
- `.mcp.json` (Claude Code's project-level MCP server config) isn't ignored either. It commonly ends up holding personal MCP server credentials once a user adds a server (e.g. a plugin's API token) — same risk class the repo already treats `.env` / `**/.env.local` with.

## Test plan

- [x] `node test-all.mjs --quick` — full suite green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project ignore settings to exclude additional IDE/editor configuration files and local credential-related configuration.
  * Added guidance clarifying the credential risk associated with local configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->