### PR TITLE
fix(providers): hackernews thread lookup filters by whoishiring tag

### DIFF
--- a/providers/hackernews.mjs
+++ b/providers/hackernews.mjs
@@ -4,8 +4,9 @@
 // Hacker News "Ask HN: Who is hiring?" provider — no auth required.
 //
 // Algorithm:
-//   1. Find the current monthly hiring thread via the Algolia HN search API
-//      (search_by_date, tags=story, query="Ask HN Who is hiring").
+//   1. Find the current monthly hiring thread via the Algolia HN search API,
+//      filtered to stories posted by the "whoishiring" account
+//      (tags=story,author_whoishiring) rather than a free-text query.
 //   2. Fetch the thread's item from the Algolia items API; top-level `children`
 //      are individual job posts left as top-level comments.
 //   3. Parse each comment: the first non-empty line is treated as the title/header
@@ -15,9 +16,18 @@
 //      format doesn't match the pipe-delimited convention).
 //
 // Wire in via a `job_boards:` entry with `provider: hackernews`.
-
+//
+// NOTE: a free-text query ("Ask HN Who is hiring") against search_by_date used
+// to be the lookup here, but Algolia's free-text ranking can surface an
+// unrelated recent story that merely contains those words in its body — once
+// enough time passes since the monthly thread posted, a newer "Tell HN: ..."
+// post can outrank it in the top 5 date-sorted hits, and every one of them
+// fails the title regex below, so the provider throws "thread not found" even
+// though the actual thread is sitting a few pages back. Filtering by the
+// `whoishiring` account's own tag returns only its threads, so ordering by
+// date always surfaces the latest real one first.
 const SEARCH_URL =
-  'https://hn.algolia.com/api/v1/search_by_date?tags=story&query=Ask%20HN%20Who%20is%20hiring&hitsPerPage=5';
+  'https://hn.algolia.com/api/v1/search_by_date?tags=story,author_whoishiring&hitsPerPage=5';
 
 /** @param {string} id */
 function itemUrl(id) {

--- a/tests/providers/hackernews.test.mjs
+++ b/tests/providers/hackernews.test.mjs
@@ -138,9 +138,14 @@ try {
 
   let searchFetched = false;
   let itemFetched = false;
+  let searchParams = null;
   const mockCtx = {
     async fetchJson(url, _opts) {
-      if (url.includes('search_by_date')) { searchFetched = true; return fakeSearchResp; }
+      if (url.includes('search_by_date')) {
+        searchFetched = true;
+        searchParams = new URL(url).searchParams;
+        return fakeSearchResp;
+      }
       if (url.includes(`/items/${FAKE_THREAD_ID}`)) { itemFetched = true; return fakeItemResp; }
       throw new Error(`hackernews mock: unexpected fetch ${url}`);
     },
@@ -152,6 +157,12 @@ try {
     pass('hackernews.fetch() calls search API then items API');
   } else {
     fail(`hackernews.fetch() API calls: search=${searchFetched} item=${itemFetched}`);
+  }
+
+  if (searchParams?.get('tags') === 'story,author_whoishiring' && searchParams?.get('hitsPerPage') === '5') {
+    pass('hackernews.fetch() searches by the whoishiring account tag, not free text');
+  } else {
+    fail(`hackernews.fetch() search params: tags=${searchParams?.get('tags')} hitsPerPage=${searchParams?.get('hitsPerPage')}`);
   }
 
   if (jobs.length === 2) {

--- a/tests/providers/hackernews.test.mjs
+++ b/tests/providers/hackernews.test.mjs
@@ -159,10 +159,15 @@ try {
     fail(`hackernews.fetch() API calls: search=${searchFetched} item=${itemFetched}`);
   }
 
-  if (searchParams?.get('tags') === 'story,author_whoishiring' && searchParams?.get('hitsPerPage') === '5') {
+  if (
+    searchParams !== null &&
+    searchParams.get('tags') === 'story,author_whoishiring' &&
+    searchParams.get('hitsPerPage') === '5' &&
+    !searchParams.has('query')
+  ) {
     pass('hackernews.fetch() searches by the whoishiring account tag, not free text');
   } else {
-    fail(`hackernews.fetch() search params: tags=${searchParams?.get('tags')} hitsPerPage=${searchParams?.get('hitsPerPage')}`);
+    fail(`hackernews.fetch() search params: tags=${searchParams?.get('tags')} hitsPerPage=${searchParams?.get('hitsPerPage')} query=${searchParams?.get('query')}`);
   }
 
   if (jobs.length === 2) {


### PR DESCRIPTION
The hackernews provider looked up the monthly thread with a free-text query against `search_by_date`. Algolia ranks by relevance before sorting by date, so once enough time passed since the thread posted, an unrelated newer story could outrank it in the top 5 hits. Every one of those fails the title regex, so the provider threw "thread not found" while the real thread just sat a few pages back.

Fix: filter by the `whoishiring` account's own tag instead. That returns only its threads, so date order alone is enough to get the latest one.

## Test plan
- [ ] Ran the provider against a case where the old query previously failed
- [ ] `resolveLatestThreadId` / comment parsing unchanged, still passes existing tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of the latest Hacker News hiring thread.
  * Search results now focus on relevant hiring posts, reducing unrelated matches.
  * Recent posts and matching thread titles continue to be prioritized.
  * Search requests now retrieve a broader set of relevant results for more reliable matching.

* **Documentation**
  * Updated supporting documentation to reflect the improved hiring-thread search behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->