### PR TITLE
feat(pdf): declare CV section order in config/profile.yml (#2533)

### DIFF
--- a/config/profile.example.yml
+++ b/config/profile.example.yml
@@ -135,6 +135,27 @@ cv:
   # (e.g. "use the modern template").
   # template: modern
   # For a restrained Chinese technical CV, use: template: zh-minimal
+  #
+  # (Optional) Section order for the generated CV (#2533). The sections you name
+  # are placed into the slots they already occupy, in the order you list them;
+  # every section you leave out stays exactly where the template puts it — so a
+  # section added by a later release lands where upstream put it instead of
+  # breaking this list.
+  #
+  # Moving a section past its neighbours is a rotation, so name the sections it
+  # displaces too. To render Skills before Education with the built-in template
+  # (which ends Education → Certifications → Awards → Skills):
+  #
+  #   sections: [skills, education, certifications, awards]
+  #
+  # Recognized names: summary, competencies, experience, projects, education,
+  # certifications, awards, skills. An unrecognized name is reported and ignored.
+  #
+  # This exists so the order can live in your profile instead of in
+  # templates/cv-template.html, which update-system.mjs restores on every update.
+  # cv.md stays the source of truth: the section-order guard still compares the
+  # rendered CV against it, and still fails if they disagree.
+  # sections: [skills, education, certifications, awards]
 
 # ── Culture Screen ───────────────────────────────────────────────────────────
 #

--- a/config/profile.example.yml
+++ b/config/profile.example.yml
@@ -151,6 +151,9 @@ cv:
   # Recognized names: summary, competencies, experience, projects, education,
   # certifications, awards, skills. An unrecognized name is reported and ignored.
   #
+  # Applies to the HTML output only. With output_format: latex the order comes
+  # from templates/cv-template.tex and this setting does nothing.
+  #
   # This exists so the order can live in your profile instead of in
   # templates/cv-template.html, which update-system.mjs restores on every update.
   # cv.md stays the source of truth: the section-order guard still compares the

--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -39,7 +39,7 @@ import { readFile } from 'fs/promises';
 import { existsSync, lstatSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from 'fs';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { randomUUID } from 'node:crypto';
-import { readStyleTokens, injectThemeStyle } from './theme-style.mjs';
+import { readStyleTokens, injectThemeStyle, readCvSectionOrder } from './theme-style.mjs';
 import { resolvePdfIndexPath, resolveTrackerPath, resolveWorkspaceRoot } from './tracker-utils.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -326,6 +326,425 @@ export function validateCvSectionOrder(html, cvMarkdown, { allowReorder = false 
       throw new Error(message);
     }
   }
+}
+
+/**
+ * Every canonical section key the alias table can produce, in template order.
+ * Derived from the table rather than restated so the two cannot drift.
+ */
+export const CV_SECTION_KEYS = [...new Set(SECTION_ALIASES.values())];
+
+// The all-caps comments the templates use to delimit sections, matched exactly
+// as cv-sections-core.mjs matches them when stripping empty sections.
+const SECTION_MARKER_RE = /<!--\s+[A-Z][A-Z ]*-->/g;
+const SECTION_TITLE_RE = /class=["'][^"']*\bsection-title\b[^"']*["'][^>]*>([\s\S]*?)<\/[^>]+>/gi;
+
+/**
+ * The text of the first real section title in html[start, end), skipping any
+ * that sits in raw text (a heading quoted inside a script names nothing).
+ *
+ * @param {string} html
+ * @param {number} start
+ * @param {number} end
+ * @param {[number, number][]} inert
+ * @returns {string|null}
+ */
+function findSectionTitle(html, start, end, inert) {
+  // Matched against the slice, not the whole document: a marker with no title
+  // under it would otherwise send the engine looking as far as the next title
+  // anywhere in the file, which is quadratic across many markers. The slices
+  // partition the document, so this is linear overall.
+  const within = html.slice(start, end);
+  SECTION_TITLE_RE.lastIndex = 0;
+  let match;
+  while ((match = SECTION_TITLE_RE.exec(within)) !== null) {
+    if (!isInRanges(inert, start + match.index)) return match[1];
+  }
+  return null;
+}
+
+// Elements that never have a closing tag, so they must not open a nesting level.
+const VOID_ELEMENTS = new Set([
+  'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input',
+  'link', 'meta', 'param', 'source', 'track', 'wbr',
+]);
+
+// Elements whose content is text, not markup. `<style>.x { content: "</div>" }`
+// closes nothing, and counting that as a close tag would end a section early.
+// The legacy entries (xmp, plaintext, noembed, noframes) and iframe are here
+// because a parser doesn't build elements from their contents either; leaving
+// one out means markup-shaped text inside it is mistaken for structure.
+const RAW_TEXT_ELEMENTS = new Set([
+  'script', 'style', 'textarea', 'title',
+  'xmp', 'plaintext', 'iframe', 'noembed', 'noframes',
+]);
+
+/**
+ * Index of the `>` that ends the tag opening at `from`, or -1.
+ *
+ * Quote-aware, because `>` is legal inside an attribute value:
+ * `<span data-x="> <div>">` is one tag, not a tag plus a stray `<div>`. Reading
+ * it as the latter miscounts the depth — and since a forged count can be made
+ * to balance, it would let a section pass validation and then be moved into
+ * markup it doesn't belong to.
+ *
+ * @param {string} html
+ * @param {number} from - Index of the `<`.
+ * @returns {number}
+ */
+function tagEnd(html, from) {
+  let quote = null;
+  for (let i = from + 1; i < html.length; i++) {
+    const char = html[i];
+    if (quote) {
+      if (char === quote) quote = null;
+    } else if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === '>') {
+      return i;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Ranges of html holding raw text rather than markup — the contents of
+ * `<script>`, `<style>`, `<textarea>` and `<title>`.
+ *
+ * Needed from the start of the document, not from a section: a marker comment
+ * quoted inside a script string (`const fixture = '<!-- SKILLS -->…'`) is text,
+ * but a search that begins at that marker has no way to know it. Treating it as
+ * a section would move part of a script body around the document.
+ *
+ * @param {string} html
+ * @returns {[number, number][]}
+ */
+function rawTextRanges(html) {
+  const ranges = [];
+  let index = 0;
+
+  while (index < html.length) {
+    const open = html.indexOf('<', index);
+    if (open === -1) break;
+
+    if (html.startsWith('<!--', open)) {
+      const close = html.indexOf('-->', open + 4);
+      index = close === -1 ? html.length : close + 3;
+      continue;
+    }
+
+    const close = tagEnd(html, open);
+    if (close === -1) break;
+    const inner = html.slice(open + 1, close);
+    index = close + 1;
+    if (inner.startsWith('/')) continue;
+
+    // No self-closing check: `<script/>` opens raw text, it does not stand alone.
+    const name = /^([a-zA-Z][\w:-]*)/.exec(inner);
+    if (!name || !RAW_TEXT_ELEMENTS.has(name[1].toLowerCase())) continue;
+
+    // <plaintext> has no end tag at all: everything after it is text to the end
+    // of the document, so a literal `</plaintext>` closes nothing.
+    if (name[1].toLowerCase() === 'plaintext') {
+      ranges.push([index, html.length]);
+      break;
+    }
+
+    const closeTag = new RegExp(`</${name[1]}\\s*>`, 'gi');
+    closeTag.lastIndex = index;
+    const end = closeTag.exec(html);
+    ranges.push([index, end ? end.index : html.length]);
+    index = end ? end.index + end[0].length : html.length;
+  }
+
+  return ranges;
+}
+
+/**
+ * Whether `position` falls inside one of the ranges, which are ascending and
+ * disjoint by construction. Binary search rather than a scan: this is asked
+ * once per marker and once per candidate title, and a linear answer makes the
+ * pair quadratic on a document with many of both.
+ *
+ * @param {[number, number][]} ranges
+ * @param {number} position
+ * @returns {boolean}
+ */
+function isInRanges(ranges, position) {
+  let low = 0;
+  let high = ranges.length - 1;
+  while (low <= high) {
+    const mid = (low + high) >> 1;
+    if (position < ranges[mid][0]) high = mid - 1;
+    else if (position >= ranges[mid][1]) low = mid + 1;
+    else return true;
+  }
+  return false;
+}
+
+/**
+ * Walk html[from, to) and report what it does to the nesting depth.
+ *
+ * A forward scan built on indexOf rather than a regex tokenizer: a pattern like
+ * `<!--[\s\S]*?-->` restarts its search from every `<!--`, which is quadratic on
+ * a run of unterminated comments (measured 728ms for 32k of them) and
+ * exponential when nested inside a repetition. Every step here consumes input.
+ *
+ * @param {string} html
+ * @param {number} from
+ * @param {number} to
+ * @returns {{depth: number, exitAt: number}|null} `depth` is the net change at
+ *   `to`; `exitAt` is where a close tag first tried to rise above the starting
+ *   level, or -1. null means the markup could not be read at all (an
+ *   unterminated comment, tag or raw-text element), which callers treat as
+ *   "don't touch this".
+ */
+function scanNesting(html, from, to) {
+  let index = from;
+  let depth = 0;
+
+  while (index < to) {
+    const open = html.indexOf('<', index);
+    if (open === -1 || open >= to) break;
+
+    if (html.startsWith('<!--', open)) {
+      const close = html.indexOf('-->', open + 4);
+      if (close === -1 || close + 3 > to) return null;
+      index = close + 3;
+      continue;
+    }
+
+    const close = tagEnd(html, open);
+    if (close === -1 || close >= to) return null;
+    const inner = html.slice(open + 1, close);
+    index = close + 1;
+
+    if (inner.startsWith('/')) {
+      if (!/^\/[a-zA-Z][\w:-]*\s*$/.test(inner)) continue; // not a close tag
+      if (depth === 0) return { depth, exitAt: open };
+      depth--;
+      continue;
+    }
+
+    const name = /^([a-zA-Z][\w:-]*)/.exec(inner);
+    if (!name) continue; // <!DOCTYPE …>, <?xml …>, or a stray '<'
+    const tag = name[1].toLowerCase();
+
+    // Checked before the self-closing branch: trailing-slash syntax has no
+    // effect on an HTML element, so `<script/>` opens raw text rather than
+    // standing alone, and treating it as self-closing would read the script
+    // body as markup.
+    if (RAW_TEXT_ELEMENTS.has(tag)) {
+      // <plaintext> never ends, so a slice containing one can't be read as
+      // markup at all — refuse rather than guess where it stops.
+      if (tag === 'plaintext') return null;
+      const closeTag = new RegExp(`</${tag}\\s*>`, 'gi');
+      closeTag.lastIndex = index;
+      const end = closeTag.exec(html);
+      if (!end || end.index + end[0].length > to) return null;
+      index = end.index + end[0].length; // consumed whole, depth unchanged
+      continue;
+    }
+
+    if (inner.endsWith('/') || VOID_ELEMENTS.has(tag)) continue;
+
+    depth++;
+  }
+
+  return { depth, exitAt: -1 };
+}
+
+/**
+ * True when html[from, to) is only whitespace, comments and closing tags —
+ * the shape of a document tail (`</div></body></html>`) and of nothing else.
+ *
+ * @param {string} html
+ * @param {number} from
+ * @returns {boolean}
+ */
+function isStructuralTail(html, from) {
+  let index = from;
+
+  while (index < html.length) {
+    const open = html.indexOf('<', index);
+    if (open === -1) break;
+    if (html.slice(index, open).trim() !== '') return false; // stray text
+
+    if (html.startsWith('<!--', open)) {
+      const close = html.indexOf('-->', open + 4);
+      if (close === -1) return false;
+      index = close + 3;
+      continue;
+    }
+
+    const close = tagEnd(html, open);
+    if (close === -1) return false;
+    if (!/^\/[a-zA-Z][\w:-]*\s*$/.test(html.slice(open + 1, close))) return false;
+    index = close + 1;
+  }
+
+  return html.slice(index).trim() === '';
+}
+
+/**
+ * Locate each CV section in a rendered document as a [start, end) slice.
+ *
+ * A section runs from its marker comment to the next one — the extent comes
+ * from the markers, never from matching tags. That matters more than it looks:
+ * when extent is derived by pairing tags, any markup the scanner reads wrongly
+ * yields a *plausible but wrong* extent, and moving it truncates the CV. Here a
+ * misread can only make a section fail the balance check below, and a section
+ * that fails is left alone. Mistakes cost the feature, not the document.
+ *
+ * It also means a section is whatever sits between two markers, so a template
+ * that marks sections with a bare heading —
+ *
+ *   <!-- EDUCATION -->
+ *   <h2 class="section-title">Education</h2>
+ *   <div class="edu-item">BSc</div>
+ *
+ * — moves its heading and body together, rather than being refused.
+ *
+ * Each slice must be balanced: as many elements closed as opened, never rising
+ * above the level it started at. That single check does double duty. It rejects
+ * a slice that would leave markup unclosed, and it establishes that every
+ * accepted section sits at the same nesting level as its neighbours, so filling
+ * one section's place with another can't move it into a container of its own
+ * (`<div class="education-layout"><!-- EDUCATION -->…</div>` fails, because its
+ * slice closes a div it never opened).
+ *
+ * Identity comes from the rendered section title, resolved through the same
+ * alias table validateCvSectionOrder() uses, so the reorder and the guard
+ * cannot disagree about what a section is. A marker with no `.section-title`
+ * under it (`<!-- HEADER -->`) is not a section — which is also what leaves a
+ * cover letter untouched.
+ *
+ * @param {string} html
+ * @returns {{blocks: {key: string, start: number, end: number}[], ambiguous: Set<string>}}
+ */
+function extractSectionBlocks(html) {
+  // A marker quoted inside a script or style is text, not a section boundary.
+  const inert = rawTextRanges(html);
+  const markers = [...html.matchAll(SECTION_MARKER_RE)]
+    .filter(marker => !isInRanges(inert, marker.index));
+  const blocks = [];
+  const ambiguous = new Set();
+
+  for (let i = 0; i < markers.length; i++) {
+    const start = markers[i].index;
+    const next = i + 1 < markers.length ? markers[i + 1].index : html.length;
+
+    // A title quoted inside a script is text too, so it cannot name a section:
+    // taking it would label this block from markup that only looks like a
+    // heading, and apply the user's ordering to the wrong section.
+    const title = findSectionTitle(html, start, next, inert);
+    if (!title) continue;
+    const text = normalizeSectionTitle(title);
+    if (!text) continue;
+    const key = sectionKey(text);
+
+    const scan = scanNesting(html, start, next);
+    if (!scan) {
+      ambiguous.add(key);
+      continue;
+    }
+
+    // The last section has no following marker to bound it, so it ends where
+    // its content first tries to close an element it doesn't own — the parent's
+    // closing tag. Everything after that must be document tail: anything else
+    // means the scan stopped in the wrong place (raw text it misread, say), and
+    // trusting it would move a fragment.
+    const end = scan.exitAt === -1 ? next : scan.exitAt;
+    const bounded = scan.exitAt === -1 ? scan : scanNesting(html, start, end);
+    if (!bounded || bounded.depth !== 0 || (end !== next && !isStructuralTail(html, end))) {
+      ambiguous.add(key);
+      continue;
+    }
+
+    blocks.push({ key, start, end });
+  }
+
+  return { blocks, ambiguous };
+}
+
+/**
+ * Render the CV's sections in the order declared by `cv.sections` in
+ * config/profile.yml (#2533).
+ *
+ * The named sections are permuted among the slots they already occupy;
+ * everything else stays exactly where the template put it. So a list is a local
+ * statement ("these sections, in this order") rather than a full table of
+ * contents the user has to keep in sync — a section added by a later release
+ * lands where upstream put it instead of breaking the config. Moving a section
+ * past its neighbours is therefore a rotation: name the sections it displaces
+ * too, in the order they should end up in.
+ *
+ * Runs before validateCvSectionOrder(), so the guard still judges what will
+ * actually be printed — this satisfies the guard rather than bypassing it, which
+ * is what separates it from --allow-reorder.
+ *
+ * No `cv.sections` → the input string is returned unchanged.
+ *
+ * @param {string} html
+ * @param {string[]} order - Canonical section keys, e.g. ['skills', 'education'].
+ * @returns {string}
+ */
+export function reorderCvSections(html, order) {
+  if (!Array.isArray(order) || order.length < 2) return html;
+
+  // No early return on an empty block list: a CV whose sections are all
+  // ambiguous produces none, and silently doing nothing is the failure mode
+  // this feature exists to remove. The per-name loop below reports first.
+  const { blocks, ambiguous } = extractSectionBlocks(html);
+
+  const byKey = new Map();
+  for (const block of blocks) {
+    if (!byKey.has(block.key)) byKey.set(block.key, block);
+  }
+
+  const chosen = [];
+  const seen = new Set();
+  for (const name of order) {
+    if (seen.has(name)) {
+      console.warn(`⚠️  config/profile.yml cv.sections lists "${name}" more than once — keeping its first position.`);
+      continue;
+    }
+    seen.add(name);
+    if (!CV_SECTION_KEYS.includes(name)) {
+      console.warn(`⚠️  config/profile.yml cv.sections lists "${name}", which is not a CV section — ignoring it. Recognized: ${CV_SECTION_KEYS.join(', ')}.`);
+      continue;
+    }
+    const block = byKey.get(name);
+    if (block) {
+      chosen.push(block);
+    } else if (ambiguous.has(name)) {
+      // Present, but its markup doesn't stand on its own — it opens or closes
+      // elements outside itself, so moving it would leave tags unbalanced.
+      // Reported rather than skipped quietly: the section stays where the
+      // template put it, and the user would otherwise see a setting that
+      // silently does nothing.
+      console.warn(`⚠️  config/profile.yml cv.sections lists "${name}", but this CV's markup does not enclose that section on its own — leaving it in place, because moving it would leave tags unbalanced.`);
+    }
+    // Recognized and unambiguous but simply absent (an optional section with no
+    // entries is stripped before the PDF step) — ordinary, so no warning: it
+    // just has no slot to take part in.
+  }
+  if (chosen.length < 2) return html;
+
+  // The slots are the named sections' own positions, in document order; the
+  // sections fill them in the configured order. No separate sibling check is
+  // needed: every accepted block is balanced, so they all sit at the same
+  // nesting level by construction.
+  const slots = [...chosen].sort((a, b) => a.start - b.start);
+
+  let out = '';
+  let cursor = 0;
+  for (let i = 0; i < slots.length; i++) {
+    out += html.slice(cursor, slots[i].start);
+    out += html.slice(chosen[i].start, chosen[i].end);
+    cursor = slots[i].end;
+  }
+  return out + html.slice(cursor);
 }
 
 /**
@@ -636,6 +1055,12 @@ async function generatePDF() {
   } catch (err) {
     if (err?.code !== 'ENOENT') throw err;
   }
+  // Apply the user's declared section order (config/profile.yml `cv.sections`)
+  // before the guard runs, so the guard judges the document that will be
+  // printed. Anchored to __dirname rather than the cwd so it is found when the
+  // script is invoked from outside the repo, as the usage line shows.
+  html = reorderCvSections(html, readCvSectionOrder(resolve(__dirname, 'config', 'profile.yml')));
+
   validateCvSectionOrder(html, cvMarkdown, { allowReorder });
 
   // Normalize text for ATS compatibility (issue #1)

--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -1239,6 +1239,10 @@ async function runBatchFromManifest(manifestPath, globals) {
   } catch (err) {
     if (err?.code !== 'ENOENT') throw err;
   }
+  // One profile governs the whole batch, so the declared order is read once
+  // rather than per entry. Anchored to __dirname for the same reason the single
+  // render is: the script is routinely invoked from outside the repo.
+  const cvSectionOrder = readCvSectionOrder(resolve(__dirname, 'config', 'profile.yml'));
 
   for (let i = 0; i < manifest.length; i++) {
     const spec = manifest[i];
@@ -1274,6 +1278,10 @@ async function runBatchFromManifest(manifestPath, globals) {
       }
 
       let html = await readFile(entryInput, 'utf-8');
+      // Same order as the single render: reorder first so the guard judges the
+      // document that will actually be printed. Without this the batch path
+      // rendered N CVs with cv.sections silently inert.
+      html = reorderCvSections(html, cvSectionOrder);
       validateCvSectionOrder(html, cvMarkdown, { allowReorder: globals.allowReorder });
       html = normalizeTextForATS(html).html;
 

--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -339,6 +339,45 @@ export const CV_SECTION_KEYS = [...new Set(SECTION_ALIASES.values())];
 const SECTION_MARKER_RE = /<!--\s+[A-Z][A-Z ]*-->/g;
 const SECTION_TITLE_RE = /class=["'][^"']*\bsection-title\b[^"']*["'][^>]*>([\s\S]*?)<\/[^>]+>/gi;
 
+const DISPLAY_TITLE_MAX = 60;
+
+/**
+ * A rendered section title, made safe to quote back in a console warning.
+ *
+ * The title comes out of the CV, and a warning goes to a terminal or a log, so
+ * it is untrusted output rather than untrusted input: C0/C1 controls are
+ * dropped (an ANSI escape here would let a CV repaint the operator's console or
+ * forge a line of output), and the result is truncated, since nothing stops a
+ * heading being thousands of characters long.
+ *
+ * @param {string} raw - Inner markup of the title element.
+ * @returns {string}
+ */
+function displayTitle(raw) {
+  const text = raw
+    .replace(/<[^>]+>/g, ' ')
+    // C0/C1 controls, then the bidi overrides and isolates. Both let text
+    // rewrite a terminal line rather than merely occupy it: an escape repaints
+    // it, and U+202E reverses what follows, so a title can appear to be output
+    // the tool produced. Stripped rather than escaped — a section heading has
+    // no legitimate use for either.
+    .replace(/[\u0000-\u001f\u007f-\u009f]/g, ' ')
+    .replace(/[\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  // Truncate by code point, not UTF-16 unit, so the cap can't end on half a
+  // surrogate pair; then step back off any trailing combining marks so it
+  // can't end on a mark whose base character was just removed. Marks *within*
+  // the cap are left alone — they are ordinary in many scripts, and the length
+  // bound is what keeps a stacked run from running away.
+  const points = [...text];
+  if (points.length <= DISPLAY_TITLE_MAX) return text;
+  const kept = points.slice(0, DISPLAY_TITLE_MAX - 1);
+  while (kept.length > 0 && /\p{M}/u.test(kept[kept.length - 1])) kept.pop();
+  return `${kept.join('')}…`;
+}
+
 /**
  * The text of the first real section title in html[start, end), skipping any
  * that sits in raw text (a heading quoted inside a script names nothing).
@@ -620,7 +659,14 @@ function isStructuralTail(html, from) {
  * cover letter untouched.
  *
  * @param {string} html
- * @returns {{blocks: {key: string, start: number, end: number}[], ambiguous: Set<string>}}
+ * @returns {{
+ *   blocks: {key: string, start: number, end: number, title: string}[],
+ *   ambiguous: Set<string>,
+ *   unrecognized: Map<string, string>,
+ * }} `blocks` are the movable sections, each carrying its title as rendered (see
+ *   displayTitle). `ambiguous` holds keys whose extent could not be established.
+ *   `unrecognized` maps key -> title for sections the alias table cannot name,
+ *   which are movable but can never match a configured name.
  */
 function extractSectionBlocks(html) {
   // A marker quoted inside a script or style is text, not a section boundary.
@@ -661,10 +707,19 @@ function extractSectionBlocks(html) {
       continue;
     }
 
-    blocks.push({ key, start, end });
+    blocks.push({ key, start, end, title: displayTitle(title) });
   }
 
-  return { blocks, ambiguous };
+  // Titles the alias table doesn't cover. sectionKey() falls back to the
+  // normalized title, so such a block is real and movable but can never match a
+  // configured name — and without this, a CV rendered with titles outside
+  // SECTION_ALIASES makes cv.sections do nothing at all, silently.
+  const unrecognized = new Map();
+  for (const block of blocks) {
+    if (!CV_SECTION_KEYS.includes(block.key)) unrecognized.set(block.key, block.title);
+  }
+
+  return { blocks, ambiguous, unrecognized };
 }
 
 /**
@@ -690,12 +745,19 @@ function extractSectionBlocks(html) {
  * @returns {string}
  */
 export function reorderCvSections(html, order) {
-  if (!Array.isArray(order) || order.length < 2) return html;
+  if (!Array.isArray(order) || order.length === 0) return html;
+  if (order.length < 2) {
+    // Not an error, but not a no-op worth staying quiet about either: one name
+    // states no relationship, so there is nothing to apply and the user would
+    // otherwise be left thinking the setting took effect.
+    console.warn(`⚠️  config/profile.yml cv.sections lists only "${order[0]}". An order needs at least two sections — one name states no relationship, so nothing was changed.`);
+    return html;
+  }
 
   // No early return on an empty block list: a CV whose sections are all
   // ambiguous produces none, and silently doing nothing is the failure mode
   // this feature exists to remove. The per-name loop below reports first.
-  const { blocks, ambiguous } = extractSectionBlocks(html);
+  const { blocks, ambiguous, unrecognized } = extractSectionBlocks(html);
 
   const byKey = new Map();
   for (const block of blocks) {
@@ -703,6 +765,7 @@ export function reorderCvSections(html, order) {
   }
 
   const chosen = [];
+  const unresolved = [];
   const seen = new Set();
   for (const name of order) {
     if (seen.has(name)) {
@@ -724,12 +787,35 @@ export function reorderCvSections(html, order) {
       // template put it, and the user would otherwise see a setting that
       // silently does nothing.
       console.warn(`⚠️  config/profile.yml cv.sections lists "${name}", but this CV's markup does not enclose that section on its own — leaving it in place, because moving it would leave tags unbalanced.`);
+    } else {
+      // Recognized and unambiguous but with no block. Ordinarily that just means
+      // the section isn't in this CV (an optional one with no entries is
+      // stripped before the PDF step), which is not worth a warning on its own.
+      unresolved.push(name);
     }
-    // Recognized and unambiguous but simply absent (an optional section with no
-    // entries is stripped before the PDF step) — ordinary, so no warning: it
-    // just has no slot to take part in.
   }
-  if (chosen.length < 2) return html;
+
+  // It is worth one when the CV also renders titles the alias table can't name,
+  // because then "not in this CV" may be a misreading: the section could be
+  // sitting right there under a heading nothing could identify.
+  //
+  // Whether that is what happened is not knowable here — an unresolved name may
+  // equally be an optional section with no entries. So the report states only
+  // what is checkable (this name matched nothing; these titles are unidentified)
+  // and leaves the conclusion to the reader. Deliberately not conditioned on
+  // whether the document changed: a name that did nothing did nothing, whether
+  // or not its neighbours moved, and treating "output identical" as the failure
+  // signal misreads an order that was already satisfied.
+  const reportUnresolved = () => {
+    if (unresolved.length === 0 || unrecognized.size === 0) return;
+    const names = unresolved.map(name => `"${name}"`).join(', ');
+    const titles = [...unrecognized.values()].map(title => `"${title}"`).join(', ');
+    console.warn(`⚠️  config/profile.yml cv.sections names ${names}, which matched no section in this CV. The CV also renders ${unrecognized.size} section title(s) the section-order alias table doesn't recognize (${titles}) — if one of those is the section you meant, its title needs an entry in SECTION_ALIASES in generate-pdf.mjs. Otherwise the name has no effect and can be dropped.`);
+  };
+  if (chosen.length < 2) {
+    reportUnresolved();
+    return html;
+  }
 
   // The slots are the named sections' own positions, in document order; the
   // sections fill them in the configured order. No separate sibling check is
@@ -744,7 +830,10 @@ export function reorderCvSections(html, order) {
     out += html.slice(chosen[i].start, chosen[i].end);
     cursor = slots[i].end;
   }
-  return out + html.slice(cursor);
+
+  const reordered = out + html.slice(cursor);
+  reportUnresolved();
+  return reordered;
 }
 
 /**

--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -750,7 +750,7 @@ export function reorderCvSections(html, order) {
     // Not an error, but not a no-op worth staying quiet about either: one name
     // states no relationship, so there is nothing to apply and the user would
     // otherwise be left thinking the setting took effect.
-    console.warn(`⚠️  config/profile.yml cv.sections lists only "${order[0]}". An order needs at least two sections — one name states no relationship, so nothing was changed.`);
+    console.warn(`⚠️  config/profile.yml cv.sections lists only "${displayTitle(order[0])}". An order needs at least two sections — one name states no relationship, so nothing was changed.`);
     return html;
   }
 
@@ -768,13 +768,19 @@ export function reorderCvSections(html, order) {
   const unresolved = [];
   const seen = new Set();
   for (const name of order) {
+    // `name` comes from a config file and is quoted straight into console
+    // output, so it gets the same treatment as a rendered title: displayTitle()
+    // strips C0/C1 controls and bidi overrides (either can repaint a terminal
+    // line so a warning appears to say something the tool never printed) and
+    // bounds the length so one long entry cannot bury the message.
+    const shown = displayTitle(name);
     if (seen.has(name)) {
-      console.warn(`⚠️  config/profile.yml cv.sections lists "${name}" more than once — keeping its first position.`);
+      console.warn(`⚠️  config/profile.yml cv.sections lists "${shown}" more than once — keeping its first position.`);
       continue;
     }
     seen.add(name);
     if (!CV_SECTION_KEYS.includes(name)) {
-      console.warn(`⚠️  config/profile.yml cv.sections lists "${name}", which is not a CV section — ignoring it. Recognized: ${CV_SECTION_KEYS.join(', ')}.`);
+      console.warn(`⚠️  config/profile.yml cv.sections lists "${shown}", which is not a CV section — ignoring it. Recognized: ${CV_SECTION_KEYS.join(', ')}.`);
       continue;
     }
     const block = byKey.get(name);
@@ -786,7 +792,7 @@ export function reorderCvSections(html, order) {
       // Reported rather than skipped quietly: the section stays where the
       // template put it, and the user would otherwise see a setting that
       // silently does nothing.
-      console.warn(`⚠️  config/profile.yml cv.sections lists "${name}", but this CV's markup does not enclose that section on its own — leaving it in place, because moving it would leave tags unbalanced.`);
+      console.warn(`⚠️  config/profile.yml cv.sections lists "${shown}", but this CV's markup does not enclose that section on its own — leaving it in place, because moving it would leave tags unbalanced.`);
     } else {
       // Recognized and unambiguous but with no block. Ordinarily that just means
       // the section isn't in this CV (an optional one with no entries is
@@ -808,7 +814,7 @@ export function reorderCvSections(html, order) {
   // signal misreads an order that was already satisfied.
   const reportUnresolved = () => {
     if (unresolved.length === 0 || unrecognized.size === 0) return;
-    const names = unresolved.map(name => `"${name}"`).join(', ');
+    const names = unresolved.map(name => `"${displayTitle(name)}"`).join(', ');
     const titles = [...unrecognized.values()].map(title => `"${title}"`).join(', ');
     console.warn(`⚠️  config/profile.yml cv.sections names ${names}, which matched no section in this CV. The CV also renders ${unrecognized.size} section title(s) the section-order alias table doesn't recognize (${titles}) — if one of those is the section you meant, its title needs an entry in SECTION_ALIASES in generate-pdf.mjs. Otherwise the name has no effect and can be dropped.`);
   };
@@ -1146,9 +1152,12 @@ async function generatePDF() {
   }
   // Apply the user's declared section order (config/profile.yml `cv.sections`)
   // before the guard runs, so the guard judges the document that will be
-  // printed. Anchored to __dirname rather than the cwd so it is found when the
-  // script is invoked from outside the repo, as the usage line shows.
-  html = reorderCvSections(html, readCvSectionOrder(resolve(__dirname, 'config', 'profile.yml')));
+  // printed. Anchored to workspaceRoot, NOT __dirname: readStyleTokens() reads
+  // the same file from workspaceRoot, and cv.md is read from there too, so an
+  // __dirname anchor made CAREER_OPS_TRACKER split one logical profile across
+  // two files — style from the workspace, section order from the checkout —
+  // and validated the workspace's CV against the checkout's declared order.
+  html = reorderCvSections(html, readCvSectionOrder(resolve(workspaceRoot, 'config', 'profile.yml')));
 
   validateCvSectionOrder(html, cvMarkdown, { allowReorder });
 
@@ -1240,9 +1249,10 @@ async function runBatchFromManifest(manifestPath, globals) {
     if (err?.code !== 'ENOENT') throw err;
   }
   // One profile governs the whole batch, so the declared order is read once
-  // rather than per entry. Anchored to __dirname for the same reason the single
-  // render is: the script is routinely invoked from outside the repo.
-  const cvSectionOrder = readCvSectionOrder(resolve(__dirname, 'config', 'profile.yml'));
+  // rather than per entry. Anchored to workspaceRoot for the same reason the
+  // single render is: it is the anchor readStyleTokens() and the cv.md read
+  // already use, so one profile.yml supplies every setting.
+  const cvSectionOrder = readCvSectionOrder(resolve(workspaceRoot, 'config', 'profile.yml'));
 
   for (let i = 0; i < manifest.length; i++) {
     const spec = manifest[i];

--- a/tests/cv-section-order.test.mjs
+++ b/tests/cv-section-order.test.mjs
@@ -15,6 +15,12 @@ import { tmpdir } from 'os';
 
 console.log('\nCV section order from config/profile.yml (#2533)');
 
+// Wall-clock budget for the scan-complexity assertions below. Deliberately far
+// above what the linear scans cost (single-digit ms) so a loaded CI runner
+// can't trip it, and far below what the superlinear implementations they
+// replaced cost on the fixtures used (several seconds each).
+const TIME_BUDGET_MS = 2000;
+
 // Section titles the builders render for each key, mirroring
 // DEFAULT_SECTION_TITLES in build-cv-html.mjs. Used to turn the shipped
 // template into a realistic rendered document.
@@ -153,12 +159,21 @@ try {
 
   // ── The no-op contract ────────────────────────────────────────────────────
 
+  const single = captureWarnings(() => reorderCvSections(FIXTURE, ['skills']));
   if (reorderCvSections(FIXTURE, []) === FIXTURE
       && reorderCvSections(FIXTURE, undefined) === FIXTURE
-      && reorderCvSections(FIXTURE, ['skills']) === FIXTURE) {
+      && single.value === FIXTURE) {
     pass('reorderCvSections is byte-identical with no order, an empty order, or a single name');
   } else {
     fail('reorderCvSections should be a no-op without at least two named sections');
+  }
+  // A single name is a no-op that looks like a setting, so it says so. An empty
+  // or absent list is not a statement at all, so it stays quiet.
+  if (single.warnings.some(w => w.includes('skills'))
+      && captureWarnings(() => reorderCvSections(FIXTURE, [])).warnings.length === 0) {
+    pass('a one-name order reports that it states no relationship; an empty one is silent');
+  } else {
+    fail(`single-name handling: ${JSON.stringify(single.warnings)}`);
   }
 
   const alreadyInOrder = reorderCvSections(FIXTURE, ['education', 'skills']);
@@ -351,19 +366,26 @@ try {
 
   // The markup scan runs over every candidate section, so no template should be
   // able to stall a render through it. Both shapes below defeated an earlier
-  // regex-based scanner: a run of complete comments made it exponential (4.4s at
-  // 28 repetitions), and a run of unterminated ones made it quadratic (728ms at
-  // 32k). Thresholds are set so a regression is reported rather than hanging the
-  // suite, since a scan that never returns produces no failure at all.
+  // regex-based scanner: a run of complete comments made it exponential, and a
+  // run of unterminated ones made it quadratic.
+  //
+  // On the bound: it has to sit far enough above the linear cost that a loaded
+  // CI runner can't cross it, and far enough below the regressed cost to still
+  // fail. Those pull in opposite directions, so the *fixtures* are sized rather
+  // than the threshold loosened — each one is large enough that the regressed
+  // implementation needs several seconds, while the linear scan stays in
+  // single-digit milliseconds. Sizing them any larger would make a regression
+  // hang the suite instead of reporting, and a scan that never returns produces
+  // no failure at all.
   for (const [label, filler] of [
-    ['complete comments', '<!-- x --> '.repeat(28) + 'y'],
-    ['unterminated comments', '<!--'.repeat(32000)],
+    ['complete comments', '<!-- x --> '.repeat(30) + 'y'],
+    ['unterminated comments', '<!--'.repeat(96000)],
   ]) {
     const noisy = FIXTURE.replace('  <!-- EDUCATION -->', `  ${filler}\n  <!-- EDUCATION -->`);
     const started = Date.now();
     reorderCvSections(noisy, ['skills', 'education']);
     const elapsed = Date.now() - started;
-    if (elapsed < 500) {
+    if (elapsed < TIME_BUDGET_MS) {
       pass(`a run of ${label} is scanned linearly (${elapsed}ms)`);
     } else {
       fail(`scanning a run of ${label} took ${elapsed}ms — superlinear scanning is back`);
@@ -460,19 +482,149 @@ try {
   // it 16k x 16k if the lookup is a scan — 619ms before this became a search,
   // against 13ms after.
   {
-    const many = '<script></script><!-- EXPERIENCE -->'.repeat(16000)
+    const many = '<script></script><!-- EXPERIENCE -->'.repeat(48000)
       + '<div class="cv"><!-- EDUCATION --><div class="section"><div class="section-title">Education</div>E</div>'
       + '<!-- SKILLS --><div class="section"><div class="section-title">Skills</div>K</div></div>';
     const started = Date.now();
     const shuffled = reorderCvSections(many, ['skills', 'education']);
     const elapsed = Date.now() - started;
-    if (elapsed < 500 && shuffled.indexOf('Skills') < shuffled.indexOf('Education')) {
-      pass(`raw-text ranges are consulted by search, not by scan (16k ranges and markers in ${elapsed}ms)`);
-    } else if (elapsed >= 500) {
-      fail(`16k interleaved ranges and markers took ${elapsed}ms — a lookup is linear again`);
+    if (elapsed < TIME_BUDGET_MS && shuffled.indexOf('Skills') < shuffled.indexOf('Education')) {
+      pass(`raw-text ranges are consulted by search, not by scan (48k ranges and markers in ${elapsed}ms)`);
+    } else if (elapsed >= TIME_BUDGET_MS) {
+      fail(`48k interleaved ranges and markers took ${elapsed}ms — a lookup is linear again`);
     } else {
       fail('the scaling fixture stopped reordering, so it no longer measures the lookup path');
     }
+  }
+
+  // sectionKey() falls back to the normalized title when SECTION_ALIASES has no
+  // entry for it, so a CV rendered with titles outside that table produces
+  // blocks that are real and movable but can never match a configured name.
+  // Without a warning that is indistinguishable, from the user's side, from a
+  // setting that does nothing — the failure this feature exists to remove.
+  const unknownTitles = `<html><body><div class="cv">
+  <!-- EDUCATION -->
+  <div class="section"><div class="section-title">Ausbildung</div><div>Uni</div></div>
+
+  <!-- SKILLS -->
+  <div class="section"><div class="section-title">Kenntnisse</div><div>Node.js</div></div>
+</div></body></html>`;
+  const unknownRun = captureWarnings(() => reorderCvSections(unknownTitles, ['skills', 'education']));
+  if (unknownRun.value === unknownTitles
+      && unknownRun.warnings.some(w => w.includes('Ausbildung') && w.includes('Kenntnisse'))) {
+    pass('a CV whose titles are outside the alias table says so, instead of quietly doing nothing');
+  } else {
+    fail(`unrecognized rendered titles went unreported: ${JSON.stringify(unknownRun.warnings)}`);
+  }
+
+  // The report has to key on which names failed to resolve, not on how many
+  // sections were placed: here two of three names resolve, the two that do are
+  // already in the requested order, so nothing changes and a count-based check
+  // would see a successful reorder and stay silent.
+  const partial = `<html><body><div class="cv">
+  <!-- PROJECTS -->
+  <div class="section"><div class="section-title">Projects</div><div>P</div></div>
+  <!-- EDUCATION -->
+  <div class="section"><div class="section-title">Education</div><div>E</div></div>
+  <!-- SKILLS -->
+  <div class="section"><div class="section-title">Kenntnisse</div><div>K</div></div>
+</div></body></html>`;
+  const partialRun = captureWarnings(() => reorderCvSections(partial, ['skills', 'projects', 'education']));
+  if (partialRun.value === partial
+      && partialRun.warnings.some(w => w.includes('"skills"') && w.includes('Kenntnisse'))) {
+    pass('a partly-resolving order that changes nothing still names what it could not resolve');
+  } else {
+    fail(`partial resolution went unreported: ${JSON.stringify(partialRun.warnings)}`);
+  }
+
+  // The title is quoted back into a terminal, so it is untrusted output: an
+  // escape sequence would let a CV repaint the console or forge a line of it,
+  // and an unbounded title would bury the warning it belongs to.
+  const ESC = String.fromCharCode(27);
+  const hostileTitle = unknownTitles
+    .replace('Ausbildung', `${ESC}[31mFAKE ERROR${ESC}[0m`)
+    .replace('Kenntnisse', 'X'.repeat(500));
+  const hostileRun = captureWarnings(() => reorderCvSections(hostileTitle, ['skills', 'education']));
+  const emitted = hostileRun.warnings.join('\n');
+  if (emitted.includes(ESC)) {
+    fail('control characters from a rendered title survived into a warning');
+  } else if (emitted.length >= 700) {
+    fail(`a 500-character title produced a ${emitted.length}-character warning — it is not being truncated`);
+  } else {
+    pass('a rendered title is stripped of control characters and truncated before it reaches a warning');
+  }
+
+  // A control character is not the only way text rewrites a terminal line:
+  // U+202E reverses what follows, so a title can be made to read as output the
+  // tool produced. And truncating by UTF-16 unit can cut a surrogate pair in
+  // half, emitting a lone surrogate into the log.
+  const RTL_OVERRIDE = '‮';
+  const bidiAndAstral = unknownTitles
+    .replace('Ausbildung', `${RTL_OVERRIDE}gnudlibsuA`)
+    .replace('Kenntnisse', '😀'.repeat(80));
+  const bidiRun = captureWarnings(() => reorderCvSections(bidiAndAstral, ['skills', 'education']));
+  const bidiText = bidiRun.warnings.join('\n');
+  const hasLoneSurrogate = [...bidiText].some(ch => {
+    const code = ch.charCodeAt(0);
+    return code >= 0xd800 && code <= 0xdfff && ch.length === 1;
+  });
+  if (!bidiText.includes(RTL_OVERRIDE) && !hasLoneSurrogate) {
+    pass('bidi overrides are stripped and truncation never splits a surrogate pair');
+  } else {
+    fail(`title sanitization leaked ${bidiText.includes(RTL_OVERRIDE) ? 'a bidi override' : 'a lone surrogate'}`);
+  }
+
+  // The report is per-name, not per-render, and says only what can be checked.
+  // Whether an unresolved name is an absent optional section or the section
+  // under an unidentifiable heading is not knowable here, so the message states
+  // both facts and draws no conclusion. It must not depend on whether the
+  // document changed: an order that was already satisfied changes no bytes and
+  // is a success, while a partly-resolving order can change none and be a
+  // failure — the byte count distinguishes neither.
+  const alreadySatisfied = FIXTURE.replace('>Certifications<', '>Portfolio<');
+  const satisfiedRun = captureWarnings(() => reorderCvSections(alreadySatisfied, ['education', 'skills', 'awards']));
+  const swapRun = captureWarnings(() => reorderCvSections(alreadySatisfied, ['skills', 'education', 'awards']));
+  const namesAwardsAndPortfolio = (w) => w.includes('"awards"') && w.includes('Portfolio') && !w.includes('changed nothing');
+  // Byte-for-byte equality of the emitted warnings, not merely "both mention
+  // awards" — the claim is that the report does not vary with the outcome, and
+  // a weaker check would hold even if the wording differed between the paths.
+  if (satisfiedRun.value === alreadySatisfied && swapRun.value !== alreadySatisfied
+      && JSON.stringify(satisfiedRun.warnings) === JSON.stringify(swapRun.warnings)
+      && satisfiedRun.warnings.some(namesAwardsAndPortfolio)) {
+    pass('the unresolved-name report is identical whether the order was already satisfied or had to be applied');
+  } else {
+    fail(`report depends on whether bytes changed: satisfied=${JSON.stringify(satisfiedRun.warnings)} swapped=${JSON.stringify(swapRun.warnings)}`);
+  }
+
+  // And it stays quiet when every configured name resolved, however many
+  // unidentifiable headings the CV carries elsewhere.
+  const allResolved = captureWarnings(() => reorderCvSections(alreadySatisfied, ['skills', 'education']));
+  if (allResolved.warnings.length === 0) {
+    pass('no report when every configured name resolved, whatever else the CV renders');
+  } else {
+    fail(`spurious report when all names resolved: ${JSON.stringify(allResolved.warnings)}`);
+  }
+
+  // The same must not fire when the setting simply had nothing to do: an
+  // English CV missing an optional section is ordinary, not a misconfiguration.
+  const quiet = captureWarnings(() => reorderCvSections(FIXTURE, ['skills', 'awards']));
+  if (quiet.warnings.length === 0) {
+    pass('a recognized-but-absent section still warns about nothing');
+  } else {
+    fail(`unexpected warning for an ordinary absent section: ${JSON.stringify(quiet.warnings)}`);
+  }
+
+  // Nor when the reorder worked. A custom heading elsewhere in the CV is the
+  // user's business; the warning is about the setting failing, not about the
+  // alias table being incomplete in the abstract.
+  const mixed = FIXTURE.replace('>Certifications<', '>Auszeichnungen<');
+  const mixedRun = captureWarnings(() => reorderCvSections(mixed, ['skills', 'education']));
+  if (JSON.stringify(renderedTitles(mixedRun.value)) === JSON.stringify(
+        ['Professional Summary', 'Work Experience', 'Projects', 'Skills', 'Auszeichnungen', 'Education'])
+      && mixedRun.warnings.length === 0) {
+    pass('an unrecognized title elsewhere is silent when the configured sections did resolve');
+  } else {
+    fail(`spurious warning or wrong order with a mixed-language CV: ${JSON.stringify(mixedRun.warnings)} ${JSON.stringify(renderedTitles(mixedRun.value))}`);
   }
 
   // A cover letter has no sections at all — the same call must leave it alone.

--- a/tests/cv-section-order.test.mjs
+++ b/tests/cv-section-order.test.mjs
@@ -1,0 +1,564 @@
+// tests/cv-section-order.test.mjs — behavioural coverage for user-configurable CV
+// section order (#2533): reading `cv.sections` from config/profile.yml, permuting
+// the named sections among the slots they already occupy, and the end-to-end
+// promise that a CV whose order differs from the shipped template stops tripping
+// validateCvSectionOrder().
+//
+// Assertions run against rendered HTML rather than source patterns: the reorder
+// has to survive nested markup, comments, absent optional sections and a second
+// application, and none of that is observable from the source text.
+import { pass, fail, ROOT } from './helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+
+console.log('\nCV section order from config/profile.yml (#2533)');
+
+// Section titles the builders render for each key, mirroring
+// DEFAULT_SECTION_TITLES in build-cv-html.mjs. Used to turn the shipped
+// template into a realistic rendered document.
+const RENDERED_TITLES = {
+  SECTION_SUMMARY: 'Professional Summary',
+  SECTION_COMPETENCIES: 'Core Competencies',
+  SECTION_EXPERIENCE: 'Work Experience',
+  SECTION_PROJECTS: 'Projects',
+  SECTION_EDUCATION: 'Education',
+  SECTION_CERTIFICATIONS: 'Certifications',
+  SECTION_AWARDS: 'Awards & Honors',
+  SECTION_SKILLS: 'Skills',
+};
+
+// A compact stand-in for a rendered CV: marker comments, nested markup inside a
+// section, and a comment whose text contains a tag (which must not be mistaken
+// for real markup while finding where a section ends).
+const FIXTURE = `<!DOCTYPE html>
+<html lang="en">
+<head><title>Test</title></head>
+<body>
+<div class="cv">
+  <!-- HEADER -->
+  <div class="header">
+    <h1>Test Candidate</h1>
+    <img src="x.png" alt="">
+  </div>
+
+  <!-- PROFESSIONAL SUMMARY -->
+  <div class="section">
+    <div class="section-title">Professional Summary</div>
+    <div class="summary-text">Summary body.</div>
+  </div>
+
+  <!-- WORK EXPERIENCE -->
+  <div class="section">
+    <div class="section-title">Work Experience</div>
+    <div class="job">
+      <div class="job-header"><span class="job-company">Acme</span></div>
+      <ul><li>Did the thing<br>and another</li></ul>
+    </div>
+  </div>
+
+  <!-- PROJECTS -->
+  <div class="section">
+    <div class="section-title">Projects</div>
+    <!-- a comment mentioning <div class="section"> must not confuse the scanner -->
+    <div class="project">P</div>
+  </div>
+
+  <!-- EDUCATION -->
+  <div class="section">
+    <div class="section-title">Education</div>
+    <div class="edu-item">E</div>
+  </div>
+
+  <!-- CERTIFICATIONS -->
+  <div class="section">
+    <div class="section-title">Certifications</div>
+    <div class="cert-table">C</div>
+  </div>
+
+  <!-- SKILLS -->
+  <div class="section">
+    <div class="section-title">Skills</div>
+    <div class="skills-grid">K</div>
+  </div>
+</div>
+</body>
+</html>
+`;
+
+// Read back the order a document actually renders, independent of the
+// implementation's own extraction.
+function renderedTitles(html) {
+  return [...html.matchAll(/class="section-title">([^<]*)</g)].map(m => m[1].trim());
+}
+
+// Swallow the implementation's warnings while asserting on them.
+function captureWarnings(fn) {
+  const original = console.warn;
+  const lines = [];
+  console.warn = (...args) => lines.push(args.join(' '));
+  try {
+    return { value: fn(), warnings: lines };
+  } finally {
+    console.warn = original;
+  }
+}
+
+try {
+  const { cvSectionOrderFrom, readCvSectionOrder } =
+    await import(pathToFileURL(join(ROOT, 'theme-style.mjs')).href);
+  const { reorderCvSections, CV_SECTION_KEYS, validateCvSectionOrder } =
+    await import(pathToFileURL(join(ROOT, 'generate-pdf.mjs')).href);
+
+  // ── Reading the config ────────────────────────────────────────────────────
+
+  const parsed = cvSectionOrderFrom({ sections: [' Skills ', 'EDUCATION', 42, '', null] });
+  if (JSON.stringify(parsed) === JSON.stringify(['skills', 'education'])) {
+    pass('cvSectionOrderFrom trims + lowercases entries and drops non-strings');
+  } else {
+    fail(`cvSectionOrderFrom => ${JSON.stringify(parsed)}`);
+  }
+  if (cvSectionOrderFrom(undefined).length === 0 && cvSectionOrderFrom({}).length === 0
+      && cvSectionOrderFrom({ sections: 'skills' }).length === 0
+      && cvSectionOrderFrom({ sections: {} }).length === 0) {
+    pass('cvSectionOrderFrom returns [] for an absent, scalar or mapping `sections`');
+  } else {
+    fail('cvSectionOrderFrom should return [] unless `sections` is a list');
+  }
+
+  const dir = mkdtempSync(join(tmpdir(), 'career-ops-sections-'));
+  try {
+    const profile = join(dir, 'profile.yml');
+    writeFileSync(profile, 'candidate:\n  full_name: X\ncv:\n  output_format: html\n  sections: [skills, education]\n');
+    if (JSON.stringify(readCvSectionOrder(profile)) === JSON.stringify(['skills', 'education'])) {
+      pass('readCvSectionOrder reads cv.sections from a profile file');
+    } else {
+      fail(`readCvSectionOrder => ${JSON.stringify(readCvSectionOrder(profile))}`);
+    }
+    const noCv = join(dir, 'nocv.yml');
+    writeFileSync(noCv, 'candidate:\n  full_name: X\n');
+    const broken = join(dir, 'broken.yml');
+    writeFileSync(broken, 'cv:\n  sections: [unclosed\n');
+    if (readCvSectionOrder(join(dir, 'missing.yml')).length === 0
+        && readCvSectionOrder(noCv).length === 0
+        && readCvSectionOrder(broken).length === 0) {
+      pass('readCvSectionOrder returns [] for a missing, cv-less or unparseable profile');
+    } else {
+      fail('readCvSectionOrder should return [] for a missing, cv-less or unparseable profile');
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+
+  // ── The no-op contract ────────────────────────────────────────────────────
+
+  if (reorderCvSections(FIXTURE, []) === FIXTURE
+      && reorderCvSections(FIXTURE, undefined) === FIXTURE
+      && reorderCvSections(FIXTURE, ['skills']) === FIXTURE) {
+    pass('reorderCvSections is byte-identical with no order, an empty order, or a single name');
+  } else {
+    fail('reorderCvSections should be a no-op without at least two named sections');
+  }
+
+  const alreadyInOrder = reorderCvSections(FIXTURE, ['education', 'skills']);
+  if (alreadyInOrder === FIXTURE) {
+    pass('reorderCvSections is byte-identical when the configured order already holds');
+  } else {
+    fail('reorderCvSections changed a document that already matched the configured order');
+  }
+
+  // ── The permutation ───────────────────────────────────────────────────────
+
+  const swapped = reorderCvSections(FIXTURE, ['skills', 'education']);
+  const order = renderedTitles(swapped);
+  const expected = ['Professional Summary', 'Work Experience', 'Projects', 'Skills', 'Certifications', 'Education'];
+  if (JSON.stringify(order) === JSON.stringify(expected)) {
+    pass('named sections swap into each other\'s slots; unnamed sections never move');
+  } else {
+    fail(`reordered => ${JSON.stringify(order)}, expected ${JSON.stringify(expected)}`);
+  }
+
+  // Certifications sat between Education and Skills and was not named: it must
+  // still be exactly where it was, not carried along with a moving neighbour.
+  if (order[4] === 'Certifications' && renderedTitles(FIXTURE)[4] === 'Certifications') {
+    pass('an unnamed section between two moved ones keeps its slot');
+  } else {
+    fail('an unnamed section between two moved ones did not keep its slot');
+  }
+
+  // Nothing may be lost or duplicated: every section body survives exactly once.
+  const bodies = ['Summary body.', 'class="job-company">Acme', 'class="project">P', 'class="edu-item">E', 'class="cert-table">C', 'class="skills-grid">K'];
+  const intact = bodies.every(b => swapped.split(b).length === 2)
+    && swapped.includes('<h1>Test Candidate</h1>')
+    && swapped.trimEnd().endsWith('</html>');
+  if (intact) {
+    pass('reordering preserves every section body exactly once, plus header and document tail');
+  } else {
+    fail('reordering lost, duplicated or truncated document content');
+  }
+
+  // A three-way rotation, to prove the mapping is a real permutation rather
+  // than a pairwise swap that happens to work for two entries. Slots 2/3/5
+  // (Projects, Education, Skills) receive the named sections in the order given.
+  const rotated = renderedTitles(reorderCvSections(FIXTURE, ['skills', 'projects', 'education']));
+  const expectedRotation = ['Professional Summary', 'Work Experience', 'Skills', 'Projects', 'Certifications', 'Education'];
+  if (JSON.stringify(rotated) === JSON.stringify(expectedRotation)) {
+    pass('a three-section order rotates all three through their own slots');
+  } else {
+    fail(`three-way => ${JSON.stringify(rotated)}, expected ${JSON.stringify(expectedRotation)}`);
+  }
+
+  if (reorderCvSections(swapped, ['skills', 'education']) === swapped) {
+    pass('reorderCvSections is idempotent — a second pass changes nothing');
+  } else {
+    fail('reorderCvSections is not idempotent');
+  }
+
+  // ── Names that do not resolve ─────────────────────────────────────────────
+
+  const typo = captureWarnings(() => reorderCvSections(FIXTURE, ['sklls', 'skills', 'education']));
+  const typoOrder = renderedTitles(typo.value);
+  if (JSON.stringify(typoOrder) === JSON.stringify(expected)
+      && typo.warnings.some(w => w.includes('sklls'))) {
+    pass('an unrecognized section name warns by name and is skipped, leaving the rest applied');
+  } else {
+    fail(`unrecognized name: order=${JSON.stringify(typoOrder)} warnings=${JSON.stringify(typo.warnings)}`);
+  }
+
+  // Asserted against a written-out vocabulary, not against CV_SECTION_KEYS:
+  // checking the message with the same list the message is built from would
+  // pass however many sections the implementation actually knows about.
+  const EXPECTED_KEYS = ['summary', 'competencies', 'experience', 'projects', 'education', 'certifications', 'awards', 'skills'];
+  if (typo.warnings.some(w => EXPECTED_KEYS.every(k => w.includes(k)))) {
+    pass('the unrecognized-name warning lists all eight recognized section keys');
+  } else {
+    fail(`the warning should list the recognized keys: ${JSON.stringify(typo.warnings)}`);
+  }
+  if (EXPECTED_KEYS.every(k => CV_SECTION_KEYS.includes(k)) && CV_SECTION_KEYS.length === EXPECTED_KEYS.length) {
+    pass('CV_SECTION_KEYS is exactly the eight canonical sections the alias table produces');
+  } else {
+    fail(`CV_SECTION_KEYS => ${JSON.stringify(CV_SECTION_KEYS)}`);
+  }
+
+  const dup = captureWarnings(() => reorderCvSections(FIXTURE, ['skills', 'education', 'skills']));
+  if (JSON.stringify(renderedTitles(dup.value)) === JSON.stringify(expected)
+      && dup.warnings.some(w => w.toLowerCase().includes('skills'))) {
+    pass('a repeated section name warns and keeps only its first position');
+  } else {
+    fail(`duplicate name: order=${JSON.stringify(renderedTitles(dup.value))} warnings=${JSON.stringify(dup.warnings)}`);
+  }
+
+  // A recognized section the CV does not carry (awards is stripped when empty)
+  // is ordinary, not a misconfiguration: no warning, and the rest still applies.
+  const absent = captureWarnings(() => reorderCvSections(FIXTURE, ['skills', 'awards', 'education']));
+  if (JSON.stringify(renderedTitles(absent.value)) === JSON.stringify(expected)
+      && absent.warnings.length === 0) {
+    pass('a recognized section absent from this CV is skipped silently');
+  } else {
+    fail(`absent section: order=${JSON.stringify(renderedTitles(absent.value))} warnings=${JSON.stringify(absent.warnings)}`);
+  }
+
+  // Malformed markup must not be guessed at. A stray closing tag between the
+  // marker and the section element makes the section's extent unknowable: the
+  // depth scan can be pushed negative and then "balance" in the middle of the
+  // section, which would move a truncated fragment and mangle the CV. Such a
+  // section is not extractable, so it takes no part in the reorder.
+  const malformed = FIXTURE.replace(
+    '  <!-- SKILLS -->\n',
+    '  <!-- SKILLS -->\n  </span>\n',
+  );
+  const malformedRun = captureWarnings(() => reorderCvSections(malformed, ['skills', 'education']));
+  if (malformedRun.value === malformed && malformedRun.warnings.some(w => w.includes('skills'))) {
+    pass('a section whose extent cannot be determined is left out of the reorder, not truncated, and is reported');
+  } else {
+    fail(`a malformed section was reordered anyway, or went unreported: ${JSON.stringify(malformedRun.warnings)}`);
+  }
+
+  // A template may mark a section with a bare heading and leave the body as a
+  // sibling — nothing requires a wrapper element. Because a section's extent is
+  // taken from its markers rather than by pairing tags, the heading and its body
+  // move together. The failure this guards against is the heading travelling
+  // alone: the order guard compares headings only, so a CV whose Skills heading
+  // is followed by a degree would be reported as correctly ordered and pass.
+  const unwrapped = `<html><body><div class="cv">
+  <!-- EDUCATION -->
+  <h2 class="section-title">Education</h2>
+  <div class="edu-item">BSc Computer Science</div>
+
+  <!-- SKILLS -->
+  <h2 class="section-title">Skills</h2>
+  <div class="skills-grid">Node.js, Python</div>
+</div></body></html>`;
+  const unwrappedRun = captureWarnings(() => reorderCvSections(unwrapped, ['skills', 'education']));
+  const pairedCorrectly = /Skills<\/h2>\s*<div class="skills-grid">Node\.js, Python<\/div>/.test(unwrappedRun.value)
+    && /Education<\/h2>\s*<div class="edu-item">BSc Computer Science<\/div>/.test(unwrappedRun.value);
+  if (pairedCorrectly && unwrappedRun.value.indexOf('Skills') < unwrappedRun.value.indexOf('Education')) {
+    pass('a heading-marked section moves together with its sibling body, in the requested order');
+  } else {
+    fail(`a heading-only section was separated from its body:\n${unwrappedRun.value}`);
+  }
+  if (unwrappedRun.warnings.length === 0) {
+    pass('a heading-marked template needs no warning — it is supported, not merely tolerated');
+  } else {
+    fail(`unexpected warnings for a heading-marked template: ${JSON.stringify(unwrappedRun.warnings)}`);
+  }
+
+  // Raw text is not markup. A `</div>` inside <style> or <script> closes
+  // nothing, and treating it as a close tag ends the section early: the section
+  // moves as a fragment, its real closing tag stays behind, and whatever follows
+  // is swallowed into the broken wrapper. Nothing here reads as "lost" — the
+  // characters are all still present — which is what makes it worth pinning.
+  const rawText = `<html><body><div class="cv">
+  <!-- EDUCATION -->
+  <div class="section"><div class="section-title">Education</div><div class="edu-item">BSc</div></div>
+
+  <!-- SKILLS -->
+  <div class="section"><div class="section-title">Skills</div><style>/* </div> */</style></div>
+</div></body></html>`;
+  const rawOut = reorderCvSections(rawText, ['skills', 'education']);
+  const sorted = (s) => s.split('').sort().join('');
+  if (sorted(rawOut) === sorted(rawText)
+      && rawOut.includes('<style>/* </div> */</style>')
+      && /<!-- SKILLS -->[\s\S]*?Skills[\s\S]*?<\/style><\/div>/.test(rawOut)
+      && /<!-- EDUCATION -->[\s\S]*?Education[\s\S]*?edu-item">BSc/.test(rawOut)
+      && rawOut.indexOf('SKILLS') < rawOut.indexOf('EDUCATION')) {
+    pass('a </div> inside <style> does not truncate its section: both move whole, output is a permutation of the input');
+  } else {
+    fail(`raw-text handling corrupted the document:\n${rawOut}`);
+  }
+
+  // A section may sit inside a container of its own. Swapping it with a section
+  // outside that container loses nothing — both bodies survive — but relocates
+  // one into markup that was never meant to hold it, which is invisible in the
+  // section order and shows up only in the rendered layout.
+  const containered = `<html><body><div class="cv">
+  <div class="education-layout">
+  <!-- EDUCATION -->
+  <div class="section"><div class="section-title">Education</div><div class="edu-item">BSc</div></div>
+  </div>
+
+  <!-- SKILLS -->
+  <div class="section"><div class="section-title">Skills</div><div class="skills-grid">Node.js</div></div>
+</div></body></html>`;
+  const containeredRun = captureWarnings(() => reorderCvSections(containered, ['skills', 'education']));
+  if (containeredRun.value === containered
+      && containeredRun.warnings.some(w => w.includes('education'))) {
+    pass('a section wrapped in a container of its own is left alone and reported, not swapped out of it');
+  } else {
+    fail(`a section was moved into another section's container:\n${containeredRun.value}\n${JSON.stringify(containeredRun.warnings)}`);
+  }
+
+  // The markup scan runs over every candidate section, so no template should be
+  // able to stall a render through it. Both shapes below defeated an earlier
+  // regex-based scanner: a run of complete comments made it exponential (4.4s at
+  // 28 repetitions), and a run of unterminated ones made it quadratic (728ms at
+  // 32k). Thresholds are set so a regression is reported rather than hanging the
+  // suite, since a scan that never returns produces no failure at all.
+  for (const [label, filler] of [
+    ['complete comments', '<!-- x --> '.repeat(28) + 'y'],
+    ['unterminated comments', '<!--'.repeat(32000)],
+  ]) {
+    const noisy = FIXTURE.replace('  <!-- EDUCATION -->', `  ${filler}\n  <!-- EDUCATION -->`);
+    const started = Date.now();
+    reorderCvSections(noisy, ['skills', 'education']);
+    const elapsed = Date.now() - started;
+    if (elapsed < 500) {
+      pass(`a run of ${label} is scanned linearly (${elapsed}ms)`);
+    } else {
+      fail(`scanning a run of ${label} took ${elapsed}ms — superlinear scanning is back`);
+    }
+  }
+
+  // `>` is legal inside an attribute value, so a tag scan that stops at the
+  // first `>` reads one tag as several. The extra "tags" can be chosen to make
+  // an unbalanced slice look balanced, which is worse than a parse failure: the
+  // section passes validation and is then moved out of its container. The
+  // output stays a permutation and stays well-formed — only the meaning is wrong.
+  const quotedAngle = `<html><body><div class="cv"><div class="education-layout">
+<!-- EDUCATION -->
+<h2 class="section-title">Education</h2><span data-x="> <div>">BSc</span>
+</div>
+<!-- SKILLS -->
+<div class="section"><h2 class="section-title">Skills</h2>Node.js</div>
+</div></body></html>`;
+  if (reorderCvSections(quotedAngle, ['skills', 'education']) === quotedAngle) {
+    pass('a `>` inside an attribute value cannot forge a balanced slice');
+  } else {
+    fail(`attribute-quoted markup forged a balance and a section was relocated:\n${reorderCvSections(quotedAngle, ['skills', 'education'])}`);
+  }
+
+  // Marker comments quoted inside a script are text. A search that starts at the
+  // marker has no way to know that, so raw-text ranges have to be established
+  // from the start of the document — otherwise part of a script body is treated
+  // as a CV section and moved across the page.
+  const markerInScript = `<html><head><script>const fixture = '<!-- EDUCATION --><div class="section-title">Education</div><!-- SKILLS --><div class="section-title">Skills</div><div><div>';</script></head><body><div class="cv"><p>Actual body</p></div></body></html>`;
+  if (reorderCvSections(markerInScript, ['skills', 'education']) === markerInScript) {
+    pass('marker comments quoted inside a script are text, not section boundaries');
+  } else {
+    fail(`a script body was reordered as if it were CV sections:\n${reorderCvSections(markerInScript, ['skills', 'education'])}`);
+  }
+
+  // The same reasoning applies to titles, not just markers: a heading quoted
+  // inside a script names nothing, and taking it would label a block from
+  // markup that only looks like a heading — applying the user's ordering to the
+  // wrong section.
+  const fakeTitle = `<html><body><div class="cv">
+<!-- EDUCATION -->
+<div class="section"><script>var t = '<x class="section-title">Education</x>';</script><div class="edu-item">BSc</div></div>
+<!-- SKILLS -->
+<div class="section"><div class="section-title">Skills</div>Node.js</div>
+</div></body></html>`;
+  if (reorderCvSections(fakeTitle, ['skills', 'education']) === fakeTitle) {
+    pass('a section title quoted inside a script does not name a section');
+  } else {
+    fail('a script-quoted title was used to identify a section');
+  }
+
+  // Raw text is not only <script> and <style>. A parser builds no elements from
+  // <xmp>, <iframe>, <noembed>, <noframes> or <plaintext> either, so leaving one
+  // off the list means markup-shaped text inside it passes for structure.
+  // `<script/>` belongs here too: trailing-slash syntax does nothing to an HTML
+  // element, so it opens raw text rather than standing alone.
+  //
+  // Both fixtures put the sample markup at the end of the container, so that
+  // dropping the element from the raw-text list leaves two *balanced* fake
+  // sections that do get reordered — otherwise they'd be refused for unrelated
+  // reasons and the assertion would hold either way.
+  const fakeSections = '<!-- EDUCATION --><div class="section-title">Education</div><!-- SKILLS --><div class="section-title">Skills</div>';
+  const rawTextHosts = ['script', 'style', 'textarea', 'title', 'xmp', 'iframe', 'noembed', 'noframes'];
+  const leaked = rawTextHosts.filter((tag) => {
+    const doc = `<html><body><div class="cv">\n<p>Real body</p>\n<${tag}>${fakeSections}</${tag}>\n</div></body></html>`;
+    return reorderCvSections(doc, ['skills', 'education']) !== doc;
+  });
+  // <plaintext> is checked separately, and with the sample placed *after* a
+  // literal `</plaintext>`: it has no end tag in HTML, so everything from the
+  // opening tag onwards is text to the end of the document. A fixture with the
+  // sample inside would pass either way, since an implementation that wrongly
+  // honours the literal close still covers that span.
+  const plaintextDoc = `<html><body><div class="cv">\n<p>Real body</p>\n<plaintext>still text</plaintext>${fakeSections}\n</div></body></html>`;
+  if (leaked.length === 0 && reorderCvSections(plaintextDoc, ['skills', 'education']) === plaintextDoc) {
+    pass(`markup-shaped text stays out of the structure in all ${rawTextHosts.length + 1} raw-text elements`);
+  } else {
+    fail(`raw-text contents were reordered as CV sections in: ${leaked.join(', ') || 'plaintext'}`);
+  }
+
+  const selfClosedScript = `<html><body><div class="cv">
+<p>Real body</p>
+<script/><!-- EDUCATION --><div class="section-title">Education</div><!-- SKILLS --><div class="section-title">Skills</div></script>
+</div></body></html>`;
+  if (reorderCvSections(selfClosedScript, ['skills', 'education']) === selfClosedScript) {
+    pass('<script/> opens raw text rather than standing alone, so its contents stay out of the structure');
+  } else {
+    fail(`<script/> contents were reordered as CV sections:\n${reorderCvSections(selfClosedScript, ['skills', 'education'])}`);
+  }
+
+  // Establishing raw-text ranges is one pass, but consulting them is a lookup
+  // per marker and per candidate title, so both quantities have to grow
+  // together for the cost to show: 16k ranges against two markers is only four
+  // lookups, which a linear scan answers comfortably. Interleaving them makes
+  // it 16k x 16k if the lookup is a scan — 619ms before this became a search,
+  // against 13ms after.
+  {
+    const many = '<script></script><!-- EXPERIENCE -->'.repeat(16000)
+      + '<div class="cv"><!-- EDUCATION --><div class="section"><div class="section-title">Education</div>E</div>'
+      + '<!-- SKILLS --><div class="section"><div class="section-title">Skills</div>K</div></div>';
+    const started = Date.now();
+    const shuffled = reorderCvSections(many, ['skills', 'education']);
+    const elapsed = Date.now() - started;
+    if (elapsed < 500 && shuffled.indexOf('Skills') < shuffled.indexOf('Education')) {
+      pass(`raw-text ranges are consulted by search, not by scan (16k ranges and markers in ${elapsed}ms)`);
+    } else if (elapsed >= 500) {
+      fail(`16k interleaved ranges and markers took ${elapsed}ms — a lookup is linear again`);
+    } else {
+      fail('the scaling fixture stopped reordering, so it no longer measures the lookup path');
+    }
+  }
+
+  // A cover letter has no sections at all — the same call must leave it alone.
+  const letter = '<html><body><p>Dear hiring manager,</p><p>Regards</p></body></html>';
+  if (reorderCvSections(letter, ['skills', 'education']) === letter) {
+    pass('a document with no CV sections (e.g. a cover letter) is returned unchanged');
+  } else {
+    fail('reorderCvSections modified a document that has no CV sections');
+  }
+
+  // ── The shipped template ──────────────────────────────────────────────────
+
+  // Render the real template's section titles so the structural contract this
+  // feature depends on (marker comment + .section-title per section) is guarded
+  // against future template edits, not just against the fixture above.
+  const renderTemplate = (file) => {
+    let html = readFileSync(join(ROOT, 'templates', file), 'utf-8');
+    for (const [placeholder, title] of Object.entries(RENDERED_TITLES)) {
+      html = html.replaceAll(`{{${placeholder}}}`, title);
+    }
+    return html;
+  };
+
+  // Every section the template carries must be movable — checked by reversing
+  // all of them at once, so a section the extractor silently can't reach shows
+  // up as one that stayed put. Asserting only the Skills/Education pair would
+  // pass with the other six unreachable.
+  const rendered = renderTemplate('cv-template.html');
+  const shippedOrder = renderedTitles(rendered);
+  const allKeys = ['summary', 'competencies', 'experience', 'projects', 'education', 'certifications', 'awards', 'skills'];
+  const reversed = renderedTitles(reorderCvSections(rendered, [...allKeys].reverse()));
+  if (shippedOrder.length === 8 && JSON.stringify(reversed) === JSON.stringify([...shippedOrder].reverse())) {
+    pass('every one of the shipped template\'s eight sections is movable (full reversal)');
+  } else {
+    fail(`shipped template reversal: before=${JSON.stringify(shippedOrder)} after=${JSON.stringify(reversed)}`);
+  }
+
+  // The documented worked example, against each template that ships with a
+  // Skills and an Education section — including one with no Certifications at
+  // all, which exercises the "named but absent" path end to end.
+  for (const file of ['cv-template.html', 'cv-template.zh-minimal.html', 'resume-template.html']) {
+    const html = renderTemplate(file);
+    const after = renderedTitles(reorderCvSections(html, ['skills', 'education', 'certifications', 'awards']));
+    const skillsAt = after.indexOf('Skills');
+    const eduAt = after.indexOf('Education');
+    if (skillsAt !== -1 && eduAt !== -1 && skillsAt < eduAt
+        && after.length === renderedTitles(html).length) {
+      pass(`${file}: the documented cv.sections example puts Skills before Education`);
+    } else {
+      fail(`${file}: ${JSON.stringify(after)}`);
+    }
+  }
+
+  // ── The point of the whole exercise ───────────────────────────────────────
+
+  // A cv.md ordered Skills-before-Education fails the guard against the shipped
+  // template, and passes once the profile declares the same order. This is the
+  // behaviour #2533 asks for; without the reorder the second call throws too.
+  //
+  // Moving Skills up past two sections is a rotation, not a swap: the sections
+  // it displaces are named too, in the order they should end up in. That is the
+  // shape the shipped template needs (`[skills, education, certifications,
+  // awards]`), so the end-to-end case exercises it rather than the 2-cycle.
+  const cvMarkdown = [
+    '# Candidate', '', '## Professional Summary', 'x', '', '## Work Experience', 'x', '',
+    '## Projects', 'x', '', '## Skills', 'x', '', '## Education', 'x', '', '## Certifications', 'x', '',
+  ].join('\n');
+
+  let threwBefore = false;
+  try {
+    validateCvSectionOrder(FIXTURE, cvMarkdown);
+  } catch {
+    threwBefore = true;
+  }
+  let threwAfter = false;
+  try {
+    validateCvSectionOrder(reorderCvSections(FIXTURE, ['skills', 'education', 'certifications']), cvMarkdown);
+  } catch (e) {
+    threwAfter = true;
+    fail(`the guard still rejected the reordered CV: ${e.message}`);
+  }
+  if (threwBefore && !threwAfter) {
+    pass('a cv.md ordered Skills-before-Education fails the guard untouched and passes once cv.sections declares it');
+  } else if (!threwBefore) {
+    fail('the fixture no longer diverges from cv.md — the end-to-end assertion proves nothing');
+  }
+} catch (e) {
+  fail(`cv-section-order tests crashed: ${e.message}`);
+}

--- a/tests/cv-section-order.test.mjs
+++ b/tests/cv-section-order.test.mjs
@@ -7,10 +7,11 @@
 // Assertions run against rendered HTML rather than source patterns: the reorder
 // has to survive nested markup, comments, absent optional sections and a second
 // application, and none of that is observable from the source text.
-import { pass, fail, ROOT } from './helpers.mjs';
+import { pass, fail, ROOT, NODE } from './helpers.mjs';
+import { spawnSync } from 'child_process';
 import { join } from 'path';
 import { pathToFileURL } from 'url';
-import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'fs';
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync, mkdtempSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 
 console.log('\nCV section order from config/profile.yml (#2533)');
@@ -713,4 +714,127 @@ try {
   }
 } catch (e) {
   fail(`cv-section-order tests crashed: ${e.message}`);
+}
+
+
+// ── batch mode applies the declared order too (#2747 added a second render path) ──
+//    reorderCvSections() sits in the single-render path. --batch (#2384, reworked
+//    by #2747 to reuse one Chromium) prepares each entry on its own code path, and
+//    that path called validateCvSectionOrder() WITHOUT calling reorderCvSections()
+//    first. The result was not a crash: cv.sections simply did nothing in batch
+//    mode, which is precisely the silent no-op this feature exists to remove — the
+//    user configures an order, N CVs render, and nothing says the setting was
+//    ignored.
+//
+//    Driven through the CLI because runBatchFromManifest() is not exported. The
+//    playwright stub embeds the HTML it was handed into the PDF it returns (the
+//    shape tests/generate-pdf-batch.test.mjs uses), so the assertion reads the
+//    order that was actually about to be PRINTED, not the order of the input file.
+{
+  const outputRoot = join(ROOT, 'output');
+  mkdirSync(outputRoot, { recursive: true });
+  const sandbox = mkdtempSync(join(outputRoot, 'section-order-batch-'));
+  try {
+    const script = join(sandbox, 'generate-pdf.mjs');
+    for (const f of [
+      'generate-pdf.mjs', 'theme-style.mjs', 'tracker-utils.mjs',
+      'tracker-parse.mjs', 'tracker-aliases.json', 'pipeline-lock.mjs',
+    ]) {
+      copyFileSync(join(ROOT, f), join(sandbox, f));
+    }
+    mkdirSync(join(sandbox, 'data'), { recursive: true });
+    writeFileSync(join(sandbox, 'data', 'pdf-index.tsv'), '', 'utf-8');
+
+    // readCvSectionOrder() anchors to the SCRIPT's dirname, not the cwd, so the
+    // profile has to live beside the copied script for the batch run to see it.
+    mkdirSync(join(sandbox, 'config'), { recursive: true });
+    writeFileSync(
+      join(sandbox, 'config', 'profile.yml'),
+      'cv:\n  sections:\n    - education\n    - experience\n',
+      'utf-8',
+    );
+
+    const playwrightStub = join(sandbox, 'node_modules', 'playwright');
+    mkdirSync(playwrightStub, { recursive: true });
+    writeFileSync(join(playwrightStub, 'package.json'), JSON.stringify({
+      name: 'playwright', type: 'module', exports: './index.js',
+    }), 'utf-8');
+    writeFileSync(join(playwrightStub, 'index.js'), `
+import { readFile } from 'fs/promises';
+function twoPagePdf(markerText) {
+  const marker = Buffer.from(markerText, 'utf-8').toString('base64');
+  return Buffer.from(\`%PDF-1.7
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 2 /Kids [3 0 R 4 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /Marker (\${marker}) >>
+endobj
+4 0 obj
+<< /Type /Page /Parent 2 0 R >>
+endobj
+%%EOF\`, 'latin1');
+}
+function makePage() {
+  let rendered = '';
+  return {
+    async goto(url) { rendered = await readFile(new URL(url), 'utf-8'); },
+    async evaluate() {},
+    async pdf() { return twoPagePdf(rendered); },
+    async close() {},
+  };
+}
+export const chromium = {
+  async launch() {
+    return {
+      async newContext() {
+        return { async newPage() { return makePage(); }, async close() {} };
+      },
+      async newPage() { return makePage(); },
+      async close() {},
+    };
+  },
+};
+`, 'utf-8');
+
+    writeFileSync(join(sandbox, 'in.html'), FIXTURE, 'utf-8');
+    const manifest = join(sandbox, 'batch.json');
+    writeFileSync(manifest, JSON.stringify([{ input: 'in.html', output: 'out/in.pdf' }]), 'utf-8');
+
+    const run = spawnSync(NODE, [script, `--batch=${manifest}`], {
+      cwd: sandbox, encoding: 'utf-8', timeout: 60_000,
+    });
+    const outPdf = join(sandbox, 'out', 'in.pdf');
+
+    if (!existsSync(outPdf)) {
+      fail(`batch render produced no PDF: ${(run.stdout || '') + (run.stderr || '')}`);
+    } else {
+      // Recover the HTML the stub was actually handed, so the order asserted is
+      // the printed one rather than the input file's.
+      const pdf = readFileSync(outPdf).toString('latin1');
+      const m = pdf.match(/\/Marker \(([^)]*)\)/);
+      const printed = m ? Buffer.from(m[1], 'base64').toString('utf-8') : '';
+      const titles = renderedTitles(printed);
+      const iEdu = titles.indexOf('Education');
+      const iExp = titles.indexOf('Work Experience');
+      const inputTitles = renderedTitles(FIXTURE);
+
+      if (inputTitles.indexOf('Education') < inputTitles.indexOf('Work Experience')) {
+        fail('fixture already renders Education before Work Experience — the batch assertion would pass without any reordering');
+      } else if (iEdu === -1 || iExp === -1) {
+        fail(`could not read both section titles back out of the batch PDF (got ${titles.join(' -> ') || 'nothing'})`);
+      } else if (iEdu < iExp) {
+        pass('--batch applies cv.sections: Education renders before Work Experience in the printed document');
+      } else {
+        fail(`--batch ignored cv.sections: printed order was ${titles.join(' -> ')}`);
+      }
+    }
+  } catch (e) {
+    fail(`batch section-order test crashed: ${e.message}`);
+  } finally {
+    rmSync(sandbox, { recursive: true, force: true });
+  }
 }

--- a/tests/cv-section-order.test.mjs
+++ b/tests/cv-section-order.test.mjs
@@ -990,6 +990,9 @@ export const chromium = {
   const ESC = esc + '[31mFAKE-ERROR' + esc + '[0m';
   const RTL = 'testing' + String.fromCharCode(0x202e);
   const LONG = 'z'.repeat(200);
+  // Same, but carrying a double quote: displayTitle() leaves quotes alone, so
+  // this is the shape that defeats a lazy extractor.
+  const QLONG = 'aa"' + 'z'.repeat(200);
 
   const CONTROLS = new RegExp('[\u0000-\u001f\u007f-\u009f]');
   const BIDI = new RegExp('[\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]');
@@ -1001,7 +1004,12 @@ export const chromium = {
   const NAME_MAX = 60;
   // Every warning quotes the configured name as `lists "X"` or `lists only "X"`.
   const quotedName = (w) => {
-    const m = w.match(/lists (?:only )?"([^"]*)"/);
+    // GREEDY to the last quote, not lazy to the first. displayTitle() does not
+    // strip double quotes, so a name carrying one truncates a lazy capture at
+    // that character: `lists "aa"zzz..."` measured 2 code points instead of 60,
+    // which would let an overlong name pass the bound. Each site below quotes
+    // the name exactly once, so the last quote is its closing one.
+    const m = w.match(/lists (?:only )?"(.*)"/);
     return m ? [...m[1]] : null;   // spread: code points, not UTF-16 units
   };
 
@@ -1012,7 +1020,7 @@ export const chromium = {
     // The second occurrence hits `seen.has(name)`; the first spends itself on
     // the not-a-section branch, so both sites fire from this one call.
     { site: 'duplicate-name', order: ['skills', ESC, ESC] },
-    { site: 'not-a-CV-section', order: ['skills', ESC, RTL, LONG] },
+    { site: 'not-a-CV-section', order: ['skills', ESC, RTL, LONG, QLONG] },
   ];
 
   const failures = [];

--- a/tests/cv-section-order.test.mjs
+++ b/tests/cv-section-order.test.mjs
@@ -963,10 +963,22 @@ export const chromium = {
 
 // -- configured names reach the terminal, so they get displayTitle() too --
 //    The rendered-title warning already sanitizes, because these strings land in
-//    a terminal or a run log. The names from config/profile.yml were quoted in
-//    raw: an ESC sequence repaints the line so a warning can appear to say
-//    something the tool never printed, U+202E reverses what follows, and an
-//    unbounded name buries the message it is attached to (CodeRabbit).
+//    a terminal or a run log. The names from config/profile.yml did not: an ESC
+//    sequence repaints the line so a warning can appear to say something the
+//    tool never printed, U+202E reverses what follows, and an unbounded name
+//    buries the message it is attached to (CodeRabbit).
+//
+//    Every warning site an arbitrary name can REACH is exercised, not just one.
+//    Covering a single site let a dropped displayTitle() elsewhere pass: with
+//    only the not-a-section case here, reverting the duplicate-name site scored
+//    0 failures (CodeRabbit's follow-up, confirmed by mutation before fixing).
+//
+//    The two remaining sites -- the ambiguous-markup warning and the unresolved
+//    report -- are deliberately absent. Both sit after CV_SECTION_KEYS.includes(name)
+//    has passed, so `name` there is a canonical key like "skills" and no config
+//    string can reach them. A hostile-input case for those would assert nothing.
+//    displayTitle() stays on them as defence in depth, in case a later change
+//    widens what arrives.
 //
 //    The hostile names are BUILT at runtime rather than written as literals, so
 //    this file stays safe to cat and safe to paste into a review.
@@ -982,24 +994,37 @@ export const chromium = {
   const CONTROLS = new RegExp('[\u0000-\u001f\u007f-\u009f]');
   const BIDI = new RegExp('[\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]');
 
-  // Paired with a real key so the list is long enough to be applied at all; each
-  // hostile name is unrecognized, so it takes the "not a CV section" path.
-  const { warnings } = captureWarnings(() =>
-    reorder(FIXTURE, ['skills', ESC, RTL, LONG]));
-  // Test each warning on its own. Joining them first splices in a newline,
-  // which is itself inside the C0 range asserted against below, so the control
-  // check would report a leak no matter what the code did.
+  // One entry per reachable site, each with the shape that actually lands there.
+  const sites = [
+    // order.length < 2 returns early through its own warning, before the loop.
+    { site: 'single-name', order: [ESC] },
+    // The second occurrence hits `seen.has(name)`; the first spends itself on
+    // the not-a-section branch, so both sites fire from this one call.
+    { site: 'duplicate-name', order: ['skills', ESC, ESC] },
+    { site: 'not-a-CV-section', order: ['skills', ESC, RTL, LONG] },
+  ];
 
-  const leaks = [];
-  if (warnings.some(w => CONTROLS.test(w))) leaks.push('C0/C1 control');
-  if (warnings.some(w => BIDI.test(w))) leaks.push('bidi override');
-  if (warnings.some(w => w.includes(LONG))) leaks.push('unbounded name (' + LONG.length + ' chars)');
+  const failures = [];
+  for (const { site, order } of sites) {
+    const { warnings } = captureWarnings(() => reorder(FIXTURE, order));
+    if (warnings.length === 0) {
+      failures.push(site + ' emitted no warning (nothing was asserted)');
+      continue;
+    }
+    // Each warning on its own: joining them first splices in a newline, which is
+    // itself inside the C0 range below, so the control check would report a leak
+    // no matter how the code behaved. That is how the first version of this
+    // assertion "failed" against correct code.
+    const leaks = [];
+    if (warnings.some(w => CONTROLS.test(w))) leaks.push('C0/C1 control');
+    if (warnings.some(w => BIDI.test(w))) leaks.push('bidi override');
+    if (warnings.some(w => w.includes(LONG))) leaks.push('unbounded name');
+    if (leaks.length > 0) failures.push(site + ': ' + leaks.join(', '));
+  }
 
-  if (warnings.length === 0) {
-    fail('no warning was emitted for the unrecognized names - the sanitization assertion would prove nothing');
-  } else if (leaks.length === 0) {
-    pass('cv.sections names are sanitized and length-bounded before being quoted into warnings');
+  if (failures.length === 0) {
+    pass('cv.sections names are sanitized and length-bounded at every warning site a config string can reach');
   } else {
-    fail('configured name reached the warning unsanitized: ' + leaks.join(', '));
+    fail('configured name reached a warning unsanitized -- ' + failures.join(' | '));
   }
 }

--- a/tests/cv-section-order.test.mjs
+++ b/tests/cv-section-order.test.mjs
@@ -993,6 +993,17 @@ export const chromium = {
 
   const CONTROLS = new RegExp('[\u0000-\u001f\u007f-\u009f]');
   const BIDI = new RegExp('[\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]');
+  // Mirrors DISPLAY_TITLE_MAX in generate-pdf.mjs. Asserted rather than just
+  // described: "the full 200-char name is absent" is satisfied by ANY
+  // truncation, so on its own it still passed with the cap widened to 150
+  // (CodeRabbit; confirmed by mutation). Measuring the quoted name pins the
+  // documented bound instead.
+  const NAME_MAX = 60;
+  // Every warning quotes the configured name as `lists "X"` or `lists only "X"`.
+  const quotedName = (w) => {
+    const m = w.match(/lists (?:only )?"([^"]*)"/);
+    return m ? [...m[1]] : null;   // spread: code points, not UTF-16 units
+  };
 
   // One entry per reachable site, each with the shape that actually lands there.
   const sites = [
@@ -1018,7 +1029,17 @@ export const chromium = {
     const leaks = [];
     if (warnings.some(w => CONTROLS.test(w))) leaks.push('C0/C1 control');
     if (warnings.some(w => BIDI.test(w))) leaks.push('bidi override');
-    if (warnings.some(w => w.includes(LONG))) leaks.push('unbounded name');
+    if (warnings.some(w => w.includes(LONG))) leaks.push('untruncated name');
+
+    // The bound itself. A site whose warnings quote no name at all would make
+    // this assert nothing, so that counts as a failure rather than a pass.
+    const quoted = warnings.map(quotedName).filter(Boolean);
+    if (quoted.length === 0) {
+      leaks.push('no quoted name found (length bound asserted nothing)');
+    } else {
+      const over = quoted.map(cp => cp.length).filter(n => n > NAME_MAX);
+      if (over.length > 0) leaks.push('name over ' + NAME_MAX + ' code points (' + over.join(', ') + ')');
+    }
     if (leaks.length > 0) failures.push(site + ': ' + leaks.join(', '));
   }
 

--- a/tests/cv-section-order.test.mjs
+++ b/tests/cv-section-order.test.mjs
@@ -838,3 +838,168 @@ export const chromium = {
     rmSync(sandbox, { recursive: true, force: true });
   }
 }
+
+
+// ── cv.sections is read from the WORKSPACE profile, like every other setting ──
+//    readStyleTokens() resolves config/profile.yml against workspaceRoot. This
+//    read was anchored to __dirname instead, so with CAREER_OPS_TRACKER pointing
+//    at a workspace outside the checkout the two settings came from two
+//    DIFFERENT files of the same name: style tokens from the workspace, section
+//    order from the repo. cv.md is read from workspaceRoot too, so the guard was
+//    judging the workspace's CV against the repo's declared order (CodeRabbit).
+//
+//    The fixture puts the profile ONLY in the external workspace, so an
+//    __dirname-anchored read finds nothing and silently applies no order.
+{
+  const outputRoot = join(ROOT, 'output');
+  mkdirSync(outputRoot, { recursive: true });
+  const sandbox = mkdtempSync(join(outputRoot, 'section-order-anchor-'));
+  try {
+    const script = join(sandbox, 'generate-pdf.mjs');
+    for (const f of [
+      'generate-pdf.mjs', 'theme-style.mjs', 'tracker-utils.mjs',
+      'tracker-parse.mjs', 'tracker-aliases.json', 'pipeline-lock.mjs',
+    ]) {
+      copyFileSync(join(ROOT, f), join(sandbox, f));
+    }
+
+    // The external workspace: tracker, profile, CV and documents all live here,
+    // and NOT beside the script. This is the shape CAREER_OPS_TRACKER creates.
+    const ws = join(sandbox, 'ws');
+    mkdirSync(join(ws, 'data'), { recursive: true });
+    mkdirSync(join(ws, 'config'), { recursive: true });
+    writeFileSync(join(ws, 'data', 'applications.md'), '# Applications Tracker\n', 'utf-8');
+    writeFileSync(join(ws, 'data', 'pdf-index.tsv'), '', 'utf-8');
+    writeFileSync(
+      join(ws, 'config', 'profile.yml'),
+      'cv:\n  sections:\n    - education\n    - experience\n',
+      'utf-8',
+    );
+    writeFileSync(join(ws, 'in.html'), FIXTURE, 'utf-8');
+
+    const playwrightStub = join(sandbox, 'node_modules', 'playwright');
+    mkdirSync(playwrightStub, { recursive: true });
+    writeFileSync(join(playwrightStub, 'package.json'), JSON.stringify({
+      name: 'playwright', type: 'module', exports: './index.js',
+    }), 'utf-8');
+    writeFileSync(join(playwrightStub, 'index.js'), `
+import { readFile } from 'fs/promises';
+function twoPagePdf(markerText) {
+  const marker = Buffer.from(markerText, 'utf-8').toString('base64');
+  return Buffer.from(\`%PDF-1.7
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 2 /Kids [3 0 R 4 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /Marker (\${marker}) >>
+endobj
+4 0 obj
+<< /Type /Page /Parent 2 0 R >>
+endobj
+%%EOF\`, 'latin1');
+}
+function makePage() {
+  let rendered = '';
+  return {
+    async goto(url) { rendered = await readFile(new URL(url), 'utf-8'); },
+    async evaluate() {},
+    async pdf() { return twoPagePdf(rendered); },
+    async close() {},
+  };
+}
+export const chromium = {
+  async launch() {
+    return {
+      async newContext() {
+        return { async newPage() { return makePage(); }, async close() {} };
+      },
+      async newPage() { return makePage(); },
+      async close() {},
+    };
+  },
+};
+`, 'utf-8');
+
+    const manifest = join(ws, 'batch.json');
+    writeFileSync(manifest, JSON.stringify([{ input: 'in.html', output: 'out/in.pdf' }]), 'utf-8');
+
+    const run = spawnSync(NODE, [script, `--batch=${manifest}`], {
+      cwd: sandbox,
+      encoding: 'utf-8',
+      timeout: 60_000,
+      env: { ...process.env, CAREER_OPS_TRACKER: join(ws, 'data', 'applications.md') },
+    });
+    const outPdf = join(ws, 'out', 'in.pdf');
+
+    if (!existsSync(outPdf)) {
+      fail(`workspace-anchored render produced no PDF: ${(run.stdout || '') + (run.stderr || '')}`);
+    } else {
+      const pdf = readFileSync(outPdf).toString('latin1');
+      const m = pdf.match(/\/Marker \(([^)]*)\)/);
+      const printed = m ? Buffer.from(m[1], 'base64').toString('utf-8') : '';
+      const titles = renderedTitles(printed);
+      const iEdu = titles.indexOf('Education');
+      const iExp = titles.indexOf('Work Experience');
+      if (existsSync(join(sandbox, 'config', 'profile.yml'))) {
+        fail('a profile exists beside the script — the __dirname anchor would find it and the assertion would prove nothing');
+      } else if (iEdu === -1 || iExp === -1) {
+        fail(`could not read both section titles back out (got ${titles.join(' -> ') || 'nothing'})`);
+      } else if (iEdu < iExp) {
+        pass('cv.sections is read from the workspace profile when CAREER_OPS_TRACKER moves the workspace off __dirname');
+      } else {
+        fail(`the workspace profile was ignored: printed order was ${titles.join(' -> ')}`);
+      }
+    }
+  } catch (e) {
+    fail(`workspace-anchor test crashed: ${e.message}`);
+  } finally {
+    rmSync(sandbox, { recursive: true, force: true });
+  }
+}
+
+
+// -- configured names reach the terminal, so they get displayTitle() too --
+//    The rendered-title warning already sanitizes, because these strings land in
+//    a terminal or a run log. The names from config/profile.yml were quoted in
+//    raw: an ESC sequence repaints the line so a warning can appear to say
+//    something the tool never printed, U+202E reverses what follows, and an
+//    unbounded name buries the message it is attached to (CodeRabbit).
+//
+//    The hostile names are BUILT at runtime rather than written as literals, so
+//    this file stays safe to cat and safe to paste into a review.
+{
+  const { reorderCvSections: reorder } =
+    await import(pathToFileURL(join(ROOT, 'generate-pdf.mjs')).href);
+
+  const esc = String.fromCharCode(0x1b);
+  const ESC = esc + '[31mFAKE-ERROR' + esc + '[0m';
+  const RTL = 'testing' + String.fromCharCode(0x202e);
+  const LONG = 'z'.repeat(200);
+
+  const CONTROLS = new RegExp('[\u0000-\u001f\u007f-\u009f]');
+  const BIDI = new RegExp('[\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]');
+
+  // Paired with a real key so the list is long enough to be applied at all; each
+  // hostile name is unrecognized, so it takes the "not a CV section" path.
+  const { warnings } = captureWarnings(() =>
+    reorder(FIXTURE, ['skills', ESC, RTL, LONG]));
+  // Test each warning on its own. Joining them first splices in a newline,
+  // which is itself inside the C0 range asserted against below, so the control
+  // check would report a leak no matter what the code did.
+
+  const leaks = [];
+  if (warnings.some(w => CONTROLS.test(w))) leaks.push('C0/C1 control');
+  if (warnings.some(w => BIDI.test(w))) leaks.push('bidi override');
+  if (warnings.some(w => w.includes(LONG))) leaks.push('unbounded name (' + LONG.length + ' chars)');
+
+  if (warnings.length === 0) {
+    fail('no warning was emitted for the unrecognized names - the sanitization assertion would prove nothing');
+  } else if (leaks.length === 0) {
+    pass('cv.sections names are sanitized and length-bounded before being quoted into warnings');
+  } else {
+    fail('configured name reached the warning unsanitized: ' + leaks.join(', '));
+  }
+}

--- a/theme-style.mjs
+++ b/theme-style.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 /**
- * theme-style.mjs — dynamic CV/cover-letter theming from config/profile.yml (#1837)
+ * theme-style.mjs — presentation settings read from config/profile.yml for the
+ * PDF pipeline: dynamic CV/cover-letter theming (#1837) and CV section order
+ * (#2533).
  *
  * Users declare a `style:` block in config/profile.yml:
  *
@@ -14,6 +16,12 @@
  * hits the PDF pipeline. The templates read them via `var(--x, <default>)`, so a
  * profile with no `style:` block produces byte-identical output — this only ever
  * *overrides* the template defaults, never changes the baseline.
+ *
+ * `cv.sections` declares the order the CV's sections render in. Both live here
+ * for the same reason: config/profile.yml is a user-layer file, so a setting
+ * that lives in it survives `update-system.mjs apply`, while the same
+ * customization made in templates/cv-template.html (a SYSTEM_PATHS file) is
+ * reverted by every release.
  *
  * Pure + dependency-light (js-yaml only) so it's unit-testable without Playwright.
  */
@@ -59,6 +67,45 @@ export function styleTokensFrom(style) {
     if (typeof v === 'string' && v.trim()) out[cssVar] = v.trim();
   }
   return out;
+}
+
+/**
+ * Read the declared CV section order from a profile file (#2533):
+ *
+ *   cv:
+ *     sections: [skills, education]
+ *
+ * Missing file / absent block / bad YAML → []. Same defensive contract as
+ * readStyleTokens: an unreadable profile must never stop a CV rendering.
+ * @param {string} [profilePath]
+ * @returns {string[]}
+ */
+export function readCvSectionOrder(profilePath = 'config/profile.yml') {
+  try {
+    if (!existsSync(profilePath)) return [];
+    const raw = yaml.load(readFileSync(profilePath, 'utf-8')) || {};
+    return cvSectionOrderFrom(raw?.cv);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Map a parsed `cv:` block to a list of section names. Only the syntax is
+ * checked here — whether a name is a real section, and whether this CV even has
+ * it, is decided at render time by generate-pdf.mjs, which owns the section
+ * vocabulary. Exported for tests.
+ * @param {unknown} cv
+ * @returns {string[]}
+ */
+export function cvSectionOrderFrom(cv) {
+  if (!cv || typeof cv !== 'object' || Array.isArray(cv)) return [];
+  const sections = cv.sections;
+  if (!Array.isArray(sections)) return [];
+  return sections
+    .filter(v => typeof v === 'string')
+    .map(v => v.trim().toLowerCase())
+    .filter(Boolean);
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

Lets `config/profile.yml` declare the CV's section order, so the customization survives `update-system.mjs apply` instead of being reverted with `templates/cv-template.html` on every release. The sections named in `cv.sections` are permuted among the slots they already occupy; sections left out never move.

## Related issue

Closes #2533. Opened issue-first per CONTRIBUTING.md. This implements shape 2 of the three the issue proposed — the one closest to the `style.margin` precedent (#1837). Happy to switch to shape 1 (derive from `cv.md`) or shape 3 (reorder the shipped template); my reasoning for picking 2 is under "Why not the other two shapes".

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---

## Detail

### The setting

```yaml
cv:
  sections: [skills, education, certifications, awards]
```

Against the shipped template that renders:

```
before: Summary · Competencies · Experience · Projects · Education · Certifications · Awards · Skills
after:  Summary · Competencies · Experience · Projects · Skills · Education · Certifications · Awards
```

Verified against all three shipped templates — `cv-template.html`, `cv-template.zh-minimal.html`, and `resume-template.html`, which has no Certifications section at all and so exercises the "named but absent" path.

### Semantics: a permutation of the named sections' own slots

The named sections are placed into the slots they already occupy, in the order given. Sections not named keep their template position.

That choice is the part most worth arguing with, because the obvious alternative — "the list is the full running order" — has a failure mode this project just demonstrated. v1.25.0 added `AWARDS`; under full-running-order semantics every existing config would have been missing a section the day that release landed, and would need editing again. Here an unlisted section keeps its slot, so a new upstream section arrives wherever upstream put it and nothing breaks.

The cost is that moving a section *past* its neighbours is a rotation rather than a swap: you name the sections it displaces too, in the order they should end up in. That's why the example lists four names rather than two, and `config/profile.example.yml` documents it with that exact example.

### It satisfies the guard, it doesn't bypass it

`reorderCvSections()` runs immediately before `validateCvSectionOrder()`, so the guard judges the document that will actually be printed. If the configured order still disagrees with `cv.md`, the render still fails — `cv.md` stays the source of truth. That's the distinction from `--allow-reorder` (#1646), which downgrades the same disagreement to a warning; that flag is untouched and still means what it meant.

### The load-bearing decision: extents come from markers, not from pairing tags

A section runs from its marker comment to the next one. Identity comes from the rendered `.section-title`, resolved through the existing `SECTION_ALIASES` table — the same function the guard uses, so the reorder and the guard cannot disagree about what a section is.

I originally derived each section's extent by finding the element after the marker and matching its closing tag. That is the version I'd have sent if I hadn't kept attacking it, and it was wrong in a specific, nasty way: **when extent comes from pairing tags, markup the scanner misreads still yields a plausible extent** — so instead of failing, it moves the wrong slice. Every character is still present, the document is still well-formed, and only the meaning is wrong. Three separate shapes produced exactly that:

| Input | What the tag-pairing version did |
|---|---|
| `<h2 class="section-title">Education</h2>` with the body as a sibling | Moved the heading alone. Result: a Skills heading above a degree — and since the guard compares headings only, it read back the requested order and **passed** |
| `<style>/* </div> */</style>` inside the last section | Ended the section at the literal `</div>`, moved the fragment, left the real close behind, and swallowed the next section into the broken wrapper |
| `<span data-x="> <div>">` | Invented tags from an attribute value, which can be arranged to make an unbalanced slice balance — so the section passed validation and was relocated out of its container |

Taking extents from markers inverts the failure mode. Tag scanning now only *validates*: each slice must be balanced — as many elements closed as opened, never rising above the level it started at. A misread can only fail that check, and a section that fails is left where it is. **Mistakes cost the feature, not the CV.**

That single check also does the work of a separate sibling test: every accepted block is balanced, so they are all at the same nesting level by construction, and filling one section's place with another can't move it into a container of its own.

It also means a template that marks sections with a bare heading and a sibling body is *supported* rather than refused — heading and body travel together, because the extent no longer depends on a wrapper element existing.

### Scanning

A forward `indexOf` walk, not a regex tokenizer. Two things it has to get right:

- **Tag ends are found quote-aware**, because `>` is legal inside an attribute value.
- **Raw-text ranges are established from index 0**, so markers and titles quoted inside `script`, `style`, `textarea`, `title`, `xmp`, `plaintext`, `iframe`, `noembed` or `noframes` are read as the text they are. A search starting at a marker has no way to know it is already inside a script string. `<plaintext>` runs to EOF (it has no end tag), and `<script/>` opens raw text rather than standing alone — trailing-slash syntax does nothing to an HTML element.

Both scans are linear, and the ranges are consulted by binary search since there's a lookup per marker and per candidate title. Three superlinear paths were measured and removed along the way: an exponential comment pattern (4.4s at 28 repetitions), a quadratic unterminated-comment scan (728ms at 32k), and a quadratic range lookup (619ms at 16k, now 13ms).

### Observability

A section that can't be moved safely is **named in a warning**, not skipped quietly — including the case where every section fails, which would otherwise leave the user with a setting that silently does nothing. An unrecognized name warns and lists the recognized keys. A recognized name that this CV simply doesn't carry (an optional section stripped for having no entries) is silent, because that's ordinary rather than a misconfiguration.

### Why not the other two shapes

- **Derive the order from `cv.md`** (issue shape 1) removes the config surface entirely and I'd still call it the better end state. But it silently normalizes away a deliberately tailored order — exactly the case `--allow-reorder` was added for in #1646 — so it needs that interaction resolved first, and that's your call.
- **Reorder the shipped template** (issue shape 3) helps whoever shares my order, changes output for every existing user, and leaves the next person whose order differs in the same position.

### Tests

New `tests/cv-section-order.test.mjs`, auto-discovered, 35 assertions. Behavioural: they assert on rendered section order, warnings, timing and content integrity rather than source patterns, because none of "nothing was lost", "unnamed sections didn't move", "a second pass changes nothing" or "this scan is linear" is observable from the source text. The raw-text case asserts the output is a character-level *permutation* of the input, since that failure preserved every character.

Mutation-checked rather than assumed. Each of these fails at least one assertion: making the reorder a no-op (8), filling slots in document order (7), removing the balance/tail check (2), removing raw-text handling (1), the naive tag end (1), dropping the raw-text marker filter (1), letting titles come from raw text (1), removing the legacy raw-text names (1), treating `<plaintext>` as closeable (1), and a linear range lookup (1).

Two of my own assertions turned out to be vacuous under that check and were rebuilt: the `<xmp>` fixture was refused whether or not `xmp` was on the raw-text list, and the lookup-scaling fixture made only four lookups, which a linear scan satisfies comfortably.

Full suite: `3008 passed, 0 failed, 2 warnings`. Both warnings are environmental rather than related to this change — `cv-sync-check.mjs exited with error (expected without user data)`, and a symlink-traversal test skipped with `EPERM` because I'm on Windows without developer mode.

### Three things worth flagging

**`theme-style.mjs` now holds a setting that isn't style.** `readCvSectionOrder()` lives beside `readStyleTokens()` because both are "read a presentation setting out of the user-layer profile", and it kept the profile reading in one tested module. But the module name no longer quite describes its contents. If you'd prefer it elsewhere — a new module, or `cv-sections-core.mjs` as the issue suggested — say so and I'll move it. (`cv-sections-core.mjs` was my first instinct too, but it's imported by both builders and is dependency-free, while the reorder needs `SECTION_ALIASES`, which lives in the Playwright-importing `generate-pdf.mjs`. Moving the alias table down would drag a browser dependency into the LaTeX path.)

**A pre-existing gap I did not fix.** `readStyleTokens()` defaults to the cwd-relative `'config/profile.yml'`, so running `generate-pdf.mjs` from outside the repo — the invocation the usage line itself shows — silently applies no theme. I anchored my own call to `__dirname` so `cv.sections` doesn't inherit that, but left `readStyleTokens()` alone rather than changing `style:` behaviour in a PR about section order. Happy to send that separately.

**What this does not claim.** The scanner is not an HTML parser, and I won't pretend the refusal invariant is absolute for arbitrary hand-authored markup. What I can say is that every shape I could construct now ends in a refusal-with-warning rather than a wrong document, and that the escaping in `build-cv-html.mjs` means the project's own render paths can't produce markup-shaped content in the first place. If you know of a template shape I should be testing against, I'd rather add it than assume.

### Not covered

The LaTeX path — `cv.sections` is HTML-only for now. `cv-template.tex` does have banner markers (`%%%%  Education  %%%%`), so boundaries exist, but there's no rendered-title equivalent to resolve identity from: the banner text *is* the identity, and it isn't in `SECTION_ALIASES`. `validateCvSectionOrder` doesn't run on that path either, so nothing there currently fails over section order. Worth a follow-up if the direction here is right.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional configuration for controlling the order of generated CV sections.
  * Supports recognized section names, aliases, partial ordering, and graceful handling of invalid entries.
  * Applies ordering consistently to single and batch PDF generation while preserving existing content and formatting.

* **Documentation**
  * Updated configuration guidance with supported section names and ordering behavior.

* **Tests**
  * Added comprehensive coverage for configuration parsing, reordering, validation, malformed content, and template compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->