### PR TITLE
chore(gitignore): ignore timestamped user-layer backups (cv.md PII left untracked)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,8 +85,12 @@ bun.lock
 # Report-number reservation sentinels (ephemeral, created by reserve-report-num.mjs)
 reports/*-RESERVED.md
 
-# Backup files written by normalize-statuses.mjs / dedup-tracker.mjs
-*.bak
+# Backup files. Two shapes exist: `{file}.bak` (normalize-statuses.mjs,
+# dedup-tracker.mjs, tracker.mjs) and `{file}.bak-{ISO timestamp}`
+# (web/src/lib/core/safe-write.ts). A plain `*.bak` glob misses the timestamped
+# form, which for cv.md or portals.yml leaves a file holding the same PII as the
+# original sitting untracked in the repo root. Trailing `*` covers both.
+*.bak*
 
 # OpenRouter runner — generated data (personal, never commit)
 data/model-blacklist.json


### PR DESCRIPTION
## What does this PR do?

Widens the backup rule in `.gitignore` from `*.bak` to `*.bak*`, so the timestamped backups the web dashboard writes are ignored. Today a saved CV edit leaves `cv.md.bak-<ISO timestamp>` untracked in the repo root, holding the same PII as `cv.md` itself.

## Related issue

Fixes #2542

## Root cause

`web/src/lib/core/safe-write.ts:27` names its snapshots with a suffix, not an extension:

```ts
const ts = new Date().toISOString().replace(/[:.]/g, "-");
const bak = `${file}.bak-${ts}`;
```

`cv.md.bak-2026-08-05T16-55-08-641Z` does not *end* in `.bak`, so the `*.bak` rule from #774 does not match it. And because `cv.md`, `config/profile.yml` and `portals.yml` are ignored by exact path, their backups are covered by neither rule:

| Route | File written | Backup | Ignored on `main`? |
|---|---|---|---|
| `web/src/app/api/cv/route.ts:37` | `cv.md` | `cv.md.bak-<ts>` | **no** |
| `web/src/app/api/profile/route.ts:96`, `web/src/app/api/followups/cadence/route.ts:89` | `config/profile.yml` | `config/profile.yml.bak-<ts>` | **no** |
| `web/src/app/api/portals/route.ts:53` | `portals.yml` | `portals.yml.bak-<ts>` | **no** |

The backups are correct and wanted — `safe-write.ts` exists because user files are gitignored and have no git recovery path. Only the ignore rule was out of step with the naming convention.

## Why `*.bak*` and not `*.bak-*`

- It also covers numbered variants. I verified that `cv.md.bak10` escapes a `*.bak[0-9]`-style rule, so an enumerated pattern just moves the gap rather than closing it.
- It subsumes the existing `*.bak`, so this is a net one-pattern rule instead of a list that has to grow every time a writer picks a new suffix.
- It hides nothing that is tracked: `git ls-files | grep '\.bak'` returns empty on `main`, so no tracked path changes state.

Failing safe is the right trade here — a miss means PII in a public repo, an over-match means a stray `.bak*` file is ignored.

## Test evidence

Before, on `main` — all three exit `1` (not ignored):

```
$ git check-ignore -v cv.md.bak-2026-08-05T16-55-08-641Z
$ git check-ignore -v config/profile.yml.bak-2026-08-05T16-55-08-641Z
$ git check-ignore -v portals.yml.bak-2026-08-05T16-55-08-641Z
```

After, on this branch:

```
.gitignore:93:*.bak*    cv.md.bak-2026-08-05T16-55-08-641Z
.gitignore:93:*.bak*    config/profile.yml.bak-2026-08-05T16-55-08-641Z
.gitignore:93:*.bak*    portals.yml.bak-2026-08-05T16-55-08-641Z
.gitignore:93:*.bak*    cv.md.bak
.gitignore:93:*.bak*    cv.md.bak2
.gitignore:93:*.bak*    cv.md.bak10
.gitignore:93:*.bak*    data/pipeline.md.pre-reconcile.bak
```

`node test-all.mjs` — **2973 passed, 0 failed**, exit 0, including the *"user-layer files are git-ignored"* section that asserts `cv.md`, `config/profile.yml`, `modes/_profile.md`, `modes/_custom.md`, `article-digest.md`, `portals.yml`, `data/`, `reports/`, `output/` and `interview-prep/` are all still ignored. Two warnings, both environment-only and present on unmodified `main` too: no Go compiler in PATH so the dashboard build was skipped, and the plugin symlink-traversal test skipped on `EPERM` because unprivileged Windows cannot create symlinks.

## Scope note

`.gitignore` is not in `SYSTEM_PATHS`, so this reaches new clones and anyone who pulls, but not existing installs via `update-system.mjs apply` — that is #2277, and it is not something this PR tries to solve. `.npmignore:77` has the same gap; `package.json` is `private: true` with no `files` field so nothing publishes today, and I left it alone to keep this to one concern. Happy to send it separately.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignored-file rules to exclude backup files with standard and timestamped `.bak` extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->