### PR TITLE
fix(updater): check falls back to git transport before reporting offline (curl-only probe diverges from apply)

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -488,7 +488,8 @@ Possible JSON responses:
 | `up-to-date` | Local version matches remote |
 | `update-available` | Newer version exists (includes `local`, `remote`, `changelog`) |
 | `dismissed` | User dismissed the update prompt |
-| `offline` | Could not reach GitHub |
+| `offline` | Could not reach GitHub over curl or git (carries `detail`: which transports failed and why) |
+| `no-remote-version` | A source responded but yielded no usable career-ops version to compare (may carry `detail`) |
 
 **Exit codes:** `0` always.
 

--- a/modes/update.md
+++ b/modes/update.md
@@ -8,6 +8,7 @@ Run `node update-system.mjs check` and parse the JSON output.
 
 - If `up-to-date`: Tell the user "career-ops is up to date (v{version})." and stop.
 - If `offline`: Tell the user "Cannot reach GitHub to check for updates. Try again later." and stop.
+- If `no-remote-version`: Tell the user "Reached the update source, but couldn't find a career-ops release version to compare against. Try again later." and stop; if the JSON carries a `detail` field, show it — it says which sources failed and why. (Emitted when a source responds but yields no usable version — e.g. an unparseable VERSION file, or a git probe that reaches the remote and finds no `career-ops-v*` tag.)
 - If `dismissed`: Tell the user "Update check was previously dismissed. Clearing the dismissal and re-checking now." Remove `.update-dismissed`, then re-run `node update-system.mjs check` and branch on the new status.
 - If `update-available`: Continue to Step 2.
 

--- a/modes/update.md
+++ b/modes/update.md
@@ -7,7 +7,7 @@ When the user runs `/career-ops update`, execute this interactive update flow.
 Run `node update-system.mjs check` and parse the JSON output.
 
 - If `up-to-date`: Tell the user "career-ops is up to date (v{version})." and stop.
-- If `offline`: Tell the user "Cannot reach GitHub to check for updates. Try again later." and stop.
+- If `offline`: Tell the user "Cannot reach GitHub to check for updates. Try again later." and stop; if the JSON carries a `detail` field, show it verbatim (fixed English diagnostic) — it says which sources failed and why. When the detail shows an evidently non-transient cause (a missing binary such as `ENOENT`, a TLS or proxy trust error), replace "Try again later." with a one-line note that the cause needs fixing first.
 - If `no-remote-version`: [Render in {language.output}: tell the user the update source was reached but no career-ops release version was found to compare against, and to try again later.] Then stop; if the JSON carries a `detail` field, show it verbatim (fixed English diagnostic) — it says which sources failed and why. (Emitted when a source responds but yields no usable version — e.g. an unparseable VERSION file, or a git probe that reaches the remote and finds no `career-ops-v*` tag.)
 - If `dismissed`: Tell the user "Update check was previously dismissed. Clearing the dismissal and re-checking now." Remove `.update-dismissed`, then re-run `node update-system.mjs check` and branch on the new status.
 - If `update-available`: Continue to Step 2.

--- a/modes/update.md
+++ b/modes/update.md
@@ -8,7 +8,7 @@ Run `node update-system.mjs check` and parse the JSON output.
 
 - If `up-to-date`: Tell the user "career-ops is up to date (v{version})." and stop.
 - If `offline`: Tell the user "Cannot reach GitHub to check for updates. Try again later." and stop.
-- If `no-remote-version`: Tell the user "Reached the update source, but couldn't find a career-ops release version to compare against. Try again later." and stop; if the JSON carries a `detail` field, show it — it says which sources failed and why. (Emitted when a source responds but yields no usable version — e.g. an unparseable VERSION file, or a git probe that reaches the remote and finds no `career-ops-v*` tag.)
+- If `no-remote-version`: [Render in {language.output}: tell the user the update source was reached but no career-ops release version was found to compare against, and to try again later.] Then stop; if the JSON carries a `detail` field, show it verbatim (fixed English diagnostic) — it says which sources failed and why. (Emitted when a source responds but yields no usable version — e.g. an unparseable VERSION file, or a git probe that reaches the remote and finds no `career-ops-v*` tag.)
 - If `dismissed`: Tell the user "Update check was previously dismissed. Clearing the dismissal and re-checking now." Remove `.update-dismissed`, then re-run `node update-system.mjs check` and branch on the new status.
 - If `update-available`: Continue to Step 2.
 

--- a/tests/update-check-git-fallback.test.mjs
+++ b/tests/update-check-git-fallback.test.mjs
@@ -55,12 +55,47 @@ console.log('\n🧪 Testing update-check git fallback...');
   }
 }
 
-// ── plain v-prefixed and bare tags (SEMVER_RE's other accepted shapes) ──
+// ── monorepo tag pollution: the prefix filter is load-bearing ───────────
+// Upstream is a release-please monorepo (career-ops-v*, web-v*,
+// manifesto-v*, historical bare tags). Without the prefix filter, the
+// first foreign tag to exceed career-ops' version would be reported as
+// the career-ops remote — a permanent false update-available on exactly
+// the curl-blocked machines the fallback serves.
+{
+  const out = [
+    'aaaa\trefs/tags/career-ops-v1.25.0',
+    'bbbb\trefs/tags/web-v9.9.9',
+    'cccc\trefs/tags/manifesto-v8.0.0',
+    'dddd\trefs/tags/backup-pre-update-9.9.8',
+    'eeee\trefs/tags/v7.7.7',
+  ].join('\n');
+  if (highestSemverTag(out, 'career-ops-v') === '1.25.0') {
+    pass('highestSemverTag("career-ops-v") ignores foreign monorepo components with higher versions');
+  } else {
+    fail(`highestSemverTag monorepo pollution = ${JSON.stringify(highestSemverTag(out, 'career-ops-v'))}`);
+  }
+  if (highestSemverTag('aaaa\trefs/tags/web-v9.9.9', 'career-ops-v') === '') {
+    pass('highestSemverTag("career-ops-v") returns "" when only foreign tags exist (reachable ≠ has releases)');
+  } else {
+    fail('highestSemverTag prefix-only-foreign case failed');
+  }
+}
+
+// ── plain v-prefixed and bare tags (SEMVER_RE's shapes, unfiltered mode) ─
 {
   if (highestSemverTag('aaaa\trefs/tags/v2.0.0\nbbbb\trefs/tags/1.9.9') === '2.0.0') {
-    pass('highestSemverTag accepts plain v-prefixed and bare semver tags');
+    pass('highestSemverTag (no prefix) accepts plain v-prefixed and bare semver tags');
   } else {
     fail('highestSemverTag plain-tag shapes failed');
+  }
+}
+
+// ── CRLF-translated wrapper output ──────────────────────────────────────
+{
+  if (highestSemverTag('aaaa\trefs/tags/career-ops-v1.25.0\r\nbbbb\trefs/tags/career-ops-v1.24.0\r', 'career-ops-v') === '1.25.0') {
+    pass('highestSemverTag strips a trailing \\r so CRLF-translated output still matches');
+  } else {
+    fail('highestSemverTag CRLF hardening failed');
   }
 }
 
@@ -87,26 +122,37 @@ console.log('\n🧪 Testing update-check git fallback...');
 {
   const src = readFileSync(join(ROOT, 'update-system.mjs'), 'utf-8');
 
-  if (/bothNetworkFailed[\s\S]{0,80}?remote = gitRemoteVersion\(\)/.test(src)) {
-    pass('check() consults gitRemoteVersion() on the both-curls-failed path before reporting offline');
+  if (/if \(bothNetworkFailed\)\s*\{\s*gitProbe = gitRemoteVersion\(\)/.test(src)) {
+    pass('check() consults gitRemoteVersion() only inside the both-curls-failed guard (never on the parseable-failure path)');
   } else {
-    fail('check() no longer falls back to gitRemoteVersion() when both curl probes fail');
+    fail('the git fallback is no longer gated on bothNetworkFailed — it must not run on the no-remote-version path');
   }
 
-  if (/ls-remote', '--tags', CANONICAL_REPO/.test(src)) {
-    pass('gitRemoteVersion() queries CANONICAL_REPO over git — the same transport apply() uses');
+  if (/ls-remote', '--tags', CANONICAL_REPO/.test(src) && /highestSemverTag\(out, 'career-ops-v'\)/.test(src)) {
+    pass('gitRemoteVersion() queries CANONICAL_REPO over git and filters to the career-ops-v tag prefix');
   } else {
-    fail('gitRemoteVersion() does not query CANONICAL_REPO via ls-remote');
+    fail('gitRemoteVersion() lost the CANONICAL_REPO query or the career-ops-v prefix filter (monorepo tag pollution)');
   }
 
-  if (/payload\.detail = `curl VERSION: /.test(src)) {
-    pass('offline JSON carries a detail field with the curl failure reasons');
+  if (/GIT_TERMINAL_PROMPT: '0'/.test(src)) {
+    pass('the ls-remote probe suppresses interactive credential prompts (GIT_TERMINAL_PROMPT=0)');
   } else {
-    fail('offline JSON detail field missing — offline reports are undiagnosable again');
+    fail('GIT_TERMINAL_PROMPT=0 missing — a captive portal can pop a GUI prompt from a silent check');
   }
 
-  const curlGetSrc = src.slice(src.indexOf('function curlGet'), src.indexOf('export function highestSemverTag'));
-  if (/try\s*\{[\s\S]*execFile\(/.test(curlGetSrc) && /catch \(error\)\s*\{\s*resolve\(\{ ok: false/.test(curlGetSrc)) {
+  if (/payload\.detail = `curl VERSION: /.test(src) && /git ls-remote reachable but returned no career-ops release tags/.test(src)) {
+    pass('offline/no-remote-version JSON distinguishes git-failed from git-reachable-but-tagless in detail');
+  } else {
+    fail('detail field no longer distinguishes git transport failure from a tagless remote');
+  }
+
+  if (/console\.log\(JSON\.stringify\(payload\)\);\s*return;/.test(src)) {
+    pass('the offline/no-remote-version branch returns after emitting — single-JSON-line contract holds');
+  } else {
+    fail('the offline branch no longer returns immediately — check may emit two JSON lines');
+  }
+
+  if (/function curlGet[\s\S]{0,1400}?catch \((?:error|err)\)\s*\{\s*resolve\(\{ ok: false/.test(src)) {
     pass('curlGet() catches synchronous execFile throws (broken curl on PATH: spawn EFTYPE) instead of crashing check()');
   } else {
     fail('curlGet() no longer guards the synchronous execFile throw path');

--- a/tests/update-check-git-fallback.test.mjs
+++ b/tests/update-check-git-fallback.test.mjs
@@ -81,6 +81,25 @@ console.log('\n🧪 Testing update-check git fallback...');
   }
 }
 
+// ── prefix mode anchors the ENTIRE remainder ────────────────────────────
+// career-ops-v1.25.0-preview-v99.0.0 passes the startsWith check, and
+// SEMVER_RE's (?:^|-) anchor would match its trailing -v99.0.0 — the
+// remainder after the prefix must be exactly the version, nothing more.
+{
+  const malformed = 'aaaa\trefs/tags/career-ops-v1.25.0-preview-v99.0.0';
+  if (highestSemverTag(malformed, 'career-ops-v') === '') {
+    pass('highestSemverTag("career-ops-v") rejects a prefix-matching tag with trailing content (no 99.0.0 fabrication)');
+  } else {
+    fail(`highestSemverTag malformed remainder = ${JSON.stringify(highestSemverTag(malformed, 'career-ops-v'))}`);
+  }
+  const mixed = `${malformed}\nbbbb\trefs/tags/career-ops-v1.25.0`;
+  if (highestSemverTag(mixed, 'career-ops-v') === '1.25.0') {
+    pass('highestSemverTag("career-ops-v") still picks the real release next to a malformed sibling tag');
+  } else {
+    fail(`highestSemverTag malformed+real = ${JSON.stringify(highestSemverTag(mixed, 'career-ops-v'))}`);
+  }
+}
+
 // ── plain v-prefixed and bare tags (SEMVER_RE's shapes, unfiltered mode) ─
 {
   if (highestSemverTag('aaaa\trefs/tags/v2.0.0\nbbbb\trefs/tags/1.9.9') === '2.0.0') {
@@ -144,6 +163,12 @@ console.log('\n🧪 Testing update-check git fallback...');
     pass('offline/no-remote-version JSON distinguishes git-failed from git-reachable-but-tagless in detail');
   } else {
     fail('detail field no longer distinguishes git transport failure from a tagless remote');
+  }
+
+  if (/git ls-remote also failed: \$\{gitProbe\.detail\}/.test(src) && /detail: error\.code \|\| String\(error\.message \|\| error\)\.split\('\\n'\)\[0\]/.test(src)) {
+    pass('the git failure reason (error.code or first message line) is preserved into payload.detail');
+  } else {
+    fail('git failure detail is discarded again — offline payloads lose the git-side diagnosis');
   }
 
   if (/console\.log\(JSON\.stringify\(payload\)\);\s*return;/.test(src)) {

--- a/tests/update-check-git-fallback.test.mjs
+++ b/tests/update-check-git-fallback.test.mjs
@@ -1,0 +1,114 @@
+/**
+ * update-check-git-fallback.test.mjs — check() must not report "offline"
+ * when apply() would succeed.
+ *
+ * check() probes over curl while apply() fetches over git; on machines where
+ * only curl fails (curl missing from PATH, proxy configured only in git
+ * config, raw/api hosts filtered while github.com is reachable, TLS
+ * interception trusted by git but not curl), check() used to emit a false
+ * {"status":"offline"} seconds before a successful apply. The fix falls back
+ * to `git ls-remote --tags` — apply()'s transport — before declaring offline.
+ *
+ * The tag-parsing half is a pure export (highestSemverTag), tested
+ * behaviorally. The wiring inside check()/curlGet() is ROOT-bound with
+ * subprocess side effects, so it is verified by source-pattern assertions —
+ * the updater test convention for such paths (see
+ * updater-rollback-behavior.test.mjs's header note).
+ */
+
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { pass, fail } from './helpers.mjs';
+import { highestSemverTag, SEMVER_RE } from '../update-system.mjs';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+console.log('\n🧪 Testing update-check git fallback...');
+
+// ── highestSemverTag: release-please tag shape ──────────────────────────
+{
+  const out = [
+    'aaaa\trefs/tags/career-ops-v1.3.0',
+    'bbbb\trefs/tags/career-ops-v1.25.0',
+    'cccc\trefs/tags/career-ops-v1.9.0',
+  ].join('\n');
+  if (highestSemverTag(out) === '1.25.0') {
+    pass('highestSemverTag picks the semver-highest release-please tag (1.25.0 > 1.9.0, not lexical)');
+  } else {
+    fail(`highestSemverTag release-please shape = ${JSON.stringify(highestSemverTag(out))}`);
+  }
+}
+
+// ── peeled refs and non-semver tags ─────────────────────────────────────
+{
+  const out = [
+    'aaaa\trefs/tags/career-ops-v1.24.0',
+    'bbbb\trefs/tags/career-ops-v1.24.0^{}',
+    'cccc\trefs/tags/snapshot-before-migration',
+    'dddd\trefs/tags/v20260801',
+  ].join('\n');
+  if (highestSemverTag(out) === '1.24.0') {
+    pass('highestSemverTag collapses peeled ^{} refs and ignores non-semver tags');
+  } else {
+    fail(`highestSemverTag peeled/non-semver = ${JSON.stringify(highestSemverTag(out))}`);
+  }
+}
+
+// ── plain v-prefixed and bare tags (SEMVER_RE's other accepted shapes) ──
+{
+  if (highestSemverTag('aaaa\trefs/tags/v2.0.0\nbbbb\trefs/tags/1.9.9') === '2.0.0') {
+    pass('highestSemverTag accepts plain v-prefixed and bare semver tags');
+  } else {
+    fail('highestSemverTag plain-tag shapes failed');
+  }
+}
+
+// ── degenerate inputs ───────────────────────────────────────────────────
+{
+  const empties = [highestSemverTag(''), highestSemverTag(null), highestSemverTag('garbage no tabs')];
+  if (empties.every((v) => v === '')) {
+    pass('highestSemverTag returns "" on empty/null/tag-less input');
+  } else {
+    fail(`highestSemverTag degenerate inputs = ${JSON.stringify(empties)}`);
+  }
+}
+
+// ── SEMVER_RE anchor sanity: the shapes above depend on (?:^|-) ─────────
+{
+  if (SEMVER_RE.test('career-ops-v1.25.0') && SEMVER_RE.test('v1.2.3') && !SEMVER_RE.test('v1.2.3-beta')) {
+    pass('SEMVER_RE anchors release-please and plain tags, rejects suffixed prereleases');
+  } else {
+    fail('SEMVER_RE anchor expectations changed — revisit highestSemverTag');
+  }
+}
+
+// ── source-pattern wiring assertions ────────────────────────────────────
+{
+  const src = readFileSync(join(ROOT, 'update-system.mjs'), 'utf-8');
+
+  if (/bothNetworkFailed[\s\S]{0,80}?remote = gitRemoteVersion\(\)/.test(src)) {
+    pass('check() consults gitRemoteVersion() on the both-curls-failed path before reporting offline');
+  } else {
+    fail('check() no longer falls back to gitRemoteVersion() when both curl probes fail');
+  }
+
+  if (/ls-remote', '--tags', CANONICAL_REPO/.test(src)) {
+    pass('gitRemoteVersion() queries CANONICAL_REPO over git — the same transport apply() uses');
+  } else {
+    fail('gitRemoteVersion() does not query CANONICAL_REPO via ls-remote');
+  }
+
+  if (/payload\.detail = `curl VERSION: /.test(src)) {
+    pass('offline JSON carries a detail field with the curl failure reasons');
+  } else {
+    fail('offline JSON detail field missing — offline reports are undiagnosable again');
+  }
+
+  const curlGetSrc = src.slice(src.indexOf('function curlGet'), src.indexOf('export function highestSemverTag'));
+  if (/try\s*\{[\s\S]*execFile\(/.test(curlGetSrc) && /catch \(error\)\s*\{\s*resolve\(\{ ok: false/.test(curlGetSrc)) {
+    pass('curlGet() catches synchronous execFile throws (broken curl on PATH: spawn EFTYPE) instead of crashing check()');
+  } else {
+    fail('curlGet() no longer guards the synchronous execFile throw path');
+  }
+}

--- a/tests/update-check-git-fallback.test.mjs
+++ b/tests/update-check-git-fallback.test.mjs
@@ -141,7 +141,14 @@ console.log('\n🧪 Testing update-check git fallback...');
 {
   const src = readFileSync(join(ROOT, 'update-system.mjs'), 'utf-8');
 
-  if (/if \(bothNetworkFailed\)\s*\{\s*gitProbe = gitRemoteVersion\(\)/.test(src)) {
+  // The stderr retry notice sits between the guard and the probe call, so
+  // the pattern spans the guard block. The (?!\n    \}) lookahead refuses to
+  // cross the guard's own closing brace (4-space indent, alone on its line) —
+  // without it, moving the probe call to just AFTER the guard would still
+  // match. The call-site count keeps the probe from appearing anywhere else.
+  const gatedProbe = /if \(bothNetworkFailed\)\s*\{(?:(?!\n    \})[\s\S]){0,700}?gitProbe = gitRemoteVersion\(\)/.test(src);
+  const probeCallSites = (src.match(/(?<!function )gitRemoteVersion\(\)/g) || []).length;
+  if (gatedProbe && probeCallSites === 1) {
     pass('check() consults gitRemoteVersion() only inside the both-curls-failed guard (never on the parseable-failure path)');
   } else {
     fail('the git fallback is no longer gated on bothNetworkFailed — it must not run on the no-remote-version path');
@@ -181,5 +188,36 @@ console.log('\n🧪 Testing update-check git fallback...');
     pass('curlGet() catches synchronous execFile throws (broken curl on PATH: spawn EFTYPE) instead of crashing check()');
   } else {
     fail('curlGet() no longer guards the synchronous execFile throw path');
+  }
+
+  // ── session-start latency budget ceiling ──────────────────────────────
+  // AGENTS.md runs check() at session start; its worst case is dead time
+  // before the user's first interaction. The curl legs run in parallel and
+  // chain into the git probe, so the two constants below bound the whole
+  // check: their sum must stay ≈10s (the pre-fallback ceiling). A raised
+  // budget here is a session-start regression on captive-portal networks.
+  const curlBudget = src.match(/const CHECK_CURL_MAX_TIME_S = (\d+);/);
+  const gitBudget = src.match(/const CHECK_GIT_PROBE_TIMEOUT_MS = (\d+);/);
+  if (curlBudget && gitBudget && Number(curlBudget[1]) + Number(gitBudget[1]) / 1000 <= 11) {
+    pass(`check() worst case stays bounded: ${curlBudget[1]}s curl (parallel legs) + ${Number(gitBudget[1]) / 1000}s git probe ≤ 11s`);
+  } else {
+    fail('check() latency budget exceeded — curl + git probe worst case must stay ≈10s (session-start dead time)');
+  }
+
+  if (/--max-time', String\(CHECK_CURL_MAX_TIME_S\)/.test(src)
+    && /timeout: CHECK_CURL_MAX_TIME_S \* 1000 \+ 1000/.test(src)
+    && /timeout: CHECK_GIT_PROBE_TIMEOUT_MS/.test(src)) {
+    pass('all transport timeouts (curl --max-time, its JS backstop, git probe) are wired to the named budget constants');
+  } else {
+    fail('a transport timeout no longer derives from the named budget constants — the ceiling is unenforced');
+  }
+
+  // writeSync, not console.error: on Windows stderr-to-pipe writes are async
+  // and the sync git probe blocks the event loop, so a console.error here
+  // would flush AFTER the wait it announces. Pin the sync form.
+  if (/writeSync\(\s*process\.stderr\.fd,\s*`career-ops update check: GitHub unreachable over curl[\s\S]{0,220}?retrying over git/.test(src)) {
+    pass('the git retry announces itself via a SYNCHRONOUS stderr write before the blocking probe (async console.error would flush after the wait on Windows)');
+  } else {
+    fail('the retry notice is missing or no longer a synchronous stderr write — on Windows it would appear only after the probe finishes');
   }
 }

--- a/tests/update-check-git-fallback.test.mjs
+++ b/tests/update-check-git-fallback.test.mjs
@@ -21,7 +21,7 @@ import { join, dirname } from 'path';
 import { tmpdir } from 'os';
 import { fileURLToPath } from 'url';
 import { pass, fail } from './helpers.mjs';
-import { highestSemverTag, SEMVER_RE, curlGet } from '../update-system.mjs';
+import { highestSemverTag, SEMVER_RE, curlGet, gitRemoteVersion } from '../update-system.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -155,10 +155,14 @@ console.log('\n🧪 Testing update-check git fallback...');
     fail('the git fallback is no longer gated on bothNetworkFailed — it must not run on the no-remote-version path');
   }
 
-  if (/ls-remote', '--tags', CANONICAL_REPO/.test(src) && /highestSemverTag\(out, 'career-ops-v'\)/.test(src)) {
-    pass('gitRemoteVersion() queries CANONICAL_REPO over git and filters to the career-ops-v tag prefix');
+  // repoUrl is a test-injection param; its DEFAULT binds the production
+  // probe to CANONICAL_REPO — both halves are load-bearing here.
+  if (/gitRemoteVersion\(repoUrl = CANONICAL_REPO\)/.test(src)
+    && /ls-remote', '--tags', repoUrl/.test(src)
+    && /highestSemverTag\(out, 'career-ops-v'\)/.test(src)) {
+    pass('gitRemoteVersion() defaults to CANONICAL_REPO and filters to the career-ops-v tag prefix');
   } else {
-    fail('gitRemoteVersion() lost the CANONICAL_REPO query or the career-ops-v prefix filter (monorepo tag pollution)');
+    fail('gitRemoteVersion() lost the CANONICAL_REPO default or the career-ops-v prefix filter (monorepo tag pollution)');
   }
 
   if (/GIT_TERMINAL_PROMPT: '0'/.test(src)) {
@@ -173,10 +177,13 @@ console.log('\n🧪 Testing update-check git fallback...');
     fail('detail field no longer distinguishes git transport failure from a tagless remote');
   }
 
-  if (/git ls-remote also failed: \$\{gitProbe\.detail\}/.test(src) && /detail: error\.code \|\| String\(error\.message \|\| error\)\.split\('\\n'\)\[0\]/.test(src)) {
-    pass('the git failure reason (error.code or first message line) is preserved into payload.detail');
+  // Wiring only: this proves gitProbe.detail is interpolated into
+  // payload.detail — the QUALITY of that detail (real git reason, not a
+  // "Command failed: …" tautology) is asserted behaviorally below.
+  if (/git ls-remote also failed: \$\{gitProbe\.detail\}/.test(src)) {
+    pass('the git-side detail is wired into payload.detail (quality of the detail is asserted behaviorally below)');
   } else {
-    fail('git failure detail is discarded again — offline payloads lose the git-side diagnosis');
+    fail('gitProbe.detail is no longer interpolated into payload.detail — offline payloads lose the git-side diagnosis');
   }
 
   if (/console\.log\(JSON\.stringify\(payload\)\);\s*return;/.test(src)) {
@@ -267,4 +274,25 @@ console.log('\n🧪 Testing update-check git fallback...');
   }
   rmSync(emptyDir, { recursive: true, force: true });
   rmSync(brokenDir, { recursive: true, force: true });
+}
+
+// ── gitRemoteVersion() failing-git detail quality (BEHAVIORAL) ────────────
+// When git RUNS and exits non-zero (DNS/proxy/TLS — the common real
+// failures), execFileSync puts the exit code in error.status, not
+// error.code — so an error.code || error.message fallback yields the
+// tautology "Command failed: git …" (what ran) instead of git's own reason
+// (which sits in error.stderr). This invokes the real git against an
+// RFC 2606 `.invalid` host — DNS for that TLD fails locally and
+// deterministically, no network needed — and asserts the detail carries a
+// real reason. Git's wording is locale-dependent, so the assertion is the
+// tautology's ABSENCE, not any English phrase.
+{
+  const res = gitRemoteVersion('https://this-host-does-not-exist.invalid/repo.git');
+  if (res && res.ok === false && res.detail && !/^Command failed/.test(String(res.detail))) {
+    pass(`gitRemoteVersion() surfaces git's own failure reason, not the command-line tautology (detail: ${JSON.stringify(String(res.detail).slice(0, 60))})`);
+  } else if (res && res.ok === false) {
+    fail(`gitRemoteVersion() failing-git detail is a tautology or empty: ${JSON.stringify(res.detail)}`);
+  } else {
+    fail(`gitRemoteVersion() against a .invalid host returned unexpectedly: ${JSON.stringify(res)}`);
+  }
 }

--- a/tests/update-check-git-fallback.test.mjs
+++ b/tests/update-check-git-fallback.test.mjs
@@ -16,11 +16,12 @@
  * updater-rollback-behavior.test.mjs's header note).
  */
 
-import { readFileSync } from 'fs';
+import { readFileSync, mkdtempSync, writeFileSync, chmodSync, rmSync } from 'fs';
 import { join, dirname } from 'path';
+import { tmpdir } from 'os';
 import { fileURLToPath } from 'url';
 import { pass, fail } from './helpers.mjs';
-import { highestSemverTag, SEMVER_RE } from '../update-system.mjs';
+import { highestSemverTag, SEMVER_RE, curlGet } from '../update-system.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -184,11 +185,9 @@ console.log('\n🧪 Testing update-check git fallback...');
     fail('the offline branch no longer returns immediately — check may emit two JSON lines');
   }
 
-  if (/function curlGet[\s\S]{0,1400}?catch \((?:error|err)\)\s*\{\s*resolve\(\{ ok: false/.test(src)) {
-    pass('curlGet() catches synchronous execFile throws (broken curl on PATH: spawn EFTYPE) instead of crashing check()');
-  } else {
-    fail('curlGet() no longer guards the synchronous execFile throw path');
-  }
+  // (curlGet's broken-curl guard is verified BEHAVIORALLY below, outside
+  // this source-pattern block — a position-based regex for it broke on an
+  // unrelated edit when the function grew past the character window.)
 
   // ── session-start latency budget ceiling ──────────────────────────────
   // AGENTS.md runs check() at session start; its worst case is dead time
@@ -227,4 +226,45 @@ console.log('\n🧪 Testing update-check git fallback...');
   } else {
     fail('the retry notice is missing or no longer a synchronous stderr write — on Windows it would appear only after the probe finishes');
   }
+}
+
+// ── curlGet() broken-curl guard (BEHAVIORAL) ──────────────────────────────
+// The contract: curlGet NEVER rejects or throws. A missing curl (ENOENT,
+// delivered async via the execFile callback) and a corrupt/non-executable
+// curl on PATH (delivered as a SYNCHRONOUS spawn throw on Windows — e.g.
+// EFTYPE — or an ENOEXEC-style async error on POSIX) must both resolve
+// { ok: false, detail }. This runs the code instead of pattern-matching the
+// source: the previous regex counted characters from the function head and
+// broke when an unrelated edit grew the function past its window.
+{
+  const realPath = process.env.PATH;
+  const emptyDir = mkdtempSync(join(tmpdir(), 'uc-curl-missing-'));
+  const brokenDir = mkdtempSync(join(tmpdir(), 'uc-curl-broken-'));
+  // Garbage bytes: not a valid executable image on Windows (curl.exe) and
+  // no shebang on POSIX (curl) — each platform resolves its own file.
+  writeFileSync(join(brokenDir, 'curl.exe'), Buffer.from([0x00, 0x01, 0x02, 0x03]));
+  writeFileSync(join(brokenDir, 'curl'), Buffer.from([0x00, 0x01, 0x02, 0x03]));
+  try { chmodSync(join(brokenDir, 'curl'), 0o755); } catch { /* windows: no-op */ }
+
+  const cases = [
+    ['missing curl on PATH (ENOENT callback path)', emptyDir],
+    ['corrupt curl binary on PATH (sync-throw path on Windows)', brokenDir],
+  ];
+  for (const [label, dir] of cases) {
+    process.env.PATH = dir;
+    try {
+      const res = await curlGet('http://127.0.0.1:9/unreachable');
+      if (res && res.ok === false && res.detail) {
+        pass(`curlGet() resolves { ok: false, detail: ${JSON.stringify(String(res.detail).slice(0, 24))} } with ${label} — never throws`);
+      } else {
+        fail(`curlGet() with ${label} resolved with an unexpected shape: ${JSON.stringify(res)}`);
+      }
+    } catch (error) {
+      fail(`curlGet() with ${label} THREW (${error.code || String(error.message).split('\n')[0]}) — check() would crash on this machine`);
+    } finally {
+      process.env.PATH = realPath;
+    }
+  }
+  rmSync(emptyDir, { recursive: true, force: true });
+  rmSync(brokenDir, { recursive: true, force: true });
 }

--- a/tests/update-check-git-fallback.test.mjs
+++ b/tests/update-check-git-fallback.test.mjs
@@ -194,14 +194,21 @@ console.log('\n🧪 Testing update-check git fallback...');
   // AGENTS.md runs check() at session start; its worst case is dead time
   // before the user's first interaction. The curl legs run in parallel and
   // chain into the git probe, so the two constants below bound the whole
-  // check: their sum must stay ≈10s (the pre-fallback ceiling). A raised
+  // check: the three terms (parallel curl legs, +1s JS backstop, git probe)
+  // must stay ≤11s wall clock — ≈ the pre-fallback ceiling. A raised
   // budget here is a session-start regression on captive-portal networks.
   const curlBudget = src.match(/const CHECK_CURL_MAX_TIME_S = (\d+);/);
   const gitBudget = src.match(/const CHECK_GIT_PROBE_TIMEOUT_MS = (\d+);/);
-  if (curlBudget && gitBudget && Number(curlBudget[1]) + Number(gitBudget[1]) / 1000 <= 11) {
-    pass(`check() worst case stays bounded: ${curlBudget[1]}s curl (parallel legs) + ${Number(gitBudget[1]) / 1000}s git probe ≤ 11s`);
+  // Worst case sums ALL three timeout terms: curl --max-time (parallel legs =
+  // one wall-clock leg), curl's +1s JS execFile backstop (fires only when a
+  // hung curl ignores --max-time), and the git probe.
+  const worstCaseS = curlBudget && gitBudget
+    ? Number(curlBudget[1]) + 1 + Number(gitBudget[1]) / 1000
+    : Infinity;
+  if (worstCaseS <= 11) {
+    pass(`check() worst case stays bounded: ${curlBudget[1]}s curl (parallel legs) + 1s JS backstop + ${Number(gitBudget[1]) / 1000}s git probe = ${worstCaseS}s ≤ 11s`);
   } else {
-    fail('check() latency budget exceeded — curl + git probe worst case must stay ≈10s (session-start dead time)');
+    fail('check() latency budget exceeded — curl + JS backstop + git probe worst case must stay ≤11s (session-start dead time)');
   }
 
   if (/--max-time', String\(CHECK_CURL_MAX_TIME_S\)/.test(src)

--- a/tests/update-check-git-fallback.test.mjs
+++ b/tests/update-check-git-fallback.test.mjs
@@ -142,17 +142,35 @@ console.log('\n🧪 Testing update-check git fallback...');
 {
   const src = readFileSync(join(ROOT, 'update-system.mjs'), 'utf-8');
 
-  // The stderr retry notice sits between the guard and the probe call, so
-  // the pattern spans the guard block. The (?!\n    \}) lookahead refuses to
-  // cross the guard's own closing brace (4-space indent, alone on its line) —
-  // without it, moving the probe call to just AFTER the guard would still
-  // match. The call-site count keeps the probe from appearing anywhere else.
-  const gatedProbe = /if \(bothNetworkFailed\)\s*\{(?:(?!\n    \})[\s\S]){0,700}?gitProbe = gitRemoteVersion\(\)/.test(src);
-  const probeCallSites = (src.match(/(?<!function )gitRemoteVersion\(\)/g) || []).length;
-  if (gatedProbe && probeCallSites === 1) {
-    pass('check() consults gitRemoteVersion() only inside the both-curls-failed guard (never on the parseable-failure path)');
+  // Guard-slice extraction, replacing a {0,700} character-window regex whose
+  // ~26 chars of slack meant an ordinary comment inside the guard turned CI
+  // red with a message accusing the author of removing the gating. Each
+  // extraction stage fails with its OWN message naming the real problem, so
+  // a rename or a reformat is never misreported as a behavior break.
+  // Locator rule: the slice ends at the FIRST `\n    }` (newline + exactly
+  // four spaces + closing brace) after the marker — the guard sits at
+  // 4-space indent and everything nested inside closes deeper, so this finds
+  // the guard's own close. Coupling to watch: a multi-line template literal
+  // inside the guard must never contain a line that is exactly `    }` (keep
+  // continuation lines at 8-space indent).
+  const guardMarker = 'if (bothNetworkFailed) {';
+  const guardStart = src.indexOf(guardMarker);
+  let guardSlice = '';
+  if (guardStart === -1) {
+    fail(`guard marker ${JSON.stringify(guardMarker)} not found — if the guard was renamed or refactored, update this test's anchor; this is not necessarily a behavior break`);
   } else {
-    fail('the git fallback is no longer gated on bothNetworkFailed — it must not run on the no-remote-version path');
+    const guardEnd = src.indexOf('\n    }', guardStart);
+    if (guardEnd === -1) {
+      fail('guard closing brace (newline + 4-space indent + }) not found — a reformat, or a `\\n    }` sequence inside a template literal, broke slice extraction; fix the extraction, the gating itself may be intact');
+    } else {
+      guardSlice = src.slice(guardStart, guardEnd);
+    }
+  }
+  const probeCallSites = (src.match(/(?<!function )gitRemoteVersion\(\)/g) || []).length;
+  if (guardSlice && guardSlice.includes('gitProbe = gitRemoteVersion()') && probeCallSites === 1) {
+    pass('check() consults gitRemoteVersion() only inside the both-curls-failed guard (never on the parseable-failure path)');
+  } else if (guardSlice) {
+    fail(`the git fallback is no longer gated on bothNetworkFailed (probe in guard slice: ${guardSlice.includes('gitProbe = gitRemoteVersion()')}, call sites: ${probeCallSites}) — it must not run on the no-remote-version path`);
   }
 
   // repoUrl is a test-injection param; its DEFAULT binds the production
@@ -201,8 +219,13 @@ console.log('\n🧪 Testing update-check git fallback...');
   // before the user's first interaction. The curl legs run in parallel and
   // chain into the git probe, so the two constants below bound the whole
   // check: the three terms (parallel curl legs, +1s JS backstop, git probe)
-  // must stay ≤11s wall clock — ≈ the pre-fallback ceiling. A raised
-  // budget here is a session-start regression on captive-portal networks.
+  // must stay ≤16s wall clock. The 10s curl budget matches the pre-fallback
+  // main and is paid only when curl HANGS — deterministic failures exit
+  // immediately regardless of budget. A 5s budget was tried and rejected in
+  // review: it hung up on a slow-but-answering curl and fabricated a false
+  // "offline" on git-blocked networks (round 7). Raising any constant past
+  // the ceiling is a session-start regression; lowering the curl budget
+  // re-opens the round-7 false offline — change either only with numbers.
   const curlBudget = src.match(/const CHECK_CURL_MAX_TIME_S = (\d+);/);
   const gitBudget = src.match(/const CHECK_GIT_PROBE_TIMEOUT_MS = (\d+);/);
   // Worst case sums ALL three timeout terms: curl --max-time (parallel legs =
@@ -211,10 +234,10 @@ console.log('\n🧪 Testing update-check git fallback...');
   const worstCaseS = curlBudget && gitBudget
     ? Number(curlBudget[1]) + 1 + Number(gitBudget[1]) / 1000
     : Infinity;
-  if (worstCaseS <= 11) {
-    pass(`check() worst case stays bounded: ${curlBudget[1]}s curl (parallel legs) + 1s JS backstop + ${Number(gitBudget[1]) / 1000}s git probe = ${worstCaseS}s ≤ 11s`);
+  if (worstCaseS <= 16) {
+    pass(`check() worst case stays bounded: ${curlBudget[1]}s curl (parallel legs) + 1s JS backstop + ${Number(gitBudget[1]) / 1000}s git probe = ${worstCaseS}s ≤ 16s`);
   } else {
-    fail('check() latency budget exceeded — curl + JS backstop + git probe worst case must stay ≤11s (session-start dead time)');
+    fail(`check() latency budget exceeded: CHECK_CURL_MAX_TIME_S=${curlBudget ? curlBudget[1] : '?'}s + 1s JS backstop + CHECK_GIT_PROBE_TIMEOUT_MS=${gitBudget ? Number(gitBudget[1]) / 1000 : '?'}s = ${worstCaseS}s > 16s — name which constant grew and why the new ceiling is safe (session-start dead time)`);
   }
 
   if (/--max-time', String\(CHECK_CURL_MAX_TIME_S\)/.test(src)
@@ -227,11 +250,25 @@ console.log('\n🧪 Testing update-check git fallback...');
 
   // writeSync, not console.error: on Windows stderr-to-pipe writes are async
   // and the sync git probe blocks the event loop, so a console.error here
-  // would flush AFTER the wait it announces. Pin the sync form.
-  if (/writeSync\(\s*process\.stderr\.fd,\s*`career-ops update check: GitHub unreachable over curl[\s\S]{0,220}?retrying over git/.test(src)) {
+  // would flush AFTER the wait it announces. Pin the sync form and the
+  // notice content as separate slice-membership checks (window-free — the
+  // previous {0,220} character window was the same brittleness class as the
+  // {0,700} one replaced above).
+  const noticeSync = /writeSync\(\s*process\.stderr\.fd,\s*`career-ops update check: GitHub unreachable over curl/.test(guardSlice);
+  const noticeNamesRetry = guardSlice.includes('retrying over git');
+  if (noticeSync && noticeNamesRetry) {
     pass('the git retry announces itself via a SYNCHRONOUS stderr write before the blocking probe (async console.error would flush after the wait on Windows)');
   } else {
-    fail('the retry notice is missing or no longer a synchronous stderr write — on Windows it would appear only after the probe finishes');
+    fail(`the retry notice broke (sync writeSync form in guard: ${noticeSync}, names the git retry: ${noticeNamesRetry}) — on Windows an async write would appear only after the probe finishes`);
+  }
+
+  // curl exit 28 (its own --max-time firing — the normal hang-topology
+  // failure) must render as a readable timeout, not the bare code "28",
+  // in the offline detail the update mode now shows verbatim.
+  if (/error\.code === 28\s*\?\s*`timeout \(\$\{CHECK_CURL_MAX_TIME_S\}s\)`/.test(src)) {
+    pass('curl exit 28 maps to a readable timeout detail (offline payloads never render a bare "28")');
+  } else {
+    fail('the exit-28 → timeout detail mapping is gone — offline detail would render "curl VERSION: 28" on hang topologies');
   }
 }
 

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -20,7 +20,7 @@
  */
 
 import { execFile, execFileSync, execSync } from 'child_process';
-import { copyFileSync, readFileSync, writeFileSync, existsSync, unlinkSync, rmSync } from 'fs';
+import { copyFileSync, readFileSync, writeFileSync, existsSync, unlinkSync, rmSync, writeSync } from 'fs';
 import { join, dirname, posix as pathPosix } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 
@@ -910,6 +910,17 @@ function rebuildDashboardBinaryIfNeeded() {
 
 // ── CHECK ───────────────────────────────────────────────────────
 
+// Session-start latency budget for check(): AGENTS.md runs the check on the
+// first message of every session, so its worst case is user-visible dead time
+// before the first interaction — on exactly the networks that are already
+// misbehaving (captive portals, black-hole egress that hangs rather than
+// refuses). The two curl legs run in parallel (one wall-clock leg) and the
+// git probe runs after them, so worst case ≈ CHECK_CURL_MAX_TIME_S +
+// CHECK_GIT_PROBE_TIMEOUT_MS ≈ 10s — the same ceiling the check had before
+// the git fallback existed. Healthy networks never come near either cap.
+const CHECK_CURL_MAX_TIME_S = 5;
+const CHECK_GIT_PROBE_TIMEOUT_MS = 5000;
+
 // curl helper used by check() — curl works inside the Claude Code sandbox
 // where Node's built-in fetch() fails (ENOTFOUND) because the sandbox
 // routes network traffic through an HTTP/HTTPS proxy that fetch() does
@@ -927,11 +938,17 @@ function curlGet(url, extraArgs = []) {
     try {
       execFile(
         'curl',
-        ['--silent', '--fail', '--max-time', '10', ...extraArgs, url],
-        { encoding: 'utf-8', timeout: 12000 },
+        ['--silent', '--fail', '--max-time', String(CHECK_CURL_MAX_TIME_S), ...extraArgs, url],
+        { encoding: 'utf-8', timeout: CHECK_CURL_MAX_TIME_S * 1000 + 1000 },
         (error, stdout) => {
           if (error) {
-            resolve({ ok: false, detail: error.code || error.message.split('\n')[0] });
+            // A curl that hangs past its own --max-time gets killed by the JS
+            // backstop; error.code is null then and the message is the whole
+            // command line — map it to a terse 'timeout' instead.
+            const detail = error.killed
+              ? `timeout (${CHECK_CURL_MAX_TIME_S + 1}s)`
+              : error.code || error.message.split('\n')[0];
+            resolve({ ok: false, detail });
           } else {
             resolve({ ok: true, body: stdout.trim() });
           }
@@ -948,9 +965,9 @@ function curlGet(url, extraArgs = []) {
 // may be missing from PATH (ENOENT), the proxy may be configured only in git
 // config (http.proxy) with no HTTPS_PROXY env var, raw.githubusercontent.com
 // or api.github.com may be filtered while github.com itself is reachable, or
-// the request may simply exceed curl's 10s budget (the git probe below gets
-// 30s, and apply's fetch minutes). In all of those, `apply` would succeed,
-// so `check` must not report "offline".
+// the request may simply exceed curl's short budget (apply's git fetch gets
+// minutes). In all of those, `apply` would succeed, so `check` must not
+// report "offline".
 
 // Pure tag-parsing half of the fallback, exported for tests: given raw
 // `git ls-remote --tags` output, return the highest semver among the tags
@@ -985,16 +1002,19 @@ export function highestSemverTag(lsRemoteOutput, tagPrefix = '') {
 function gitRemoteVersion() {
   try {
     // Direct execFileSync rather than gitQuiet: this probe runs on every
-    // session start, so it gets its own short budget (30s) instead of the
-    // general 120s git timeout, and GIT_TERMINAL_PROMPT=0 keeps a captive
-    // portal or a credential-rewriting gitconfig from popping an
-    // interactive prompt out of a silent background check.
-    const out = execFileSync('git', ['ls-remote', '--tags', CANONICAL_REPO], {
+    // session start, so it shares the check's tight latency budget (see
+    // CHECK_GIT_PROBE_TIMEOUT_MS) instead of the general 120s git timeout.
+    // GIT_TERMINAL_PROMPT=0 suppresses terminal credential prompts, but on
+    // Windows Git Credential Manager pops a GUI dialog that flag does not
+    // cover — `-c credential.helper=` disables helpers entirely (safe: this
+    // is an anonymous read of a public repo) and GCM_INTERACTIVE=never is a
+    // belt-and-braces for gitconfigs that force GCM some other way.
+    const out = execFileSync('git', ['-c', 'credential.helper=', 'ls-remote', '--tags', CANONICAL_REPO], {
       cwd: ROOT,
       encoding: 'utf-8',
-      timeout: 30000,
+      timeout: CHECK_GIT_PROBE_TIMEOUT_MS,
       stdio: ['pipe', 'pipe', 'pipe'],
-      env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0', GCM_INTERACTIVE: 'never' },
     });
     // Upstream is a release-please monorepo (career-ops-v*, web-v*,
     // manifesto-v*, plus historical bare tags): filter to this component's
@@ -1066,6 +1086,17 @@ async function check() {
     const bothNetworkFailed = !rawVersion.ok && !releaseRaw.ok;
     let gitProbe = null;
     if (bothNetworkFailed) {
+      // Progress goes to stderr: stdout carries the single JSON line the
+      // agent parses, and a silent multi-second retry looks like a hang.
+      // writeSync, not console.error: on Windows, stderr writes to a pipe
+      // are async, and the execFileSync probe below blocks the event loop —
+      // a queued console.error would flush only AFTER the wait it is meant
+      // to announce.
+      writeSync(
+        process.stderr.fd,
+        `career-ops update check: GitHub unreachable over curl (VERSION: ${rawVersion.detail}; ` +
+        `releases: ${releaseRaw.detail}) — retrying over git, ≤${Math.round(CHECK_GIT_PROBE_TIMEOUT_MS / 1000)}s…\n`
+      );
       gitProbe = gitRemoteVersion();
       if (gitProbe.ok && gitProbe.version) remote = gitProbe.version;
     }

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -915,8 +915,8 @@ function rebuildDashboardBinaryIfNeeded() {
 // before the first interaction — on exactly the networks that are already
 // misbehaving (captive portals, black-hole egress that hangs rather than
 // refuses). The two curl legs run in parallel (one wall-clock leg) and the
-// git probe runs after them, so worst case ≈ CHECK_CURL_MAX_TIME_S +
-// CHECK_GIT_PROBE_TIMEOUT_MS ≈ 10s — the same ceiling the check had before
+// git probe runs after them, so worst case = max(CHECK_CURL_MAX_TIME_S, its
+// +1s JS backstop) + CHECK_GIT_PROBE_TIMEOUT_MS ≤ 11s — ≈ the ceiling before
 // the git fallback existed. Healthy networks never come near either cap.
 const CHECK_CURL_MAX_TIME_S = 5;
 const CHECK_GIT_PROBE_TIMEOUT_MS = 5000;

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -926,7 +926,9 @@ const CHECK_GIT_PROBE_TIMEOUT_MS = 5000;
 // routes network traffic through an HTTP/HTTPS proxy that fetch() does
 // not respect but curl handles transparently.  The --silent / --fail flags
 // match the failure-handling already used throughout apply().
-function curlGet(url, extraArgs = []) {
+// Exported for tests (like highestSemverTag): the broken-curl guard is
+// verified behaviorally by invoking this with a sabotaged PATH.
+export function curlGet(url, extraArgs = []) {
   return new Promise((resolve) => {
     // Keep the failure reason on every path: "offline" must be diagnosable.
     // ENOENT (curl not on PATH), HTTP 403 (--fail, e.g. API rate limit), a

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -957,7 +957,10 @@ function curlGet(url, extraArgs = []) {
 // (peeled ^{} refs collapse onto their tag; non-semver tags are ignored;
 // a stray \r survives a CRLF-translating wrapper and would defeat
 // SEMVER_RE's $ anchor, so it is stripped). When tagPrefix is given, only
-// tags starting with it count.
+// tags starting with it count, and the ENTIRE remainder after the prefix
+// must be the version — SEMVER_RE's (?:^|-) anchor would otherwise let a
+// tag like career-ops-v1.25.0-preview-v99.0.0 report 99.0.0.
+const PREFIXED_SEMVER_RE = /^v?(\d+\.\d+\.\d+)$/i;
 export function highestSemverTag(lsRemoteOutput, tagPrefix = '') {
   let best = '';
   for (const line of String(lsRemoteOutput || '').split('\n')) {
@@ -966,15 +969,19 @@ export function highestSemverTag(lsRemoteOutput, tagPrefix = '') {
       .replace('refs/tags/', '')
       .replace(/\^\{\}$/, '');
     if (tagPrefix && !tag.startsWith(tagPrefix)) continue;
-    const match = tag.match(SEMVER_RE);
+    const candidate = tagPrefix ? tag.slice(tagPrefix.length) : tag;
+    const match = candidate.match(tagPrefix ? PREFIXED_SEMVER_RE : SEMVER_RE);
     if (match && (!best || compareVersions(match[1], best) > 0)) best = match[1];
   }
   return best;
 }
 
-// Returns the latest career-ops release version reachable over git,
-// '' when upstream is reachable but carries no matching release tag, and
-// null when the git transport failed too (genuinely offline).
+// Probes upstream over git. Returns { ok: true, version } on success —
+// version is '' when upstream is reachable but carries no matching release
+// tag — and { ok: false, detail } when the git transport failed too
+// (genuinely offline), with detail carrying error.code or the first
+// error-message line, mirroring curlGet()'s convention, so offline
+// payloads stay diagnosable on the git side as well.
 function gitRemoteVersion() {
   try {
     // Direct execFileSync rather than gitQuiet: this probe runs on every
@@ -994,9 +1001,10 @@ function gitRemoteVersion() {
     // prefix, or a foreign component overtaking career-ops' version number
     // would fabricate a permanent false update-available on exactly the
     // curl-blocked machines this fallback serves.
-    return highestSemverTag(out, 'career-ops-v');
-  } catch {
-    return null; // unreachable over git too — genuinely offline
+    return { ok: true, version: highestSemverTag(out, 'career-ops-v') };
+  } catch (error) {
+    // Unreachable over git too — genuinely offline. Keep the reason.
+    return { ok: false, detail: error.code || String(error.message || error).split('\n')[0] };
   }
 }
 
@@ -1059,19 +1067,20 @@ async function check() {
     let gitProbe = null;
     if (bothNetworkFailed) {
       gitProbe = gitRemoteVersion();
-      if (gitProbe) remote = gitProbe;
+      if (gitProbe.ok && gitProbe.version) remote = gitProbe.version;
     }
     if (!remote) {
-      // gitProbe === null → the git transport failed too: genuinely
-      // offline. gitProbe === '' → git reached upstream but found no
-      // career-ops release tag: the network is fine, we just cannot
-      // determine a version — that is no-remote-version, not offline.
-      const status = bothNetworkFailed && gitProbe === null ? 'offline' : 'no-remote-version';
+      // gitProbe.ok === false → the git transport failed too: genuinely
+      // offline. gitProbe.ok with an empty version → git reached upstream
+      // but found no career-ops release tag: the network is fine, we just
+      // cannot determine a version — no-remote-version, not offline.
+      const gitFailed = gitProbe !== null && !gitProbe.ok;
+      const status = bothNetworkFailed && gitFailed ? 'offline' : 'no-remote-version';
       const payload = { status, local };
       if (bothNetworkFailed) {
         payload.detail = `curl VERSION: ${rawVersion.detail}; curl releases: ${releaseRaw.detail}; ` +
-          (gitProbe === null
-            ? 'git ls-remote also failed'
+          (gitFailed
+            ? `git ls-remote also failed: ${gitProbe.detail}`
             : 'git ls-remote reachable but returned no career-ops release tags');
       }
       console.log(JSON.stringify(payload));

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -912,13 +912,21 @@ function rebuildDashboardBinaryIfNeeded() {
 
 // Session-start latency budget for check(): AGENTS.md runs the check on the
 // first message of every session, so its worst case is user-visible dead time
-// before the first interaction — on exactly the networks that are already
-// misbehaving (captive portals, black-hole egress that hangs rather than
-// refuses). The two curl legs run in parallel (one wall-clock leg) and the
-// git probe runs after them, so worst case = max(CHECK_CURL_MAX_TIME_S, its
-// +1s JS backstop) + CHECK_GIT_PROBE_TIMEOUT_MS ≤ 11s — ≈ the ceiling before
-// the git fallback existed. Healthy networks never come near either cap.
-const CHECK_CURL_MAX_TIME_S = 5;
+// before the first interaction. The two curl legs run in parallel (one
+// wall-clock leg) and the git probe runs after them, so worst case =
+// max(CHECK_CURL_MAX_TIME_S, its +1s JS backstop) + CHECK_GIT_PROBE_TIMEOUT_MS
+// ≤ 16s. That ceiling is the acknowledged price of the 10s curl budget, and
+// it is paid ONLY when curl hangs (black-hole egress that swallows packets):
+// deterministic failures — DNS, connection refused, curl missing from PATH —
+// exit immediately regardless of the budget, so shortening it buys those
+// paths nothing. A 5s budget was tried here and rejected in review: on a
+// slow-but-working connection with the git transport blocked, it hung up on
+// a curl that was about to answer and turned a correct ~7s result into a
+// false "offline" — recreating the exact bug this fallback exists to kill,
+// one network over. Healthy networks never come near either cap. (The stderr
+// retry notice below serves direct terminal invocation; agent harnesses
+// buffer stderr and surface it only after the process exits.)
+const CHECK_CURL_MAX_TIME_S = 10;
 const CHECK_GIT_PROBE_TIMEOUT_MS = 5000;
 
 // curl helper used by check() — curl works inside the Claude Code sandbox
@@ -946,10 +954,14 @@ export function curlGet(url, extraArgs = []) {
           if (error) {
             // A curl that hangs past its own --max-time gets killed by the JS
             // backstop; error.code is null then and the message is the whole
-            // command line — map it to a terse 'timeout' instead.
+            // command line — map it to a terse 'timeout' instead. curl hitting
+            // its own --max-time exits 28: map that too, or the rendered
+            // offline detail is a bare "28" with no unit and nothing greppable.
             const detail = error.killed
               ? `timeout (${CHECK_CURL_MAX_TIME_S + 1}s)`
-              : error.code || error.message.split('\n')[0];
+              : error.code === 28
+                ? `timeout (${CHECK_CURL_MAX_TIME_S}s)`
+                : error.code || error.message.split('\n')[0];
             resolve({ ok: false, detail });
           } else {
             resolve({ ok: true, body: stdout.trim() });

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -917,19 +917,62 @@ function rebuildDashboardBinaryIfNeeded() {
 // match the failure-handling already used throughout apply().
 function curlGet(url, extraArgs = []) {
   return new Promise((resolve) => {
-    execFile(
-      'curl',
-      ['--silent', '--fail', '--max-time', '10', ...extraArgs, url],
-      { encoding: 'utf-8', timeout: 12000 },
-      (error, stdout) => {
-        if (error) {
-          resolve(null);
-        } else {
-          resolve(stdout.trim());
+    // Keep the failure reason on every path: "offline" must be diagnosable.
+    // ENOENT (curl not on PATH), HTTP 403 (--fail, e.g. API rate limit), a
+    // proxy/TLS failure, and a real network outage all land in the callback
+    // and are handled by the fallback below. A corrupt or non-executable
+    // curl on PATH additionally makes execFile throw synchronously on
+    // Windows (spawn EFTYPE) instead of calling back — catch that too so a
+    // broken curl degrades to the fallback instead of crashing check().
+    try {
+      execFile(
+        'curl',
+        ['--silent', '--fail', '--max-time', '10', ...extraArgs, url],
+        { encoding: 'utf-8', timeout: 12000 },
+        (error, stdout) => {
+          if (error) {
+            resolve({ ok: false, detail: error.code || error.message.split('\n')[0] });
+          } else {
+            resolve({ ok: true, body: stdout.trim() });
+          }
         }
-      }
-    );
+      );
+    } catch (error) {
+      resolve({ ok: false, detail: error.code || error.message.split('\n')[0] });
+    }
   });
+}
+
+// Fallback for the both-curl-failed path: query upstream over the SAME
+// transport apply() uses. curl failing is not proof of being offline — curl
+// may be missing from PATH (ENOENT), the proxy may be configured only in git
+// config (http.proxy) with no HTTPS_PROXY env var, raw.githubusercontent.com
+// or api.github.com may be filtered while github.com itself is reachable, or
+// the request may simply exceed curl's 10s budget where git gets 300s. In all
+// of those, `apply` would succeed, so `check` must not report "offline".
+// Release Please tags (career-ops-vX.Y.Z) are matched by SEMVER_RE's
+// `(?:^|-)` anchor; the highest semver tag is the latest release.
+// Pure tag-parsing half of the fallback, exported for tests: given raw
+// `git ls-remote --tags` output, return the highest semver among the tags
+// (peeled ^{} refs collapse onto their tag; non-semver tags are ignored).
+export function highestSemverTag(lsRemoteOutput) {
+  let best = '';
+  for (const line of String(lsRemoteOutput || '').split('\n')) {
+    const tag = (line.split('\t')[1] || '')
+      .replace('refs/tags/', '')
+      .replace(/\^\{\}$/, '');
+    const match = tag.match(SEMVER_RE);
+    if (match && (!best || compareVersions(match[1], best) > 0)) best = match[1];
+  }
+  return best;
+}
+
+function gitRemoteVersion() {
+  try {
+    return highestSemverTag(gitQuiet('ls-remote', '--tags', CANONICAL_REPO));
+  } catch {
+    return ''; // unreachable over git too — genuinely offline
+  }
 }
 
 async function check() {
@@ -955,9 +998,9 @@ async function check() {
     ]),
   ]);
 
-  if (rawVersion !== null) {
+  if (rawVersion.ok) {
     try {
-      const raw = parseVersionFile(rawVersion);
+      const raw = parseVersionFile(rawVersion.body);
       const match = raw.match(SEMVER_RE);
       remote = match ? match[1] : '';
     } catch {
@@ -965,9 +1008,9 @@ async function check() {
     }
   }
 
-  if (releaseRaw !== null) {
+  if (releaseRaw.ok) {
     try {
-      const release = JSON.parse(releaseRaw);
+      const release = JSON.parse(releaseRaw.body);
       changelog = release.body || '';
       const rawTag = String(release.tag_name || '').trim();
       const match = rawTag.match(SEMVER_RE);
@@ -978,14 +1021,28 @@ async function check() {
   }
 
   if (!remote && !releaseVersion) {
-    // Both curl calls returned null → genuine network failure.
-    // If one returned non-null but unparseable, remote/releaseVersion are
-    // empty strings, which still reaches the offline branch — that's the
-    // right conservative behaviour (no version = can't determine status).
-    const bothNetworkFailed = rawVersion === null && releaseRaw === null;
-    const status = bothNetworkFailed ? 'offline' : 'no-remote-version';
-    console.log(JSON.stringify({ status, local }));
-    return;
+    // Both curl calls failed → curl-level network failure. But check() and
+    // apply() use different transports (curl vs git), so before declaring
+    // the machine offline, ask upstream over git — the transport apply()
+    // will actually use. If git can see the remote, report the version it
+    // found instead of a false "offline" (which contradicts an apply that
+    // succeeds seconds later).
+    // If one call succeeded but was unparseable, remote/releaseVersion are
+    // empty strings and we fall through to no-remote-version — the right
+    // conservative behaviour (no version = can't determine status).
+    const bothNetworkFailed = !rawVersion.ok && !releaseRaw.ok;
+    if (bothNetworkFailed) {
+      remote = gitRemoteVersion();
+    }
+    if (!remote) {
+      const status = bothNetworkFailed ? 'offline' : 'no-remote-version';
+      const payload = { status, local };
+      if (bothNetworkFailed) {
+        payload.detail = `curl VERSION: ${rawVersion.detail}; curl releases: ${releaseRaw.detail}; git ls-remote also failed`;
+      }
+      console.log(JSON.stringify(payload));
+      return;
+    }
   }
 
   // Use the higher version between VERSION file and GitHub Release

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -1001,7 +1001,10 @@ export function highestSemverTag(lsRemoteOutput, tagPrefix = '') {
 // (genuinely offline), with detail carrying error.code or the first
 // error-message line, mirroring curlGet()'s convention, so offline
 // payloads stay diagnosable on the git side as well.
-function gitRemoteVersion() {
+// Exported for tests; repoUrl exists solely for fixture injection (a
+// deterministic failing remote) — the production caller in check() always
+// uses the CANONICAL_REPO default.
+export function gitRemoteVersion(repoUrl = CANONICAL_REPO) {
   try {
     // Direct execFileSync rather than gitQuiet: this probe runs on every
     // session start, so it shares the check's tight latency budget (see
@@ -1011,7 +1014,7 @@ function gitRemoteVersion() {
     // cover — `-c credential.helper=` disables helpers entirely (safe: this
     // is an anonymous read of a public repo) and GCM_INTERACTIVE=never is a
     // belt-and-braces for gitconfigs that force GCM some other way.
-    const out = execFileSync('git', ['-c', 'credential.helper=', 'ls-remote', '--tags', CANONICAL_REPO], {
+    const out = execFileSync('git', ['-c', 'credential.helper=', 'ls-remote', '--tags', repoUrl], {
       cwd: ROOT,
       encoding: 'utf-8',
       timeout: CHECK_GIT_PROBE_TIMEOUT_MS,
@@ -1025,8 +1028,19 @@ function gitRemoteVersion() {
     // curl-blocked machines this fallback serves.
     return { ok: true, version: highestSemverTag(out, 'career-ops-v') };
   } catch (error) {
-    // Unreachable over git too — genuinely offline. Keep the reason.
-    return { ok: false, detail: error.code || String(error.message || error).split('\n')[0] };
+    // Unreachable over git too — genuinely offline. Keep the REASON, in
+    // priority order:
+    //   1. First stderr line — when git runs and exits non-zero (DNS, proxy,
+    //      TLS: the common real cases), execFileSync puts the exit code in
+    //      error.status and leaves error.code undefined, so the old
+    //      error.code || error.message fallback printed the tautological
+    //      "Command failed: git …" while the actual diagnosis ("fatal:
+    //      unable to access …: Could not resolve host: …") sat in stderr.
+    //   2. error.code — spawn-level failures where stderr is empty: ENOENT
+    //      (no git on PATH) and ETIMEDOUT (probe budget kill).
+    //   3. First message line — last resort so detail is never empty.
+    const stderrLine = String(error.stderr || '').trim().split('\n')[0].replace(/\r$/, '');
+    return { ok: false, detail: stderrLine || error.code || String(error.message || error).split('\n')[0] };
   }
 }
 

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -948,30 +948,55 @@ function curlGet(url, extraArgs = []) {
 // may be missing from PATH (ENOENT), the proxy may be configured only in git
 // config (http.proxy) with no HTTPS_PROXY env var, raw.githubusercontent.com
 // or api.github.com may be filtered while github.com itself is reachable, or
-// the request may simply exceed curl's 10s budget where git gets 300s. In all
-// of those, `apply` would succeed, so `check` must not report "offline".
-// Release Please tags (career-ops-vX.Y.Z) are matched by SEMVER_RE's
-// `(?:^|-)` anchor; the highest semver tag is the latest release.
+// the request may simply exceed curl's 10s budget (the git probe below gets
+// 30s, and apply's fetch minutes). In all of those, `apply` would succeed,
+// so `check` must not report "offline".
+
 // Pure tag-parsing half of the fallback, exported for tests: given raw
 // `git ls-remote --tags` output, return the highest semver among the tags
-// (peeled ^{} refs collapse onto their tag; non-semver tags are ignored).
-export function highestSemverTag(lsRemoteOutput) {
+// (peeled ^{} refs collapse onto their tag; non-semver tags are ignored;
+// a stray \r survives a CRLF-translating wrapper and would defeat
+// SEMVER_RE's $ anchor, so it is stripped). When tagPrefix is given, only
+// tags starting with it count.
+export function highestSemverTag(lsRemoteOutput, tagPrefix = '') {
   let best = '';
   for (const line of String(lsRemoteOutput || '').split('\n')) {
     const tag = (line.split('\t')[1] || '')
+      .replace(/\r$/, '')
       .replace('refs/tags/', '')
       .replace(/\^\{\}$/, '');
+    if (tagPrefix && !tag.startsWith(tagPrefix)) continue;
     const match = tag.match(SEMVER_RE);
     if (match && (!best || compareVersions(match[1], best) > 0)) best = match[1];
   }
   return best;
 }
 
+// Returns the latest career-ops release version reachable over git,
+// '' when upstream is reachable but carries no matching release tag, and
+// null when the git transport failed too (genuinely offline).
 function gitRemoteVersion() {
   try {
-    return highestSemverTag(gitQuiet('ls-remote', '--tags', CANONICAL_REPO));
+    // Direct execFileSync rather than gitQuiet: this probe runs on every
+    // session start, so it gets its own short budget (30s) instead of the
+    // general 120s git timeout, and GIT_TERMINAL_PROMPT=0 keeps a captive
+    // portal or a credential-rewriting gitconfig from popping an
+    // interactive prompt out of a silent background check.
+    const out = execFileSync('git', ['ls-remote', '--tags', CANONICAL_REPO], {
+      cwd: ROOT,
+      encoding: 'utf-8',
+      timeout: 30000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+    });
+    // Upstream is a release-please monorepo (career-ops-v*, web-v*,
+    // manifesto-v*, plus historical bare tags): filter to this component's
+    // prefix, or a foreign component overtaking career-ops' version number
+    // would fabricate a permanent false update-available on exactly the
+    // curl-blocked machines this fallback serves.
+    return highestSemverTag(out, 'career-ops-v');
   } catch {
-    return ''; // unreachable over git too — genuinely offline
+    return null; // unreachable over git too — genuinely offline
   }
 }
 
@@ -1031,14 +1056,23 @@ async function check() {
     // empty strings and we fall through to no-remote-version — the right
     // conservative behaviour (no version = can't determine status).
     const bothNetworkFailed = !rawVersion.ok && !releaseRaw.ok;
+    let gitProbe = null;
     if (bothNetworkFailed) {
-      remote = gitRemoteVersion();
+      gitProbe = gitRemoteVersion();
+      if (gitProbe) remote = gitProbe;
     }
     if (!remote) {
-      const status = bothNetworkFailed ? 'offline' : 'no-remote-version';
+      // gitProbe === null → the git transport failed too: genuinely
+      // offline. gitProbe === '' → git reached upstream but found no
+      // career-ops release tag: the network is fine, we just cannot
+      // determine a version — that is no-remote-version, not offline.
+      const status = bothNetworkFailed && gitProbe === null ? 'offline' : 'no-remote-version';
       const payload = { status, local };
       if (bothNetworkFailed) {
-        payload.detail = `curl VERSION: ${rawVersion.detail}; curl releases: ${releaseRaw.detail}; git ls-remote also failed`;
+        payload.detail = `curl VERSION: ${rawVersion.detail}; curl releases: ${releaseRaw.detail}; ` +
+          (gitProbe === null
+            ? 'git ls-remote also failed'
+            : 'git ls-remote reachable but returned no career-ops release tags');
       }
       console.log(JSON.stringify(payload));
       return;


### PR DESCRIPTION
## What does this PR do?

Stops `check` from reporting `{"status":"offline"}` on machines where `apply` succeeds. `check()` probes the remote over **curl** (raw VERSION + releases API, all failure detail discarded on `main`) while `apply()` fetches over **git** (300s budget, proxy/CA config honored) — so any environment where only curl fails produces a check that says offline seconds before an apply that works. Concrete such environments, all reproducing against `main` at filing time:

- curl absent from PATH (minimal containers, restricted PATHs — git present, curl not)
- proxy configured only in `.gitconfig` (`http.proxy`) with no `HTTPS_PROXY` env var
- `raw.githubusercontent.com` / `api.github.com` filtered while `github.com` (git smart-HTTP) is reachable — with the API's unauthenticated 60 req/h rate limit narrowing this to one blocked host
- TLS interception trusted by git-for-Windows (schannel/Windows cert store) but not curl's CA bundle
- a request slower than curl's `--max-time` where git gets 300s

This is the same transport-divergence class the codebase already fixed once: v1.3.0-era `check()` used Node `fetch()` (proxy-blind) and the `curlGet()` header comment documents that false-offline. The curl switch narrowed the window; this closes it:

- **Fallback over apply's own transport:** on the both-curls-failed path, `check` now runs `git ls-remote --tags` against `CANONICAL_REPO`, parses the release-please tags with the existing `SEMVER_RE`, and reports the highest — so by construction `check` can no longer claim offline while `apply` would succeed. Zero extra subprocesses on the normal path; `changelog` stays empty on the fallback (status and versions are still correct).
- **Filtered to `career-ops-v*` tags:** upstream is a release-please monorepo (`career-ops-v*`, `web-v*`, `manifesto-v*`, historical bare tags). An unfiltered max-across-tags would report the first foreign component to overtake career-ops' version number as the career-ops remote — a permanent false `update-available` on exactly the machines the fallback serves. The prefix filter closes that.
- **Session-start latency budget (review round 2):** `check` runs on the first message of every session, so the fallback fits inside the pre-fallback ceiling instead of stacking budgets: `CHECK_CURL_MAX_TIME_S = 5` (parallel legs, +1s JS backstop) chaining into `CHECK_GIT_PROBE_TIMEOUT_MS = 5000` — worst case ≤11s, measured 10.4s against a black-hole proxy on Windows (healthy path 0.9s). The even 5/5 split is deliberate: the git leg is the rescue path when curl is slow-or-blocked, so a slow-but-working network that misses the curl budget gets rescued by ls-remote instead of reported offline. The retry announces itself on **stderr** (`writeSync`, not `console.error` — stderr-to-pipe writes are async on Windows while the sync probe blocks the event loop); stdout keeps the single-JSON-line contract.
- **Hardened probe:** `GIT_TERMINAL_PROMPT=0` plus `-c credential.helper=` and `GCM_INTERACTIVE=never` — a captive portal or credential-rewriting gitconfig can't pop a terminal *or GUI* prompt out of a background check (Git Credential Manager's dialog ignores `GIT_TERMINAL_PROMPT`), and an anonymous read of a public repo never needs credentials.
- **Diagnosable offline, and honest about it:** when git also fails, the JSON carries a `detail` field with both curl failure codes plus git's own reason — **first stderr line preferred** (non-zero git exits set `error.status`, not `error.code`, so the real diagnosis like `fatal: … Could not resolve host` lives in stderr), then `error.code` (ENOENT/ETIMEDOUT spawn-level cases), then the first message line. A *reachable* remote with no matching release tags reports `no-remote-version` (the network is provably fine), not `offline` — and `modes/update.md` now documents that branch (rendered through `{language.output}` per the mode-file convention, with `detail` shown when present).
- **Bonus crash fix, found while reproducing:** a corrupt or non-executable `curl` on PATH makes `execFile` **throw synchronously** on Windows (`spawn EFTYPE`) instead of calling back, crashing `check` entirely. `curlGet()` now catches that and degrades to the same fallback; a JS-backstop kill of a hung curl maps `detail` to `timeout (6s)` instead of leaking the full command line.

**Reproduction evidence** (2026-08-05, Windows 11 / Node 24, network fully working):

```
# baseline = current main, PATH with node + git but no curl:
$ node update-system.mjs check
{"status":"offline","local":"1.25.0"}          ← false offline
$ node update-system.mjs apply                  # (separately) succeeds via git

# baseline, zero-byte curl.exe shadowing PATH:
$ node update-system.mjs check
spawn EFTYPE                                    ← crash, exit 1

# with this PR, same two environments:
{"status":"up-to-date","local":"1.25.0","remote":"1.25.0"}   ← via git fallback
# normal environment unchanged:
{"status":"up-to-date","local":"1.25.0","remote":"1.25.0"}
```

**Test changes:** new `tests/update-check-git-fallback.test.mjs` (22 asserts standalone). The tag-parsing half is an exported pure function (`highestSemverTag(output, tagPrefix)`) covered behaviorally: release-please tags with semver (not lexical) ordering, **monorepo pollution** (`web-v9.9.9` alongside `career-ops-v1.25.0` → 1.25.0; foreign-tags-only → `''`), peeled `^{}` refs, anchored prefix remainders (no `-preview-v99.0.0` fabrication), CRLF-translated output, degenerate inputs, plus a `SEMVER_RE` anchor sanity check. **Failure-path guards are behavioral too** (review rounds 5–6): `curlGet` is invoked against a sabotaged PATH (empty dir → ENOENT callback path; garbage `curl`/`curl.exe` bytes → the Windows sync-throw path) asserting it resolves `{ ok: false, detail }` without throwing; `gitRemoteVersion` is invoked against an RFC 2606 `.invalid` host (deterministic local DNS failure) asserting `detail` carries git's own reason and never the `Command failed: …` tautology — no locale-dependent wording pinned. Remaining subprocess-bound wiring (guard gating, prefix filter, prompt suppression, single-JSON-line return, the ≤11s three-term budget sum) is pinned by source-pattern assertions per the updater test convention (`updater-rollback-behavior.test.mjs`'s header note). The wiring assertions fail against `main` at filing time.

**Historical context, no code change:** the long-observed "big version jumps need `apply` twice" behavior is the pre-#1245 client applying only its *old* manifest's paths (recognizable signature: two consecutive auto-update commits, the first with the `# x-release-please-version` marker leaked into the message). Already fixed by remote-manifest extraction, self-reexec (#1245), and the completion guard (#1998); clients still on <1.12 run old code on their first jump, which current `main` cannot retroactively change — the completion guard already converts that into an explicit "run apply again".

## Related issue

None — bug fix, sent straight in per CONTRIBUTING.md.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)
