### PR TITLE
feat(scan): AND-groups in title_filter.positive (#2544)

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -92,16 +92,57 @@ export function compileKeyword(kw) {
   return (lower) => lower.includes(kw);
 }
 
+// An AND-group: " + " (whitespace-delimited) between terms means EVERY term
+// must appear in the title, in any order. `title_filter.positive` is otherwise
+// substring-only, so it can express exact spellings and nothing else — and real
+// titles vary in separator and word order:
+//
+//   "Director of Engineering" misses  Director - Software Engineering
+//                                     Director Engineering (Mobile Platform)
+//                                     Senior Director, Platform Engineering
+//
+// The combinations are {level} x {, - of none} x {optional domain word}: no
+// hand-maintained list of literal spellings converges, and every miss is
+// silent — the summary reports one "filtered by title" count that cannot tell
+// a well-tuned filter from a leaking one (#2544).
+//
+// The separator REQUIRES surrounding whitespace on purpose. A bare split('+')
+// would turn the perfectly ordinary keyword "C++" into "c", which matches
+// almost every title — trading a silent drop for a silent flood.
+const AND_SEPARATOR = /\s+\+\s+/;
+
+/**
+ * Compile one `positive` entry into a matcher.
+ *
+ * Entries without " + " keep their exact previous behaviour, so existing
+ * configs are unaffected.
+ *
+ * @param {string} keyword - already trimmed and lowercased.
+ * @returns {(lower: string) => boolean}
+ */
+export function compilePositiveKeyword(keyword) {
+  if (!AND_SEPARATOR.test(keyword)) return compileKeyword(keyword);
+  const terms = keyword.split(AND_SEPARATOR).map(t => t.trim()).filter(Boolean);
+  if (terms.length === 0) return compileKeyword(keyword);
+  // Each term keeps compileKeyword's own rule, so a short term like "vp" is
+  // still matched on a word boundary and cannot hit "vp" inside another word.
+  const matchers = terms.map(compileKeyword);
+  return (lower) => matchers.every(m => m(lower));
+}
+
 export function buildTitleFilter(titleFilter) {
   // Normalize defensively: a malformed title_filter (a null, numeric, or otherwise
   // non-string entry in the YAML) must not crash the scan via k.toLowerCase().
-  const normalize = (arr) => (Array.isArray(arr) ? arr : [])
+  const normalize = (arr, compile) => (Array.isArray(arr) ? arr : [])
     .filter(k => typeof k === 'string')
     .map(k => k.trim().toLowerCase())
     .filter(k => k.length > 0)
-    .map(compileKeyword);
-  const positive = normalize(titleFilter?.positive);
-  const negative = normalize(titleFilter?.negative);
+    .map(compile);
+  // AND-groups are a POSITIVE-side feature only. On the negative side an entry
+  // is a veto, and " + " there would read as "reject when both appear", which
+  // is a different and much easier thing to write as two entries.
+  const positive = normalize(titleFilter?.positive, compilePositiveKeyword);
+  const negative = normalize(titleFilter?.negative, compileKeyword);
 
   return (title) => {
     const lower = (title || '').toLowerCase();
@@ -121,7 +162,7 @@ function compiledPositiveMatchers(positiveList) {
   if (compiledPositiveCache.has(positiveList)) return compiledPositiveCache.get(positiveList);
   const compiled = positiveList
     .filter(k => typeof k === 'string' && k.trim().length > 0)
-    .map(k => ({ raw: k, match: compileKeyword(k.trim().toLowerCase()) }));
+    .map(k => ({ raw: k, match: compilePositiveKeyword(k.trim().toLowerCase()) }));
   compiledPositiveCache.set(positiveList, compiled);
   return compiled;
 }

--- a/scan.mjs
+++ b/scan.mjs
@@ -94,8 +94,10 @@ export function compileKeyword(kw) {
 
 // An AND-group: " + " (whitespace-delimited) between terms means EVERY term
 // must appear in the title, in any order. `title_filter.positive` is otherwise
-// substring-only, so it can express exact spellings and nothing else — and real
-// titles vary in separator and word order:
+// matched by compileKeyword — a plain substring, EXCEPT for a 2-3 letter
+// keyword ("AI", "ML", "VP"), which is anchored on word boundaries so it
+// cannot hit inside another word. Either way an entry expresses one exact
+// spelling and nothing else, and real titles vary in separator and word order:
 //
 //   "Director of Engineering" misses  Director - Software Engineering
 //                                     Director Engineering (Mobile Platform)

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -266,6 +266,21 @@
 # skip_tiers: [intern, entry]  # optional: skip listings by seniority tier (note: unrecognized/plain titles fall back to 'mid')
 
 title_filter:
+  # A `positive` entry is matched as a case-insensitive substring, so it can
+  # only express the exact spelling you write. Real titles vary in separator and
+  # word order, and every variant your list does not literally contain is
+  # dropped in silence.
+  #
+  # Use " + " (with spaces) to require SEVERAL terms in any order:
+  #
+  #   - "director + engineering"   matches "Director of Engineering",
+  #                                "Director - Software Engineering",
+  #                                "Senior Director, Platform Engineering",
+  #                                "Director Engineering (Mobile Platform)"
+  #
+  # One entry replaces the whole {level} x {separator} x {domain word} matrix.
+  # An entry with no " + " behaves exactly as before, and a literal "+" without
+  # surrounding spaces is left alone — "C++" stays the keyword C++.
   positive:
     # [CUSTOMIZE] Add keywords matching YOUR target roles
     # -- AI/ML roles --

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -266,10 +266,12 @@
 # skip_tiers: [intern, entry]  # optional: skip listings by seniority tier (note: unrecognized/plain titles fall back to 'mid')
 
 title_filter:
-  # A `positive` entry is matched as a case-insensitive substring, so it can
-  # only express the exact spelling you write. Real titles vary in separator and
-  # word order, and every variant your list does not literally contain is
-  # dropped in silence.
+  # A `positive` entry is matched case-insensitively as a substring — except a
+  # 2-3 letter keyword ("AI", "ML", "VP"), which is matched on word boundaries
+  # so it does not fire inside another word ("AI" will not match "Maintenance").
+  # Either way an entry expresses the exact spelling you write, and nothing
+  # else: real titles vary in separator and word order, and every variant your
+  # list does not literally contain is dropped in silence.
   #
   # Use " + " (with spaces) to require SEVERAL terms in any order:
   #

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -6114,7 +6114,7 @@ try {
 // ── 11b. TITLE FILTER — acronym word boundaries ──────────────────
 console.log('\n11b. Title filter — acronym word boundaries');
 try {
-  const { buildTitleFilter, compileKeyword } = await import(pathToFileURL(join(ROOT, 'scan.mjs')).href);
+  const { buildTitleFilter, compileKeyword, matchedTitleKeywords } = await import(pathToFileURL(join(ROOT, 'scan.mjs')).href);
 
   // Short all-letter acronyms match on WORD BOUNDARIES, not as substrings.
   const cooFilter = buildTitleFilter({ positive: ['coo'] });
@@ -6140,6 +6140,64 @@ try {
     pass('compileKeyword("cfo") is word-boundary anchored');
   } else {
     fail('compileKeyword("cfo") boundary behavior wrong');
+  }
+
+  // ── AND-groups (#2544) ───────────────────────────────────────────
+  // A positive entry containing " + " requires EVERY term, in any order. The
+  // substring-only list could only express exact spellings, so every variant
+  // it did not literally contain was dropped with no warning.
+  const andFilter = buildTitleFilter({ positive: ['director + engineering', 'vp + engineering'] });
+  const shouldMatch = [
+    'Director - Software Engineering',        // hyphen, not comma
+    'Director Engineering (Mobile Platform)', // no separator at all
+    'Senior Director, Platform Engineering',  // domain word in between
+    'Director of Engineering',                // the literal spelling still works
+    'VP, Software Engineering',
+  ];
+  const missed = shouldMatch.filter((t) => andFilter(t) !== true);
+  if (missed.length === 0) pass('an AND-group matches every separator and word-order variant (#2544)');
+  else fail(`AND-group missed: ${JSON.stringify(missed)}`);
+  if (andFilter('Director of Sales') === false && andFilter('Software Engineer') === false) {
+    pass('an AND-group still requires ALL its terms — one term alone is not enough');
+  } else {
+    fail('AND-group matched a title carrying only one of its terms');
+  }
+
+  // The separator needs surrounding whitespace. A bare split on "+" would turn
+  // the ordinary keyword "C++" into "c", which matches nearly every title —
+  // trading a silent drop for a silent flood.
+  const plusFilter = buildTitleFilter({ positive: ['c++'] });
+  if (plusFilter('C++ Developer') === true && plusFilter('Marketing Manager') === false) {
+    pass('"C++" stays a literal keyword — " + " is the group separator, not "+"');
+  } else {
+    fail('"C++" must not be split into an AND-group');
+  }
+
+  // Short terms inside a group keep compileKeyword's word-boundary rule.
+  const vpGroup = buildTitleFilter({ positive: ['vp + engineering'] });
+  if (vpGroup('VP, Engineering') === true && vpGroup('Revamp Engineering Process') === false) {
+    pass('a short term inside a group is still word-boundary anchored');
+  } else {
+    fail('short term inside an AND-group lost its word boundary');
+  }
+
+  // Existing configs are untouched: no " + " means the old behaviour exactly.
+  const legacy = buildTitleFilter({ positive: ['engineering manager'], negative: ['intern'] });
+  if (legacy('Engineering Manager, Payments') === true
+      && legacy('Engineering Manager Intern') === false
+      && legacy('Manager, Engineering') === false) {
+    pass('an entry without " + " keeps exact substring behaviour (backward compatible)');
+  } else {
+    fail('a plain keyword changed behaviour — the change is not backward compatible');
+  }
+
+  // matchedTitleKeywords reports the group as written, so content_filter
+  // by_title_keyword overrides keep working against the same config strings.
+  const kw = matchedTitleKeywords('Senior Director, Platform Engineering', { positive: ['director + engineering'] });
+  if (JSON.stringify(kw) === JSON.stringify(['director + engineering'])) {
+    pass('matchedTitleKeywords reports an AND-group by its raw config string');
+  } else {
+    fail(`matchedTitleKeywords returned ${JSON.stringify(kw)}`);
   }
 
   // A malformed title_filter (null / numeric / empty entries) must not crash.

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -6200,6 +6200,16 @@ try {
     fail(`matchedTitleKeywords returned ${JSON.stringify(kw)}`);
   }
 
+  // Groups are positive-side only: on the negative side an entry is a veto, and
+  // " + " must stay literal there rather than silently becoming "reject when
+  // both appear" — which would veto far more than the user wrote.
+  const negGroup = buildTitleFilter({ positive: [], negative: ['foo + bar'] });
+  if (negGroup('Foo Bar Engineer') === true && negGroup('Widget foo + bar Lead') === false) {
+    pass('" + " in a negative entry stays a literal keyword, not an AND-group');
+  } else {
+    fail('a negative entry containing " + " was parsed as a group');
+  }
+
   // A malformed title_filter (null / numeric / empty entries) must not crash.
   const messyFilter = buildTitleFilter({ positive: ['cfo', null, 123, '', 'head of'] });
   if (messyFilter('Group CFO') === true && messyFilter('Marketing Coordinator') === false) {


### PR DESCRIPTION
Fixes #2544.

## The problem, in the reporter's words

`title_filter.positive` is a case-insensitive **substring** match, so an entry can express one exact spelling and nothing else. Real titles vary in separator and word order, and every variant the list does not literally contain is dropped **silently** — the scan summary prints a single `Filtered by title: N` that cannot tell a well-tuned filter from a leaking one. Measured impact on the reporter's config: **27 of 196 leadership titles lost**, from a list that looked careful and thorough.

## Change

`" + "` between terms means every term must appear, in any order:

```yaml
positive:
  - "director + engineering"
```

covers, in one entry, what no hand-maintained list of literal spellings converges on:

| Title | Before | After |
|---|---|---|
| `Director of Engineering` | ✅ | ✅ |
| `Director - Software Engineering` | ❌ | ✅ |
| `Director Engineering (Mobile Platform)` | ❌ | ✅ |
| `Senior Director, Platform Engineering` | ❌ | ✅ |
| `Director of Sales` | ❌ | ❌ |

## One deliberate deviation from the proposed patch

The issue proposes `k.split('+')`. **That breaks `C++`**: it becomes the single term `c`, which matches nearly every title — trading a silent drop for a silent flood, in a config the user has no reason to revisit.

The separator therefore requires surrounding whitespace (`/\s+\+\s+/`), which is also the syntax the issue documents in its own examples. `"C++"` stays a literal keyword; `"director + engineering"` is a group.

Two further details the patch in the issue drops, both preserved here:

- **Short terms keep their word boundary.** `compileKeyword` anchors 2-3 letter keywords, so `"vp + engineering"` matches `VP, Engineering` but not `Revamp Engineering Process`. Each term inside a group is compiled through the same function rather than a raw `includes`.
- **Groups are positive-side only.** On the negative side an entry is a veto, and `" + "` there would mean "reject when both appear" — a different feature, and one that is already expressible as two entries.
- **`matchedTitleKeywords()` reports the group by its raw config string**, so `content_filter.by_title_keyword` overrides keep matching the same strings users wrote.

## Backward compatibility

An entry without `" + "` goes through the existing `compileKeyword` path unchanged. Pinned by a test: `"engineering manager"` still matches `Engineering Manager, Payments`, still rejects `Manager, Engineering`, and the negative list still vetoes.

## Test plan

- [x] 6 new assertions in `test-all.mjs` §11b, including all four separator/word-order variants from the issue, the `C++` guard, the short-term word boundary, and the backward-compatibility case
- [x] `node test-all.mjs --quick` — 2982 passed, 0 failed
- [x] `node validate-portals.mjs --file templates/portals.example.yml` — 0 errors, 0 warnings
- [x] Syntax documented where users meet it: the `title_filter` block in `templates/portals.example.yml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Combine positive title keywords with `" + "` to require every term to match.
  * Matching is case-insensitive and supports flexible spacing and term order.
  * Existing acronym boundaries and literal terms such as `C++` remain supported.
* **Documentation**
  * Added guidance and examples for multi-term title filters and keyword behavior.
* **Bug Fixes**
  * Improved title-filter matching and reporting for content-filter overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->