### PR TITLE
test(followup): pin the cadence profile in test-all section 12 (#2268)

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -6168,17 +6168,70 @@ try {
 console.log('\n12. Follow-up cadence logic');
 
 try {
-  const cadence = await import(pathToFileURL(join(ROOT, 'followup-cadence.mjs')).href);
+  // Pin the cadence source BEFORE followup-cadence.mjs is evaluated (#2268).
+  // Its module-level `CADENCE = resolveCadenceConfig()` reads CAREER_OPS_PROFILE at
+  // import time and otherwise falls back to the USER's config/profile.yml - so the
+  // computeUrgency / computeNextFollowupDate cases below, which encode
+  // DEFAULT_CADENCE, went red on a perfectly healthy install where the user had
+  // customized followup_cadence. #2446 pinned the two standalone suites this way;
+  // this in-process import was the piece left over.
+  //
+  // The import below must stay DYNAMIC: ESM hoists static imports above every
+  // statement in the file, so a static import would evaluate the module before this
+  // assignment and the pin would silently do nothing.
+  const CADENCE_FIXTURE = join(ROOT, 'tests', 'fixtures', 'profile-default-cadence.yml');
+  const priorCadenceProfile = process.env.CAREER_OPS_PROFILE;
+  process.env.CAREER_OPS_PROFILE = CADENCE_FIXTURE;
 
-  // CLI regression: the import.meta.url guard must still let the module run as a CLI.
-  // Data-independent — default mode emits the result as JSON: a `metadata` object when
-  // the tracker has applications, or an `{error}` object (exit 1) when it is empty.
-  // Empty output would mean the guard wrongly suppressed main().
+  let cadence;
   let cliOut = '';
   try {
-    cliOut = execFileSync(NODE, [join(ROOT, 'followup-cadence.mjs')], { cwd: ROOT, encoding: 'utf-8', timeout: 30000 });
-  } catch (cliErr) {
-    cliOut = `${cliErr.stdout || ''}`; // exit 1 on an empty tracker is expected; keep stdout
+    cadence = await import(pathToFileURL(join(ROOT, 'followup-cadence.mjs')).href);
+
+    // CLI regression: the import.meta.url guard must still let the module run as a CLI.
+    // Data-independent — default mode emits the result as JSON: a `metadata` object when
+    // the tracker has applications, or an `{error}` object (exit 1) when it is empty.
+    // Empty output would mean the guard wrongly suppressed main().
+    //
+    // The pin is passed explicitly: this is a FRESH process, so it re-resolves the
+    // profile on its own and would otherwise read the user's config/profile.yml no
+    // matter what the parent set.
+    try {
+      cliOut = execFileSync(NODE, [join(ROOT, 'followup-cadence.mjs')], {
+        cwd: ROOT,
+        encoding: 'utf-8',
+        timeout: 30000,
+        env: { ...process.env, CAREER_OPS_PROFILE: CADENCE_FIXTURE },
+      });
+    } catch (cliErr) {
+      cliOut = `${cliErr.stdout || ''}`; // exit 1 on an empty tracker is expected; keep stdout
+    }
+  } finally {
+    // Restore immediately. followup-cadence.mjs froze CADENCE at import above, so the
+    // pin has already done its job, and other modules read the same variable
+    // (scan.mjs, cv-templates.mjs, providers/_profile-keywords.mjs, plugins/_engine.mjs)
+    // - later sections must not silently inherit the fixture.
+    if (priorCadenceProfile === undefined) delete process.env.CAREER_OPS_PROFILE;
+    else process.env.CAREER_OPS_PROFILE = priorCadenceProfile;
+  }
+
+  // Guard the pin itself: if it ever stops taking effect, the two cadence-dependent
+  // blocks below revert to silently asserting against whatever the developer happens
+  // to have configured. This fails loudly instead.
+  //
+  // The module-private CADENCE isn't exported, but resolveCadenceConfig() with no
+  // arguments re-reads the same module-level PROFILE_FILE that CADENCE was built
+  // from - which was resolved from CAREER_OPS_PROFILE at import time. So this is a
+  // faithful proxy for "the pin was in place when the module was evaluated".
+  {
+    const pinned = cadence.resolveCadenceConfig();
+    const drift = Object.keys(cadence.DEFAULT_CADENCE)
+      .filter((k) => pinned[k] !== cadence.DEFAULT_CADENCE[k]);
+    if (drift.length === 0) {
+      pass('section 12 pins CAREER_OPS_PROFILE, so cadence resolves to the documented defaults');
+    } else {
+      fail(`section 12 cadence pin did not take effect - drifted keys: ${drift.join(', ')} (got ${JSON.stringify(pinned)})`);
+    }
   }
   let cliJson = null;
   try { cliJson = JSON.parse(cliOut.trim()); } catch { /* leave null → fail below */ }


### PR DESCRIPTION
Part of #2268.

#2446 pinned the two standalone follow-up suites. This is the residual you scoped in https://github.com/santifer/career-ops/issues/2268#issuecomment-5175830179 - the in-process import inside `test-all.mjs` section 12.

## Problem

Section 12 imported the module with no profile override:

```js
const cadence = await import(pathToFileURL(join(ROOT, 'followup-cadence.mjs')).href);
```

`followup-cadence.mjs` resolves its cadence **at module load**:

```js
const PROFILE_FILE = process.env.CAREER_OPS_PROFILE || join(CAREER_OPS, 'config/profile.yml');
…
const CADENCE = resolveCadenceConfig();
```

So the `computeUrgency` and `computeNextFollowupDate` cases - which encode `DEFAULT_CADENCE` - resolved against the **user's own** `config/profile.yml`. On a profile carrying `applied_first_days: 14`:

```
❌ computeUrgency applied past applied_first → overdue: expected overdue, got waiting
❌ computeNextFollowupDate first applied follow-up = appDate + applied_first: expected 2026-05-08, got 2026-05-15
```

## Fix

Pin `CAREER_OPS_PROFILE` to `tests/fixtures/profile-default-cadence.yml` (the fixture #2446 committed) before the dynamic import, following that PR's pattern. The import must stay dynamic - ESM hoists static imports above every statement in the file, so a static import would evaluate the module before the assignment and the pin would silently do nothing. That is called out in a comment at the site.

**The `execFileSync` CLI check gets the pin passed explicitly.** To be precise about this one: it was *not* among the failures; its assertion only checks that the output parses as `{metadata}` or `{error}`, which holds under any cadence. But it spawns a fresh process that re-resolves the profile independently of the parent, so leaving it unpinned would keep a live path to the user's real profile inside a section whose whole point is now determinism.

**The pin is restored immediately after the import.** `CADENCE` is frozen at module evaluation, so the pin has already done its job by then, and four other modules read the same variable (`scan.mjs`, `cv-templates.mjs`, `providers/_profile-keywords.mjs`, `plugins/_engine.mjs`). Leaving it set would have later sections silently inherit the fixture; trading one hidden environmental dependency for another.

**One new assertion guards the pin.** `CADENCE` isn't exported, so it checks `resolveCadenceConfig()` with no arguments, which re-reads the same module-level `PROFILE_FILE`. This is the same concern #2446 raised: a pin that degrades into *ignoring* the profile would leave every existing assertion passing while the isolation quietly disappeared. The existing `resolveCadenceConfig({ profilePath })` cases at the end of the section still cover the opposite direction; that overrides are read - so both failure modes stay pinned down.

## Test plan

Verified the way the issue was originally proven - with a customized cadence in place, then with the profile moved aside; so the section is green in **both** states rather than green only when the profile is absent.

Profile used: `applied_first_days: 14`, `applied_subsequent_days: 10`, `applied_max_followups: 2`.

| State | Before | After |
|---|---|---|
| `node test-all.mjs`, customized profile in place | 2973 passed, **3 failed** | 2976 passed, 1 failed |
| `node test-all.mjs`, `config/profile.yml` moved aside | - | 2975 passed, 1 failed |

The 1 remaining failure in both columns is `skill entrypoint index-mode`, pre-existing on my machine and unrelated to this change (a local gitignore collision on `.agents/skills/`). Section 12 itself is clean in both states.

**Mutation check on the new guard**;  commented out the pin, left the guard in place, kept the customized profile:

```
❌ section 12 cadence pin did not take effect; drifted keys: applied_first, applied_subsequent
   (got {"applied_first":14,"applied_subsequent":10,"applied_max_followups":2,…})
❌ computeUrgency applied past applied_first → overdue: expected overdue, got waiting
❌ computeNextFollowupDate first applied follow-up = appDate + applied_first: expected 2026-05-08, got 2026-05-15
```

The guard fails first and names the drifted keys, so a future regression reports the cause rather than two mystery date mismatches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Improved follow-up cadence tests to use a consistent default-cadence configuration.
  * Added checks to detect unexpected cadence changes and preserve the surrounding environment during test execution.
  * Strengthened command-line regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
