### PR TITLE
docs(i18n): add Spanish translation for interview README

### DIFF
--- a/modes/es/interview/README.md
+++ b/modes/es/interview/README.md
@@ -1,0 +1,33 @@
+# Habilidades para Entrevistas
+
+Un conjunto de habilidades reutilizables para la preparación integral de entrevistas.
+
+## Habilidades
+
+| Habilidad | Archivo | Cuándo usarla |
+|---|---|---|
+| Planificador de Preparación | `plan.md` | Dada una descripción del puesto (JD) y la fecha de la entrevista, crea un plan de preparación estructurado por bloques de tiempo |
+| Entrevistador de Práctica | `practice.md` | Ejecuta preguntas de práctica para la entrevista con retroalimentación estructurada |
+| Informe Post-Entrevista | `debrief.md` | Después de una entrevista real, cierra brechas y actualiza el banco de preguntas |
+
+## Habilidades Relacionadas (en la carpeta padre `modes/`)
+
+| Habilidad | Archivo | Cuándo usarla |
+|---|---|---|
+| Investigación de Empresas | `../../interview-prep.md` | Investiga una empresa y un rol específicos antes de la entrevista |
+
+## Convenciones de Archivos
+
+Estas habilidades asumen que existen los siguientes archivos (valores predeterminados de career-ops):
+
+| Archivo | Propósito |
+|---|---|
+| `cv.md` | CV de la persona candidata — fuente de verdad para experiencia y puntos de prueba |
+| `article-digest.md` | Puntos de prueba resumidos del portafolio (opcional) |
+| `config/profile.yml` | Perfil de la persona candidata — roles objetivo, compensación, narrativa |
+| `modes/_profile.md` | Arquetipos de la persona candidata, narrativa y factores excluyentes |
+| `interview-prep/story-bank.md` | Historias STAR+R acumuladas |
+| `interview-prep/question-bank.md` | Banco de preguntas con seguimiento de brechas (se crea en el primer uso) |
+| `interview-prep/interview-prep-guide.md` | Principios generales para la entrevista (opcional) |
+| `interview-prep/{company}-{role}.md` | Archivo de preparación específico para el rol |
+| `interview-prep/retracted-claims.md` | Afirmaciones que la persona candidata ha retirado por considerarlas indefendibles — filtro estricto en la práctica y el informe (formato: `**"[afirmación]"** ([contexto]). Razón: [motivo de una línea + encuadre correcto si corresponde].`) |


### PR DESCRIPTION
Adds the Spanish translation for `modes/interview/README.md` at `modes/es/interview/README.md`, following the structure of the Italian version.

Fixes #2426

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Spanish-language documentation for interview preparation skills.
  * Described related skills, usage scenarios, and required career-operation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->