### PR TITLE
fix(invite-match): keep non-Latin company names in normalizeCompanyName

### DIFF
--- a/invite-match.mjs
+++ b/invite-match.mjs
@@ -111,7 +111,14 @@ export function normalizeCompanyName(name) {
     .toLowerCase()
     .replace(/\([^)]*\)/g, ' ')
     .replace(/&/g, ' and ')
-    .replace(/[^a-z0-9 ]/g, ' ')
+    // Keep letters and numbers from any script, not just ASCII. The old
+    // [^a-z0-9 ] class deleted every non-Latin character, so a company name
+    // written in Japanese, Cyrillic, Greek, etc. collapsed to '' and
+    // matchInvite bailed with zero candidates even when the exact tracker row
+    // was present (issue #2517). \p{L}\p{N} keeps the letters/digits and drops
+    // only punctuation and symbols, matching the ASCII behaviour for Latin
+    // names while leaving non-Latin names intact.
+    .replace(/[^\p{L}\p{N} ]/gu, ' ')
     .replace(/\s+/g, ' ')
     .trim();
 

--- a/invite-match.test.mjs
+++ b/invite-match.test.mjs
@@ -118,6 +118,23 @@ eq('Zoom URL with explicit port detected as Zoom', extractPlatform('Join: https:
 eq('Microsoft Teams URL with explicit port detected as Microsoft Teams', extractPlatform('https://teams.microsoft.com:8443/l/meetup-join/abc'), 'Microsoft Teams');
 eq('Google Meet URL with explicit port detected as Google Meet', extractPlatform('https://meet.google.com:443/xyz-abcd-efg'), 'Google Meet');
 
+// --- Non-Latin company names (issue #2517) ---
+// normalizeCompanyName used to strip every non-ASCII character, so a company
+// name in a non-Latin script collapsed to '' and matchInvite returned zero
+// candidates even when the exact tracker row was present.
+eq('normalizeCompanyName keeps a Japanese name instead of emptying it', normalizeCompanyName('アクメ株式会社'), 'アクメ株式会社');
+eq('normalizeCompanyName lowercases and keeps a Cyrillic name', normalizeCompanyName('Яндекс'), 'яндекс');
+eq('normalizeCompanyName keeps a Greek name', normalizeCompanyName('Ακμή'), 'ακμή');
+eq('normalizeCompanyName still strips punctuation and legal suffix around non-Latin text', normalizeCompanyName('«アクメ», Inc.'), 'アクメ');
+// Latin behaviour is unchanged: punctuation still dropped, suffix still stripped.
+eq('normalizeCompanyName still reduces a Latin name with punctuation', normalizeCompanyName('Acme, Inc.'), 'acme');
+// matchInvite must surface the exact non-Latin row, not return [].
+const nonLatinRows = [
+  { num: 1, company: 'アクメ株式会社', role: 'SWE', status: 'Applied', date: '2026-01-01', notes: '' },
+  { num: 2, company: 'Acme Inc', role: 'SWE', status: 'Applied', date: '2026-01-01', notes: '' },
+];
+eq('matchInvite returns the exact Japanese-named row (issue #2517)', matchInvite({ company: 'アクメ株式会社' }, nonLatinRows).map(c => c.appNumber), [1]);
+
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) {
   console.log('Failures:', failures.join(', '));


### PR DESCRIPTION
Fixes #2517.

## What was happening

`normalizeCompanyName()` in `invite-match.mjs` reduced names with `.replace(/[^a-z0-9 ]/g, ' ')`. That class keeps only ASCII letters and digits, so a company name written in any non-Latin script (Japanese, Cyrillic, Greek, …) was stripped down to `''`. `matchInvite()` then bailed immediately:

```js
const targetKey = normalizeCompanyName(signals.company);
if (!targetKey) return [];
```

So pasting an invite from a non-Latin company returned zero candidates even when the exact tracker row was sitting right there.

## The fix

One line: swap the ASCII class for a Unicode-aware one.

```js
.replace(/[^\p{L}\p{N} ]/gu, ' ')
```

`\p{L}\p{N}` keeps letters and digits from every script and drops only punctuation and symbols, so Latin names normalize exactly as before while non-Latin names survive. Everything downstream (legal-suffix stripping, generic-descriptor stripping, `companySimilarity`) already works on whatever tokens it's given, so no other change was needed.

## Tests

Added to `invite-match.test.mjs`:

- Japanese (`アクメ株式会社`), Cyrillic (`Яндекс`), and Greek (`Ακμή`) names normalize to themselves instead of `''`.
- Punctuation and legal suffixes are still stripped around non-Latin text (`«アクメ», Inc.` → `アクメ`).
- Latin behaviour is unchanged (`Acme, Inc.` → `acme`).
- `matchInvite()` surfaces the exact Japanese-named row instead of returning `[]`.

Evidence (reverting only the source line):

```
WITH fix:     33 passed, 0 failed
WITHOUT fix:  28 passed, 5 failed   (exactly the 5 new non-Latin cases)
restored:     33 passed, 0 failed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved company-name matching for Japanese, Cyrillic, Greek, and other non-Latin names.
  * Preserved letters and numbers from international company names while continuing to remove punctuation and legal suffixes.
  * Maintained existing behavior for Latin names and exact matching scenarios.

* **Tests**
  * Added regression coverage for multilingual company-name normalization and matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->