### PR TITLE
docs(i18n): add Chinese interview README

### DIFF
--- a/modes/zh/interview/README.md
+++ b/modes/zh/interview/README.md
@@ -1,0 +1,33 @@
+# 面试技能
+
+一组可复用的技能，覆盖端到端的面试准备流程。
+
+## 技能
+
+| 技能 | 文件 | 使用场景 |
+|---|---|---|
+| 面试准备计划器 | `plan.md` | 根据职位描述（JD）和面试日期，制定结构化、按时间分块的准备计划 |
+| 模拟面试官 | `practice.md` | 进行模拟面试提问，并在每次作答后给出结构化反馈 |
+| 面试后复盘 | `debrief.md` | 在真实面试结束后补齐短板，并更新题库 |
+
+## 相关技能（位于上级 `modes/` 目录）
+
+| 技能 | 文件 | 使用场景 |
+|---|---|---|
+| 公司调研 | `../../interview-prep.md` | 在面试前调研具体公司和岗位 |
+
+## 文件约定
+
+这些技能假定以下文件已存在（career-ops 默认约定）：
+
+| 文件 | 用途 |
+|---|---|
+| `cv.md` | 候选人简历——经历与证明点的事实来源 |
+| `article-digest.md` | 从作品集中提炼的精简证明点（可选） |
+| `config/profile.yml` | 候选人画像——目标岗位、薪酬与职业叙事 |
+| `modes/_profile.md` | 候选人原型、职业叙事与底线条件 |
+| `interview-prep/story-bank.md` | 累积的 STAR+R 故事库 |
+| `interview-prep/question-bank.md` | 带短板跟踪的题库（首次使用时创建） |
+| `interview-prep/interview-prep-guide.md` | 通用面试原则（可选） |
+| `interview-prep/{company}-{role}.md` | 针对具体岗位的准备文件 |
+| `interview-prep/retracted-claims.md` | 候选人已认定无法自证的撤回主张——在模拟面试与复盘中作为硬门禁（格式：`**"[claim]"** ([context]). Reason: [one-line reason + correct framing if applicable].`） |


### PR DESCRIPTION
## Summary

- add the missing Simplified Chinese index for the interview skill set
- mirror the English README structure and existing Chinese terminology
- preserve file names and use the localized relative link to the company-research skill

## Validation

- compared heading hierarchy and table row counts with the English source
- verified all four relative Markdown links resolve
- ran `git diff --check` and scanned the contribution for sensitive account values

Part of #2426

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Chinese-language README for reusable interview-preparation skills.
  * Documented available skill files, use cases, related resources, and required career-operations files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->