### PR TITLE
test(skills): isolate the index-mode fixture from ambient git config (#2269)

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4945,16 +4945,43 @@ console.log('\n12c. Materialized skill index mode');
 
 {
   const fixtureRoot = mkdtempSync(join(tmpdir(), 'career-ops-skill-git-'));
+  // The fixture stages the very paths career-ops legitimately tracks - .agents/,
+  // .claude/, .opencode/ - and those are exactly the paths agent-tool users
+  // exclude machine-wide. A fresh `git init` still honours the ambient global
+  // and system config, so on such a machine `git add` refused the path and the
+  // whole block aborted into a single "crashed" failure that read like a
+  // regression in materializeSkillEntrypoints (#2269).
+  //
+  // Fix the class rather than the instance: pin the global and system config to
+  // an empty file outside the fixture work tree, so nothing ambient reaches it -
+  // init.templateDir and core.autocrlf as much as core.excludesFile. Same shape
+  // as the GIT_CONFIG_GLOBAL pin in upgrade-tests.mjs. Empty on purpose; the
+  // fixture's own `git config` calls below set everything it actually needs.
+  const gitConfigRoot = mkdtempSync(join(tmpdir(), 'career-ops-skill-gitcfg-'));
+  const gitConfigPath = join(gitConfigRoot, 'gitconfig');
+  writeFileSync(gitConfigPath, '');
+  // That pin alone does NOT close the ignore path. When core.excludesFile is
+  // unset git falls back to the XDG default ~/.config/git/ignore, and that
+  // fallback is independent of which config file it just read - so the excludes
+  // path has to be pointed somewhere inert explicitly, below. An empty real file
+  // rather than /dev/null, which git rejects as an excludes source on Windows
+  // ("fatal: cannot use nul as an exclude file"); empty-string semantics work on
+  // both platforms tested but are not worth depending on.
+  const emptyExcludes = join(gitConfigRoot, 'empty-excludes');
+  writeFileSync(emptyExcludes, '');
+  const gitEnv = { ...process.env, GIT_CONFIG_GLOBAL: gitConfigPath, GIT_CONFIG_SYSTEM: gitConfigPath };
   const gitRun = (args, opts = {}) => execFileSync('git', args, {
     cwd: fixtureRoot,
     encoding: 'utf-8',
     timeout: 30000,
+    env: gitEnv,
     ...opts,
   }).trim();
   const gitRaw = (args) => execFileSync('git', args, {
     cwd: fixtureRoot,
     encoding: 'utf-8',
     timeout: 30000,
+    env: gitEnv,
   });
 
   try {
@@ -4969,14 +4996,46 @@ console.log('\n12c. Materialized skill index mode');
     const pointer = '../../../.agents/skills/career-ops/SKILL.md';
 
     gitRun(['init']);
+    // core.excludesFile is only the GLOBAL layer. `git init` also seeds
+    // .git/info/exclude from a template, which GIT_TEMPLATE_DIR can still point
+    // at an ambient one, so empty that layer too rather than assume it is inert.
+    writeFileSync(join(fixtureRoot, '.git', 'info', 'exclude'), '');
     gitRun(['config', 'core.symlinks', 'false']);
+    gitRun(['config', 'core.excludesFile', emptyExcludes]);
     gitRun(['config', 'user.email', 'test@example.com']);
     gitRun(['config', 'user.name', 'Test User']);
 
     writeFileSync(join(canonicalDir, 'SKILL.md'), fixtureSkill);
     writeFileSync(join(claudeDir, 'SKILL.md'), pointer);
     writeFileSync(join(opencodeDir, 'SKILL.md'), pointer);
-    gitRun(['add', '--', '.agents/skills/career-ops/SKILL.md']);
+    // Guard the isolation itself, as a first-class assertion. If the pin above
+    // ever stops taking effect the fixture cannot stage its own input, and every
+    // assertion below collapses into a single "crashed" carrying git's ignore
+    // message - which reads as a regression in materializeSkillEntrypoints
+    // rather than an environment leak. Name the real cause here instead.
+    //
+    // Both shapes have to be caught, because git reports them differently: an
+    // ignored path named EXPLICITLY makes `git add` exit non-zero, while an
+    // ignored path merely covered by a directory pathspec (the `.claude/skills/`
+    // add further down) is skipped silently and exits 0. So run the add and the
+    // index check together, and let one assertion speak for both.
+    let canonicalStaged = '';
+    try {
+      gitRun(['add', '--', '.agents/skills/career-ops/SKILL.md']);
+      canonicalStaged = gitRun(['ls-files', '--', '.agents/skills/career-ops/SKILL.md']);
+    } catch {
+      // Left empty: the assertion below is the report.
+    }
+    if (canonicalStaged) {
+      pass('skill index-mode fixture is isolated from ambient git ignore rules (#2269)');
+    } else {
+      fail('skill index-mode fixture: canonical entrypoint did not stage - ambient git config reached the fixture (#2269)');
+      fail('materialized skill entrypoints stage as regular files, not symlink blobs (skipped: fixture not staged)');
+      fail('materialized skill blobs contain canonical skill content (skipped: fixture not staged)');
+      const reported = new Error('fixture staging precondition failed');
+      reported.alreadyReported = true;
+      throw reported;
+    }
 
     const pointerBlob = gitRun(['hash-object', '-w', '--stdin'], { input: pointer });
     gitRun(['update-index', '--add', '--cacheinfo', `120000,${pointerBlob},.claude/skills/career-ops/SKILL.md`]);
@@ -5004,9 +5063,12 @@ console.log('\n12c. Materialized skill index mode');
       fail('materialized skill blobs do not contain canonical skill content');
     }
   } catch (e) {
-    fail(`skill entrypoint index-mode test crashed: ${e.message}`);
+    // The staging-precondition branch already reported all three assertions
+    // individually; re-reporting here would double-count and re-bury the cause.
+    if (!e?.alreadyReported) fail(`skill entrypoint index-mode test crashed: ${e.message}`);
   } finally {
     rmSync(fixtureRoot, { recursive: true, force: true });
+    rmSync(gitConfigRoot, { recursive: true, force: true });
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

Isolates the section 12c fixture repo from ambient git configuration, so a machine with a global agent-dir ignore stops losing both assertions to a single "crashed" failure. Also turns the staging precondition into a first-class assertion, so the next occurrence names its own cause.

## Related issue

Closes #2269.

## Problem

The fixture stages `.agents/skills/`, `.claude/skills/` and `.opencode/skills/` - paths career-ops legitimately tracks, and the same paths agent-tool users routinely exclude machine-wide. A fresh `git init` still honours the ambient global config, so on such a machine:

```
12c. Materialized skill index mode
The following paths are ignored by one of your .gitignore files:
.agents
hint: Use -f if you really want to add them.
  ❌ skill entrypoint index-mode test crashed: Command failed: git add -- .agents/skills/career-ops/SKILL.md
```

Both assertions are lost, and the failure is indistinguishable from a real regression in `materializeSkillEntrypoints` / `prepareMaterializedSkillEntrypointsForStage`.

## Fix

Isolation is done at the class level, not the instance: `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` are pinned to an empty file outside the fixture work tree, which closes `init.templateDir` and `core.autocrlf` along with the reported symptom. Same shape as the existing `GIT_CONFIG_GLOBAL` pin in `upgrade-tests.mjs`, so this is not a new pattern in the repo.

**That pin alone does not close the ignore path, which is the part worth flagging.** When `core.excludesFile` is unset, git falls back to the XDG default `~/.config/git/ignore`, and that fallback is independent of which config file it just read. I had this wrong on the first pass and the suite told me so - with only the config pin in place, section 12c still failed identically. So `core.excludesFile` is also set explicitly, to an empty real file.

Not `/dev/null`: per @LayerC0de's data point on the issue, git rejects the null device as an excludes source on Windows (`fatal: cannot use nul as an exclude file`). Empty-string worked on both platforms tested, but an empty real file is unambiguous everywhere and costs one line, which was their recommendation.

`.git/info/exclude` is emptied after `init` for the template layer - the other half of @LayerC0de's note that `core.excludesFile` only covers the global layer. With the config pin in place `init.templateDir` cannot come from config, but `GIT_TEMPLATE_DIR` can still be set in the environment, so that layer is emptied rather than assumed inert.

`git add -f` was deliberately not used: it would paper over this one call while leaving the class open, and it would mask a genuine ignore bug if one ever appeared here.

## Making the block self-diagnosing

The second half of the issue: the `catch` collapsed two independent assertions into one generic `fail()`. The staging precondition is now its own assertion.

It has to cover both shapes, because git reports the same condition two different ways:

| How the ignored path is named | git's behavior |
|---|---|
| Explicitly (`git add -- .agents/.../SKILL.md`) | exits **non-zero**, the block throws |
| Covered by a directory pathspec (`git add -- .claude/skills/`) | skipped **silently**, exits 0 |

So the `add` and the index check run together and one assertion speaks for both. My first attempt only handled the silent shape and the mutation check caught it - the guard sat after an `add` that had already thrown.

When it fires, the two downstream assertions are reported individually as skipped rather than vanishing, and the generic crash handler stands down so nothing is double-counted.

## Test plan

Verified in both directions, since a fix for an environment-dependent failure that is only green in one environment has proven nothing. `~/.config/git/ignore` on this machine contains `.agents/` and `.claude/`, which is the reproducing condition; the clean-machine column points `XDG_CONFIG_HOME` at an empty directory instead of touching that file.

| State | Section 12c before | Section 12c after |
|---|---|---|
| Ambient agent-dir ignore present (reproduces #2269) | crashed, 0 of 2 assertions run | **3 passed** |
| No ambient ignore (clean machine / CI) | 2 passed | **3 passed** |

Full suite goes from 2968 passed / 4 failed to 2971 passed / 3 failed. The 3 remaining failures are pre-existing on my machine and untouched by this change: two are the section 12 cadence assertions from #2268 (PR #2553 pending), and one is a `data/` ignore assertion from local repo state.

**Mutation check** - commented out the `core.excludesFile` pin, kept the guard, ambient ignore in place:

```
12c. Materialized skill index mode
  ❌ skill index-mode fixture: canonical entrypoint did not stage - ambient git config reached the fixture (#2269)
  ❌ materialized skill entrypoints stage as regular files, not symlink blobs (skipped: fixture not staged)
  ❌ materialized skill blobs contain canonical skill content (skipped: fixture not staged)
```

Against the same mutation, the pre-fix code produced the single `crashed` line at the top of this description. The named cause and the two individually-reported assertions are the behavior change.

Environment: git 2.50.1 (Apple Git-155), macOS. The Windows claims above are @LayerC0de's from the issue thread, not re-verified here.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` - section 12c is green in both environment states; 3 pre-existing unrelated failures are itemized above rather than claimed as passing
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the skill index-mode test to reliably run in environments with existing Git configuration or exclude rules.
  * Added clearer handling when staging prerequisites cannot be completed, preventing redundant failure reports.
  * Strengthened cleanup of temporary Git configuration data after tests finish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->