### PR TITLE
feat(scan): make the pipeline and scan-history paths env-overridable (#2271)

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -549,6 +549,26 @@ npm run scan
 node scan.mjs --include-blacklisted   # audit: let blacklisted companies through, annotated
 ```
 
+**Parallel search lanes (#2271):** all four of `scan.mjs`'s files are overridable by environment variable, so a second search with different targeting (a bridge/income track, a career-change track, or a partner sharing the checkout) can be fully self-contained in one clone:
+
+| Variable | Default |
+|---|---|
+| `CAREER_OPS_PORTALS` | `portals.yml` |
+| `CAREER_OPS_PROFILE` | `config/profile.yml` |
+| `CAREER_OPS_PIPELINE` | `data/pipeline.md` |
+| `CAREER_OPS_SCAN_HISTORY` | `data/scan-history.tsv` |
+
+```bash
+CAREER_OPS_PORTALS=portals.bridge.yml \
+CAREER_OPS_PIPELINE=data/pipeline.bridge.md \
+CAREER_OPS_SCAN_HISTORY=data/scan-history.bridge.tsv \
+  node scan.mjs
+```
+
+Give a lane its own `CAREER_OPS_SCAN_HISTORY`, not just its own pipeline. That file is the dedup source, so lanes sharing it silently suppress each other: a posting surfaced in one lane counts as a duplicate in the other and never appears there, with only the `Duplicates: skipped` counter to show for it.
+
+Defaults are unchanged, so a single-lane setup needs none of this. Note that the remaining outputs (`data/scan-runs.tsv`, `data/portal-health.tsv`, `data/applications.md`) are still shared across lanes, so `stats.mjs` and the other analytics scripts pool lanes together.
+
 **Exit codes:** `0` scan completed, `1` configuration error or no portals.yml found.
 
 ---

--- a/scan.mjs
+++ b/scan.mjs
@@ -63,12 +63,23 @@ const parseYaml = yaml.load;
 
 const PORTALS_PATH = process.env.CAREER_OPS_PORTALS || 'portals.yml';
 const PROFILE_PATH = process.env.CAREER_OPS_PROFILE || 'config/profile.yml';
-const SCAN_HISTORY_PATH = 'data/scan-history.tsv';
-const PIPELINE_PATH = 'data/pipeline.md';
+// Overridable for the same reason the two inputs above are (#2271). A second
+// search lane - a bridge/income track, a career-change track, a partner sharing
+// the checkout - already gets its own portals.yml and profile, but without these
+// two it still writes into the one inbox and the one dedup history. That is not
+// just untidy: scan-history.tsv IS the dedup source, so a posting surfaced in
+// lane A is silently counted as a duplicate in lane B and never shown at all.
+const SCAN_HISTORY_PATH = process.env.CAREER_OPS_SCAN_HISTORY || 'data/scan-history.tsv';
+const PIPELINE_PATH = process.env.CAREER_OPS_PIPELINE || 'data/pipeline.md';
 const APPLICATIONS_PATH = 'data/applications.md';
 const PROVIDERS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), 'providers');
 
-// Ensure required directories exist (fresh setup)
+// Ensure required directories exist (fresh setup). Stays literal: the paths that
+// are NOT overridable still live here. The two that are need no equivalent -
+// scan-history creates its own parent before writing, and the pipeline's parent
+// is created by acquirePipelineLock, which runs before the first pipeline write.
+// tests/scan-output-paths.test.mjs pins that, so an override into a directory
+// that does not exist yet keeps working if either of those changes.
 mkdirSync('data', { recursive: true });
 
 const CONCURRENCY = 10;

--- a/tests/scan-output-paths.test.mjs
+++ b/tests/scan-output-paths.test.mjs
@@ -1,0 +1,175 @@
+// tests/scan-output-paths.test.mjs - scan.mjs's two outputs must be
+// env-overridable, the same way its two inputs already are (#2271).
+//
+// `CAREER_OPS_PORTALS` and `CAREER_OPS_PROFILE` already let a second search lane
+// bring its own targeting, but data/pipeline.md and data/scan-history.tsv were
+// hardcoded, so every lane landed in one inbox. The quiet half is dedup:
+// scan-history.tsv is the dedup source, so a posting surfaced by lane A is
+// skipped as a duplicate in lane B and never reaches the user at all - the
+// counter increments and no row appears.
+//
+// End-to-end rather than unit, because the defect is in module-level path
+// resolution: importing the module in-process would read this process's env, not
+// a lane's. Each check spawns a real scan.mjs over the local-parser fixture
+// board, so nothing here touches the network.
+import { pass, fail, ROOT, NODE } from './helpers.mjs';
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { execFileSync } from 'child_process';
+
+console.log('\nscan.mjs - pipeline and scan-history paths are env-overridable (#2271)');
+
+const TRACKER = `# Applications Tracker
+
+| # | Date | Company | Role | Score | Status | PDF | Report | Notes |
+|---|------|---------|------|-------|--------|-----|--------|-------|
+`;
+
+const PORTALS = `title_filter:
+  positive:
+    - "Strategic Finance"
+tracked_companies:
+  - name: Fixture Defense
+    careers_url: https://boards.example.com/fixture
+    parser:
+      command: node
+      script: tests/fixtures/three-city-board.mjs
+`;
+
+/** A scan sandbox: temp cwd, empty tracker, fixture portals. */
+function makeLane() {
+  const dir = mkdtempSync(join(tmpdir(), 'scan-outpaths-'));
+  mkdirSync(join(dir, 'data'), { recursive: true });
+  writeFileSync(join(dir, 'data', 'applications.md'), TRACKER);
+  const portals = join(dir, 'portals.yml');
+  writeFileSync(portals, PORTALS);
+  return { dir, portals };
+}
+
+const runScan = (dir, env) => execFileSync(NODE, [join(ROOT, 'scan.mjs')], {
+  cwd: dir,
+  env: { ...process.env, ...env },
+  encoding: 'utf-8',
+  stdio: ['ignore', 'pipe', 'pipe'],
+});
+
+/** Pending rows in a pipeline file; [] when the file was never created. */
+function entries(pipelinePath) {
+  if (!existsSync(pipelinePath)) return [];
+  return readFileSync(pipelinePath, 'utf-8')
+    .split('\n')
+    .filter((l) => /^- \[[ x]\]\s+https?:\/\//.test(l));
+}
+
+// 1. Defaults unchanged. The override is worthless if adding it moved the
+//    single-lane user's files, so pin the untouched behavior first.
+{
+  const { dir, portals } = makeLane();
+  try {
+    runScan(dir, { CAREER_OPS_PORTALS: portals });
+    const defaultEntries = entries(join(dir, 'data', 'pipeline.md')).length;
+    const defaultHistory = existsSync(join(dir, 'data', 'scan-history.tsv'));
+    if (defaultEntries > 0 && defaultHistory) {
+      pass('with no override, scan still writes data/pipeline.md and data/scan-history.tsv');
+    } else {
+      fail(`default output paths regressed: ${defaultEntries} pipeline entr(y/ies), history file ${defaultHistory ? 'present' : 'MISSING'}`);
+    }
+  } catch (err) {
+    fail(`default-path scan failed: ${err.message}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// 2. The override actually redirects, and - the half that matters - the default
+//    files stay untouched. Asserting only that the lane file filled up would
+//    pass just as happily if scan wrote to BOTH.
+{
+  const { dir, portals } = makeLane();
+  try {
+    const lanePipeline = join(dir, 'data', 'pipeline.bridge.md');
+    const laneHistory = join(dir, 'data', 'scan-history.bridge.tsv');
+    runScan(dir, {
+      CAREER_OPS_PORTALS: portals,
+      CAREER_OPS_PIPELINE: lanePipeline,
+      CAREER_OPS_SCAN_HISTORY: laneHistory,
+    });
+
+    const laneEntries = entries(lanePipeline).length;
+    const defaultTouched = existsSync(join(dir, 'data', 'pipeline.md'))
+      || existsSync(join(dir, 'data', 'scan-history.tsv'));
+
+    if (laneEntries > 0 && existsSync(laneHistory) && !defaultTouched) {
+      pass('CAREER_OPS_PIPELINE / CAREER_OPS_SCAN_HISTORY redirect both outputs, leaving the defaults untouched');
+    } else {
+      fail(`override did not fully redirect: ${laneEntries} lane entr(y/ies), lane history ${existsSync(laneHistory) ? 'present' : 'MISSING'}, default files ${defaultTouched ? 'WRITTEN' : 'untouched'}`);
+    }
+  } catch (err) {
+    fail(`overridden-path scan failed: ${err.message}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// 3. The consequence the issue calls the quiet one: with a shared history the
+//    second lane silently suppresses postings the first lane already saw. Two
+//    lanes in ONE checkout, same fixture board - separate histories must let
+//    both surface it, and the shared-history control proves the suppression is
+//    real rather than assumed.
+{
+  const { dir, portals } = makeLane();
+  try {
+    const laneA = { pipeline: join(dir, 'data', 'pipeline.a.md'), history: join(dir, 'data', 'scan-history.a.tsv') };
+    const laneB = { pipeline: join(dir, 'data', 'pipeline.b.md'), history: join(dir, 'data', 'scan-history.b.tsv') };
+
+    runScan(dir, { CAREER_OPS_PORTALS: portals, CAREER_OPS_PIPELINE: laneA.pipeline, CAREER_OPS_SCAN_HISTORY: laneA.history });
+    runScan(dir, { CAREER_OPS_PORTALS: portals, CAREER_OPS_PIPELINE: laneB.pipeline, CAREER_OPS_SCAN_HISTORY: laneB.history });
+
+    const aCount = entries(laneA.pipeline).length;
+    const bCount = entries(laneB.pipeline).length;
+
+    // Control: lane B pointed at lane A's history is the pre-fix behavior.
+    const shared = join(dir, 'data', 'pipeline.shared.md');
+    runScan(dir, { CAREER_OPS_PORTALS: portals, CAREER_OPS_PIPELINE: shared, CAREER_OPS_SCAN_HISTORY: laneA.history });
+    const sharedCount = entries(shared).length;
+
+    if (aCount > 0 && bCount === aCount && sharedCount === 0) {
+      pass('separate histories let both lanes surface the same posting; a shared history suppresses it');
+    } else {
+      fail(`cross-lane dedup behavior unexpected: lane A ${aCount}, lane B ${bCount} (want equal and non-zero), shared-history lane ${sharedCount} (want 0)`);
+    }
+  } catch (err) {
+    fail(`two-lane scan failed: ${err.message}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// 4. An override pointing outside data/ must not fail on its first write. Two
+//    different code paths happen to provide this today: scan-history creates its
+//    own parent, and the pipeline's parent is created by acquirePipelineLock
+//    before the first pipeline write. Neither was written with lane overrides in
+//    mind, so pin the behavior rather than trust it to stay incidental - the
+//    failure mode if either changes is an ENOENT on a lane's very first scan.
+{
+  const { dir, portals } = makeLane();
+  try {
+    const lanePipeline = join(dir, 'lanes', 'bridge', 'pipeline.md');
+    const laneHistory = join(dir, 'lanes', 'bridge', 'scan-history.tsv');
+    runScan(dir, {
+      CAREER_OPS_PORTALS: portals,
+      CAREER_OPS_PIPELINE: lanePipeline,
+      CAREER_OPS_SCAN_HISTORY: laneHistory,
+    });
+    if (entries(lanePipeline).length > 0 && existsSync(laneHistory)) {
+      pass('an override into a not-yet-existing directory creates it instead of failing');
+    } else {
+      fail('override into a new directory did not produce both outputs');
+    }
+  } catch (err) {
+    fail(`scan into a new directory failed: ${err.message}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Adds `CAREER_OPS_SCAN_HISTORY` and `CAREER_OPS_PIPELINE`, so `scan.mjs`'s two outputs are overridable the same way its two inputs already are. Defaults are unchanged.

## Related issue

Closes #2271.

## Why now

@santifer's note on the issue was that #1444 (`CAREER_OPS_ROOT`) would cover this wholesale if it landed, and that the narrow version stands on its own if it stalls. As of today #1444 is `CHANGES_REQUESTED` and `CONFLICTING` against `main`, 45 files, last touched Jul 18. Taking that as stalled rather than imminent. Nothing here blocks it: if `CAREER_OPS_ROOT` lands later, these two variables collapse into it the same way `CAREER_OPS_PORTALS` and `CAREER_OPS_PROFILE` do.

## The change

```js
const SCAN_HISTORY_PATH = process.env.CAREER_OPS_SCAN_HISTORY || 'data/scan-history.tsv';
const PIPELINE_PATH     = process.env.CAREER_OPS_PIPELINE     || 'data/pipeline.md';
```

The inbox collision the issue describes is the visible half. The dedup collision is the one worth stating plainly: `scan-history.tsv` **is** the dedup source, so a posting surfaced in lane A is skipped as a duplicate in lane B and never appears there at all. The `Duplicates: skipped` counter increments and no row is written, so from lane B's side the posting simply does not exist.

## What is deliberately not in scope

`data/scan-runs.tsv`, `data/portal-health.tsv` and `data/applications.md` stay shared.

Portal health is genuinely machine-global - whether a board is reachable is not a property of a lane. The other two are a judgement call: splitting the run counters would only half-solve consequence (3) from the issue, because `stats.mjs`, `analyze-patterns.mjs` and `detect-reposts.mjs` would still need to know lanes exist to keep them apart. That is the `--lane` concept sketched in the issue, and it wants to be designed rather than accreted. The limitation is documented in `docs/SCRIPTS.md` instead of left for someone to discover from a skewed funnel.

## Tests

`tests/scan-output-paths.test.mjs`, picked up by the existing `tests/` auto-discovery. End-to-end rather than unit, because the defect is in module-level path resolution - importing the module in-process would read the test runner's env, not a lane's. Each check spawns a real `scan.mjs` over the existing local-parser fixture board (`tests/fixtures/three-city-board.mjs`), so nothing touches the network.

| # | Assertion | Why it is there |
|---|---|---|
| 1 | No override still writes `data/pipeline.md` and `data/scan-history.tsv` | The override is worthless if adding it moved the single-lane user's files |
| 2 | Both outputs redirect **and** the defaults stay untouched | Asserting only that the lane file filled up would pass just as happily if scan wrote to both |
| 3 | Two lanes with separate histories both surface the same posting; a shared history suppresses it | The quiet consequence, with the pre-fix behavior as an in-test control rather than an assumption |
| 4 | An override into a directory that does not exist yet works | See below |

**Mutation check** - reverted the two constants to hardcoded, kept the tests:

```
✅ with no override, scan still writes data/pipeline.md and data/scan-history.tsv
❌ override did not fully redirect: 0 lane entr(y/ies), lane history MISSING, default files WRITTEN
❌ cross-lane dedup behavior unexpected: lane A 0, lane B 0 (want equal and non-zero), shared-history lane 0 (want 0)
❌ override into a new directory did not produce both outputs
```

3 of 4 fail, and assertion 1 correctly passes in both states, which is what makes it a backward-compat pin rather than a duplicate.

**A second mutation removed a line I had written.** My first draft also added a `mkdirSync(path.dirname(...))` loop for the two resolved paths, on the reasoning that a lane pointing outside `data/` would ENOENT on its first write. Mutating that line out left all four assertions green, so it was not doing anything: `scan-history` already creates its own parent, and the pipeline's parent is created by `acquirePipelineLock` before the first pipeline write. The line is gone. Assertion 4 stayed, since neither of those code paths was written with lane overrides in mind and the failure mode if either changes is an ENOENT on a lane's very first scan.

Full suite: 2968 passed → 2972 passed, exactly the four new assertions. The 4 failures on my machine are pre-existing and unrelated (two are #2268, one is #2269 which #2567 fixes, one is a local `data/` ignore assertion).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] Issue opened first (#2271), and confirmed by a maintainer there
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` - the new suite is 4/4; pre-existing unrelated failures are itemized above rather than claimed as passing
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) - `scan.mjs` is system layer, and the defaults for every user-layer file it writes are unchanged
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable output paths for pipeline and scan-history files through environment variables.
  * Supports independent scan lanes with separate history files and deduplication.
  * Automatically creates missing parent directories for custom output paths.

* **Documentation**
  * Added guidance, examples, and details about shared outputs and independent scan histories.

* **Tests**
  * Added end-to-end coverage for default paths, custom paths, deduplication, and directory creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->