### PR TITLE
fix(scan): Unicode-aware keys for role dedup and company matching

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -42,7 +42,7 @@ import { loadProviders, resolveProvider } from './providers/_registry.mjs';
 import { mergeProviderPlugins } from './plugins/_engine.mjs';
 import { classifyFetchError } from './verify-portals.mjs';
 import { fingerprintText, findCrossListings } from './fingerprint-core.mjs';
-import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
+import { resolveColumns, parseTrackerRow, normalizeTextKey } from './tracker-parse.mjs';
 import { normalizeCompany } from './tracker-utils.mjs';
 import { normalizeCompanyName } from './invite-match.mjs';
 import { withPipelineLock } from './pipeline-lock.mjs';
@@ -709,14 +709,17 @@ export function buildSalaryFilter(salaryFilter) {
 }
 
 export function companyMatch(jobCompany, windowCompany) {
-  const cleanNoSpaces = (str) => String(str || '').toLowerCase().replace(/[^a-z0-9]/g, '');
-  const c1NoSpaces = cleanNoSpaces(jobCompany);
-  const c2NoSpaces = cleanNoSpaces(windowCompany);
-  if (c1NoSpaces === c2NoSpaces) return true;
+  // Unicode-aware (#2393 family): the [a-z0-9] strip this used to carry erased
+  // non-Latin scripts outright, so 株式会社アカネ and 合同会社ゾロ both cleaned
+  // to '' and the equality check below reported two unrelated companies as the
+  // same one. The empty guard is part of the fix, not decoration — "no usable
+  // signal on either side" must never read as "identical".
+  const c1NoSpaces = normalizeTextKey(jobCompany);
+  const c2NoSpaces = normalizeTextKey(windowCompany);
+  if (c1NoSpaces && c1NoSpaces === c2NoSpaces) return true;
 
-  const cleanWithSpaces = (str) => String(str || '').toLowerCase().replace(/[^a-z0-9\s]/g, ' ').replace(/\s+/g, ' ').trim();
-  const c1WithSpaces = cleanWithSpaces(jobCompany);
-  const c2WithSpaces = cleanWithSpaces(windowCompany);
+  const c1WithSpaces = normalizeTextKey(jobCompany, ' ');
+  const c2WithSpaces = normalizeTextKey(windowCompany, ' ');
   if (!c1WithSpaces || !c2WithSpaces) return false;
 
   const regex1 = new RegExp('\\b' + c2WithSpaces.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&') + '\\b');
@@ -1277,13 +1280,27 @@ function isRoleLocationSuffix(tag) {
  * @returns {string} Normalized role key.
  */
 export function normalizeRoleForDedup(role) {
-  let title = String(role ?? '').toLowerCase();
+  // NFKC up front so full-width brackets fold to their ASCII forms while the
+  // suffix loop can still see them: "Engineer （Remote）" now strips the same
+  // way "Engineer (Remote)" always did.
+  //
+  // This does NOT make the loop understand non-Latin suffixes — the tag itself
+  // is still matched against the English-only ROLE_LOCATION_SUFFIXES set via
+  // normalizeRoleSuffixTag(), which carries its own [a-z0-9] strip. So
+  // "エンジニア（東京）" and "エンジニア（大阪）" remain two keys. Teaching the
+  // suffix vocabulary other scripts is a separate change (new vocabulary, not
+  // a key fix) and is deliberately out of scope here.
+  let title = String(role ?? '').normalize('NFKC').toLowerCase();
   while (true) {
     const match = title.match(/\s*[\[(]([^[\]()]+)[\])]\s*$/);
     if (!match || !isRoleLocationSuffix(match[1])) break;
     title = title.slice(0, match.index).trimEnd();
   }
-  return title.replace(/[^a-z0-9]+/g, ' ').trim();
+  // Unicode-aware (#2393 family): the [a-z0-9] strip this used to carry keyed
+  // every non-Latin title to '', so バックエンドエンジニア and フロントエンド
+  // エンジニア at one company shared a dedupe key and the scan dropped the
+  // second as already-seen. Space separator keeps the word-collapsing shape.
+  return normalizeTextKey(title, ' ');
 }
 
 /**

--- a/scan.mjs
+++ b/scan.mjs
@@ -722,9 +722,38 @@ export function companyMatch(jobCompany, windowCompany) {
   const c2WithSpaces = normalizeTextKey(windowCompany, ' ');
   if (!c1WithSpaces || !c2WithSpaces) return false;
 
-  const regex1 = new RegExp('\\b' + c2WithSpaces.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&') + '\\b');
-  const regex2 = new RegExp('\\b' + c1WithSpaces.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&') + '\\b');
-  return regex1.test(c1WithSpaces) || regex2.test(c2WithSpaces);
+  // Containment: a short window name should still match a longer official one
+  // ("Acme" vs "Acme Corp"), bounded so "Acme" does not match "Acmetric".
+  //
+  // The anchors are lookarounds, not \b: JS defines \b against ASCII \w even
+  // under the u flag. Keeping the accent (rather than stripping it to a space,
+  // as the [a-z0-9] filter did before) means '\bnestlé\b' can never hold —
+  // neither side of the trailing anchor is a word character — so Nestlé
+  // Deutschland vs Nestlé would silently stop matching. Same for Ørsted, Zoë
+  // and every other name whose first or last letter is non-ASCII.
+  //
+  // The anchor class is the one normalizeTextKey keeps, deliberately. An anchor
+  // class without \p{M} would treat a Devanagari matra as a boundary and split
+  // कंपनी mid-word — the key and its boundaries have to agree on what a letter
+  // is, or they drift the way #2397 and #2445 fixed elsewhere.
+  //
+  // Non-Latin containment does not fire here (株式会社メルカリ vs メルカリ): the
+  // lookbehind sees 社, a letter, so there is no boundary to assert, and
+  // Japanese is not space-delimited so no anchor rule recovers it. Note this
+  // pair DID match before this change, but only via the '' === '' collision
+  // that erased both names — not through this path. Making it match on purpose
+  // needs corporate-form normalisation, tracked separately in #2570.
+  //
+  // compileLocationKeyword() above reached for lookarounds too, for a related
+  // reason ("\b behaves surprisingly at a punctuation edge"); its escape set is
+  // reused here because '\-' is an invalid identity escape under u. Both
+  // operands are already normalizeTextKey output — letters, marks, digits and
+  // spaces only — so the escape is defensive, not load-bearing.
+  const bounded = (name) => new RegExp(
+    `(?<![\\p{L}\\p{M}\\p{N}])${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?![\\p{L}\\p{M}\\p{N}])`,
+    'u',
+  );
+  return bounded(c2WithSpaces).test(c1WithSpaces) || bounded(c1WithSpaces).test(c2WithSpaces);
 }
 
 export function addDays(dateStr, days) {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -11331,6 +11331,51 @@ try {
     fail('Latin companyMatch behavior changed');
   }
 
+  // -- Accented Latin: the containment fallback must survive keeping the accent --
+  // Before this change the [a-z0-9] strip turned é into a space, which left the
+  // \b anchors sitting on ASCII letters, so 'Nestlé Deutschland' vs 'Nestlé'
+  // matched. Preserving the accent breaks \b (it is ASCII-only in JS even under
+  // the u flag), so the anchors are Unicode lookarounds. A pure-ASCII assertion
+  // cannot detect this — the accent has to be at a word edge.
+  const accented = [
+    ['Nestlé Deutschland', 'Nestlé'],
+    ['Ørsted Energy', 'Ørsted'],
+    ['Zoë Ltd', 'Zoë'],
+    ['Telefónica Tech', 'Telefónica'],   // accent mid-word: matched on main too
+  ];
+  const accentedMiss = accented.filter(([a, b]) => companyMatch(a, b) !== true);
+  if (accentedMiss.length === 0) {
+    pass('companyMatch still matches accented Latin names at a word edge (Nestlé, Ørsted, Zoë)');
+  } else {
+    fail(`accented Latin containment lost: ${JSON.stringify(accentedMiss)}`);
+  }
+
+  // The boundary must still bound: a prefix that is not a whole word stays out.
+  if (companyMatch('Acme', 'Acmetric Ltd') === false && companyMatch('Nestlé', 'Danone') === false) {
+    pass('companyMatch keeps the containment fallback bounded (no bare-substring matching)');
+  } else {
+    fail('containment fallback over-matched: a non-word-boundary prefix was accepted');
+  }
+
+  // The anchor class must be the same one normalizeTextKey keeps, so a mark or
+  // a digit at the edge is a letter to the boundary too. Both witnesses put the
+  // character *immediately* after the candidate: a case where the next
+  // character is a space passes whatever the anchor class is, and would assert
+  // nothing. Each one flips if its class is dropped from the lookarounds.
+  const matraWitness = companyMatch('टाटा कंपनीी', 'टाटा कंपनी');       // \p{M}
+  const digitWitness = companyMatch('Acme2 Ltd', 'Acme');               // \p{N}
+  if (matraWitness === false && digitWitness === false) {
+    pass('companyMatch anchors treat combining marks and digits as letters (no split mid-word)');
+  } else {
+    fail(`anchor class too narrow: matra=${matraWitness} digit=${digitWitness} (both should be false)`);
+  }
+  // Positive direction: a genuine non-Latin containment with a space boundary.
+  if (companyMatch('कंपनी सॉफ्टवेयर', 'कंपनी') === true) {
+    pass('companyMatch matches a Devanagari name at a space boundary');
+  } else {
+    fail('Devanagari containment lost at a space boundary');
+  }
+
   // normalizeTextKey's separator arg must not disturb its existing callers.
   if (normalizeTextKey('株式会社アカネ') === '株式会社アカネ'
       && normalizeTextKey('Acme, Inc.') === 'acmeinc'

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -11224,6 +11224,124 @@ try {
   fail(`scan company+role dedup tests crashed: ${e.message}`);
 }
 
+
+// ── 45c. SCAN DEDUP/MATCH KEYS ARE UNICODE-AWARE ─────────────────────
+// Follow-up to #2393/#2397/#2445: those routed the tracker-side keys through
+// normalizeTextKey, but scan.mjs still carried two private [a-z0-9] strips.
+// On a non-Latin pipeline that strip erases the whole string, so:
+//   - normalizeRoleForDedup keyed EVERY Japanese title to '', making two
+//     genuinely different roles at one company share a dedupe key — the scan
+//     then discarded the second as already-seen.
+//   - companyMatch cleaned both sides to '' and its `c1 === c2` equality check
+//     reported two unrelated companies as a match.
+// Both directions are asserted: distinct inputs must stay distinct, and the
+// controls confirm the checks still fire on genuinely identical input.
+
+console.log('\n45c. Scan dedup/match keys are Unicode-aware (non-Latin pipelines)');
+try {
+  const {
+    normalizeRoleForDedup,
+    companyRoleDedupKey,
+    companyMatch,
+  } = await import(pathToFileURL(join(ROOT, 'scan.mjs')).href);
+  const { normalizeTextKey } = await import(pathToFileURL(join(ROOT, 'tracker-parse.mjs')).href);
+
+  // -- Discrimination: distinct non-Latin roles must not share a dedupe key --
+  const beKey = companyRoleDedupKey('株式会社アカネ', 'バックエンドエンジニア');
+  const feKey = companyRoleDedupKey('株式会社アカネ', 'フロントエンドエンジニア');
+  if (beKey !== feKey) {
+    pass('companyRoleDedupKey keeps two distinct Japanese roles at one company apart');
+  } else {
+    fail(`distinct Japanese roles collapsed to one dedupe key: ${JSON.stringify(beKey)}`);
+  }
+
+  // The role half must actually carry the title, not an empty remainder.
+  if (normalizeRoleForDedup('バックエンドエンジニア') !== '') {
+    pass('normalizeRoleForDedup preserves a non-Latin title instead of keying it to ""');
+  } else {
+    fail('normalizeRoleForDedup erased a non-Latin title');
+  }
+
+  // -- Discrimination: unrelated non-Latin companies must not match --
+  if (companyMatch('株式会社アカネ', '合同会社ゾロ') === false) {
+    pass('companyMatch keeps two unrelated Japanese companies apart');
+  } else {
+    fail('companyMatch reported two unrelated Japanese companies as a match');
+  }
+
+  // An empty/absent company on both sides is "no signal", never "identical".
+  if (companyMatch('', '') === false && companyMatch(null, undefined) === false) {
+    pass('companyMatch treats empty/absent company names as no-match, not as equal');
+  } else {
+    fail('companyMatch matched two empty/absent company names');
+  }
+
+  // -- Controls: the checks must still fire on genuinely identical input --
+  if (companyRoleDedupKey('株式会社アカネ', 'バックエンドエンジニア')
+      === companyRoleDedupKey('株式会社アカネ', 'バックエンドエンジニア')) {
+    pass('control: identical Japanese company+role still produces one dedupe key');
+  } else {
+    fail('control failed: identical Japanese company+role no longer dedupes');
+  }
+  if (companyMatch('株式会社アカネ', '株式会社アカネ') === true) {
+    pass('control: identical Japanese company names still match');
+  } else {
+    fail('control failed: identical Japanese company names no longer match');
+  }
+
+  // NFKC folds half-width katakana onto the canonical form, so the same title
+  // typed either way is one role rather than two.
+  // Assert non-empty as well as equal: with the old [a-z0-9] strip both sides
+  // keyed to '' and an equality-only assertion would have passed vacuously.
+  const halfWidthKey = normalizeRoleForDedup('ｴﾝｼﾞﾆｱ');
+  if (halfWidthKey !== '' && halfWidthKey === normalizeRoleForDedup('エンジニア')) {
+    pass('normalizeRoleForDedup folds half-width katakana onto full-width (NFKC)');
+  } else {
+    fail(`half-width/full-width katakana keys wrong: ${JSON.stringify(halfWidthKey)}`);
+  }
+
+  // The NFKC pass in normalizeRoleForDedup runs BEFORE the trailing-suffix loop,
+  // which is the only thing it is there for: normalizeTextKey already NFKCs at
+  // the end, so any assertion on the final key alone cannot detect whether the
+  // early pass exists. Full-width brackets are the observable difference — the
+  // suffix matcher only recognizes ASCII "(" / "[", so without the early fold
+  // "Engineer （Remote）" keeps its tag and keys as 'engineer remote'.
+  if (normalizeRoleForDedup('Engineer （Remote）') === 'engineer'
+      && normalizeRoleForDedup('Engineer ［Berlin］') === 'engineer') {
+    pass('normalizeRoleForDedup strips full-width bracketed location/remote tags (NFKC before suffix loop)');
+  } else {
+    fail(`full-width bracketed suffix not stripped: ${JSON.stringify(normalizeRoleForDedup('Engineer （Remote）'))}`);
+  }
+
+  // -- Regression: Latin behavior and the space-separated key shape are unchanged --
+  if (normalizeRoleForDedup('Senior Engineer (Senior) (Berlin, Germany)') === 'senior engineer senior') {
+    pass('regression: Latin role keys keep their space-separated shape');
+  } else {
+    fail(`Latin role key shape changed: ${JSON.stringify(normalizeRoleForDedup('Senior Engineer (Senior) (Berlin, Germany)'))}`);
+  }
+  if (companyMatch('Acme Inc.', 'acme inc') === true && companyMatch('Acme', 'Zoro Inc') === false) {
+    pass('regression: Latin companyMatch still matches equivalents and rejects unrelated names');
+  } else {
+    fail('Latin companyMatch behavior changed');
+  }
+
+  // normalizeTextKey's separator arg must not disturb its existing callers.
+  if (normalizeTextKey('株式会社アカネ') === '株式会社アカネ'
+      && normalizeTextKey('Acme, Inc.') === 'acmeinc'
+      && normalizeTextKey('Acme, Inc.', ' ') === 'acme inc') {
+    pass('normalizeTextKey default stays solid-key; separator arg only affects opt-in callers');
+  } else {
+    fail('normalizeTextKey separator arg changed default behavior');
+  }
+  if (normalizeTextKey(null) === '' && normalizeTextKey(undefined) === '') {
+    pass('normalizeTextKey keys null/undefined to "" rather than "null"/"undefined"');
+  } else {
+    fail(`normalizeTextKey mis-keys nullish input: ${JSON.stringify(normalizeTextKey(null))}`);
+  }
+} catch (e) {
+  fail(`scan Unicode dedup/match key tests crashed: ${e.message}`);
+}
+
 // ── Plugin engine (contract + sandbox + firewall) ────────────────
 console.log('\n49. Plugin engine (contract + sandbox + firewall)');
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -11276,17 +11276,23 @@ try {
     fail('companyMatch matched two empty/absent company names');
   }
 
-  // -- Controls: the checks must still fire on genuinely identical input --
-  if (companyRoleDedupKey('株式会社アカネ', 'バックエンドエンジニア')
-      === companyRoleDedupKey('株式会社アカネ', 'バックエンドエンジニア')) {
-    pass('control: identical Japanese company+role still produces one dedupe key');
+  // -- Controls: the checks must still fire on equivalent input --
+  // Comparing a call against itself would be a tautology (a pure function on
+  // the same arguments), so these vary the surface form instead — half-width
+  // katakana and full-width spacing — and additionally require the shared key
+  // to carry the role. Equality alone would still hold if both sides keyed to
+  // '', which is precisely the bug being fixed.
+  const ctrlKey = companyRoleDedupKey('株式会社アカネ', 'バックエンドエンジニア');
+  const ctrlKeyVariant = companyRoleDedupKey('株式会社アカネ', '　ﾊﾞｯｸｴﾝﾄﾞｴﾝｼﾞﾆｱ　');
+  if (ctrlKey === ctrlKeyVariant && ctrlKey !== '株式会社アカネ::') {
+    pass('control: equivalent Japanese company+role (half-width kana, full-width spacing) still dedupes to one non-empty key');
   } else {
-    fail('control failed: identical Japanese company+role no longer dedupes');
+    fail(`control failed: ${JSON.stringify(ctrlKey)} vs ${JSON.stringify(ctrlKeyVariant)}`);
   }
-  if (companyMatch('株式会社アカネ', '株式会社アカネ') === true) {
-    pass('control: identical Japanese company names still match');
+  if (companyMatch('株式会社アカネ', '　株式会社ｱｶﾈ　') === true) {
+    pass('control: equivalent Japanese company names (half-width kana, full-width spacing) still match');
   } else {
-    fail('control failed: identical Japanese company names no longer match');
+    fail('control failed: equivalent Japanese company names no longer match');
   }
 
   // NFKC folds half-width katakana onto the canonical form, so the same title

--- a/tracker-parse.mjs
+++ b/tracker-parse.mjs
@@ -377,9 +377,25 @@ export function normalizeVia(name) {
  * This is the one key every grouping consumer should share, so company/role
  * identity cannot drift between scripts the way Via identity did.
  *
+ * `separator` exists because not every consumer wants a solid key: scan.mjs
+ * keys role titles as space-separated words so "engineer (senior)" and
+ * "engineer, senior" collapse without "data engineer" and "dataengineer"
+ * merging. Passing ' ' keeps that shape while sharing this exact rule, so a
+ * second private [a-z0-9] strip never has to exist to get it.
+ *
  * @param {string} value - Raw cell value (company, role, agency, slug, …).
+ * @param {string} [separator=''] - Replacement for each run of stripped chars.
+ *   Passed straight to String.replace, so `$` is special ('$&' would re-insert
+ *   the stripped run). Callers should pass a literal such as '' or ' '.
  * @returns {string} Case-folded, punctuation-free, script-preserving key.
  */
-export function normalizeTextKey(value) {
-  return String(value).normalize('NFKC').toLowerCase().replace(/[^\p{L}\p{M}\p{N}]/gu, '');
+export function normalizeTextKey(value, separator = '') {
+  // `value ?? ''` rather than String(value): a null/undefined cell must key to
+  // '' like any other empty field, not to the literal strings "null"/"undefined"
+  // — which would compare equal to each other and form a bogus group.
+  return String(value ?? '')
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/[^\p{L}\p{M}\p{N}]+/gu, separator)
+    .trim();
 }


### PR DESCRIPTION
## What does this PR do?

Routes the two remaining private grouping keys in `scan.mjs` through the Unicode-aware `normalizeTextKey()` instead of a `[^a-z0-9]` strip. This is the follow-up to #2445: that PR fixed the three keys in `verify-pipeline.mjs`, but `scan.mjs` still carried its own strips at two call sites.

## Related issue

Refs #2393, #2397, #2445 — same root cause, different call sites. No new issue opened: per the template, bug fixes go straight in.

## The bug

On a non-Latin pipeline (Japanese, in my case), a `[^a-z0-9]` strip does not degrade the key — it deletes the entire string. Two checks were affected, and they fail in opposite directions.

**`normalizeRoleForDedup()` — the scanner silently drops roles.** Every Japanese title keys to `''`, so the company+role dedupe key collapses:

```
companyRoleDedupKey('株式会社アカネ', 'バックエンドエンジニア')  → "株式会社アカネ::"
companyRoleDedupKey('株式会社アカネ', 'フロントエンドエンジニア') → "株式会社アカネ::"
```

Two genuinely different openings, one key. The scan treats the second as already-seen and discards it. The company half was never affected (`defaultCompanyNormalizer` is `trim().toLowerCase()` with no strip), so this is purely the role half — and it means a Japanese-market user only ever sees the first role per company per run.

**`companyMatch()` — unrelated companies compare equal.** Both sides clean to `''`, and the equality branch is unguarded:

```js
if (c1NoSpaces === c2NoSpaces) return true;   // '' === '' → true
```

```
companyMatch('株式会社アカネ', '合同会社ゾロ')  → true
companyMatch('Acme', 'Zoro Inc')               → false   // control
```

At the call site (`buildCooldownFilter`, fed by `re_apply_windows` in `config/profile.yml`) a `true` means "this cooldown window applies, skip the job". So a single CJK entry in `re_apply_windows` suppressed **every** CJK job in the scan.

## The fix

Generalize `normalizeTextKey(value, separator = '')`. `scan.mjs` keys role titles as space-separated words — `normalizeRoleForDedup('Senior Engineer (Senior) (Berlin, Germany)') === 'senior engineer senior'` is an existing assertion — so a solid key is not a drop-in there. The separator lets it share this exact rule instead of keeping a second private strip to get that shape. Default `''` is unchanged for the four existing callers.

Both `scan.mjs` sites now call it, and the empty case is guarded explicitly (`c1NoSpaces && c1NoSpaces === c2NoSpaces`) — "no usable signal on either side" must never read as "identical".

Two smaller things in the same diff:

- `String(value)` → `String(value ?? '')` in `normalizeTextKey`. A nullish cell keyed to the literal string `"null"` / `"undefined"`; two such cells compared equal and formed a bogus group.
- `.normalize('NFKC')` at the top of `normalizeRoleForDedup`, before the trailing-suffix loop, so full-width brackets fold to ASCII and `Engineer （Remote）` strips the same way `Engineer (Remote)` always did.

## Review follow-up: accented-Latin regression (fixed)

@santifer caught a regression I had convinced myself wasn't there, and the diagnosis was exactly right. Because the fix keeps the accent that the old `[a-z0-9]` strip used to turn into a space, the containment fallback's `\b` anchors stopped holding for any name whose first or last character is non-ASCII:

```
'Nestlé Deutschland' vs 'Nestlé'   main=true → false
'Ørsted Energy'      vs 'Ørsted'   main=true → false
'Telefónica Tech'    vs 'Telefónica'  still true  (accent mid-word)
```

`\b` had been silently depending on the strip. Fixed with Unicode lookarounds plus the `u` flag, as suggested. The anchor class is `[\p{L}\p{M}\p{N}]` — the one `normalizeTextKey` keeps — deliberately: an anchor class without `\p{M}` treats a Devanagari matra as a boundary and splits `कंपनी` mid-word, which is the same key/boundary drift #2397 and #2445 removed elsewhere. Assertions cover all three classes, each with a witness that places the character immediately after the candidate (a space-boundary witness asserts nothing about the class).

I mis-scoped this in two ways worth recording: I framed the axis as Latin vs non-Latin when the real axis is *where* the non-ASCII character sits, and my "Latin regression" assertion was pure ASCII, so it was structurally incapable of catching it.

## Behaviour changes users will notice

- **Japanese pipelines will surface jobs that were previously skipped.** On `main`, any non-Latin entry in `re_apply_windows` matched every non-Latin-named job through the `'' === ''` collision, putting the whole JP pipeline into cooldown. That mass over-skip is gone, so the first scan after this lands may return noticeably more results. That is the fix working, not a new bug.
- **NFC and NFD spellings now agree.** `'Nestlé'.normalize('NFD')` vs `'Nestle'` matched on `main` (the strip removed the decomposed accent) while the NFC spelling did not. Both now behave the same way.

## Backward compatibility

The default path of `normalizeTextKey` is unchanged. Verified by comparing old vs new over every code point `0x0 … 0x10FFFF`, each tested alone, embedded (`a<ch>b`), and doubled: **0 differences**. The `+` quantifier and the added `.trim()` are provably no-ops when `separator === ''`, since no whitespace survives the strip. Same for the two `scan.mjs` functions on Latin input: 600k randomized ASCII titles through `normalizeRoleForDedup` and 300k randomized ASCII company pairs through `companyMatch`, **0 differences**.

The `u` flag cannot introduce a throw: both operands are already `normalizeTextKey(x, ' ')` output. Sweeping every code point `0 … 0x10FFFF` (including the lone-surrogate range) produced **0 outputs containing anything outside `[\p{L}\p{M}\p{N} ]`** and **0 throws** from `companyMatch` in either direction. The one pattern-length `RangeError` (≥~40k chars) exists identically on `main`. Lookbehind and `\p{…}` are both well below the `engines` floor of Node 18, and `compileLocationKeyword` already ships a lookbehind on `main`.

Dedupe keys are never persisted — `companyRoleDedupKey` is recomputed per run from `applications.md` / `scan-history.tsv` / `pipeline.md` — so there is no key migration for existing user data.

## Undisclosed regression I found while re-auditing — your call on scope

Fuzzing for more instances of the class you caught turned up one that the anchor fix cannot reach, because it lives in the key rather than the boundary. Disclosing it rather than deciding the scope myself.

`toLowerCase('İ')` (U+0130, Turkish/Azeri/Lithuanian dotted capital I) yields `i` + U+0307 COMBINING DOT ABOVE. `main`'s strip deleted the mark; `normalizeTextKey` keeps it via `\p{M}`, so two spellings of one company key differently:

```
'BİLİŞİM A.Ş.'  →  "bi̇li̇şi̇m a ş"   (0069 0307 …)
'Bilişim A.Ş.'  →  "bilişim a ş"     (0069 …)

companyMatch('BİLİŞİM A.Ş.', 'Bilişim A.Ş.')   main=true → false
```

Same user-visible symptom as the Nestlé case — a cooldown window silently stops being honoured — and realistic, since job boards routinely render company names in all caps.

**Where it comes from:** the behaviour is `normalizeTextKey`'s and has been live since #2445 for `normalizeCompany` / `normalizeVia`. This PR is what routes `companyMatch` through that function, so the regression *at this call site* is caused by this PR, but fixing it only here would make `companyMatch` disagree with every other consumer. Fixing it properly means case-folding U+0307 inside `normalizeTextKey`, which changes tracker dedup and Via identity too.

That is a scope decision I don't think is mine to make. Happy to fold it into this PR if you want it in, or file it as a sibling of #2570 — tell me which and I'll turn it around.

## Known gaps (deliberate)

The containment fallback does not fire for non-Latin names. `株式会社メルカリ` vs `メルカリ` does not match: the lookbehind sees 社, a letter, so there is no boundary to assert, and Japanese is not space-delimited so no anchor rule recovers it. To be precise about the delta — that pair *did* return `true` on `main`, but through the `'' === ''` collision that erased both names, not through this path. Making it match on purpose needs corporate-form normalisation (株式会社 / 合同会社 / …), i.e. new vocabulary rather than a key fix, filed as #2570.

Same reasoning for `normalizeRoleSuffixTag()`, which carries a third `[a-z0-9]` strip: making it Unicode-aware alone changes nothing, because the tag is then matched against the English-only `ROLE_LOCATION_SUFFIXES` set. `エンジニア（東京）` and `エンジニア（大阪）` therefore remain two keys. Noted in a code comment so the next reader doesn't assume the NFKC pass covers it.

## Testing

`node test-all.mjs` → **2993 passed, 0 failed**.

Sixteen assertions in section 45c, covering both directions:

- distinct Japanese roles at one company stay apart
- a non-Latin title is preserved rather than keyed to `''`
- unrelated Japanese companies stay apart
- empty/absent company names are no-match, not equal
- **control:** equivalent Japanese company+role (half-width kana, full-width spacing) still dedupes to one non-empty key
- **control:** equivalent Japanese company names still match
- half-width katakana folds onto full-width
- full-width bracketed suffixes strip (the only assertion that can detect the early NFKC pass — `normalizeTextKey` NFKCs at the end, so the final key alone can't distinguish)
- **regression:** Latin role keys keep their space-separated shape
- **regression:** Latin `companyMatch` still matches equivalents and rejects unrelated names
- accented Latin names still match at a word edge (Nestlé, Ørsted, Zoë)
- the containment fallback stays bounded (`Acme` does not match `Acmetric`)
- the anchor class treats combining marks and digits as letters
- a Devanagari name still matches at a space boundary
- `normalizeTextKey`'s separator arg doesn't disturb the default
- `normalizeTextKey` keys nullish input to `''`

Every assertion is mutation-checked. Reverting only the source change fails 10 of 16 while both controls and both Latin regressions still pass. Removing only `.normalize('NFKC')` fails exactly 1. Dropping `\p{M}` from the anchors fails the matra witness only; dropping `\p{N}` fails the digit witness only; reverting only the lookbehind fails `Ørsted` only. Two earlier assertions were vacuous (a control comparing a pure function to itself, and a Devanagari witness whose next character was a space) and have been replaced with witnesses that actually flip.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data) — test fixtures use invented company names
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved matching and deduplication for multilingual company and role names.
  * Preserved distinctions between non-Latin titles and company names.
  * Added support for Unicode variations, including full-width brackets and half-width katakana.
  * Prevented empty company values from matching entries.
  * Improved handling of missing values and configurable separators during text normalization.

* **Tests**
  * Added regression coverage for Unicode normalization, multilingual data, separators, and existing Latin-text behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->