### PR TITLE
fix(cover): a custom template's unfilled {{TOKEN}} shipped into the letter

### DIFF
--- a/generate-cover-letter.mjs
+++ b/generate-cover-letter.mjs
@@ -172,8 +172,29 @@ export function buildHtml(payload, templatePath) {
   // the original template. A single regex pass (rather than iterative
   // split/join) ensures a substituted value that itself contains a {{TOKEN}}
   // sequence is left literal instead of being re-interpreted as a placeholder.
-  // Tokens with no entry in the map are left untouched.
-  return html.replace(/\{\{[A-Z_]+\}\}/g, (token) => replacements[token] ?? token);
+  //
+  // A token with no entry in the map is a template the renderer cannot fill —
+  // a custom cover-letter template (KINDS.cover in cv-templates.mjs) carrying a
+  // typo'd or unsupported token. Collect those DURING the pass rather than
+  // scanning the result: a scan of the output cannot tell a template token from
+  // the same sequence appearing inside a substituted value, which is exactly
+  // what the single pass above is careful to leave literal.
+  const unresolved = new Set();
+  const rendered = html.replace(/\{\{[A-Z_]+\}\}/g, (token) => {
+    const value = replacements[token];
+    if (value == null) {
+      unresolved.add(token);
+      return token;
+    }
+    return value;
+  });
+
+  // Fail loudly, matching build-cv-html.mjs and build-cv-latex.mjs. Shipping a
+  // letter with a literal {{TOKEN}} in it is worse than not producing one.
+  if (unresolved.size) {
+    throw new Error(`Unresolved placeholders: ${[...unresolved].join(', ')}`);
+  }
+  return rendered;
 }
 
 /** Parse a payload, run the fact gate, and render the cover-letter PDF. */

--- a/tests/cover-unresolved-placeholders.test.mjs
+++ b/tests/cover-unresolved-placeholders.test.mjs
@@ -1,0 +1,72 @@
+// tests/cover-unresolved-placeholders.test.mjs — buildHtml must not ship a
+// literal {{TOKEN}} into a rendered cover letter.
+//
+// build-cv-html.mjs throws on unresolved placeholders and build-cv-latex.mjs
+// exits 1; generate-cover-letter.mjs left them untouched, so a custom
+// cover-letter template (KINDS.cover) carrying a typo'd or unsupported token
+// rendered that token verbatim into the PDF. Silent, and only visible to
+// whoever reads the letter afterwards — which may be the employer.
+//
+// The second test is the one that matters for the fix's shape: the single-pass
+// substitution deliberately leaves a {{TOKEN}} sequence *inside a substituted
+// value* literal, so the guard has to distinguish an unfilled template token
+// from user text that merely looks like one. A post-hoc scan of the output
+// cannot, which is why detection happens during the pass.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildHtml } from '../generate-cover-letter.mjs';
+
+const writeTemplate = (body) => {
+  const dir = mkdtempSync(join(tmpdir(), 'cover-placeholder-'));
+  const path = join(dir, 'cover-letter-template.html');
+  writeFileSync(path, `<html><body>${body}</body></html>`);
+  return path;
+};
+
+const payload = () => ({
+  candidate: { name: 'Jane Doe', email: 'jane@example.test' },
+  letter: {
+    role_title: 'Backend Engineer',
+    opening: 'I am applying for this role.',
+    profile_intro: 'Five years of backend work.',
+  },
+});
+
+test('throws on a template token the renderer cannot fill', () => {
+  const tpl = writeTemplate('<p>{{OPENING}}</p><p>Dear team at {{COMPANY}},</p>');
+  assert.throws(
+    () => buildHtml(payload(), tpl),
+    /Unresolved placeholders: \{\{COMPANY\}\}/,
+    'a custom template with an unsupported token must fail loudly, not render it verbatim',
+  );
+});
+
+test('a {{TOKEN}} inside a substituted value stays literal and is not flagged', () => {
+  // The single-pass substitution guarantees this text is not re-interpreted as
+  // a placeholder. It must also not be mistaken for an unfilled one.
+  const p = payload();
+  p.letter.opening = 'My last team called the config {{PLACEHOLDER}} for short.';
+  const tpl = writeTemplate('<p>{{OPENING}}</p>');
+  const html = buildHtml(p, tpl);
+  assert.match(html, /\{\{PLACEHOLDER\}\}/, 'user text containing a token sequence survives verbatim');
+});
+
+test('reports every unresolved token, not just the first', () => {
+  const tpl = writeTemplate('<p>{{COMPANY}}</p><p>{{HIRING_MANAGER}}</p><p>{{OPENING}}</p>');
+  assert.throws(() => buildHtml(payload(), tpl), (err) => {
+    assert.match(err.message, /\{\{COMPANY\}\}/);
+    assert.match(err.message, /\{\{HIRING_MANAGER\}\}/);
+    return true;
+  });
+});
+
+test('the shipped template still renders clean', () => {
+  // Guards the fix itself: if the bundled template ever gains a token the
+  // renderer does not map, this fails instead of every user's render failing.
+  const html = buildHtml(payload(), 'templates/cover-letter-template.html');
+  assert.doesNotMatch(html, /\{\{[A-Z_]+\}\}/, 'bundled template must be fully mapped');
+  assert.match(html, /Jane Doe/);
+});


### PR DESCRIPTION
## The bug

`buildHtml()` substitutes every token it knows and leaves the rest untouched, so a **custom** cover-letter template (`KINDS.cover` in `cv-templates.mjs`) carrying a typo'd or unsupported token renders that token verbatim into the PDF.

Nothing warns. The render succeeds. The literal `{{COMPANY}}` is only visible to whoever reads the letter afterwards — which may be the employer.

```js
buildHtml(
  { candidate: { name: 'Jane Doe' },
    letter: { role_title: 'Backend Engineer', opening: 'Y', profile_intro: 'Z' } },
  tpl,   // a custom template containing: <p>Dear team at {{COMPANY}},</p>
)
// before: "Dear team at {{COMPANY}},"
// after:  throws  Unresolved placeholders: {{COMPANY}}
```

Both sibling renderers already guard this — `build-cv-html.mjs` throws, `build-cv-latex.mjs` exits 1. This brings the third into line.

## Why the guard runs during the pass, not after

This is the part worth reviewing. The single-pass substitution deliberately leaves a `{{TOKEN}}` sequence *inside a substituted value* literal — the comment on that line calls it out explicitly.

So scanning the rendered output for `{{[A-Z_]+}}` would be wrong: it cannot distinguish an unfilled template token from user text that merely looks like one, and it would start throwing on letters whose `opening` happens to mention a placeholder. Collecting unresolved tokens **inside** the replace callback distinguishes them exactly, and preserves the existing single-pass semantics unchanged.

There's a test for that case specifically.

## Blast radius

None on the default path. The bundled `templates/cover-letter-template.html` uses exactly the 13 tokens the renderer maps — I diffed the two sets. A test pins that, so if the bundled template ever gains an unmapped token it fails here rather than in every user's render.

The behaviour change is for custom templates that today ship a broken letter: they now fail loudly instead. That's the intent, and it matches the two siblings.

## Tests

`tests/cover-unresolved-placeholders.test.mjs`, 4 cases, auto-discovered under `tests/**/*.test.mjs`:

- throws on a token the renderer cannot fill
- **a `{{TOKEN}}` inside a substituted value stays literal and is not flagged** (the regression guard for the approach above)
- reports every unresolved token, not just the first
- the shipped template still renders clean

I verified the suite actually catches the bug: with the fix reverted, 2 of the 4 fail.

`node test-all.mjs` → **3058 passed, 0 failed** (matches the baseline on `origin/main`; `node:test` suites count as one entry in that total).

Filed directly as a PR per CONTRIBUTING.md — bug fixes don't need an issue first. Happy to open one if you'd rather track it that way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cover letters now report unresolved template placeholders instead of silently leaving them unchanged.
  - All unresolved placeholders are identified in the resulting error.
  - Placeholder-like text within user-provided values is preserved correctly.
  - Bundled cover-letter templates render without unresolved placeholders.

- **Tests**
  - Added coverage for unresolved placeholders, multiple missing tokens, literal user content, and complete template rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->