### PR TITLE
fix(dedup): distinct non-Latin companies merged into one, deleting a row

### DIFF
--- a/dedup-tracker.mjs
+++ b/dedup-tracker.mjs
@@ -14,7 +14,7 @@ import { readFileSync, copyFileSync, existsSync, mkdirSync } from 'fs';
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
 import {
-  openTrackerTransaction, rebuildRow, resolveTrackerPath,
+  openTrackerTransaction, rebuildRow, resolveTrackerPath, normalizeCompany,
 } from './tracker-utils.mjs';
 import { resolveColumns, parseTrackerRow, normalizeVia } from './tracker-parse.mjs';
 
@@ -60,25 +60,6 @@ const STATUS_RANK = {
   'contratado': 7,
   'contratada': 7,
 };
-
-/**
- * Normalize a company name into the grouping key used by deduplication.
- *
- * The tracker may contain punctuation, parenthetical branding, or spacing
- * differences for the same employer. This function removes those presentation
- * differences while keeping the alphanumeric company identity that determines
- * which rows are safe to compare for duplicate roles.
- *
- * @param {string} name - Company name from an applications.md row.
- * @returns {string} Lowercase company key used for same-company grouping.
- */
-function normalizeCompany(name) {
-  return name.toLowerCase()
-    .replace(/[()]/g, '')
-    .replace(/\s+/g, ' ')
-    .replace(/[^a-z0-9 ]/g, '')
-    .trim();
-}
 
 /**
  * Normalize tracker status text before ranking or comparing it.
@@ -312,10 +293,13 @@ console.log(`📊 ${entries.length} entries loaded`);
 // normalize to the same empty key, so they group by their Via channel instead:
 // the same agency re-blasting one listing IS a duplicate, while the same role
 // via two different agencies is two real submissions and must never merge.
-// The channel key is Unicode-aware (#1603/#2393): normalizeCompany() strips
-// everything outside [a-z0-9], so distinct non-Latin agency names (リクルート,
-// パーソル, …) all collapsed to the same empty key and one of two genuinely
-// separate submissions was DELETED. normalizeVia() is the same key that
+// The channel key is Unicode-aware (#1603/#2393): this file's own
+// normalizeCompany() used to strip everything outside [a-z0-9], so distinct
+// non-Latin agency names (リクルート, パーソル, …) all collapsed to the same empty
+// key and one of two genuinely separate submissions was DELETED. Both keys are
+// now Unicode-aware — normalizeCompany comes from tracker-utils.mjs (#2429), so
+// the ordinary company path cannot regress the way this channel path did.
+// normalizeVia() is the same key that
 // merge-tracker.mjs uses for its cross-channel guard, so the two scripts
 // cannot drift on agency identity. An absent Via (empty or `—`) still keys to
 // '' and groups with other via-less blind rows, matching merge-tracker, whose

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -8143,6 +8143,71 @@ try {
   fail(`dedup blind-via channel key tests crashed (#2393): ${e.message}`);
 }
 
+// ── DEDUP ORDINARY COMPANY KEY: NON-LATIN COMPANIES (#2429) ──
+// The sibling of the blind-via case directly above, on the path that runs for
+// every normal row. #2429 made tracker-utils.mjs's normalizeCompany
+// Unicode-aware and merge-tracker/set-status inherited it, but dedup-tracker
+// carried its own local [^a-z0-9] copy, so two DIFFERENT companies written in
+// a non-Latin script both keyed to '' and one row was deleted outright.
+// Controls: punctuation/spacing variants of one Latin employer must still
+// merge, and two distinct Latin employers must still stay apart.
+console.log('\n🧪 Testing dedup company key with non-Latin companies (#2429)...');
+try {
+  const coDedupTmp = mkdtempSync(join(tmpdir(), 'career-ops-dedup-company-'));
+  try {
+    mkdirSync(join(coDedupTmp, 'data'));
+    const tracker = join(coDedupTmp, 'data', 'applications.md');
+    writeFileSync(tracker,
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Via | Role | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|-----|------|-------|--------|-----|--------|-------|\n' +
+      // (a) Two DIFFERENT non-Latin employers, same role — two real
+      // applications, both must survive.
+      '| 71 | 2026-04-01 | アクメ株式会社 | — | Backend Engineer | 4.2/5 | Evaluated | ❌ | [71](../reports/071-a.md) | first company |\n' +
+      '| 72 | 2026-04-02 | グロベックス合同会社 | — | Backend Engineer | 3.0/5 | Evaluated | ❌ | [72](../reports/072-b.md) | different company |\n' +
+      // (b) Control: presentation variants of ONE Latin employer still merge.
+      '| 73 | 2026-04-03 | Acme (Inc.) | — | Data Engineer | 3.1/5 | Evaluated | ❌ | [73](../reports/073-c.md) | punctuated |\n' +
+      '| 74 | 2026-04-04 | Acme Inc | — | Data Engineer | 4.5/5 | Evaluated | ❌ | [74](../reports/074-d.md) | same employer |\n' +
+      // (c) Control: two distinct Latin employers still stay apart.
+      '| 75 | 2026-04-05 | Globex | — | Platform Engineer | 3.9/5 | Evaluated | ❌ | [75](../reports/075-e.md) | one |\n' +
+      '| 76 | 2026-04-06 | Initech | — | Platform Engineer | 4.0/5 | Evaluated | ❌ | [76](../reports/076-f.md) | another |\n');
+
+    const r = run(NODE, ['dedup-tracker.mjs'], { env: { ...process.env, CAREER_OPS_TRACKER: tracker } });
+    if (r === null) {
+      fail('dedup-tracker.mjs crashed during non-Latin company key test (#2429)');
+    } else {
+      const out = readFileSync(tracker, 'utf-8');
+
+      const backendRows = out.split('\n').filter(l => l.includes('Backend Engineer'));
+      if (backendRows.length === 2
+          && backendRows.some(l => l.includes('アクメ株式会社'))
+          && backendRows.some(l => l.includes('グロベックス合同会社'))) {
+        pass('dedup-tracker keeps two distinct non-Latin companies apart (#2429)');
+      } else {
+        fail(`dedup-tracker merged distinct non-Latin companies: ${backendRows.length} Backend Engineer rows`);
+      }
+
+      const dataRows = out.split('\n').filter(l => l.includes('Data Engineer'));
+      if (dataRows.length === 1 && dataRows[0].includes('4.5/5')) {
+        pass('dedup-tracker still merges punctuation variants of one Latin employer (#2429)');
+      } else {
+        fail(`dedup-tracker Latin punctuation merge broken: ${dataRows.length} Data Engineer rows`);
+      }
+
+      const platformRows = out.split('\n').filter(l => l.includes('Platform Engineer'));
+      if (platformRows.length === 2) {
+        pass('dedup-tracker still keeps two distinct Latin employers apart (#2429)');
+      } else {
+        fail(`dedup-tracker merged distinct Latin employers: ${platformRows.length} Platform Engineer rows`);
+      }
+    }
+  } finally {
+    rmSync(coDedupTmp, { recursive: true, force: true });
+  }
+} catch (e) {
+  fail(`dedup company key tests crashed (#2429): ${e.message}`);
+}
+
 // ── VERIFY-PIPELINE GROUPING KEYS: NON-LATIN COMPANIES AND ROLES (#2393) ──
 // Same root cause as the blind-via key above, one layer up. verify-pipeline
 // keyed Check 2 (duplicate tracker rows), Check 9 (duplicate report files) and


### PR DESCRIPTION
## The bug

`dedup-tracker.mjs` kept its own local `normalizeCompany()` using the pre-#2429 ASCII fold:

```js
.replace(/[^a-z0-9 ]/g, '')
```

Any company name written entirely in a non-Latin script folds to `''` under that. Two **different** employers therefore share a grouping key, pass `roleMatch()` when their titles agree — common, since "Engineer" / "Backend Engineer" recur everywhere — and the lower-scored row is **deleted**.

```
| 1 | アクメ株式会社       | Engineer | 4.2/5 |
| 2 | グロベックス合同会社 | Engineer | 3.0/5 |
```

```
before: 🗑️  Remove #2 (グロベックス合同会社 — Engineer, 3.0/5) → kept #1 (4.2/5)
after:  📊 0 duplicates removed
```

The run prints its normal success output. Nothing warns. Only the `.bak` preserves the deleted application.

## This is the third instance of the same class here

That's the part I think matters more than the fix:

- `f589ce83` (#2429) made `tracker-utils.mjs`'s `normalizeCompany` Unicode-aware. `merge-tracker.mjs` and `set-status.mjs` picked it up automatically **because they import the shared helper**. `dedup-tracker.mjs` had forked its own copy, so it didn't.
- `fe4561b` (#2397) then fixed *this same file's* blind-via key — while the ordinary company path twelve lines below kept the old fold.
- The comment block right above that code already describes this exact defect, for the Via key.

So the fix is to delete the local copy and import the shared one, rather than patch the regex — that's what stops a fourth instance.

## Why this is safe

The value is only ever an in-memory grouping key (`groups` Map, `dedup-tracker.mjs:328`). It is never persisted, never written to a row, and never compared against a key produced by another script. Adopting the shared normalization changes no stored data.

I checked the Latin path explicitly rather than assuming: `Acme (Inc.)` and `Acme Inc` still merge, and `Globex` / `Initech` still stay apart.

## Tests

A sibling of the existing #2393 blind-via block, placed next to it, on the ordinary company path:

- two distinct non-Latin employers stay apart *(fails before this change)*
- punctuation variants of one Latin employer still merge
- two distinct Latin employers still stay apart

The last two are the regression guards for the normalization swap.

`node test-all.mjs` → **0 failed**.

Filed directly per CONTRIBUTING.md (bug fix, no issue needed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate detection for company names using Unicode-aware normalization.
  * Distinct non-Latin company names, including Japanese names, are now kept separate.
  * Equivalent Latin company names with punctuation or spacing differences continue to be combined while retaining the higher-scoring entry.
  * Distinct Latin companies are no longer incorrectly grouped together.

* **Tests**
  * Added regression coverage for multilingual names and company-name variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->