### PR TITLE
fix(cv): $-patterns in candidate text splice the template into the CV

### DIFF
--- a/build-cv-html.mjs
+++ b/build-cv-html.mjs
@@ -261,20 +261,26 @@ function parsePartial(source) {
 function fillEntry(entryTemplate, blocks, fields, blockValues) {
   let out = entryTemplate;
 
+  // Every replacement below passes a FUNCTION rather than the value directly.
+  // A string replacement argument is scanned by JS for $-patterns, so candidate
+  // text containing $&, $', $` or $$ (escaping leaves those sequences intact)
+  // would splice part of the template into the CV instead of being inserted
+  // literally. A replacer function's return value is never interpreted.
+
   // Resolve conditional blocks: replace {{BLOCK_NAME}} with the
   // present/absent markup depending on whether the field has a value.
   if (blockValues) {
     for (const [name, { value, present }] of blockValues) {
       const block = blocks.get(name);
       if (!block) continue;
-      const markup = present ? block.present.replace(`{{${name}}}`, value) : block.absent;
-      out = out.replace(`{{${name}}}`, markup);
+      const markup = present ? block.present.replace(`{{${name}}}`, () => value) : block.absent;
+      out = out.replace(`{{${name}}}`, () => markup);
     }
   }
 
   // Fill remaining scalar placeholders.
   for (const [key, value] of Object.entries(fields)) {
-    out = out.replace(new RegExp(`\\{\\{${key}\\}\\}`, 'g'), value);
+    out = out.replace(new RegExp(`\\{\\{${key}\\}\\}`, 'g'), () => value);
   }
 
   return out;

--- a/build-cv-latex.mjs
+++ b/build-cv-latex.mjs
@@ -159,8 +159,13 @@ async function main() {
     SKILLS: buildSkills(payload.skills),
   };
 
+  // Replacer FUNCTION, not a string: escapeLatex turns `$` into `\$` but leaves
+  // the next character alone, so a bullet containing `$'` survives as the JS
+  // replacement pattern meaning "everything after the match" and splices the
+  // rest of the template into the document — silently, with a valid-looking
+  // exit 0. A replacer function's return value is inserted literally.
   for (const [key, value] of Object.entries(substitutions)) {
-    template = template.replace(new RegExp(`\\{\\{${key}\\}\\}`, 'g'), value);
+    template = template.replace(new RegExp(`\\{\\{${key}\\}\\}`, 'g'), () => value);
   }
 
   const unresolved = template.match(PLACEHOLDER_RE);
@@ -282,8 +287,9 @@ async function runSelfTest() {
     SKILLS: buildSkills(sample.skills),
   };
 
+  // Replacer function, same reason as the render path above.
   for (const [key, value] of Object.entries(substitutions)) {
-    template = template.replace(new RegExp(`\\{\\{${key}\\}\\}`, 'g'), value);
+    template = template.replace(new RegExp(`\\{\\{${key}\\}\\}`, 'g'), () => value);
   }
 
   const unresolved = template.match(PLACEHOLDER_RE);

--- a/tests/cv-dollar-pattern.test.mjs
+++ b/tests/cv-dollar-pattern.test.mjs
@@ -1,0 +1,112 @@
+// tests/cv-dollar-pattern.test.mjs — candidate text containing a JS
+// String.replace $-pattern must not be interpreted during template fill.
+//
+// Both CV builders filled placeholders by passing the escaped value as the
+// STRING replacement argument. JS scans that argument for $&, $', $` and $$,
+// and neither escapeLatex nor escapeHtml neutralizes those two-character
+// sequences — escapeLatex turns `$` into `\$` and leaves the next character be.
+//
+// So a perfectly ordinary bullet corrupted the document:
+//   "$'000"  -> $' means "everything after the match", splicing the remainder
+//              of the TEMPLATE into the CV. build-cv-latex emitted a .tex with
+//              two \end{document} and still reported "valid": true, exit 0.
+//   "$&500K" -> $& means "the matched text", re-inserting {{BULLETS}} itself,
+//              which then tripped build-cv-html's unresolved-placeholder guard
+//              and failed the build with a misattributed error.
+//
+// Money amounts in bullets are exactly where this shows up, which is to say:
+// on real CVs.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const tmp = () => mkdtempSync(join(tmpdir(), 'cv-dollar-'));
+
+const run = (script, payload, out) =>
+  execFileSync(process.execPath, [join(ROOT, script), payload, out], {
+    cwd: ROOT,
+    encoding: 'utf-8',
+    maxBuffer: 10 * 1024 * 1024,
+  });
+
+test("build-cv-latex: a $' in a bullet does not splice the template", () => {
+  const dir = tmp();
+  const payload = join(dir, 'p.json');
+  const out = join(dir, 'out.tex');
+  writeFileSync(payload, JSON.stringify({
+    name: 'Test Candidate',
+    contact_line: 'City',
+    email: { url: 't@example.com', display: 't@example.com' },
+    linkedin: { url: '', display: '' },
+    github: { url: '', display: '' },
+    education: [], projects: [], awards: [], skills: [],
+    experience: [{
+      company: 'Test Corp', role: 'Engineer', location: 'Remote', dates: '2024',
+      bullets: ["Reported budget lines in $'000 format for quarterly reviews"],
+    }],
+  }));
+
+  run('build-cv-latex.mjs', payload, out);
+  const tex = readFileSync(out, 'utf-8');
+
+  // The splice duplicated everything after the match, including the preamble's end.
+  const endCount = (tex.match(/\\end\{document\}/g) || []).length;
+  assert.equal(endCount, 1, 'template must not be spliced into the body');
+  assert.match(tex, /Reported budget lines in \\\$'000 format for quarterly reviews/);
+});
+
+test('build-cv-html: a $& in a bullet does not re-insert the placeholder', () => {
+  const dir = tmp();
+  const payload = join(dir, 'p.json');
+  const out = join(dir, 'out.html');
+  writeFileSync(payload, JSON.stringify({
+    lang: 'en',
+    page_format: 'letter',
+    candidate: { name: 'Test Candidate', email: 't@example.com' },
+    summary: 'Backend engineer.',
+    competencies: ['Cloud'],
+    projects: [], education: [], certifications: [], awards: [], skills: [],
+    experience: [{
+      company: 'Test Corp', role: 'Engineer', dates: '2024',
+      bullets: ['Delivered cost savings of $&500K across the org'],
+    }],
+  }));
+
+  // Before the fix this exited non-zero with "Unresolved placeholders: {{BULLETS}}".
+  run('build-cv-html.mjs', payload, out);
+  const html = readFileSync(out, 'utf-8');
+
+  assert.doesNotMatch(html, /\{\{[A-Z_]+\}\}/, 'no placeholder may survive the fill');
+  assert.match(html, /Delivered cost savings of \$&amp;500K across the org/);
+});
+
+test('build-cv-latex: $` and $$ in a bullet survive verbatim', () => {
+  const dir = tmp();
+  const payload = join(dir, 'p.json');
+  const out = join(dir, 'out.tex');
+  writeFileSync(payload, JSON.stringify({
+    name: 'Test Candidate',
+    contact_line: 'City',
+    email: { url: 't@example.com', display: 't@example.com' },
+    linkedin: { url: '', display: '' },
+    github: { url: '', display: '' },
+    education: [], projects: [], awards: [], skills: [],
+    experience: [{
+      company: 'Test Corp', role: 'Engineer', location: 'Remote', dates: '2024',
+      // $` = text before the match; $$ = a literal single $.
+      bullets: ['Cut spend from $$4M using the $`legacy pipeline'],
+    }],
+  }));
+
+  run('build-cv-latex.mjs', payload, out);
+  const tex = readFileSync(out, 'utf-8');
+
+  assert.equal((tex.match(/\\end\{document\}/g) || []).length, 1);
+  // $$ must not collapse to a single $, and $` must not pull in preceding text.
+  assert.match(tex, /Cut spend from \\\$\\\$4M using the \\\$`legacy pipeline/);
+});


### PR DESCRIPTION
## The bug

Both CV builders fill placeholders by passing the escaped value as the **string** replacement argument to `String.replace`. JS scans that argument for `$&`, `$'`, `` $` `` and `$$` — and neither `escapeLatex` nor `escapeHtml` neutralizes them (`escapeLatex` turns `$` into `\$` and leaves the *next* character alone).

So an ordinary CV bullet corrupts the document.

**`$'` — silent corruption, exit 0:**

```
bullet: "Reported budget lines in $'000 format for quarterly reviews"
```

`$'` means *everything after the match*, so the remainder of the template is spliced into the body:

```
Reported budget lines in \
  \resumeSubHeadingListEnd
%%%%%%%%%%%%  Technical Skills  %%%%%%%%%%%%
\section{Technical Skills}
...
```

The produced `.tex` contained **two `\end{document}`**. `build-cv-latex.mjs` printed `"valid": true` and exited 0.

**`$&` — misattributed build failure:**

```
bullet: "Delivered cost savings of $&500K across the org"
```

`$&` re-inserts the matched text — i.e. `{{BULLETS}}` itself — which then trips `build-cv-html`'s unresolved-placeholder guard and fails the build with `Unresolved placeholders: {{BULLETS}}`, pointing at the template rather than at the input that caused it.

Money amounts in bullets are exactly where these sequences occur, which is to say: on real CVs.

## The fix

Pass a replacer **function** at every fill site. A function's return value is inserted literally, with no `$`-pattern interpretation. No behaviour change for text that doesn't contain those sequences.

I swept every `.replace()` with a non-literal string replacement rather than patching only the two paths that surfaced, so this covers **five sites**:

| | |
|---|---|
| `build-cv-html.mjs` | `fillEntry` — conditional block fill (×2) and scalar fill |
| `build-cv-latex.mjs` | the render loop, and the identical loop in `--test` |

`generate-pdf.mjs:197` also calls `.replace()` on placeholders but with a literal `' '`, so it is unaffected. `generate-cover-letter.mjs` already uses a replacer function.

## Tests

`tests/cv-dollar-pattern.test.mjs`:

- `$'` in a bullet does not splice the template (asserts exactly one `\end{document}`)
- `$&` in a bullet does not re-insert the placeholder
- `` $` `` and `$$` survive verbatim — `$$` must not collapse to a single `$`

All three fail before this change.

`node test-all.mjs` → **3058 passed, 0 failed**.

Filed directly per CONTRIBUTING.md (bug fix, no issue needed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CV generation so special dollar-sign sequences in candidate text are preserved as literal content.
  * Prevented unintended template substitutions, duplicated text, and unresolved placeholders in HTML and LaTeX output.

* **Tests**
  * Added coverage validating correct handling and escaping of special replacement patterns in generated CVs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->