### PR TITLE
fix(scan): --company/--posted-after/--posted-before ignored in =value form

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -46,6 +46,7 @@ import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 import { normalizeCompany } from './tracker-utils.mjs';
 import { normalizeCompanyName } from './invite-match.mjs';
 import { withPipelineLock } from './pipeline-lock.mjs';
+import { flagValue } from './lib/cli-flags.mjs';
 import { withPortalHealthLock } from './portal-health-lock.mjs';
 
 try {
@@ -1969,8 +1970,9 @@ async function main() {
   // --include-blacklisted: bypass the data/blacklist.md filter for auditing.
   // Matching postings flow through annotated instead of being counted out.
   const includeBlacklisted = args.includes('--include-blacklisted');
-  const companyFlag = args.indexOf('--company');
-  const filterCompany = companyFlag !== -1 ? args[companyFlag + 1]?.toLowerCase() : null;
+  // flagValue reads both `--flag value` and `--flag=value`; a bare indexOf misses
+  // the second form entirely and silently falls back to the unfiltered default.
+  const filterCompany = flagValue(args, '--company')?.toLowerCase() ?? null;
   // --posted-after / --posted-before <YYYY-MM-DD>: absolute-date bounds on the
   // employer's real posting date (job.postedAt), gated against a typo since a
   // silently-ignored bound would look like "no jobs matched" instead of an error.
@@ -1979,10 +1981,8 @@ async function main() {
     const d = new Date(`${s}T00:00:00Z`);
     return !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === s;
   };
-  const postedAfterFlag = args.indexOf('--posted-after');
-  const postedAfter = postedAfterFlag !== -1 ? args[postedAfterFlag + 1] : null;
-  const postedBeforeFlag = args.indexOf('--posted-before');
-  const postedBefore = postedBeforeFlag !== -1 ? args[postedBeforeFlag + 1] : null;
+  const postedAfter = flagValue(args, '--posted-after') ?? null;
+  const postedBefore = flagValue(args, '--posted-before') ?? null;
   if (postedAfter != null && !isValidIsoDate(postedAfter)) {
     console.error(`Error: --posted-after expects YYYY-MM-DD, got "${postedAfter}"`);
     process.exit(1);

--- a/scan.mjs
+++ b/scan.mjs
@@ -46,7 +46,7 @@ import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 import { normalizeCompany } from './tracker-utils.mjs';
 import { normalizeCompanyName } from './invite-match.mjs';
 import { withPipelineLock } from './pipeline-lock.mjs';
-import { flagValue } from './lib/cli-flags.mjs';
+import { flagValue, hasFlag } from './lib/cli-flags.mjs';
 import { withPortalHealthLock } from './portal-health-lock.mjs';
 
 try {
@@ -1972,7 +1972,23 @@ async function main() {
   const includeBlacklisted = args.includes('--include-blacklisted');
   // flagValue reads both `--flag value` and `--flag=value`; a bare indexOf misses
   // the second form entirely and silently falls back to the unfiltered default.
-  const filterCompany = flagValue(args, '--company')?.toLowerCase() ?? null;
+  //
+  // flagValue alone cannot tell an ABSENT flag from one passed with no operand —
+  // both give undefined — so it is paired with hasFlag, per cli-flags.mjs's own
+  // guidance. Without that, a trailing `--posted-after` would fall back to "no
+  // bound" and scan everything: the same silent-default failure this fixes.
+  const requireValue = (flag) => {
+    const value = flagValue(args, flag);
+    if (value === undefined || value === '') {
+      if (hasFlag(args, flag)) {
+        console.error(`Error: ${flag} requires a value`);
+        process.exit(1);
+      }
+      return null;
+    }
+    return value;
+  };
+  const filterCompany = requireValue('--company')?.toLowerCase() ?? null;
   // --posted-after / --posted-before <YYYY-MM-DD>: absolute-date bounds on the
   // employer's real posting date (job.postedAt), gated against a typo since a
   // silently-ignored bound would look like "no jobs matched" instead of an error.
@@ -1981,8 +1997,8 @@ async function main() {
     const d = new Date(`${s}T00:00:00Z`);
     return !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === s;
   };
-  const postedAfter = flagValue(args, '--posted-after') ?? null;
-  const postedBefore = flagValue(args, '--posted-before') ?? null;
+  const postedAfter = requireValue('--posted-after');
+  const postedBefore = requireValue('--posted-before');
   if (postedAfter != null && !isValidIsoDate(postedAfter)) {
     console.error(`Error: --posted-after expects YYYY-MM-DD, got "${postedAfter}"`);
     process.exit(1);

--- a/tests/scan-flag-forms.test.mjs
+++ b/tests/scan-flag-forms.test.mjs
@@ -1,0 +1,57 @@
+// tests/scan-flag-forms.test.mjs — scan.mjs must read --flag=value, not only
+// --flag value.
+//
+// `args.indexOf('--posted-after')` returns -1 for `--posted-after=2026-07-28`,
+// so the bound resolved to null — indistinguishable from the flag never having
+// been passed. The run then scanned with NO date bound and reported a clean
+// result, which is the failure mode lib/cli-flags.mjs was written to end
+// (#2401/#2402/#2498, and 37055d7d which fixed five other scripts).
+//
+// The sharpest symptom is that the typo guard stops guarding: scan.mjs
+// validates --posted-after and exits 1 on a malformed date precisely "since a
+// silently-ignored bound would look like 'no jobs matched' instead of an
+// error" — but with the = form the value never reached the validator, so a
+// typo'd bound was silently ignored, which is the exact outcome the guard
+// exists to prevent.
+//
+// Asserting via the validator is deliberate: it is observable without a
+// portals.yml, a network call, or a fixture board.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+
+const runScan = (...args) =>
+  spawnSync(process.execPath, [join(ROOT, 'scan.mjs'), ...args], {
+    cwd: ROOT,
+    encoding: 'utf-8',
+    timeout: 30_000,
+  });
+
+for (const flag of ['--posted-after', '--posted-before']) {
+  test(`${flag}=BAD is validated, not silently ignored`, () => {
+    const r = runScan(`${flag}=not-a-date`);
+    assert.match(
+      `${r.stderr}${r.stdout}`,
+      new RegExp(`${flag} expects YYYY-MM-DD`),
+      `${flag}=value must reach the date validator`,
+    );
+    assert.notEqual(r.status, 0, 'a malformed bound must fail the run');
+  });
+
+  test(`${flag} BAD (space form) still validated`, () => {
+    const r = runScan(flag, 'not-a-date');
+    assert.match(`${r.stderr}${r.stdout}`, new RegExp(`${flag} expects YYYY-MM-DD`));
+    assert.notEqual(r.status, 0);
+  });
+
+  test(`${flag}=VALID passes validation`, () => {
+    const r = runScan(`${flag}=2026-07-28`);
+    // It fails later (no portals.yml in a bare checkout) — the point is that it
+    // gets *past* the date validator rather than being rejected as malformed.
+    assert.doesNotMatch(`${r.stderr}${r.stdout}`, new RegExp(`${flag} expects YYYY-MM-DD`));
+  });
+}

--- a/tests/scan-flag-forms.test.mjs
+++ b/tests/scan-flag-forms.test.mjs
@@ -1,5 +1,5 @@
 // tests/scan-flag-forms.test.mjs — scan.mjs must read --flag=value, not only
-// --flag value.
+// --flag value, and must reject a flag passed with no operand.
 //
 // `args.indexOf('--posted-after')` returns -1 for `--posted-after=2026-07-28`,
 // so the bound resolved to null — indistinguishable from the flag never having
@@ -8,50 +8,78 @@
 // (#2401/#2402/#2498, and 37055d7d which fixed five other scripts).
 //
 // The sharpest symptom is that the typo guard stops guarding: scan.mjs
-// validates --posted-after and exits 1 on a malformed date precisely "since a
+// validates these dates and exits 1 on a malformed one precisely "since a
 // silently-ignored bound would look like 'no jobs matched' instead of an
 // error" — but with the = form the value never reached the validator, so a
-// typo'd bound was silently ignored, which is the exact outcome the guard
-// exists to prevent.
+// typo'd bound was silently ignored, the exact outcome the guard exists to
+// prevent.
 //
-// Asserting via the validator is deliberate: it is observable without a
-// portals.yml, a network call, or a fixture board.
+// HERMETIC: every run pins CAREER_OPS_PORTALS at a path that does not exist, so
+// scan.mjs stops at its portals check and can never load providers, reach the
+// network, or write scan state — regardless of whether the developer running
+// the suite has a real portals.yml. Each assertion also checks the subprocess
+// actually ran (no spawn error, no signal), so a timeout cannot pass silently.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
 const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const NO_PORTALS = join(tmpdir(), 'career-ops-no-such-portals.yml');
 
-const runScan = (...args) =>
-  spawnSync(process.execPath, [join(ROOT, 'scan.mjs'), ...args], {
+function runScan(...args) {
+  const r = spawnSync(process.execPath, [join(ROOT, 'scan.mjs'), ...args], {
     cwd: ROOT,
     encoding: 'utf-8',
     timeout: 30_000,
+    env: { ...process.env, CAREER_OPS_PORTALS: NO_PORTALS },
   });
+  assert.equal(r.error, undefined, `scan.mjs failed to spawn: ${r.error?.message}`);
+  assert.equal(r.signal, null, `scan.mjs was killed by ${r.signal} (timeout?)`);
+  return { ...r, all: `${r.stdout ?? ''}${r.stderr ?? ''}` };
+}
 
 for (const flag of ['--posted-after', '--posted-before']) {
+  const expects = new RegExp(`${flag} expects YYYY-MM-DD`);
+
   test(`${flag}=BAD is validated, not silently ignored`, () => {
     const r = runScan(`${flag}=not-a-date`);
-    assert.match(
-      `${r.stderr}${r.stdout}`,
-      new RegExp(`${flag} expects YYYY-MM-DD`),
-      `${flag}=value must reach the date validator`,
-    );
+    assert.match(r.all, expects, `${flag}=value must reach the date validator`);
     assert.notEqual(r.status, 0, 'a malformed bound must fail the run');
   });
 
   test(`${flag} BAD (space form) still validated`, () => {
     const r = runScan(flag, 'not-a-date');
-    assert.match(`${r.stderr}${r.stdout}`, new RegExp(`${flag} expects YYYY-MM-DD`));
+    assert.match(r.all, expects);
     assert.notEqual(r.status, 0);
   });
 
-  test(`${flag}=VALID passes validation`, () => {
+  test(`${flag}=VALID reaches the validator and passes it`, () => {
     const r = runScan(`${flag}=2026-07-28`);
-    // It fails later (no portals.yml in a bare checkout) — the point is that it
-    // gets *past* the date validator rather than being rejected as malformed.
-    assert.doesNotMatch(`${r.stderr}${r.stdout}`, new RegExp(`${flag} expects YYYY-MM-DD`));
+    assert.doesNotMatch(r.all, expects, 'a valid date must not be rejected');
+    // Proof it got PAST the date gate rather than never reaching it: the run
+    // stops at the pinned-missing portals file, which is checked afterwards.
+    assert.match(r.all, /portals\.yml not found|not found/i);
+  });
+
+  test(`${flag} with no operand is rejected, not treated as absent`, () => {
+    const r = runScan(flag);
+    assert.match(r.all, new RegExp(`${flag} requires a value`));
+    assert.notEqual(r.status, 0, 'a missing operand must not fall back to no bound');
   });
 }
+
+test('--company=VALUE reaches the filter (regression for the = form)', () => {
+  // A bare indexOf missed this too, silently scanning every tracked company.
+  const r = runScan('--company=acme');
+  assert.doesNotMatch(r.all, /--company requires a value/);
+  assert.match(r.all, /portals\.yml not found|not found/i);
+});
+
+test('--company with no operand is rejected', () => {
+  const r = runScan('--company');
+  assert.match(r.all, /--company requires a value/);
+  assert.notEqual(r.status, 0);
+});


### PR DESCRIPTION
## The bug

`scan.mjs` reads `--company`, `--posted-after` and `--posted-before` with a bare `args.indexOf(flag)`, which returns `-1` for `--posted-after=2026-07-28`. The value resolves to `null` — indistinguishable from the flag never having been passed — so the run scans with **no bound at all** and reports a clean result.

The sharpest consequence is that **the typo guard stops guarding**. `scan.mjs` validates these dates and exits 1 on a malformed one, and its own comment says why:

> gated against a typo since a silently-ignored bound would look like "no jobs matched" instead of an error

With the `=` form the value never reaches that validator, producing exactly the outcome the guard exists to prevent:

```
before:  node scan.mjs --posted-after=not-a-date
         → no complaint; run continues unbounded

after:   Error: --posted-after expects YYYY-MM-DD, got "not-a-date"
```

## Fix

Use `flagValue` from `lib/cli-flags.mjs` — the module `37055d7d` added for precisely this and applied to five other scripts. `scan.mjs` didn't import it at all.

## Two scope notes

**`--since` is not affected.** It parses the `=` form itself (`1d9ff634`), so I left it alone. Mentioning it because a mechanical grep flags it and it looks like a miss.

**15 other scripts still have this pattern.** I swept every root `.mjs` for value-taking flags read via `args.indexOf`:

| script | flags |
|---|---|
| `analyze-patterns.mjs` | `--min-threshold`, `--min-vendor-n` |
| `contacts.mjs` | `--vcf` |
| `extract-latex-content.mjs` | `--out` |
| `fix-slugs.mjs` | `--file` |
| `followup-cadence.mjs` | `--applied-days` |
| `invite-match.mjs` | `--file` |
| `match-star.mjs` | `--jd`, `--top` |
| `paste-reply.mjs` | `--file` |
| `plugins.mjs` | `--sha` |
| `salary-gap.mjs` | `--stated-for` |
| `scan-interamt.mjs` | `--keyword` |
| `seed-fixture.mjs` | `--state` |
| `upskill.mjs` | `--url-text`, `--min-reports` |
| `verify-portals.mjs` | `--add`, `--file` |
| `weekly-digest.mjs` | `--from` |

I have **kept this PR to `scan.mjs`** — the one with a reproduced failure and the highest-traffic entry point — rather than shipping a 16-file sweep you didn't ask for. Say the word and I'll do the rest as a separate PR. I haven't verified each of those individually, so the table is a lead, not a finding.

## Tests

`tests/scan-flag-forms.test.mjs` — both bounds, in `=value` and space form, plus a valid-value control asserting the validator is *reached* rather than bypassed. The two `=value` cases fail before this change (4 pass / 2 fail → 6 pass).

`node test-all.mjs` → **3058 passed, 0 failed**.

Filed directly per CONTRIBUTING.md (bug fix, no issue needed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for both `--flag value` and `--flag=value` formats for company and date filters.

* **Bug Fixes**
  * Improved validation for malformed or missing company and date filter values.
  * Invalid or incomplete filters now produce clear errors instead of silently disabling filtering.

* **Tests**
  * Added coverage for both supported flag formats, validation scenarios, and successful command execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->