### PR TITLE
fix(web): states.yml cached for the process lifetime, so core updates go unseen

### DIFF
--- a/web/src/lib/core/states.ts
+++ b/web/src/lib/core/states.ts
@@ -30,12 +30,30 @@ const FALLBACK: CanonicalState[] = [
   { id: "hired", label: "Hired", aliases: ["contratado", "contratada", "hired", "accepted", "accept"], description: "Offer accepted, job landed!", group: "hired" },
 ];
 
-let cache: CanonicalState[] | null = null;
+/**
+ * Cached per resolved states.yml path and keyed on the file's mtime+size (one
+ * statSync per call, no full read), mirroring loadHeaderAliases in
+ * tracker-table.mjs.
+ *
+ * A bare `if (cache) return cache` made the "READ it live" contract above true
+ * only for the first request a server process ever served: a core update that
+ * rewrote templates/states.yml (git pull, update-system.mjs apply) was then
+ * invisible until restart, so a newly canonical status was rejected by
+ * POST /api/status and a removed one kept being accepted.
+ *
+ * Failures are NEVER cached, so a states.yml that is momentarily unreadable
+ * falls back for that call only, instead of pinning FALLBACK for the lifetime
+ * of the process.
+ */
+const statesCache = new Map<string, { mtimeMs: number; size: number; states: CanonicalState[] }>();
 
 export function readCanonicalStates(): CanonicalState[] {
-  if (cache) return cache;
+  const file = path.join(careerOpsRoot(), "templates", "states.yml");
   try {
-    const raw = fs.readFileSync(path.join(careerOpsRoot(), "templates", "states.yml"), "utf8");
+    const { mtimeMs, size } = fs.statSync(file);
+    const cached = statesCache.get(file);
+    if (cached && cached.mtimeMs === mtimeMs && cached.size === size) return cached.states;
+    const raw = fs.readFileSync(file, "utf8");
     const doc = yaml.load(raw) as { states?: unknown };
     const list = Array.isArray(doc?.states) ? doc.states : null;
     if (list && list.length) {
@@ -51,14 +69,17 @@ export function readCanonicalStates(): CanonicalState[] {
         });
       }
       if (parsed.length) {
-        cache = parsed;
+        statesCache.set(file, { mtimeMs, size, states: parsed });
         return parsed;
       }
     }
+    // Readable but unusable (empty/!states) — drop any stale entry so a
+    // repaired file is picked up on the next request rather than after a
+    // restart, and fall back for this call only.
+    statesCache.delete(file);
   } catch {
-    /* fall through to fallback */
+    /* unreadable — fall back for this call, never cache the failure */
   }
-  cache = FALLBACK;
   return FALLBACK;
 }
 


### PR DESCRIPTION
## The bug

`readCanonicalStates()` used a bare module-level `if (cache) return cache`, so `templates/states.yml` was read **once per server process** — on the first request it ever served. The file's own doc comment says the opposite:

> we READ it live and never hardcode the list (the maintainer once mis-listed it from memory — the file had one more)

After a core update rewrites `states.yml` (a `git pull`, or `update-system.mjs apply`) without restarting the dashboard, `POST /api/status` keeps validating against the old snapshot:

- a status that is **now canonical** is rejected with `not a canonical status: …`
- a status upstream **removed or renamed** keeps being silently accepted

Nothing anywhere indicates the definitions are stale.

**A second, sharper edge:** the `FALLBACK` was cached too. A `states.yml` that was momentarily unreadable on the very first request pinned the hardcoded fallback for the rest of the process — later reads never recovered even after the file was fine again.

## Fix

Mirrors `loadHeaderAliases` in `tracker-table.mjs` exactly, since that function already solved this same problem for `tracker-aliases.json` and documents the reasoning:

- a `Map` keyed by resolved path holding `{mtimeMs, size, states}`
- one `statSync` per call, no full read on a hit
- **failures are never cached**, so a repaired file is picked up on the next request

Using the existing pattern rather than inventing one keeps the two read paths consistent.

## Verification

Exercised the real module with the `@/` alias import stubbed, rewriting `states.yml` between two calls:

```
origin/main : 1st "Applied,Rejected"   2nd "Applied,Rejected"                 ← stale
this branch : 1st "Applied,Rejected"   2nd "Applied,Rejected,Shortlisted"     ← live
```

`npx tsc --noEmit` clean.

## On the missing test

I did not add one, and I'd rather say why than quietly omit it: `web/` has no harness that can import a `.ts` module. All three suites under `web/tests/lib/` import `.mjs`, and `states.ts` pulls the `@/` alias, so plain `node --test` can't load it.

Standing that harness up is real infrastructure, and smuggling it into a bug fix is how a small PR becomes an unreviewable one. Happy to send it as its own PR if you want the coverage — just say which shape you'd prefer (a loader for `node --test`, or vitest).

Filed directly per CONTRIBUTING.md (bug fix, no issue needed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when loading application states.
  * Updated state information is now recognized automatically when source files change.
  * Invalid or unavailable state data no longer affects future loading attempts.
  * Temporary fallback behavior is limited to the affected request, helping prevent stale results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->