### PR TITLE
fix(doctor): `CLAUDE_CODE_USE_BEDROCK=0` reported that you were billing to Bedrock

### DIFF
--- a/doctor.mjs
+++ b/doctor.mjs
@@ -71,8 +71,16 @@ function checkNodeVersion() {
 function checkBillingSource() {
   const key = process.env.ANTHROPIC_API_KEY;
   const authToken = process.env.ANTHROPIC_AUTH_TOKEN;
+  // Enabled means SET TO A TRUTHY VALUE, not merely present. These switches are
+  // documented as `=1`, so `CLAUDE_CODE_USE_BEDROCK=0` is how someone turns one
+  // off — and mere presence would then report "requests bill to your cloud
+  // account" at exactly the user who just said they don't. A billing check that
+  // misreads an explicit opt-out causes the confusion it exists to remove.
+  // Matches the repo's own env-flag convention (=== '1' in merge-tracker.mjs
+  // and update-system.mjs), while also accepting `true` since these are
+  // third-party switches users copy from assorted docs.
   const cloud = ['CLAUDE_CODE_USE_BEDROCK', 'CLAUDE_CODE_USE_VERTEX', 'CLAUDE_CODE_USE_FOUNDRY']
-    .filter((v) => process.env[v]);
+    .filter((v) => /^(1|true|yes|on)$/i.test(String(process.env[v] ?? '').trim()));
 
   if (cloud.length) {
     return {

--- a/tests/doctor-billing-source.test.mjs
+++ b/tests/doctor-billing-source.test.mjs
@@ -1,0 +1,77 @@
+// tests/doctor-billing-source.test.mjs — the billing-source check in doctor.mjs.
+//
+// The check exists to tell a user which account their tokens are billed to, so
+// a FALSE warning is worse than none: it tells someone who explicitly opted out
+// of a cloud provider that they're billing to it. The cloud switches are
+// documented as `=1`, which makes `=0` the natural way to turn one off.
+import { pass, fail, NODE, ROOT } from './helpers.mjs';
+import { execFileSync } from 'child_process';
+import { join } from 'path';
+
+console.log('\ndoctor.mjs — billing source');
+
+const DOCTOR = join(ROOT, 'doctor.mjs');
+
+/** Run doctor and return its human output (it exits non-zero when it finds issues). */
+function runDoctor(env) {
+  try {
+    return execFileSync(NODE, [DOCTOR], {
+      cwd: ROOT,
+      env: { ...process.env, ...env },
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (e) {
+    return String(e.stdout || '');
+  }
+}
+
+const CLOUD_VARS = ['CLAUDE_CODE_USE_BEDROCK', 'CLAUDE_CODE_USE_VERTEX', 'CLAUDE_CODE_USE_FOUNDRY'];
+// Clear every billing-related var so each case starts from a known state.
+const CLEAN = Object.fromEntries(
+  [...CLOUD_VARS, 'ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN'].map((v) => [v, '']),
+);
+
+const warnsAbout = (out, v) => new RegExp(`${v} is set`).test(out);
+
+// Truthy values must warn — the check's actual job.
+for (const value of ['1', 'true']) {
+  const out = runDoctor({ ...CLEAN, CLAUDE_CODE_USE_BEDROCK: value });
+  if (warnsAbout(out, 'CLAUDE_CODE_USE_BEDROCK')) {
+    pass(`CLAUDE_CODE_USE_BEDROCK=${value} warns that requests bill to the cloud account`);
+  } else {
+    fail(`CLAUDE_CODE_USE_BEDROCK=${value} did not warn`);
+  }
+}
+
+// Explicit opt-outs must NOT warn. Mere presence used to be enough, so `=0`
+// told a user who had just disabled Bedrock that they were billing to it.
+for (const value of ['0', 'false', 'no', 'off', '']) {
+  const out = runDoctor({ ...CLEAN, CLAUDE_CODE_USE_BEDROCK: value });
+  if (!warnsAbout(out, 'CLAUDE_CODE_USE_BEDROCK')) {
+    pass(`CLAUDE_CODE_USE_BEDROCK=${JSON.stringify(value)} is an opt-out and stays quiet`);
+  } else {
+    fail(`CLAUDE_CODE_USE_BEDROCK=${JSON.stringify(value)} produced a false cloud-billing warning`);
+  }
+}
+
+// The other two switches share the rule.
+for (const v of ['CLAUDE_CODE_USE_VERTEX', 'CLAUDE_CODE_USE_FOUNDRY']) {
+  const on = runDoctor({ ...CLEAN, [v]: '1' });
+  const off = runDoctor({ ...CLEAN, [v]: '0' });
+  if (warnsAbout(on, v) && !warnsAbout(off, v)) {
+    pass(`${v} warns at =1 and stays quiet at =0`);
+  } else {
+    fail(`${v} truthiness handling is inconsistent with CLAUDE_CODE_USE_BEDROCK`);
+  }
+}
+
+// An API key still takes precedence and must still be reported.
+{
+  const out = runDoctor({ ...CLEAN, ANTHROPIC_API_KEY: 'sk-ant-test' });
+  if (/ANTHROPIC_API_KEY is set/.test(out)) {
+    pass('an API key in the environment is still reported as the billing source');
+  } else {
+    fail('the API key path regressed');
+  }
+}


### PR DESCRIPTION
Closes #2592.

`checkBillingSource()` treated the cloud switches as enabled whenever the variable was **present**, so any non-empty string counted:

```js
.filter((v) => process.env[v])
```

Measured A/B against `main`:

```
                                 BEFORE   AFTER
CLAUDE_CODE_USE_BEDROCK=1        ⚠ warns   ⚠ warns
CLAUDE_CODE_USE_BEDROCK=0        ⚠ warns   ✓ quiet
CLAUDE_CODE_USE_BEDROCK=false    ⚠ warns   ✓ quiet
```

These switches are documented as `=1`, so `=0` is how you turn one off — and `docs/RUNNING_ON_A_BUDGET.md` already points users at them when hunting a stray billing source. Someone who sets `=0` *because* they were chasing exactly this, then runs `npm run doctor`, was told the thing they just disabled was still billing them.

That's worse than a normal false positive given what this check is for. Its own comment says the problem is a user not knowing they're paying per token instead of using the plan they already bought — a billing diagnostic that misreads an explicit opt-out manufactures that confusion, on the check people trust most when they're already worried about cost.

## Fix

Require a truthy value. Matches the repo's own env-flag convention (`=== '1'` in `merge-tracker.mjs:75` and `update-system.mjs:912`), and also accepts `true`/`yes`/`on` because these are third-party switches users copy from assorted docs rather than a convention we control.

The `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` paths are untouched.

## Tests

`doctor.mjs` has no exports and no main-module guard — importing it runs the entire diagnostic — so the test drives the real CLI as a subprocess, which is the honest way to test it and needs no refactor of a core file inside a bug fix.

```
✅ CLAUDE_CODE_USE_BEDROCK=1 / =true warn
✅ =0 / =false / =no / =off / ="" stay quiet
✅ CLAUDE_CODE_USE_VERTEX and _FOUNDRY share the rule
✅ an API key is still reported as the billing source
```

`node test-all.mjs --quick` → **3064 passed, 0 failed** · `validate-system-paths-coverage` → OK.

2 commits (fix + test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved billing-source detection by recognizing common affirmative values consistently, regardless of capitalization or surrounding whitespace.
  * Explicit opt-out values such as `0` no longer trigger cloud billing warnings.
  * Billing checks now behave consistently across supported cloud providers while continuing to report API key usage.

* **Tests**
  * Added coverage for affirmative values, opt-out values, multiple cloud providers, and API key reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->