### PR TITLE
fix(merge-tracker): a re-eval kept the superseded report's ✅ on a report with no PDF

### DIFF
--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -890,7 +890,17 @@ for (const file of tsvFiles) {
       `${downgrade ? '🔽' : '🔄'} Update: #${duplicate.num} ${addition.company} — ${addition.role} (${oldScore}→${newScore})`
       + (downgrade ? ' — DOWNGRADE, re-eval scored lower' : ''),
     );
-    const pdf = reportNum && pdfIndex.has(String(reportNum)) ? '✅' : duplicate.pdf;
+    // The PDF flag describes THE ROW'S REPORT, and this branch replaces that
+    // report link. Inheriting duplicate.pdf across a report change carried the
+    // superseded report's ✅ onto the new one: the row then claimed a tailored
+    // PDF exists for a report that has none, and the only PDF on disk belonged
+    // to the evaluation that was just superseded. Fall back to the existing
+    // flag only when the report is unchanged; when it changes, the manifest is
+    // the sole authority (#2594).
+    const reportChanged = reportNum && oldReportNum && String(reportNum) !== String(oldReportNum);
+    const pdf = reportNum && pdfIndex.has(String(reportNum))
+      ? '✅'
+      : (reportChanged ? '❌' : duplicate.pdf);
     const updatedLine = buildRow({
       num: duplicate.num, date: addition.date, company: addition.company,
       role: reportNumMatched ? addition.role : duplicate.role,

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -897,7 +897,12 @@ for (const file of tsvFiles) {
     // to the evaluation that was just superseded. Fall back to the existing
     // flag only when the report is unchanged; when it changes, the manifest is
     // the sole authority (#2594).
-    const reportChanged = reportNum && oldReportNum && String(reportNum) !== String(oldReportNum);
+    // "different, INCLUDING one-side-absent". Requiring both to be truthy meant
+    // a row whose report cell is `—` had oldReportNum === null, so reportChanged
+    // was falsy and the stale ✅ was inherited exactly as before this fix — and a
+    // `—` row with a ✅ is ordinary, it is what a tracker entry added before its
+    // evaluation looks like. Both absent stays "unchanged", which is correct.
+    const reportChanged = String(reportNum ?? '') !== String(oldReportNum ?? '');
     const pdf = reportNum && pdfIndex.has(String(reportNum))
       ? '✅'
       : (reportChanged ? '❌' : duplicate.pdf);

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -9043,6 +9043,43 @@ try {
   } else {
     fail('merge-tracker left a newly merged row at ❌ despite a matching pdf-index.tsv entry');
   }
+
+  // A re-evaluation REPLACES the row's report link, and the PDF flag describes
+  // that report. Inheriting the old flag across the change carried the
+  // superseded report's ✅ onto a report with no PDF: the row then claimed a
+  // tailored CV exists, and the only PDF on disk belonged to the evaluation
+  // that had just been superseded (#2594).
+  const reevalRow = '| 3 | 2026-01-04 | Acme | Backend Engineer, Payments | 4.5/5 | Evaluated | ✅ | [1](../reports/001-acme-2026-01-04.md) | first |';
+  const reevalTsv = (n) => ({
+    name: `00${n}-acme.tsv`,
+    content: `${n}\t2026-02-01\tAcme\tBackend Engineer, Payments\tEvaluated\t3.9/5\t❌\t[${n}](reports/00${n}-acme-2026-02-01.md)\tre-eval\n`,
+  });
+
+  const staleFlag = runPdfSyncFixture(
+    'reeval-stale',
+    reevalRow,
+    '# report\tpdf\thtml\tformat\tdate\n1\toutput/acme-1.pdf\t\t\t2026-01-04\n',
+    [reevalTsv(2)],
+  );
+  const staleRow = staleFlag.merged.split('\n').find((l) => l.startsWith('| 3 ')) || '';
+  if (staleFlag.result !== null && /\[2\]/.test(staleRow) && staleRow.split('|')[7].trim() === '❌') {
+    pass('a re-eval that changes the report clears a ✅ the new report has no PDF for (#2594)');
+  } else {
+    fail(`stale PDF flag survived a report change: ${staleRow.trim()}`);
+  }
+
+  const keptFlag = runPdfSyncFixture(
+    'reeval-kept',
+    reevalRow,
+    '# report\tpdf\thtml\tformat\tdate\n1\toutput/acme-1.pdf\t\t\t2026-01-04\n2\toutput/acme-2.pdf\t\t\t2026-02-01\n',
+    [reevalTsv(2)],
+  );
+  const keptRow = keptFlag.merged.split('\n').find((l) => l.startsWith('| 3 ')) || '';
+  if (keptFlag.result !== null && /\[2\]/.test(keptRow) && keptRow.split('|')[7].trim() === '✅') {
+    pass('a re-eval keeps ✅ when the NEW report does have a generated PDF (#2594)');
+  } else {
+    fail(`re-eval wrongly cleared a valid PDF flag: ${keptRow.trim()}`);
+  }
 } catch (e) {
   fail(`merge-tracker PDF flag sync test crashed: ${e.message}`);
 }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -9068,6 +9068,24 @@ try {
     fail(`stale PDF flag survived a report change: ${staleRow.trim()}`);
   }
 
+  // The `—`-to-`[2]` variant. extractReportNum returns null for `—`, so a guard
+  // demanding BOTH sides be truthy fell straight back to duplicate.pdf and
+  // inherited the stale ✅ exactly as before the fix. A `—` row carrying a ✅ is
+  // ordinary — it is a tracker entry added before its evaluation (#2594 review).
+  const dashRow = '| 4 | 2026-01-04 | Acme | Backend Engineer, Payments | 4.5/5 | Evaluated | ✅ | — | backfilled |';
+  const dashFlag = runPdfSyncFixture(
+    'reeval-dash',
+    dashRow,
+    '# report\tpdf\thtml\tformat\tdate\n',
+    [reevalTsv(2)],
+  );
+  const dashResult = dashFlag.merged.split('\n').find((l) => l.startsWith('| 4 ')) || '';
+  if (dashFlag.result !== null && /\[2\]/.test(dashResult) && dashResult.split('|')[7].trim() === '❌') {
+    pass('a re-eval from a report-less (—) row clears the inherited ✅ too (#2594)');
+  } else {
+    fail(`stale PDF flag survived a —-to-[2] report change: ${dashResult.trim()}`);
+  }
+
   const keptFlag = runPdfSyncFixture(
     'reeval-kept',
     reevalRow,


### PR DESCRIPTION
Closes #2594.

The update branch replaces the row's **report link**, but computed the PDF cell as:

```js
const pdf = reportNum && pdfIndex.has(String(reportNum)) ? '✅' : duplicate.pdf;
```

That fallback inherits the **old** row's flag. The PDF cell describes the row's report, and the report just changed — so a `✅` earned by the superseded report rides onto the new one.

## Measured

Existing row: report `[1]`, PDF `✅`. Incoming re-eval: report `[2]`. Varying only the manifest:

| old flag | pdf-index has | before | after |
|---|---|---|---|
| ✅ | report 1 only | **✅** | ❌ |
| ✅ | reports 1 + 2 | ✅ | ✅ |
| ❌ | report 2 | ✅ | ✅ |
| ❌ | report 1 only | **✅** | ❌ |

Before the change the flag reads `✅` in **all four** cases — once a re-eval replaces the report link it stops tracking the manifest entirely. That's a stronger statement than the one-line diff suggests, and it's why I've pinned the whole matrix rather than the single case I first noticed.

## Why it bites now

The tracker claims a tailored CV exists for the current evaluation while the only PDF on disk belongs to the one just superseded. A user scanning for what's ready to send either finds nothing, or attaches a PDF tailored to a different — usually higher-scored — report.

#2411 made this far more reachable: re-evals now write through instead of being discarded, downgrades included, and a downgrade is exactly the case where sending the superseded PDF is worst.

`sync-pdf-flags.mjs` can't rescue it — it only flips ❌ → ✅ and never clears a stale ✅.

## Fix

Fall back to the existing flag only when the report is unchanged. When it changes, the manifest is the sole authority:

```js
const reportChanged = reportNum && oldReportNum && String(reportNum) !== String(oldReportNum);
const pdf = reportNum && pdfIndex.has(String(reportNum)) ? '✅' : (reportChanged ? '❌' : duplicate.pdf);
```

Same-report merges keep inheriting, so a row re-merged against its own report is untouched.

## Tests

Two cases on the existing pdf-sync fixture — the stale flag must clear, **and** a genuinely-present PDF must survive, so the fix can't be read as always clearing. Confirmed the first fails without the code change.

`node test-all.mjs --quick` → **3056 passed, 0 failed**.

2 commits (fix + test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected PDF status tracking when a duplicate entry’s report number changes.
  * PDF indicators are now cleared when the replacement report has no available PDF and retained when it does.

* **Tests**
  * Added regression coverage for PDF status updates during report re-evaluations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->