### PR TITLE
fix(theme-style): a `$`-pattern in a profile style value splices the body into the CV's <head> (#2588 sweep)

### DIFF
--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -364,7 +364,12 @@ export function injectPrintPageCss(html, format = 'a4') {
   const pageStyle = `<style id="career-ops-page-setup">\n@page { size: ${pageSize}; margin: var(--page-margin, ${PDF_PAGE_MARGIN}); }\n</style>`;
 
   if (/<\/head>/i.test(html)) {
-    return html.replace(/<\/head>/i, `${pageStyle}\n</head>`);
+    // Replacer function, matching the <html> branch just below. `pageStyle`
+    // interpolates only internal constants today, so this is hardening rather
+    // than a live bug — but the two branches sat in one function disagreeing
+    // about it, and the safe spelling is the one that stays correct if a
+    // configurable value is ever interpolated here (#2596).
+    return html.replace(/<\/head>/i, () => `${pageStyle}\n</head>`);
   }
 
   if (/<html\b[^>]*>/i.test(html)) {

--- a/tests/theme-style-dollar-pattern.test.mjs
+++ b/tests/theme-style-dollar-pattern.test.mjs
@@ -1,0 +1,67 @@
+// tests/theme-style-dollar-pattern.test.mjs — the same $-pattern class #2588
+// fixed in the CV builders, in the two <head>-injection sites it did not reach.
+//
+// injectThemeStyle() splices a <style> block carrying values straight from the
+// user's config/profile.yml `style:` section, and did so with a STRING
+// replacement argument. JS scans that argument for $&, $', $` and $$, so a
+// style value containing one of them was interpreted as a replacement pattern
+// rather than inserted literally.
+//
+// The sharp case is $': it means "everything after the match", so the entire
+// document BODY was spliced into the <head>, inside the style element — with
+// no error and a valid-looking exit 0. buildThemeStyleBlock drops `; { } < >`
+// but has no reason to drop `$`, which is a legal character in a CSS value.
+import { pass, fail } from './helpers.mjs';
+import { injectThemeStyle, styleTokensFrom } from '../theme-style.mjs';
+import { injectPrintPageCss } from '../generate-pdf.mjs';
+
+console.log('\ntheme-style / generate-pdf — $-pattern head injection');
+
+const HTML = '<html><head><title>CV</title></head><body>BODY-SENTINEL</body></html>';
+
+// Every $-pattern must land in the CSS value verbatim, and none may drag
+// document content into the head.
+for (const [label, value] of [
+  ["$' (everything after the match)", "Fira$'Sans"],
+  ['$& (the matched text)', 'Fira$&Sans'],
+  ['$` (everything before the match)', 'Fira$`Sans'],
+  ['$$ (an escaped dollar)', 'Fira$$Sans'],
+]) {
+  const out = injectThemeStyle(HTML, styleTokensFrom({ font_family: value }));
+  const head = out.split('</head>')[0];
+  const declared = (head.match(/--font-family:\s*([^;]*)/) || [])[1];
+
+  if (!/BODY-SENTINEL/.test(head)) {
+    pass(`${label} does not splice document content into <head>`);
+  } else {
+    fail(`${label} spliced the body into <head>: ${JSON.stringify(head.slice(-120))}`);
+  }
+  if (declared === value) {
+    pass(`${label} is inserted literally into the CSS value`);
+  } else {
+    fail(`${label} was interpreted: declared ${JSON.stringify(declared)}, expected ${JSON.stringify(value)}`);
+  }
+}
+
+// A style block with no $-patterns must be byte-identical to before.
+{
+  const out = injectThemeStyle(HTML, styleTokensFrom({ accent_color: '#2563eb' }));
+  if (out.includes('--accent-color: #2563eb;') && out.includes('BODY-SENTINEL') && out.split('BODY-SENTINEL').length === 2) {
+    pass('an ordinary style block is injected exactly once, unchanged');
+  } else {
+    fail(`ordinary injection regressed: ${out}`);
+  }
+}
+
+// generate-pdf's <head> branch interpolates only internal constants today, so
+// this pins the safe spelling rather than a live bug — and keeps it consistent
+// with the <html> branch beside it, which already used a replacer function.
+{
+  const out = injectPrintPageCss(HTML, 'a4');
+  const head = out.split('</head>')[0];
+  if (!/BODY-SENTINEL/.test(head) && /@page/.test(head) && out.split('BODY-SENTINEL').length === 2) {
+    pass('injectPrintPageCss injects the page setup without disturbing the body');
+  } else {
+    fail(`injectPrintPageCss output looks wrong: ${JSON.stringify(head.slice(-140))}`);
+  }
+}

--- a/theme-style.mjs
+++ b/theme-style.mjs
@@ -90,6 +90,13 @@ export function buildThemeStyleBlock(tokens) {
 export function injectThemeStyle(html, tokens) {
   const block = buildThemeStyleBlock(tokens);
   if (!block) return html;
-  if (/<\/head>/i.test(html)) return html.replace(/<\/head>/i, `${block}\n</head>`);
+  // Replacer FUNCTION, not a string: `block` carries values straight from the
+  // user's config/profile.yml `style:` block, and a string replacement argument
+  // is scanned by JS for $-patterns. A font_family of `A$'B` makes `$'` mean
+  // "everything after the match", splicing the entire document body INTO the
+  // <head> inside the style element — silently, with a valid-looking exit 0.
+  // The sanitizer drops `; { } < >` but has no reason to drop `$`, which is
+  // legal in a CSS value. Same class as #2588 fixed in the CV builders.
+  if (/<\/head>/i.test(html)) return html.replace(/<\/head>/i, () => `${block}\n</head>`);
   return `${block}\n${html}`;
 }


### PR DESCRIPTION
Closes #2596.

#2588 fixed `String.replace` `$`-pattern interpretation in the two CV builders. Two `<head>`-injection sites do the same thing and weren't in that sweep.

## The live one: `theme-style.mjs`

```js
if (/<\/head>/i.test(html)) return html.replace(/<\/head>/i, `${block}\n</head>`);
```

`block` carries values straight from the user's `config/profile.yml` `style:` section, and `renderHtmlToPdf` calls this on every render (`generate-pdf.mjs:602-603`). `buildThemeStyleBlock` drops `; { } < >` but has no reason to drop `$` — it's legal in a CSS value.

`font_family: "Fira$'Sans"` produces:

```
<style id="career-ops-dynamic-theme">:root { --font-family: Fira<body>BODY-SENTINEL</body></html>Sans; }</style>
```

The whole document body, spliced **into the `<head>`**, inside the style element. All three non-trivial patterns corrupt it:

| value | declared as |
|---|---|
| `Fira$'Sans` | `Fira<body>BODY-SENTINEL</body></html>Sans` |
| `Fira$&Sans` | `Fira` |
| ``Fira$`Sans`` | `Fira<html><head><title>CV</title>Sans` |

Silent, valid-looking exit 0 — the failure shape #2588 already describes.

## The latent one: `generate-pdf.mjs:367`

Not exploitable today: `pageStyle` interpolates only internal constants (`pageSize` is a fixed ternary, `PDF_PAGE_MARGIN` a module constant). **I'm calling that out rather than inflating it.** It's worth fixing because the very next branch in the same function already does it right:

```js
return html.replace(/<html\b[^>]*>/i, match => `${match}\n<head>\n${pageStyle}\n</head>`);
```

Two branches of one function disagreeing about the hazard is how the next one gets written wrong.

## Fix

Replacer function at both sites, exactly as #2588 did — a replacer's return value is never scanned for patterns.

After: every pattern lands verbatim (`"A$'B"`, `"A$&B"`, ``"A$`B"``, `"A$$B"`) with no leakage, and an ordinary style block is byte-identical.

## Tests

`tests/theme-style-dollar-pattern.test.mjs`, mirroring #2588's file: each of the four patterns must reach the CSS value verbatim **and** must not drag document content into the head; an ordinary block must still inject exactly once; `injectPrintPageCss` must leave the body alone.

Confirmed it fails without the fix — the `$'` case splices `<body>` into `<head>`, and `$&`/`` $` `` corrupt the value differently.

`node test-all.mjs --quick` → **3084 passed, 0 failed**.

2 commits (fix + test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where dollar-sign sequences in CSS values could be incorrectly interpreted during style injection.
  * Improved print-page style injection while preserving the document content and generated output.

* **Tests**
  * Added regression coverage for special characters in CSS values and print-page style handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->