### PR TITLE
perf(scan): read each dedup source once per scan run

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -1026,38 +1026,43 @@ export function normalizeUrlForDedup(url) {
   return parsed.toString();
 }
 
-export function loadSeenUrls(policy = {}) {
+/**
+ * Build the seen-URL set from already-read source texts. An absent file is
+ * passed as '' (the readIfExists convention shared with
+ * `collectSeenCompanyRoles`) — every parse below yields nothing on ''.
+ */
+export function collectSeenUrls(sources = {}, policy = {}) {
+  const { scanHistoryText = '', pipelineText = '', applicationsText = '' } = sources;
   const seen = new Set();
   let recheckEligible = 0;
 
   // scan-history.tsv
-  if (existsSync(SCAN_HISTORY_PATH)) {
-    const lines = readFileSync(SCAN_HISTORY_PATH, 'utf-8').split('\n');
-    for (const line of lines.slice(1)) { // skip header
-      const [url, firstSeen, , , , status = 'added'] = line.split('\t');
-      if (!url) continue;
-      if (shouldDedupScanHistoryRow({ firstSeen, status }, policy)) seen.add(normalizeUrlForDedup(url));
-      else recheckEligible++;
-    }
+  for (const line of scanHistoryText.split('\n').slice(1)) { // skip header
+    const [url, firstSeen, , , , status = 'added'] = line.split('\t');
+    if (!url) continue;
+    if (shouldDedupScanHistoryRow({ firstSeen, status }, policy)) seen.add(normalizeUrlForDedup(url));
+    else recheckEligible++;
   }
 
   // pipeline.md — extract URLs from checkbox lines
-  if (existsSync(PIPELINE_PATH)) {
-    const text = readFileSync(PIPELINE_PATH, 'utf-8');
-    for (const match of text.matchAll(/- \[[ x]\] (https?:\/\/\S+)/g)) {
-      seen.add(normalizeUrlForDedup(match[1]));
-    }
+  for (const match of pipelineText.matchAll(/- \[[ x]\] (https?:\/\/\S+)/g)) {
+    seen.add(normalizeUrlForDedup(match[1]));
   }
 
   // applications.md — extract URLs from report links and any inline URLs
-  if (existsSync(APPLICATIONS_PATH)) {
-    const text = readFileSync(APPLICATIONS_PATH, 'utf-8');
-    for (const match of text.matchAll(/https?:\/\/[^\s|)]+/g)) {
-      seen.add(normalizeUrlForDedup(match[0]));
-    }
+  for (const match of applicationsText.matchAll(/https?:\/\/[^\s|)]+/g)) {
+    seen.add(normalizeUrlForDedup(match[0]));
   }
 
   return { seen, recheckEligible };
+}
+
+export function loadSeenUrls(policy = {}) {
+  return collectSeenUrls({
+    scanHistoryText: readIfExists(SCAN_HISTORY_PATH),
+    pipelineText: readIfExists(PIPELINE_PATH),
+    applicationsText: readIfExists(APPLICATIONS_PATH),
+  }, policy);
 }
 
 /**
@@ -1584,16 +1589,16 @@ export function formatScanHistoryRow(offer, date, status = 'added') {
 }
 
 /**
- * Read scan-history.tsv rows that carry a fingerprint, for the cross-listing
- * check. Older rows without the 8th column simply never match.
+ * Parse scan-history.tsv rows that carry a fingerprint, for the cross-listing
+ * check. Older rows without the 8th column simply never match. Takes the file
+ * text ('' for an absent file), like its `collect*` siblings.
  *
- * @param {string} [historyPath] - Override for tests.
+ * @param {string} [scanHistoryText] - Full scan-history.tsv contents.
  * @returns {Array<{url: string, dateStr: string, company: string, title: string, fingerprint: string}>}
  */
-export function loadFingerprintHistory(historyPath = SCAN_HISTORY_PATH) {
-  if (!existsSync(historyPath)) return [];
+export function collectFingerprintHistory(scanHistoryText = '') {
   const rows = [];
-  for (const line of readFileSync(historyPath, 'utf-8').split('\n')) {
+  for (const line of scanHistoryText.split('\n')) {
     const cols = line.split('\t');
     // Skip the header row. Older 7-col headers fall out of the `cols.length < 8`
     // guard below on their own, but the 12-col header names col 7 `fingerprint`
@@ -1610,6 +1615,44 @@ export function loadFingerprintHistory(historyPath = SCAN_HISTORY_PATH) {
     });
   }
   return rows;
+}
+
+/**
+ * Filesystem wrapper over {@link collectFingerprintHistory}.
+ *
+ * @param {string} [historyPath] - Override for tests.
+ */
+export function loadFingerprintHistory(historyPath = SCAN_HISTORY_PATH) {
+  return collectFingerprintHistory(readIfExists(historyPath));
+}
+
+/**
+ * Read the three dedup sources once and derive every per-run dedup structure
+ * from that single read (#2382). A scan run used to parse scan-history.tsv
+ * three times and pipeline.md/applications.md twice each — at 50k history rows
+ * that is ~600 ms of redundant parsing per run.
+ *
+ * The snapshot is deliberately per-run: callers hold the returned object in
+ * run-scoped locals and nothing is cached at module level, so a later run
+ * always re-reads the files. Dedup state is therefore frozen at run start;
+ * rows appended by a concurrent process mid-run are picked up by the next run
+ * (the previous re-read at the cross-listing step could not safely observe
+ * them anyway — scan-history appends are not locked).
+ *
+ * @param {{recheckAfterDays?: number|null, today?: string}} [policy] -
+ *   Scan-history recheck policy, shared by the URL and company+role sets.
+ * @param {(name: unknown) => string} [canonicalize=defaultCompanyNormalizer] -
+ *   Company canonicalizer for the role keys.
+ * @returns {{seen: Set<string>, recheckEligible: number, seenCompanyRoles: Set<string>, fingerprintHistory: Array<{url: string, dateStr: string, company: string, title: string, fingerprint: string}>}}
+ */
+export function loadDedupSnapshot(policy = {}, canonicalize = defaultCompanyNormalizer) {
+  const scanHistoryText = readIfExists(SCAN_HISTORY_PATH);
+  const pipelineText = readIfExists(PIPELINE_PATH);
+  const applicationsText = readIfExists(APPLICATIONS_PATH);
+  const { seen, recheckEligible } = collectSeenUrls({ scanHistoryText, pipelineText, applicationsText }, policy);
+  const seenCompanyRoles = collectSeenCompanyRoles({ applicationsText, scanHistoryText, pipelineText }, policy, canonicalize);
+  const fingerprintHistory = collectFingerprintHistory(scanHistoryText);
+  return { seen, recheckEligible, seenCompanyRoles, fingerprintHistory };
 }
 
 // Standard skeleton created on fresh install — matches the format documented
@@ -2158,12 +2201,12 @@ async function main() {
   // empty Map = the filter below never fires.
   const blacklist = loadBlacklist();
 
-  // 4. Load dedup sets
+  // 4. Load dedup sets — one read per source file for the whole run (#2382).
   const historyPolicy = scanHistoryPolicy(config);
-  const seenUrlState = loadSeenUrls(historyPolicy);
-  const seenUrls = seenUrlState.seen;
   const canonicalizeCompany = buildCompanyCanonicalizer(config.company_aliases);
-  const seenCompanyRoles = loadSeenCompanyRoles(APPLICATIONS_PATH, canonicalizeCompany, { policy: historyPolicy });
+  const dedupSnapshot = loadDedupSnapshot(historyPolicy, canonicalizeCompany);
+  const seenUrls = dedupSnapshot.seen;
+  const seenCompanyRoles = dedupSnapshot.seenCompanyRoles;
 
   // 5. Fetch from each target
   const date = new Date().toISOString().slice(0, 10);
@@ -2367,7 +2410,10 @@ async function main() {
   for (const offer of verifiedOffers) {
     offer.fingerprint = fingerprintText(offer.description);
   }
-  const crossListings = findCrossListings(verifiedOffers, loadFingerprintHistory());
+  // History rows come from the run-start snapshot: nothing has appended to
+  // scan-history.tsv yet at this point in the run (all writes happen below),
+  // so this sees the same bytes a re-read would — minus the third full parse.
+  const crossListings = findCrossListings(verifiedOffers, dedupSnapshot.fingerprintHistory);
 
   // 6. Write results
   if (!dryRun && verifiedOffers.length > 0) {
@@ -2476,7 +2522,7 @@ async function main() {
     console.log(`  If one side is an agency, apply through ONE channel only — a double submission burns both (#1596).`);
   }
   if (historyPolicy.recheckAfterDays != null) {
-    console.log(`Recheck eligible:      ${seenUrlState.recheckEligible} old scan-history URL(s)`);
+    console.log(`Recheck eligible:      ${dedupSnapshot.recheckEligible} old scan-history URL(s)`);
   }
   if (verify) {
     console.log(`Expired (verified):    ${expiredOffers.length} dropped`);

--- a/tests/scan-dedup-snapshot.test.mjs
+++ b/tests/scan-dedup-snapshot.test.mjs
@@ -1,0 +1,199 @@
+// tests/scan-dedup-snapshot.test.mjs — one read per dedup source per scan run (#2382).
+//
+// A scan run used to parse scan-history.tsv three separate times (loadSeenUrls,
+// loadSeenCompanyRoles, loadFingerprintHistory) and pipeline.md/applications.md
+// twice each. `loadDedupSnapshot` reads each file once and hands the text to the
+// three collectors, so the run operates on one coherent snapshot.
+//
+// The maintainer's mergeability bar for #2382 is "identical output before/after
+// on the same fixture". The expected values below are GOLDEN: they were captured
+// by running the three pre-refactor loaders on this exact fixture at upstream
+// 402e798, then hard-coded. They must never be regenerated from the code under
+// test — that would turn the behaviour proof into a tautology.
+//
+// The fixture deliberately exercises every policy branch that could silently
+// diverge: a recheck-aged `added` row (the recheck TTL is the easiest thing to
+// lose in a wiring mistake — a double-wrapped policy object reads as
+// `recheckAfterDays: undefined` and dedups aged rows forever), a permanent
+// status, an active and an expired cooldown, a legacy 7-column row, and a
+// cosmetic utm query param.
+import { pass, fail } from './helpers.mjs';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { loadDedupSnapshot } from '../scan.mjs';
+
+console.log('\nscan.mjs — dedup snapshot: one read per source, golden outputs (#2382)');
+
+const HISTORY_HEADER = 'url\tfirst_seen\tportal\ttitle\tcompany\tstatus\tlocation\tfingerprint\tposted_at\ttrust_score\ttrust_flags\tnormalized_company';
+
+const HISTORY = [
+  HISTORY_HEADER,
+  // fresh `added` inside the recheck window, with fingerprint + cosmetic utm param
+  'https://boards.greenhouse.io/acme/jobs/1?utm_source=x\t2026-08-01\tgreenhouse\tPlatform Engineer\tAcme\tadded\tRemote\tfp-acme-1\t2026-07-30\t\t\tacme',
+  // recheck-aged `added` (recheckAfterDays=30, today=2026-08-07): NOT deduped, recheck-eligible
+  'https://jobs.lever.co/beta/2\t2026-01-01\tlever\tData Engineer\tBeta\tadded\tBerlin\tfp-beta-2\t2025-12-28\t\t\tbeta',
+  // permanent status: dedups the URL forever, never seeds a role key, fingerprint still recorded
+  'https://boards.greenhouse.io/gamma/3\t2026-07-01\tgreenhouse\tML Engineer\tGamma\tskipped_expired\tRemote\tfp-gamma-3\t2026-06-28\t\t\tgamma',
+  // active cooldown (until 2026-12-31 > today): dedups, no role key, no fingerprint
+  'https://jobs.example.com/delta/4\t2026-07-15\tashby\tBackend Engineer\tDelta\tcooldown:refused:2026-12-31\tRemote\t\t\t\t\tdelta',
+  // expired cooldown (until 2026-07-01 < today): NOT deduped, recheck-eligible
+  'https://jobs.example.com/eps/5\t2026-06-01\tashby\tFrontend Engineer\tEpsilon\tcooldown:refused:2026-07-01\tRemote\t\t\t\t\tepsilon',
+  // legacy 7-col row, fresh `added`: dedups + seeds a role key, no fingerprint column at all
+  'https://old.example.com/zeta/6\t2026-08-05\tpersonio-feed\tSRE\tZeta\tadded\tMunich',
+  '',
+].join('\n');
+
+const PIPELINE = `# Pipeline — Pending URLs
+
+## Pending
+
+- [ ] https://boards.greenhouse.io/pipeco/jobs/7 | PipeCo | Staff Engineer | Remote
+- [x] https://jobs.lever.co/doneco/8 | DoneCo | Principal Engineer
+
+## Processed
+`;
+
+const APPLICATIONS = `# Applications Tracker
+
+| # | Date | Company | Role | Score | Status | PDF | Report | Notes |
+|---|------|---------|------|-------|--------|-----|--------|-------|
+| 1 | 2026-07-20 | TrackCo | Head of Platform | 4.2/5 | Applied | ✅ | [12](reports/012-trackco-2026-07-20.md) | https://trackco.example.com/careers/9 |
+`;
+
+const POLICY = { recheckAfterDays: 30, today: '2026-08-07' };
+
+// Golden outputs from the pre-refactor loaders (see header comment).
+const GOLDEN = {
+  seen: [
+    'https://boards.greenhouse.io/acme/jobs/1',
+    'https://boards.greenhouse.io/gamma/3',
+    'https://boards.greenhouse.io/pipeco/jobs/7',
+    'https://jobs.example.com/delta/4',
+    'https://jobs.lever.co/doneco/8',
+    'https://old.example.com/zeta/6',
+    'https://trackco.example.com/careers/9',
+  ],
+  recheckEligible: 2,
+  companyRoles: [
+    'acme::platform engineer',
+    'doneco::principal engineer',
+    'pipeco::staff engineer',
+    'trackco::head of platform',
+    'zeta::sre',
+  ],
+  fingerprints: [
+    { url: 'https://boards.greenhouse.io/acme/jobs/1?utm_source=x', dateStr: '2026-08-01', title: 'Platform Engineer', company: 'Acme', fingerprint: 'fp-acme-1' },
+    { url: 'https://jobs.lever.co/beta/2', dateStr: '2026-01-01', title: 'Data Engineer', company: 'Beta', fingerprint: 'fp-beta-2' },
+    { url: 'https://boards.greenhouse.io/gamma/3', dateStr: '2026-07-01', title: 'ML Engineer', company: 'Gamma', fingerprint: 'fp-gamma-3' },
+  ],
+};
+
+// The module-level data/ paths are relative to process.cwd(), so run each call
+// chdir'd into a sandbox (same pattern as the #2065 fixture in test-all.mjs).
+function inSandbox(files, fn) {
+  const dir = mkdtempSync(join(tmpdir(), 'dedup-snapshot-'));
+  mkdirSync(join(dir, 'data'), { recursive: true });
+  for (const [name, content] of Object.entries(files)) {
+    writeFileSync(join(dir, 'data', name), content, 'utf-8');
+  }
+  const originalCwd = process.cwd();
+  process.chdir(dir);
+  try {
+    return fn();
+  } finally {
+    process.chdir(originalCwd);
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function sameArray(actual, expected) {
+  return actual.length === expected.length && actual.every((v, i) => v === expected[i]);
+}
+
+// ── 1. Golden equivalence on the full fixture ───────────────────────────────
+{
+  const snapshot = inSandbox(
+    { 'scan-history.tsv': HISTORY, 'pipeline.md': PIPELINE, 'applications.md': APPLICATIONS },
+    () => loadDedupSnapshot(POLICY),
+  );
+
+  if (sameArray([...snapshot.seen].sort(), GOLDEN.seen)) {
+    pass('snapshot seen-URL set matches the pre-refactor golden output');
+  } else {
+    fail(`seen-URL set diverged from golden: [${[...snapshot.seen].sort().join(', ')}]`);
+  }
+
+  if (snapshot.recheckEligible === GOLDEN.recheckEligible) {
+    pass('snapshot recheckEligible count matches golden (aged row + expired cooldown)');
+  } else {
+    fail(`recheckEligible diverged: got ${snapshot.recheckEligible}, want ${GOLDEN.recheckEligible} — the recheck TTL policy is not reaching the collector`);
+  }
+
+  if (sameArray([...snapshot.seenCompanyRoles].sort(), GOLDEN.companyRoles)) {
+    pass('snapshot company+role key set matches golden (permanent/cooldown rows excluded, aged row expired)');
+  } else {
+    fail(`company+role keys diverged from golden: [${[...snapshot.seenCompanyRoles].sort().join(', ')}]`);
+  }
+
+  if (JSON.stringify(snapshot.fingerprintHistory) === JSON.stringify(GOLDEN.fingerprints)) {
+    pass('snapshot fingerprint rows match golden (status- and age-independent, legacy rows skipped)');
+  } else {
+    fail(`fingerprint rows diverged from golden: ${JSON.stringify(snapshot.fingerprintHistory)}`);
+  }
+}
+
+// ── 2. Recheck policy must actually reach the collectors ────────────────────
+// The same fixture without a recheck TTL (clock still pinned — cooldown expiry
+// is clock-driven, not TTL-driven) dedups the aged Beta row and seeds its role
+// key, and only the expired cooldown stays recheck-eligible. If this returned
+// the same thing as the TTL run, the policy argument is being dropped somewhere
+// in the composition — the exact silent change #2382's review flagged as
+// unmergeable.
+{
+  const files = { 'scan-history.tsv': HISTORY, 'pipeline.md': PIPELINE, 'applications.md': APPLICATIONS };
+  const noTtl = inSandbox(files, () => loadDedupSnapshot({ today: '2026-08-07' }));
+  if (
+    noTtl.seen.has('https://jobs.lever.co/beta/2') &&
+    noTtl.seenCompanyRoles.has('beta::data engineer') &&
+    noTtl.recheckEligible === 1
+  ) {
+    pass('without a recheck TTL the aged row dedups and seeds its role key (policy argument is live, not defaulted)');
+  } else {
+    fail(`no-TTL snapshot wrong: hasBetaUrl=${noTtl.seen.has('https://jobs.lever.co/beta/2')} hasBetaRole=${noTtl.seenCompanyRoles.has('beta::data engineer')} recheckEligible=${noTtl.recheckEligible} (want true/true/1)`);
+  }
+}
+
+// ── 3. Fresh install: absent files degrade to empty, never throw ────────────
+{
+  try {
+    const snapshot = inSandbox({}, () => loadDedupSnapshot(POLICY));
+    if (
+      snapshot.seen.size === 0 &&
+      snapshot.recheckEligible === 0 &&
+      snapshot.seenCompanyRoles.size === 0 &&
+      snapshot.fingerprintHistory.length === 0
+    ) {
+      pass('absent dedup sources degrade to empty sets on a fresh install');
+    } else {
+      fail(`fresh-install snapshot not empty: seen=${snapshot.seen.size} roles=${snapshot.seenCompanyRoles.size} fingerprints=${snapshot.fingerprintHistory.length}`);
+    }
+  } catch (err) {
+    fail(`fresh-install snapshot threw: ${err.message}`);
+  }
+}
+
+// ── 4. Empty file ≡ absent file ─────────────────────────────────────────────
+// readIfExists hands '' to the collectors for an absent file; a zero-byte file
+// must land in the same place.
+{
+  const snapshot = inSandbox(
+    { 'scan-history.tsv': '', 'pipeline.md': '', 'applications.md': '' },
+    () => loadDedupSnapshot(POLICY),
+  );
+  if (snapshot.seen.size === 0 && snapshot.seenCompanyRoles.size === 0 && snapshot.fingerprintHistory.length === 0) {
+    pass('zero-byte dedup sources behave exactly like absent ones');
+  } else {
+    fail(`zero-byte sources diverged: seen=${snapshot.seen.size} roles=${snapshot.seenCompanyRoles.size} fingerprints=${snapshot.fingerprintHistory.length}`);
+  }
+}


### PR DESCRIPTION
Closes #2382, following the constraints from [the acceptance comment](https://github.com/santifer/career-ops/issues/2382#issuecomment-5216110737): per-run only, no dedup behaviour change, `normalizeUrlForDedup` left alone.

## What changed

- New text-taking exports `collectSeenUrls(sources, policy)` and `collectFingerprintHistory(text)`. The parsing bodies moved verbatim out of `loadSeenUrls` and `loadFingerprintHistory`, which are now thin path wrappers with unchanged signatures. All three loaders now share the shape `collectSeenCompanyRoles` already had: a pure text-to-structure core plus a filesystem wrapper. Existing callers (scan-ats-full.mjs, scan-interamt.mjs) and existing tests are untouched.
- New `loadDedupSnapshot(policy, canonicalize)` reads scan-history.tsv, pipeline.md, and applications.md once each through the existing `readIfExists` (absent file reads as `''`, which every parser treats the same as the old `existsSync` skip) and derives all four dedup structures from that single read. The scan entrypoint calls it once; the cross-listing check consumes `snapshot.fingerprintHistory` instead of re-reading the file.
- Nothing is cached at module level. The snapshot lives in locals inside the run and dies with it, so a later run or a long-lived agent session always re-reads the files.

## Behaviour proof

`tests/scan-dedup-snapshot.test.mjs` pins golden outputs that were captured by running the pre-refactor loaders (at 402e798) against a fixture, then hard-coded. The fixture covers the branches most likely to drift silently: a recheck-aged `added` row, a permanent status, an active and an expired cooldown, a legacy 7-column row, and a cosmetic utm param. A second check runs the same fixture without a recheck TTL to prove the policy argument actually reaches the collectors, since a wiring mistake there (for example a double-wrapped options object) would disable the recheck feature without failing anything else. Fresh-install and zero-byte-file cases are pinned as equivalent.

One semantic note: the fingerprint history used to be re-read after fetching. Every `appendToScanHistory` call happens later in the run than that read, so within a run the snapshot is byte-identical to what the re-read saw. What changes is visibility of rows appended by a *concurrent* process mid-run. Those appends hold no lock, so the old re-read could equally catch a torn half-written line; the honest fix is locking the TSV the way pipeline.md already is, filed as #2600.

## Measured

50k-row history, 200-row pipeline, 100-row tracker, mean of 5 runs after warmup (Node 22, Windows):

| | 5k rows | 50k rows |
|---|---|---|
| before (7 file parses) | 51.3 ms | 427.8 ms |
| after (3 file parses) | 46.6 ms | 415.3 ms |

Smaller than the issue's framing suggested, and worth being plain about: the duplicate reads and splits were the cheap part. Most of the loader cost sits in `normalizeUrlForDedup` (the issue measured ~227 ms of the 361 ms URL pass at 50k), which is out of scope here per the acceptance comment and would be the follow-up with the actual large win. What this PR buys is the structural half: one coherent snapshot per run, roughly a third of the transient string allocation, and the `collect*` seam that makes the later work safe to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved duplicate detection across scan history, pipelines, and applications.
  - More reliably handles URL normalization, legacy records, missing or empty files, cooldowns, statuses, and recheck timing.
  - Prevents inconsistent results caused by repeatedly reading changing scan data during a run.

- **Tests**
  - Added coverage for deduplication, fingerprint tracking, recheck behavior, and edge cases involving incomplete or missing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->