### PR TITLE
fix(cv-facts): a k/M/B magnitude suffix let an inflated claim past the gate

### DIFF
--- a/verify-cv-facts.mjs
+++ b/verify-cv-facts.mjs
@@ -56,8 +56,18 @@ const METRIC_NOUNS = [
 // for the chain — modifiers are alphabetic only — so a wider window still
 // cannot jump across an intervening figure to bind an unrelated noun.
 const MODIFIER_WINDOW = 4;
+// The number capture takes an immediately-adjacent magnitude suffix (50k, 1.5M)
+// as part of the number, mirroring what the currency pattern below already does.
+// Without it the modifier window re-consumed that letter as a generic word, so
+// "50k users" normalized to the claim "50 users" and matched a CV that said 50 —
+// letting a 1000x inflation through the gate while a smaller "900 users" was
+// correctly caught.
+//
+// `[kKmMbB]\b` requires the suffix to END the token, so "50 million users" (space,
+// handled by the modifier window) and "50kg users" (k not at a boundary) both keep
+// their existing behaviour and still normalize to "50".
 const COUNT_CLAIM_RE = new RegExp(
-  String.raw`\b(\d[\d,.]*)\s*\+?\s*(?:[A-Za-z][A-Za-z-]*\s+){0,${MODIFIER_WINDOW}}(${METRIC_NOUNS.join('|')})\b`,
+  String.raw`\b(\d[\d,.]*(?:[kKmMbB]\b)?)\s*\+?\s*(?:[A-Za-z][A-Za-z-]*\s+){0,${MODIFIER_WINDOW}}(${METRIC_NOUNS.join('|')})\b`,
   'gi'
 );
 const NOUN_SYNONYMS = new Map([
@@ -540,6 +550,37 @@ function runSelfTest() {
     'no cross-number binding invents evidence',
     auditClaims('Shipped 3 integrations', 'Shipped 3 features across 12 integrations').invented,
     ['3 integrations']
+  );
+
+  // A magnitude suffix belongs to the number, not the modifier window. Without
+  // that, "50k users" normalized to "50 users" and matched a CV saying 50 — the
+  // gate passed a 1000x inflation while catching a smaller "900 users".
+  equal(
+    'an inflated magnitude suffix is caught',
+    auditClaims('Grew the product to 50k users', 'Reached 50 users.').invented,
+    ['50k users']
+  );
+  equal(
+    'a magnitude claim the source supports still passes',
+    auditClaims('Grew to 50k users', 'Reached 50k users.').invented,
+    []
+  );
+  equal(
+    'a lowercase m suffix is caught too',
+    auditClaims('Drove 1.5M downloads', 'Drove 50 downloads.').invented,
+    ['1.5m downloads']
+  );
+  // The suffix must END the token, so a spelled-out magnitude and a unit that
+  // merely starts with k/m/b keep their previous normalization.
+  equal(
+    'a spelled-out magnitude is unaffected',
+    auditClaims('Reached 50 million users', 'Reached 50 million users.').invented,
+    []
+  );
+  equal(
+    'a unit beginning with a suffix letter is unaffected',
+    auditClaims('Shipped 50kg units', 'Shipped 50kg units.').invented,
+    []
   );
 
   console.log(`verify-cv-facts self-test: ${passed} passed, ${failed} failed`);

--- a/verify-cv-facts.mjs
+++ b/verify-cv-facts.mjs
@@ -570,17 +570,26 @@ function runSelfTest() {
     auditClaims('Drove 1.5M downloads', 'Drove 50 downloads.').invented,
     ['1.5m downloads']
   );
+  equal(
+    'an uppercase B suffix is caught too',
+    auditClaims('Reached 2B users', 'Reached 1B users.').invented,
+    ['2b users']
+  );
   // The suffix must END the token, so a spelled-out magnitude and a unit that
-  // merely starts with k/m/b keep their previous normalization.
+  // merely starts with k/m/b keep their previous normalization. Asserting on
+  // metricClaims directly (not auditClaims(...).invented) matters here: target
+  // and source text are identical, so an empty `invented` list would pass even
+  // if metricClaims extracted nothing at all — these assert the real claim a
+  // truthful CV would produce.
   equal(
     'a spelled-out magnitude is unaffected',
-    auditClaims('Reached 50 million users', 'Reached 50 million users.').invented,
-    []
+    [...metricClaims('Reached 50 million users')],
+    ['50 users']
   );
   equal(
     'a unit beginning with a suffix letter is unaffected',
-    auditClaims('Shipped 50kg units', 'Shipped 50kg units.').invented,
-    []
+    [...metricClaims('Shipped 50kg servers')],
+    ['50 servers']
   );
 
   console.log(`verify-cv-facts self-test: ${passed} passed, ${failed} failed`);


### PR DESCRIPTION
## The bug

`COUNT_CLAIM_RE` captures the digits of a metric claim but not an adjacent magnitude suffix. The modifier window then re-consumes that letter as a generic word, so `50k users` normalizes to the claim `50 users` — which matches a CV that says 50.

The gate therefore passes a 1000× inflation while correctly catching a smaller one:

```js
auditClaims('Reached 900 users', 'Reached 50 users.')
// → invented: ["900 users"]      correct

auditClaims('Reached 50k users', 'Reached 50 users.')
// → invented: []                 ← the bug
```

Order-of-magnitude inflation is the most damaging fabrication a CV can carry, and it was the one shape the anti-fabrication gate could not see. It also fails in the unsafe direction: the gate reports clean.

## Fix

One regex change, and it only brings the count pattern in line with what this same file already does for money — `CURRENCY` at line 73 already consumes `(?:\s?[kKmMbB])?`.

```diff
-\b(\d[\d,.]*)\s*\+?\s*…
+\b(\d[\d,.]*(?:[kKmMbB]\b)?)\s*\+?\s*…
```

`[kKmMbB]\b` requires the suffix to **end the token**, which is what keeps two existing behaviours intact:

| input | before | after |
|---|---|---|
| `50k users` | `50 users` | `50k users` |
| `50 million users` (spelled out) | `50 users` | `50 users` — unchanged |
| `50kg units` (`k` not at a boundary) | `50 units` | `50 units` — unchanged |

I deliberately did **not** copy currency's `\s?`, which would allow a space: on counts that would capture `50 m` out of `50 million` and change the spelled-out case. Both preserved cases have tests pinning them, so a future loosening fails loudly.

## Tests

Five cases added to the existing `--self-test` (39 → 44):

- an inflated magnitude suffix is caught
- a magnitude claim the source supports still passes
- a lowercase `m` suffix is caught too
- a spelled-out magnitude is unaffected
- a unit beginning with a suffix letter is unaffected

Verified they actually catch the bug: with the regex reverted and the tests kept, 2 fail. (Stashing the whole file proves nothing, since the tests live in it too.)

`node test-all.mjs` → **3110 passed, 0 failed**.

Filed directly per CONTRIBUTING.md (bug fix, no issue needed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of numeric claims using magnitude suffixes such as `k`, `M`, and `B`, including lowercase variants.
  * Preserved valid claims such as `50k` while correctly excluding suffix-prefixed units such as `50kg`.
  * Added support for spelled-out magnitudes and improved handling of inflated or unsupported metric claims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->