### PR TITLE
fix(liveness): a rate-limited posting was classified expired, not uncertain

### DIFF
--- a/liveness-core.mjs
+++ b/liveness-core.mjs
@@ -129,7 +129,14 @@ export function classifyLiveness({ status = 0, requestedUrl = '', finalUrl = '',
   if (botChallenge) {
     return { result: 'uncertain', code: 'bot_challenge', reason: `anti-bot challenge: ${botChallenge.source}` };
   }
-  if (status === 403 || status === 503) {
+  // 429 belongs with 403/503: rate limiting is the board throttling US, never
+  // evidence the posting is gone. Its body is a short "Too Many Requests", well
+  // under MIN_CONTENT_CHARS, so without this it fell through to
+  // insufficient_content and read as `expired` — and an expired result is
+  // written to scan-history as skipped_expired, whose URL every later scan
+  // dedup-skips (indefinitely, unless scan_history.recheck_after_days is set).
+  // Scanning harder is exactly what earns a 429, so this compounds.
+  if (status === 403 || status === 429 || status === 503) {
     return { result: 'uncertain', code: 'access_blocked', reason: `HTTP ${status} (access blocked, likely anti-bot)` };
   }
   // Any other 5xx is a transient origin error (502/504 gateway hiccups, 500s

--- a/tests/liveness-core.test.mjs
+++ b/tests/liveness-core.test.mjs
@@ -85,6 +85,21 @@ blocked.result === 'uncertain' && blocked.code === 'access_blocked'
   ? pass('HTTP 503 still classifies as uncertain/access_blocked, not server_error')
   : fail(`HTTP 503 classified ${blocked.result}/${blocked.code}, expected uncertain/access_blocked`);
 
+// 429 is throttling, never evidence the posting is gone. Its body is a short
+// "Too Many Requests" — under MIN_CONTENT_CHARS — so before the guard covered it
+// the verdict fell through to insufficient_content and read as `expired`, which
+// scan-history records as skipped_expired and every later scan dedup-skips.
+const throttled = classifyLiveness({
+  status: 429,
+  requestedUrl: 'https://boards.greenhouse.io/acme/jobs/1234567',
+  finalUrl: 'https://boards.greenhouse.io/acme/jobs/1234567',
+  bodyText: 'Too Many Requests. Please retry after some time.',
+  applyControls: [],
+});
+throttled.result === 'uncertain' && throttled.code === 'access_blocked'
+  ? pass('HTTP 429 classifies as uncertain/access_blocked, not expired')
+  : fail(`HTTP 429 classified ${throttled.result}/${throttled.code}, expected uncertain/access_blocked`);
+
 // A real 404/410 is still authoritative expiry — both statuses, both halves.
 for (const status of [404, 410]) {
   const gone = classifyLiveness({


### PR DESCRIPTION
## The bug

`classifyLiveness` special-cases 403 and 503 as `access_blocked`, and any other 5xx as a transient `server_error`. **429 matched neither.** A rate-limit response carries a short "Too Many Requests" body — well under `MIN_CONTENT_CHARS` — so it fell through to the content heuristic and came out as `expired`:

```
status 429 -> {"result":"expired",   "code":"insufficient_content"}   ← the bug
status 403 -> {"result":"uncertain", "code":"access_blocked"}
status 503 -> {"result":"uncertain", "code":"access_blocked"}
status 500 -> {"result":"uncertain", "code":"server_error"}
```

429 means the board is throttling *us*. It is never evidence the posting is gone.

## Why it matters beyond one verdict

`scan.mjs --verify` records an expired result in scan-history as `skipped_expired`, and later scans dedup-skip that URL (`scan.mjs:2390`).

I checked how long that lasts rather than assuming: `skipped_expired` is **not** in `PERMANENT_SCAN_HISTORY_STATUSES`, but `shouldDedupScanHistoryRow` returns `true` indefinitely while `scan_history.recheck_after_days` is unset — which is the default. So a live job that happened to be throttled once is dropped from every future scan until the user configures a recheck window.

It also compounds in the worst direction: **scanning harder is exactly what earns a 429**, so a large sweep quietly discards the most jobs.

(To be precise about the blast radius: this does *not* poison the role-level key. `loadSeenUrls`' documented semantics only seed a role key from `added` rows, so city variants still self-heal. The damage is URL-level.)

## Fix

One status added to the existing guard:

```diff
-if (status === 403 || status === 503) {
+if (status === 403 || status === 429 || status === 503) {
```

This file's history is a run of the same class — `#2371` added 5xx, `#783` added 403 anti-bot walls, `#2163`/`#2212` added phrasing cases. 429 was the remaining gap in that set.

## Test

Mirrors the existing 503 case in `tests/liveness-core.test.mjs`, asserting **both halves** of the verdict (the file's own comment notes the 5xx guard sits below, so checking only the code would be weaker). Verified it fails with the guard reverted:

```
❌ HTTP 429 classified expired/insufficient_content, expected uncertain/access_blocked
```

`node test-all.mjs` → **3111 passed, 0 failed**.

Filed directly per CONTRIBUTING.md (bug fix, no issue needed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of rate-limited responses so they are recognized as access restrictions instead of incorrectly marking content as expired.
  * Preserved accurate status classification when a service returns limited or incomplete response content.

* **Tests**
  * Added regression coverage for rate-limited responses with short response bodies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->