### PR TITLE
fix(agent-inbox): concurrent adds silently dropped queued requests

### DIFF
--- a/agent-inbox-tests.mjs
+++ b/agent-inbox-tests.mjs
@@ -149,10 +149,13 @@ console.log('7. concurrent adds do not lose items (append, not rewrite)');
   const failedSpawn = exits.filter((c) => c !== 0).length;
   check('every concurrent add exited cleanly', failedSpawn === 0, `${failedSpawn} non-zero exits`);
   const body = readFileSync(inbox, 'utf8');
-  const kept = body.split('\n').filter((l) => l.startsWith('- [ ]')).length;
+  const pending = body.split('\n').filter((l) => l.startsWith('- [ ]'));
+  const kept = pending.length;
   check(`all ${N} concurrently queued items survive`, kept === N, `kept=${kept} of ${N}`);
-  const distinct = new Set(body.split('\n').filter((l) => l.startsWith('- [ ]')).map((l) => l.slice(l.indexOf('— ')))).size;
-  check('no item is duplicated or truncated', distinct === N, `distinct=${distinct} of ${N}`);
+  const actual = new Set(pending.map((l) => l.slice(l.indexOf('— ') + 2)));
+  const expected = new Set(Array.from({ length: N }, (_, i) => `item-${i}`));
+  const complete = actual.size === expected.size && [...expected].every((item) => actual.has(item));
+  check('no item is duplicated or truncated', complete, `actual=${[...actual].join(', ')}`);
 }
 
 console.log(`\nResults: ${passed} passed, ${failed} failed`);

--- a/agent-inbox-tests.mjs
+++ b/agent-inbox-tests.mjs
@@ -12,12 +12,14 @@
  *   5. An empty `add` fails loudly (exit 1) rather than queuing a blank line.
  *   6. On the default path, a first `add` self-heals .gitignore (idempotent) so
  *      the personal queue isn't accidentally tracked.
+ *   7. Concurrent `add` calls all survive — the queue is appended to, never
+ *      rewritten, so simultaneous writers cannot clobber each other.
  *
  * Provisions a throwaway queue via CAREER_OPS_INBOX and a temp CWD; never
  * touches real user data.
  */
 
-import { execFileSync } from 'child_process';
+import { execFileSync, spawn } from 'child_process';
 import { readFileSync, writeFileSync, mkdtempSync } from 'fs';
 import { join, dirname } from 'path';
 import { tmpdir } from 'os';
@@ -121,6 +123,36 @@ console.log('6. first add on the default path self-heals .gitignore (idempotent)
   const gi = readFileSync(join(repo, '.gitignore'), 'utf8');
   const ruleCount = gi.split('\n').filter((l) => l.trim() === 'data/agent-inbox.md').length;
   check('.gitignore gains exactly one data/agent-inbox.md rule', ruleCount === 1, `count=${ruleCount}`);
+}
+
+// ---------------------------------------------------------------------------
+console.log('7. concurrent adds do not lose items (append, not rewrite)');
+{
+  // The queue's whole point is that anything — a dashboard, a script, cron —
+  // can drop a request in without a session running, so simultaneous adds are
+  // the expected case, not an exotic one. A read-whole-file/write-whole-file
+  // cycle silently dropped every item that landed between the read and the
+  // write: 30 concurrent adds kept 15.
+  const dir = tmp('inbox-concurrent-');
+  const inbox = join(dir, 'agent-inbox.md');
+  const N = 30;
+  // spawn(), not spawnSync() — a synchronous loop would serialize the adds and
+  // pass even against the buggy rewrite, proving nothing.
+  const exits = await Promise.all(
+    Array.from({ length: N }, (_, i) => new Promise((res) => {
+      const p = spawn(NODE, [CLI, 'add', `item-${i}`], {
+        cwd: dir, env: { ...process.env, CAREER_OPS_INBOX: inbox }, stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      p.on('exit', (code) => res(code));
+    })),
+  );
+  const failedSpawn = exits.filter((c) => c !== 0).length;
+  check('every concurrent add exited cleanly', failedSpawn === 0, `${failedSpawn} non-zero exits`);
+  const body = readFileSync(inbox, 'utf8');
+  const kept = body.split('\n').filter((l) => l.startsWith('- [ ]')).length;
+  check(`all ${N} concurrently queued items survive`, kept === N, `kept=${kept} of ${N}`);
+  const distinct = new Set(body.split('\n').filter((l) => l.startsWith('- [ ]')).map((l) => l.slice(l.indexOf('— ')))).size;
+  check('no item is duplicated or truncated', distinct === N, `distinct=${distinct} of ${N}`);
 }
 
 console.log(`\nResults: ${passed} passed, ${failed} failed`);

--- a/agent-inbox.mjs
+++ b/agent-inbox.mjs
@@ -26,7 +26,10 @@
  *   node agent-inbox.mjs resolve 1 [--result "scored 4.3 — report 012"]
  */
 
-import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync } from 'fs';
+import {
+  readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync,
+  openSync, fstatSync, readSync, closeSync,
+} from 'fs';
 import { dirname } from 'path';
 
 const PATH = process.env.CAREER_OPS_INBOX || 'data/agent-inbox.md';
@@ -70,7 +73,34 @@ function ensureFile() {
   if (existsSync(PATH)) return;
   ensureGitignored();
   mkdirSync(dirname(PATH), { recursive: true });
-  writeFileSync(PATH, HEADER);
+  // 'wx': atomic create-exclusive. Two concurrent first-time `add` calls can
+  // both pass the existsSync check above before either writes; without an
+  // exclusive flag, the second writeFileSync (default 'w', which truncates)
+  // lands after the first has already appended its item and wipes it back to
+  // just the header. 'wx' makes only one of them win the create — the loser
+  // gets EEXIST and does nothing, same as if it had seen existsSync === true.
+  try {
+    writeFileSync(PATH, HEADER, { flag: 'wx' });
+  } catch (err) {
+    if (err?.code !== 'EEXIST') throw err;
+  }
+}
+
+// Whether appending to `path` needs a leading newline first, i.e. the file is
+// non-empty and doesn't already end in one. Reads only the last byte instead
+// of the whole file — the full-file read this replaced was only ever used to
+// check one byte.
+function needsLeadingNewline(path) {
+  const fd = openSync(path, 'r');
+  try {
+    const size = fstatSync(fd).size;
+    if (size === 0) return false;
+    const buf = Buffer.alloc(1);
+    readSync(fd, buf, 0, 1, size - 1);
+    return buf[0] !== 0x0a; // '\n'
+  } finally {
+    closeSync(fd);
+  }
 }
 
 // Parse the checklist into items, in file order.
@@ -102,11 +132,10 @@ function add() {
   //
   // POSIX guarantees an O_APPEND write is atomic below PIPE_BUF, and one
   // checklist line is far under it, so concurrent appends interleave instead of
-  // clobbering. Reading the tail first only decides whether a separating newline
-  // is needed (for a file someone hand-edited without one); the write itself is
-  // still a single atomic append.
-  const existing = readFileSync(PATH, 'utf8');
-  const separator = existing.length && !existing.endsWith('\n') ? '\n' : '';
+  // clobbering. Checking the last byte first only decides whether a separating
+  // newline is needed (for a file someone hand-edited without one); the write
+  // itself is still a single atomic append.
+  const separator = needsLeadingNewline(PATH) ? '\n' : '';
   appendFileSync(PATH, `${separator}- [ ] ${stamp()} — ${text}\n`);
   process.stdout.write(`Queued: ${text}\n`);
 }

--- a/agent-inbox.mjs
+++ b/agent-inbox.mjs
@@ -26,7 +26,7 @@
  *   node agent-inbox.mjs resolve 1 [--result "scored 4.3 — report 012"]
  */
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync } from 'fs';
 import { dirname } from 'path';
 
 const PATH = process.env.CAREER_OPS_INBOX || 'data/agent-inbox.md';
@@ -95,8 +95,19 @@ function add() {
   const text = oneLine(process.argv.slice(3).join(' '));
   if (!text) fail('add needs a request, e.g. node agent-inbox.mjs add "evaluate https://..."');
   ensureFile();
-  const body = readFileSync(PATH, 'utf8').replace(/\s+$/, '');
-  writeFileSync(PATH, `${body}\n- [ ] ${stamp()} — ${text}\n`);
+  // Append rather than rewrite. This is the queue's concurrent path — anything
+  // running in the background can drop an item in — and a read-whole-file /
+  // write-whole-file cycle loses every request that lands between the two. With
+  // 30 concurrent `add` calls, half the queue vanished silently.
+  //
+  // POSIX guarantees an O_APPEND write is atomic below PIPE_BUF, and one
+  // checklist line is far under it, so concurrent appends interleave instead of
+  // clobbering. Reading the tail first only decides whether a separating newline
+  // is needed (for a file someone hand-edited without one); the write itself is
+  // still a single atomic append.
+  const existing = readFileSync(PATH, 'utf8');
+  const separator = existing.length && !existing.endsWith('\n') ? '\n' : '';
+  appendFileSync(PATH, `${separator}- [ ] ${stamp()} — ${text}\n`);
   process.stdout.write(`Queued: ${text}\n`);
 }
 


### PR DESCRIPTION
## The bug

`add` reads the whole queue, appends a line in memory, and writes the whole file back. Every request that lands between the read and the write is overwritten and lost — silently, with a cheerful `Queued: ...` printed for each one.

```
30 concurrent `node agent-inbox.mjs add` calls  ->  3 items survived
```

(The loss rate varies with timing; I saw 15/30 and 3/30 on different runs. Both are catastrophic.)

## This is the designed usage, not an exotic case

Straight from the file's own docblock:

> an **append-only queue** the agent drains at the start of a session
> … any tool (a dashboard, a script, cron) **can append to it**

Several writers with no session running is the *point* of the feature — it exists precisely so you can drop a request in when you're not in a session. `agent-inbox-tests.mjs` also already asserted "`add` is append-only". Nothing was actually appending.

## Fix

Append the line instead of rewriting the file. POSIX guarantees an `O_APPEND` write is atomic below `PIPE_BUF`, and one checklist line is far under it, so concurrent adds interleave rather than clobber.

The file is still read first, but only to decide whether a separating newline is needed for a queue someone hand-edited without a trailing one. The write itself is a single atomic append.

## What this does NOT fix

`resolve` is still a read-modify-write over the whole file, so an `add` landing mid-`resolve` can still be lost.

I left it deliberately: that path is interactive and one-at-a-time, so the window is far narrower than automated adds, and closing it properly means introducing a lock rather than a one-line change — a different PR with a different risk profile. Say the word and I'll follow up with it (`pipeline-lock.mjs` already generalizes over a path, so it may be reusable as-is).

## Test

30 genuinely concurrent adds must all survive, none duplicated or truncated.

It uses `spawn()`, **not** `spawnSync()` — I wrote it with `spawnSync` first and caught that a synchronous loop serializes the adds and passes against the buggy rewrite, proving nothing. There's a comment in the test saying so, because it's an easy trap to reintroduce.

Verified it fails with the rewrite restored:

```
❌ all 30 concurrently queued items survive — kept=3 of 30
❌ no item is duplicated or truncated — distinct=3 of 30
```

`node test-all.mjs` → **3110 passed, 0 failed**.

Filed directly per CONTRIBUTING.md (bug fix, no issue needed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when multiple items are added to the inbox simultaneously.
  * Prevented existing queued items from being overwritten during concurrent additions.
  * Ensured each new item remains complete, distinct, and correctly separated.

* **Tests**
  * Added coverage for 30 simultaneous inbox additions.
  * Verified all additions complete successfully and remain queued without duplication or data loss.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->