### PR TITLE
fix(states): aliases the engine accepts were missing from states.yml

### DIFF
--- a/normalize-statuses.mjs
+++ b/normalize-statuses.mjs
@@ -13,7 +13,7 @@
 
 import { readFileSync, copyFileSync, existsSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import {
   openTrackerTransaction, rebuildRow, resolveTrackerPath,
 } from './tracker-utils.mjs';
@@ -44,7 +44,11 @@ function normalizeStatus(raw) {
   if (/^descartado$/i.test(s)) return { status: 'Discarded' };
 
   // Rechazada / Rechazado → Rejected
-  if (/^rechazada?$/i.test(s)) return { status: 'Rejected' };
+  // `rechazada?` reads as "rechazad" + an OPTIONAL trailing "a", so it accepted
+  // "rechazada" and the bare stem "rechazad" but never "rechazado" — the masculine
+  // form this comment claims to handle, that states.yml lists as an alias, and that
+  // the header of this file names. A bare "Rechazado" fell through to unknown.
+  if (/^rechazad[oa]$/i.test(s)) return { status: 'Rejected' };
   if (/^rechazado\s+\d{4}/i.test(s)) return { status: 'Rejected' };
 
   // Aplicado with date → Applied (strip date)
@@ -88,6 +92,16 @@ function normalizeStatus(raw) {
   return { status: null, unknown: true };
 }
 
+export { normalizeStatus };
+
+// Everything below is the CLI. It is guarded because importing this module used to
+// run it: the import alone opened a tracker transaction and rewrote applications.md.
+// That is why tests could only scrape this file's source with regexes instead of
+// calling the function, and why the rechazado gap went unnoticed.
+const IS_CLI = process.argv[1]
+  && pathToFileURL(process.argv[1]).href === import.meta.url;
+
+if (IS_CLI) {
 // Read applications.md
 if (!existsSync(APPS_FILE)) {
   console.log('No applications.md found. Nothing to normalize.');
@@ -187,3 +201,4 @@ if (!DRY_RUN && changes > 0) {
 } finally {
   trackerTransaction?.close();
 }
+} // end IS_CLI

--- a/templates/states.yml
+++ b/templates/states.yml
@@ -9,7 +9,7 @@
 states:
   - id: evaluated
     label: Evaluated
-    aliases: [evaluada]
+    aliases: [evaluada, condicional, hold, evaluar, verificar]
     description: Offer evaluated with report, pending decision
     dashboard_group: evaluated
 
@@ -51,7 +51,7 @@ states:
 
   - id: skip
     label: SKIP
-    aliases: [no_aplicar, no aplicar, skip, monitor]
+    aliases: [no_aplicar, no aplicar, skip, monitor, geo blocker, geo_blocker]
     description: Doesn't fit, don't apply
     dashboard_group: skip
 

--- a/tests/states-alias-coverage.test.mjs
+++ b/tests/states-alias-coverage.test.mjs
@@ -1,0 +1,84 @@
+// tests/states-alias-coverage.test.mjs — templates/states.yml must know every
+// alias the rest of the engine already accepts.
+//
+// states.yml calls itself "Source of truth for career-ops (writer) and dashboard
+// (reader). Both systems MUST use these exact states." But normalize-statuses.mjs
+// carried alias mappings states.yml had never heard of (condicional, hold,
+// evaluar, verificar -> Evaluated; geo blocker -> SKIP), and the two lists drifted
+// silently because nothing compared them.
+//
+// The drift is not cosmetic. set-status.mjs writes the row's PREVIOUS status text
+// into data/status-log.tsv as the transition's `from` cell, and funnel-velocity.mjs
+// validates that cell against states.yml. A row sitting on an accepted-but-unlisted
+// status produced a log line funnel-velocity discarded as unparseable, so the row's
+// first tracked transition vanished from velocity and coverage math.
+//
+// The vocabulary is read out of normalize-statuses.mjs rather than hardcoded, so
+// adding an alias there without adding it to states.yml fails here.
+import { pass, fail, ROOT } from './helpers.mjs';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nstates.yml alias coverage — the engine and the source of truth agree');
+
+try {
+  const { loadCanonicalStates, resolveCanonicalState } = await import(
+    pathToFileURL(join(ROOT, 'tracker-utils.mjs')).href
+  );
+  const states = loadCanonicalStates(join(ROOT, 'templates', 'states.yml'));
+
+  const src = readFileSync(join(ROOT, 'normalize-statuses.mjs'), 'utf-8');
+
+  // Rules of the shape:  if (/^<pattern>$/i.test(s)) return { status: 'Canonical' };
+  // <pattern> may be a bare literal or a (a|b|c) alternation. Alternatives that
+  // carry regex metacharacters (\d, ?, ., +) are not plain aliases — they match
+  // shapes like "rechazado 2026" — so they are skipped rather than guessed at.
+  // Loose, unanchored patterns (e.g. /geo.?blocker/) are covered by the explicit
+  // spot-checks below instead.
+  const RULE_RE = /\/\^\(?([A-Za-zÀ-ÿ|_ ]+)\)?\$\/i\.test\([^)]*\)\)\s*return\s*\{\s*status:\s*'([^']+)'/g;
+  const extracted = [];
+  for (const m of src.matchAll(RULE_RE)) {
+    for (const alias of m[1].split('|')) {
+      const a = alias.trim();
+      if (a) extracted.push({ alias: a, expected: m[2] });
+    }
+  }
+
+  extracted.length > 0
+    ? pass(`extracted ${extracted.length} plain alias rule(s) from normalize-statuses.mjs`)
+    : fail("extracted no alias rules — this guard's parser no longer matches normalize-statuses.mjs and is checking nothing");
+
+  const orphans = extracted.filter(({ alias, expected }) => {
+    const resolved = resolveCanonicalState(alias, states);
+    return !resolved || resolved.toLowerCase() !== expected.toLowerCase();
+  });
+
+  orphans.length === 0
+    ? pass('every alias normalize-statuses accepts resolves to the same state in states.yml')
+    : fail(`states.yml is missing or disagrees on ${orphans.length} alias(es): ${orphans.map(o => `"${o.alias}"->${o.expected}`).join(', ')}`);
+
+  // The specific drift this was written for, including the loose geo-blocker
+  // pattern the extractor deliberately does not try to parse.
+  for (const [alias, expected] of [
+    ['hold', 'Evaluated'],
+    ['verificar', 'Evaluated'],
+    ['condicional', 'Evaluated'],
+    ['evaluar', 'Evaluated'],
+    ['geo blocker', 'SKIP'],
+    ['geo_blocker', 'SKIP'],
+  ]) {
+    const resolved = resolveCanonicalState(alias, states);
+    resolved === expected
+      ? pass(`"${alias}" resolves to ${expected}`)
+      : fail(`"${alias}" resolved to ${resolved ?? 'nothing'}, expected ${expected}`);
+  }
+
+  // The other direction: widening the alias lists must not shadow a real state.
+  const shadowed = states.filter(s => resolveCanonicalState(s.label, states) !== s.label);
+  shadowed.length === 0
+    ? pass('every canonical label still resolves to itself')
+    : fail(`alias widening shadowed canonical label(s): ${shadowed.map(s => s.label).join(', ')}`);
+} catch (err) {
+  fail(`states alias coverage test threw: ${err?.message ?? err}`);
+}

--- a/tests/states-alias-coverage.test.mjs
+++ b/tests/states-alias-coverage.test.mjs
@@ -45,6 +45,20 @@ try {
     }
   }
 
+  // Rules of the second shape normalize-statuses.mjs also uses:
+  //   if (['evaluada'].includes(lower)) return { status: 'Evaluated' };
+  // A plain list-membership check against the already-lowercased `lower`,
+  // rather than an anchored regex. RULE_RE above never matches these, so
+  // without this pass a missing alias here (e.g. dropping 'evaluada' from
+  // states.yml) would sail through the test undetected.
+  const LIST_RULE_RE = /\[((?:'[^']*'|"[^"]*")(?:\s*,\s*(?:'[^']*'|"[^"]*"))*)\]\.includes\(lower\)\)\s*return\s*\{\s*status:\s*'([^']+)'/g;
+  for (const m of src.matchAll(LIST_RULE_RE)) {
+    for (const lit of m[1].matchAll(/'([^']*)'|"([^"]*)"/g)) {
+      const a = (lit[1] ?? lit[2] ?? '').trim();
+      if (a) extracted.push({ alias: a, expected: m[2] });
+    }
+  }
+
   extracted.length > 0
     ? pass(`extracted ${extracted.length} plain alias rule(s) from normalize-statuses.mjs`)
     : fail("extracted no alias rules — this guard's parser no longer matches normalize-statuses.mjs and is checking nothing");

--- a/tests/states-alias-coverage.test.mjs
+++ b/tests/states-alias-coverage.test.mjs
@@ -52,16 +52,27 @@ try {
   // without this pass a missing alias here (e.g. dropping 'evaluada' from
   // states.yml) would sail through the test undetected.
   const LIST_RULE_RE = /\[((?:'[^']*'|"[^"]*")(?:\s*,\s*(?:'[^']*'|"[^"]*"))*)\]\.includes\(lower\)\)\s*return\s*\{\s*status:\s*'([^']+)'/g;
+  const fromListRules = [];
   for (const m of src.matchAll(LIST_RULE_RE)) {
     for (const lit of m[1].matchAll(/'([^']*)'|"([^"]*)"/g)) {
       const a = (lit[1] ?? lit[2] ?? '').trim();
-      if (a) extracted.push({ alias: a, expected: m[2] });
+      if (a) fromListRules.push({ alias: a, expected: m[2] });
     }
   }
+  extracted.push(...fromListRules);
 
-  extracted.length > 0
-    ? pass(`extracted ${extracted.length} plain alias rule(s) from normalize-statuses.mjs`)
-    : fail("extracted no alias rules — this guard's parser no longer matches normalize-statuses.mjs and is checking nothing");
+  // Each extractor is asserted separately on purpose. A combined
+  // `extracted.length > 0` passes on the regex arm alone, so if
+  // normalize-statuses.mjs reshapes its list rules and LIST_RULE_RE stops
+  // matching, that arm silently checks nothing while the test stays green —
+  // exactly the kind of quiet drift this file exists to catch.
+  extracted.length > fromListRules.length
+    ? pass(`extracted ${extracted.length - fromListRules.length} anchored alias rule(s) from normalize-statuses.mjs`)
+    : fail("extracted no anchored alias rules — RULE_RE no longer matches normalize-statuses.mjs and is checking nothing");
+
+  fromListRules.length > 0
+    ? pass(`extracted ${fromListRules.length} list-membership alias rule(s) from normalize-statuses.mjs`)
+    : fail("extracted no list-membership alias rules — LIST_RULE_RE no longer matches normalize-statuses.mjs and is checking nothing");
 
   const orphans = extracted.filter(({ alias, expected }) => {
     const resolved = resolveCanonicalState(alias, states);

--- a/tests/states-alias-coverage.test.mjs
+++ b/tests/states-alias-coverage.test.mjs
@@ -104,6 +104,51 @@ try {
   shadowed.length === 0
     ? pass('every canonical label still resolves to itself')
     : fail(`alias widening shadowed canonical label(s): ${shadowed.map(s => s.label).join(', ')}`);
+
+  // ---------------------------------------------------------------------------
+  // The reverse direction: every alias states.yml PROMISES must actually be
+  // accepted by normalize-statuses.mjs.
+  //
+  // Everything above reads states.yml through tracker-utils, so it only ever
+  // proves "the normalizer's vocabulary is listed in states.yml". It cannot see
+  // the opposite drift — states.yml advertising an alias the normalizer rejects.
+  // That gap was real: states.yml listed `rechazado`, but the rule was
+  // /^rechazada?$/i ("rechazad" + an optional "a"), which matches "rechazada" and
+  // never "rechazado", so a bare Rechazado row normalized to unknown.
+  //
+  // This calls normalizeStatus directly rather than pattern-matching source, so
+  // it cannot be fooled by a rule shape the extractors above do not parse — which
+  // is exactly how the rechazado rule escaped: its `?` is not in RULE_RE's class.
+  const { normalizeStatus } = await import(
+    pathToFileURL(join(ROOT, 'normalize-statuses.mjs')).href
+  );
+
+  const unaccepted = [];
+  for (const state of states) {
+    for (const alias of [state.label, ...(state.aliases ?? [])]) {
+      const got = normalizeStatus(alias).status;
+      if (got !== state.label) unaccepted.push(`"${alias}"->${got ?? 'unknown'} (want ${state.label})`);
+    }
+  }
+  unaccepted.length === 0
+    ? pass(`normalize-statuses accepts all ${states.reduce((n, s) => n + 1 + (s.aliases?.length ?? 0), 0)} labels and aliases states.yml declares`)
+    : fail(`states.yml declares ${unaccepted.length} value(s) normalize-statuses rejects: ${unaccepted.join(', ')}`);
+
+  // Boundary samples for the loose regex rules, which neither extractor parses.
+  // `geoblocker` (no separator) is accepted by /geo.?blocker/i but was covered by
+  // no test; the spaced and underscored forms above are the only ones asserted.
+  for (const [raw, expected] of [
+    ['geoblocker', 'SKIP'],
+    ['GEO BLOCKER', 'SKIP'],
+    ['rechazado 2026', 'Rejected'],
+    ['aplicado 2026', 'Applied'],
+    ['**Rechazado**', 'Rejected'],
+  ]) {
+    const got = normalizeStatus(raw).status;
+    got === expected
+      ? pass(`normalizeStatus("${raw}") -> ${expected}`)
+      : fail(`normalizeStatus("${raw}") -> ${got ?? 'unknown'}, expected ${expected}`);
+  }
 } catch (err) {
   fail(`states alias coverage test threw: ${err?.message ?? err}`);
 }


### PR DESCRIPTION
## The bug

`normalize-statuses.mjs` maps `condicional` / `hold` / `evaluar` / `verificar` → **Evaluated**, and `geo blocker` → **SKIP**. `templates/states.yml` listed none of them — despite its own header:

> Source of truth for career-ops (writer) and dashboard (reader). **Both systems MUST use these exact states.**

Two lists, no comparison between them, so they drifted.

## Why it costs data, not just tidiness

`set-status.mjs` writes the row's **previous** status text into `data/status-log.tsv` as the transition's `from` cell. `funnel-velocity.mjs` validates that cell against `states.yml`. So a row sitting on an accepted-but-unlisted status produced a log line that funnel-velocity threw away:

```
| 1 | Acme   | … | Hold     |    → set-status 1 Interview
| 2 | Globex | … | Aplicado |    → set-status 2 Interview
```

```
before:  observations 1, coveredRows 1
         unparseable: [{ reason: 'unknown from-state "Hold"' }]

after:   observations 2, coveredRows 2, unparseable 0
```

The row's **first tracked transition** was invisible to velocity and coverage math, and the only signal was a terse per-line warning.

## Fix

Two parts, and the second is the one that matters:

1. Add the missing aliases to `states.yml`.
2. **A coverage guard so they cannot drift again.** `tests/states-alias-coverage.test.mjs` reads the alias vocabulary *out of* `normalize-statuses.mjs` rather than hardcoding it, so adding an alias there without a `states.yml` entry fails the suite instead of quietly dropping observations months later.

It also asserts the reverse direction — that widening the alias lists never shadows a canonical label.

Two deliberate limits, stated in the test:

- Alternatives carrying regex metacharacters (`rechazado \d{4}`, `cancelada…`) are skipped by the extractor. Those match *shapes*, not plain aliases, and guessing at them would make the guard flaky.
- The loose unanchored `geo.?blocker` pattern isn't machine-extractable, so it has an explicit spot-check.

The guard also fails loudly if it extracts nothing, so a future refactor of `normalize-statuses.mjs`'s rule shape can't silently turn it into a no-op that passes forever.

## Verification

Against the unfixed `states.yml` the guard reports exactly the drift:

```
❌ states.yml is missing or disagrees on 4 alias(es):
   "condicional"->Evaluated, "hold"->Evaluated, "evaluar"->Evaluated, "verificar"->Evaluated
```

`node test-all.mjs` → **3119 passed, 0 failed**.

Filed directly per CONTRIBUTING.md (bug fix, no issue needed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added additional status aliases for evaluated states, including `condicional`, `hold`, `evaluar`, and `verificar`.
  - Added `geo blocker` and `geo_blocker` aliases for skipped states.

- **Tests**
  - Added coverage to verify alias mappings, canonical status handling, and geo-blocker aliases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->