### PR TITLE
fix(cv): Korean and Traditional Chinese CVs had no font rule

### DIFF
--- a/templates/cv-template.html
+++ b/templates/cv-template.html
@@ -543,6 +543,62 @@
       'Noto Sans SC', 'Source Han Sans SC', sans-serif;
   }
 
+  /* === Korean typography ===
+     modes/ko/ ships as a supported locale, but no rule matched html[lang="ko"],
+     so a Korean CV fell back to the Latin-only stack and Hangul rendered via
+     whatever the PDF engine happened to substitute. Same shape as the ja and
+     zh blocks above: Latin-capable faces first for stable ATS extraction, then
+     platform-native and open-source Korean faces for Hangul glyphs. */
+  html[lang="ko"] body,
+  html[lang="ko"] body {
+    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'Apple SD Gothic Neo',
+      'Malgun Gothic', 'Noto Sans CJK KR',
+      'Noto Sans KR', 'Nanum Gothic', sans-serif;
+    line-break: strict;
+    word-break: normal;
+    overflow-wrap: break-word;
+  }
+
+  html[lang="ko"] .header h1,
+  html[lang="ko"] .section-title,
+  html[lang="ko"] .job-company,
+  html[lang="ko"] .project-title,
+  html[lang="ko"] .contact-row,
+  html[lang="ko"] .competency-tag,
+  html[lang="ko"] .skill-category,
+  html[lang="ko"] .skill-category {
+    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'Apple SD Gothic Neo',
+      'Malgun Gothic', 'Noto Sans CJK KR',
+      'Noto Sans KR', 'Nanum Gothic', sans-serif;
+  }
+
+  /* === Traditional Chinese typography ===
+     modes/zh-TW/ ships as a supported locale. html[lang="zh"] does not match
+     lang="zh-TW", so it needs its own rule — and it must use TC faces, not the
+     Simplified stack above, which substitutes the wrong glyph forms. */
+  html[lang="zh-TW"] body,
+  html[lang="zh-TW"] body {
+    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'PingFang TC',
+      'Microsoft JhengHei', 'Noto Sans CJK TC',
+      'Noto Sans TC', 'Source Han Sans TC', sans-serif;
+    line-break: strict;
+    word-break: normal;
+    overflow-wrap: break-word;
+  }
+
+  html[lang="zh-TW"] .header h1,
+  html[lang="zh-TW"] .section-title,
+  html[lang="zh-TW"] .job-company,
+  html[lang="zh-TW"] .project-title,
+  html[lang="zh-TW"] .contact-row,
+  html[lang="zh-TW"] .competency-tag,
+  html[lang="zh-TW"] .skill-category,
+  html[lang="zh-TW"] .skill-category {
+    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'PingFang TC',
+      'Microsoft JhengHei', 'Noto Sans CJK TC',
+      'Noto Sans TC', 'Source Han Sans TC', sans-serif;
+  }
+
   html[lang="zh-CN"] .summary-text,
   html[lang="zh"] .summary-text,
   html[lang="zh-CN"] .job li,

--- a/templates/cv-template.zh-minimal.html
+++ b/templates/cv-template.zh-minimal.html
@@ -516,6 +516,17 @@ version: 1.0.0
     overflow-wrap: break-word;
   }
 
+  /* Traditional Chinese. `html[lang="zh"]` does not match `zh-TW`, and this
+     template's default stack is Simplified — which substitutes the wrong glyph
+     forms for TC text — so zh-TW needs TC faces explicitly. modes/zh-TW/ ships
+     as a supported locale. (No `ko` rule here on purpose: this is the Chinese
+     minimal template, not a general one.) */
+  html[lang="zh-TW"] body {
+    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'PingFang TC',
+      'Microsoft JhengHei', 'Noto Sans CJK TC',
+      'Noto Sans TC', 'Source Han Sans TC', sans-serif;
+  }
+
   .header {
     margin-bottom: 18px;
   }

--- a/templates/cv-template.zh-minimal.html
+++ b/templates/cv-template.zh-minimal.html
@@ -521,7 +521,8 @@ version: 1.0.0
      forms for TC text — so zh-TW needs TC faces explicitly. modes/zh-TW/ ships
      as a supported locale. (No `ko` rule here on purpose: this is the Chinese
      minimal template, not a general one.) */
-  html[lang="zh-TW"] body {
+  html[lang="zh-TW"] body,
+  html[lang="zh-TW"] .contact-row {
     font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'PingFang TC',
       'Microsoft JhengHei', 'Noto Sans CJK TC',
       'Noto Sans TC', 'Source Han Sans TC', sans-serif;

--- a/templates/resume-template.html
+++ b/templates/resume-template.html
@@ -493,7 +493,6 @@
      html[lang="ko"], so Hangul fell back to the Latin-only stack. */
   html[lang="ko"] body,
   html[lang="ko"] .contact-row,
-  html[lang="ko"] .competency-tag,
   html[lang="ko"] .competency-tag {
     font-family: 'DM Sans', 'Apple SD Gothic Neo', 'Malgun Gothic',
       'Noto Sans CJK KR', 'Noto Sans KR',
@@ -507,7 +506,6 @@
      zh-TW, and TC needs TC faces, not the Simplified stack above. */
   html[lang="zh-TW"] body,
   html[lang="zh-TW"] .contact-row,
-  html[lang="zh-TW"] .competency-tag,
   html[lang="zh-TW"] .competency-tag {
     font-family: 'DM Sans', 'PingFang TC', 'Microsoft JhengHei',
       'Noto Sans CJK TC', 'Noto Sans TC',
@@ -515,6 +513,28 @@
     line-break: strict;
     word-break: normal;
     overflow-wrap: break-word;
+  }
+
+  /* .header h1/.section-title/.job-company/.project-title set their own
+     font-family (Space Grotesk, see lines ~104/165/221/267), so the body
+     rule above can't reach them — same gap CodeRabbit flagged on #2616,
+     fixed the same way as the ja/zh-CN blocks below. */
+  html[lang="ko"] .header h1,
+  html[lang="ko"] .section-title,
+  html[lang="ko"] .job-company,
+  html[lang="ko"] .project-title {
+    font-family: 'Space Grotesk', 'Apple SD Gothic Neo', 'Malgun Gothic',
+      'Noto Sans CJK KR', 'Noto Sans KR',
+      'Nanum Gothic', sans-serif;
+  }
+
+  html[lang="zh-TW"] .header h1,
+  html[lang="zh-TW"] .section-title,
+  html[lang="zh-TW"] .job-company,
+  html[lang="zh-TW"] .project-title {
+    font-family: 'Space Grotesk', 'PingFang TC', 'Microsoft JhengHei',
+      'Noto Sans CJK TC', 'Noto Sans TC',
+      'Source Han Sans TC', sans-serif;
   }
 
   html[lang="zh-CN"] .header h1,
@@ -530,15 +550,37 @@
       'Source Han Sans SC', sans-serif;
   }
 
+  html[lang="ko"] .header h1,
+  html[lang="ko"] .section-title,
+  html[lang="ko"] .job-company,
+  html[lang="ko"] .project-title {
+    font-family: 'Space Grotesk', 'Apple SD Gothic Neo', 'Malgun Gothic',
+      'Noto Sans CJK KR', 'Noto Sans KR', 'Nanum Gothic', sans-serif;
+  }
+
+  html[lang="zh-TW"] .header h1,
+  html[lang="zh-TW"] .section-title,
+  html[lang="zh-TW"] .job-company,
+  html[lang="zh-TW"] .project-title {
+    font-family: 'Space Grotesk', 'PingFang TC', 'Microsoft JhengHei',
+      'Noto Sans CJK TC', 'Noto Sans TC', 'Source Han Sans TC', sans-serif;
+  }
+
   html[lang="zh-CN"] .summary-text,
   html[lang="zh"] .summary-text,
+  html[lang="ko"] .summary-text,
+  html[lang="zh-TW"] .summary-text,
   html[lang="zh-CN"] .job li,
-  html[lang="zh"] .job li {
+  html[lang="zh"] .job li,
+  html[lang="ko"] .job li,
+  html[lang="zh-TW"] .job li {
     line-height: 1.7;
   }
 
   html[lang="zh-CN"] .section-title,
-  html[lang="zh"] .section-title {
+  html[lang="zh"] .section-title,
+  html[lang="ko"] .section-title,
+  html[lang="zh-TW"] .section-title {
     letter-spacing: 0.03em;
   }
 </style>

--- a/templates/resume-template.html
+++ b/templates/resume-template.html
@@ -550,22 +550,6 @@
       'Source Han Sans SC', sans-serif;
   }
 
-  html[lang="ko"] .header h1,
-  html[lang="ko"] .section-title,
-  html[lang="ko"] .job-company,
-  html[lang="ko"] .project-title {
-    font-family: 'Space Grotesk', 'Apple SD Gothic Neo', 'Malgun Gothic',
-      'Noto Sans CJK KR', 'Noto Sans KR', 'Nanum Gothic', sans-serif;
-  }
-
-  html[lang="zh-TW"] .header h1,
-  html[lang="zh-TW"] .section-title,
-  html[lang="zh-TW"] .job-company,
-  html[lang="zh-TW"] .project-title {
-    font-family: 'Space Grotesk', 'PingFang TC', 'Microsoft JhengHei',
-      'Noto Sans CJK TC', 'Noto Sans TC', 'Source Han Sans TC', sans-serif;
-  }
-
   html[lang="zh-CN"] .summary-text,
   html[lang="zh"] .summary-text,
   html[lang="ko"] .summary-text,

--- a/templates/resume-template.html
+++ b/templates/resume-template.html
@@ -489,6 +489,34 @@
     overflow-wrap: break-word;
   }
 
+  /* === Korean typography === modes/ko/ ships as a locale but nothing matched
+     html[lang="ko"], so Hangul fell back to the Latin-only stack. */
+  html[lang="ko"] body,
+  html[lang="ko"] .contact-row,
+  html[lang="ko"] .competency-tag,
+  html[lang="ko"] .competency-tag {
+    font-family: 'DM Sans', 'Apple SD Gothic Neo', 'Malgun Gothic',
+      'Noto Sans CJK KR', 'Noto Sans KR',
+      'Nanum Gothic', sans-serif;
+    line-break: strict;
+    word-break: normal;
+    overflow-wrap: break-word;
+  }
+
+  /* === Traditional Chinese typography === html[lang="zh"] does not match
+     zh-TW, and TC needs TC faces, not the Simplified stack above. */
+  html[lang="zh-TW"] body,
+  html[lang="zh-TW"] .contact-row,
+  html[lang="zh-TW"] .competency-tag,
+  html[lang="zh-TW"] .competency-tag {
+    font-family: 'DM Sans', 'PingFang TC', 'Microsoft JhengHei',
+      'Noto Sans CJK TC', 'Noto Sans TC',
+      'Source Han Sans TC', sans-serif;
+    line-break: strict;
+    word-break: normal;
+    overflow-wrap: break-word;
+  }
+
   html[lang="zh-CN"] .header h1,
   html[lang="zh-CN"] .section-title,
   html[lang="zh-CN"] .job-company,


### PR DESCRIPTION
## The bug

`modes/ko/` and `modes/zh-TW/` both ship as supported locales, and `payload.lang` flows straight into `<html lang>` with no whitelist — but the CV templates only carried font blocks for `ja`, `zh`, `zh-CN` and `ar`.

A Korean CV therefore rendered with the Latin-only stack, and its Hangul came out as whatever the PDF engine happened to substitute. `build-cv-html` reported `"valid": true` and exited 0, because nothing was wrong as far as the pipeline could tell.

```
before:  selectors matching lang="ko"  →  0   (only the <html lang="ko"> tag itself)
after:   selectors matching lang="ko"  →  12
```

`zh-TW` is the same shape with an extra trap: `html[lang="zh"]` does **not** match `zh-TW`, so it fell back to the **Simplified** stack — which substitutes the *wrong glyph forms* rather than missing ones. That is harder to spot and worse on a CV than a visible tofu box.

## Fix

`ko` and `zh-TW` blocks mirroring the existing `ja`/`zh` ones, in `cv-template.html` and `resume-template.html`: Latin-capable faces first for stable ATS text extraction, then platform-native and open-source faces for the script —

- **Korean:** Apple SD Gothic Neo, Malgun Gothic, Noto Sans CJK KR, Noto Sans KR, Nanum Gothic
- **Traditional Chinese:** PingFang TC, Microsoft JhengHei, Noto Sans CJK TC, Noto Sans TC, Source Han Sans TC

I cloned each template's *existing* `zh` rule rather than hand-transcribing selectors, so the selector list matches whatever that template already uses — the three templates don't share one shape (`resume-template` uses a single combined rule and leads with `DM Sans`).

**`cv-template.zh-minimal.html` gets `zh-TW` only, on purpose.** Its default stack is already Simplified, so TC genuinely needs the override — but it is the Chinese *minimal* template, not a general one, and a Korean CV would not select it. Adding `ko` there would be speculative, so I didn't, and there's a comment saying why.

## Verification

A Korean payload through `build-cv-html` now matches 12 CSS rules and carries the Korean stack, where previously no selector matched `lang="ko"` at all.

`node test-all.mjs` → **3110 passed, 0 failed**.

No test added: this is a stylesheet-only change and the repo's CV coverage is the visual-regression harness (`test/cv-visual/`), whose baselines are `en`/`zh`. Adding `ko`/`zh-TW` baselines means committing new reference PNGs, which felt like a separate call for you to make — happy to add them if you want that coverage.

Filed directly per CONTRIBUTING.md (bug fix, no issue needed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved Korean and Traditional Chinese typography across CV and resume templates.
  * Added locale-specific font fallbacks for clearer character rendering.
  * Enhanced line breaking, word wrapping, line spacing, and heading readability.
  * Updated the minimal Chinese template with Traditional Chinese font support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->