### PR TITLE
fix(web): update vulnerable dependencies

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,7 +11,7 @@
         "@paper-design/shaders-react": "^0.0.78",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "js-yaml": "^4.2.0",
+        "js-yaml": "^4.3.1",
         "lucide-react": "^1.8.0",
         "next": "16.3.0",
         "playwright-core": "^1.61.0",
@@ -1653,9 +1653,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -2826,9 +2826,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/web/package.json
+++ b/web/package.json
@@ -14,7 +14,7 @@
     "@paper-design/shaders-react": "^0.0.78",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.1",
     "lucide-react": "^1.8.0",
     "next": "16.3.0",
     "playwright-core": "^1.61.0",


### PR DESCRIPTION
## Summary
- bump the web app's direct `js-yaml` dependency from `^4.2.0` to `^4.3.1`
- refresh the lockfile to use patched `js-yaml@4.3.1` and `nanoid@3.3.18`
- resolve GHSA-5p4m-2wfm-xmqj and GHSA-2v37-7h3g-55p8 reported by `npm audit`

## Validation
- `cd web && npm audit` - 0 vulnerabilities
- `npm run typecheck`
- `npm test` - 60 passed
- `npm run build`
- `node test-all.mjs --quick` - 3133 passed, 0 failed (2 expected warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the YAML processing dependency to a newer compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->