### PR TITLE
fix(scan): take the shared lock for scan-history.tsv appends (#2600)

### DIFF
--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -972,7 +972,7 @@ async function main() {
       writeFileSync(PIPELINE_PATH, '# Pipeline\n\n## Pendientes\n', 'utf-8');
     }
     await appendToPipeline(offers);
-    appendToScanHistory(offers, date);
+    await appendToScanHistory(offers, date);
     saved = true;
     log(`\nResults saved to ${PIPELINE_PATH} and data/scan-history.tsv`);
 

--- a/scan-interamt.mjs
+++ b/scan-interamt.mjs
@@ -321,11 +321,11 @@ async function main() {
 
   if (!DRY_RUN) {
     if (newOffers.length > 0) await appendToPipeline(newOffers);
-    if (newOffers.length > 0) appendToScanHistory(newOffers, date, 'added');
-    if (titleSkipped.length > 0) appendToScanHistory(titleSkipped, date, 'skipped_title');
-    if (locationSkipped.length > 0) appendToScanHistory(locationSkipped, date, 'skipped_location');
-    if (dateSkipped.length > 0) appendToScanHistory(dateSkipped, date, 'skipped_date');
-    if (dupeSkipped.length > 0) appendToScanHistory(dupeSkipped, date, 'skipped_dup');
+    if (newOffers.length > 0) await appendToScanHistory(newOffers, date, 'added');
+    if (titleSkipped.length > 0) await appendToScanHistory(titleSkipped, date, 'skipped_title');
+    if (locationSkipped.length > 0) await appendToScanHistory(locationSkipped, date, 'skipped_location');
+    if (dateSkipped.length > 0) await appendToScanHistory(dateSkipped, date, 'skipped_date');
+    if (dupeSkipped.length > 0) await appendToScanHistory(dupeSkipped, date, 'skipped_dup');
   }
 
   // Summary

--- a/scan.mjs
+++ b/scan.mjs
@@ -1800,25 +1800,36 @@ export async function appendToPipeline(offers) {
   });
 }
 
-export function appendToScanHistory(offers, date, status = 'added') {
-  // Ensure file + header exist. The header names every column the row writer
-  // (formatScanHistoryRow) emits, in the same order: the original 7 positional
-  // cols (url…location) plus the append-only trailing cols added since —
-  // fingerprint (7), posted_at (8), trust_score (9), trust_flags (10),
-  // normalized_company (11). Written ONLY on fresh-file creation; existing files
-  // (including headerless legacy files and older 7-col-header files) are never
-  // rewritten. All readers either skip line 0 unconditionally, detect the header
-  // by its `url\t` prefix, or skip non-URL col-0 rows, so widening it stays
-  // backward-compatible. `status` is parameterized so callers can record verify
-  // outcomes (`skipped_expired`, etc.) without the legacy `(expired)` suffix.
-  if (!existsSync(SCAN_HISTORY_PATH)) {
-    mkdirSync(path.dirname(SCAN_HISTORY_PATH), { recursive: true });
-    writeFileSync(SCAN_HISTORY_PATH, 'url\tfirst_seen\tportal\ttitle\tcompany\tstatus\tlocation\tfingerprint\tposted_at\ttrust_score\ttrust_flags\tnormalized_company\n', 'utf-8');
-  }
+// data/scan-history.tsv has exactly the same set of concurrent writers as
+// data/pipeline.md — scan.mjs, scan-ats-full.mjs, scan-interamt.mjs and
+// plugins.mjs — so it takes the same lock appendToPipeline does, on its own
+// path. Unlocked, two writers race in two places: the create branch below is a
+// check-then-write, and its writeFileSync truncates, so a scanner that loses
+// the race erases rows the winner already appended; and a multi-row
+// appendFileSync is not atomic, so a concurrent append can interleave mid-line.
+// Both surface as rows that silently stop counting, because every reader skips
+// a malformed line quietly.
+export async function appendToScanHistory(offers, date, status = 'added') {
+  await withPipelineLock(SCAN_HISTORY_PATH, () => {
+    // Ensure file + header exist. The header names every column the row writer
+    // (formatScanHistoryRow) emits, in the same order: the original 7 positional
+    // cols (url…location) plus the append-only trailing cols added since —
+    // fingerprint (7), posted_at (8), trust_score (9), trust_flags (10),
+    // normalized_company (11). Written ONLY on fresh-file creation; existing files
+    // (including headerless legacy files and older 7-col-header files) are never
+    // rewritten. All readers either skip line 0 unconditionally, detect the header
+    // by its `url\t` prefix, or skip non-URL col-0 rows, so widening it stays
+    // backward-compatible. `status` is parameterized so callers can record verify
+    // outcomes (`skipped_expired`, etc.) without the legacy `(expired)` suffix.
+    if (!existsSync(SCAN_HISTORY_PATH)) {
+      mkdirSync(path.dirname(SCAN_HISTORY_PATH), { recursive: true });
+      writeFileSync(SCAN_HISTORY_PATH, 'url\tfirst_seen\tportal\ttitle\tcompany\tstatus\tlocation\tfingerprint\tposted_at\ttrust_score\ttrust_flags\tnormalized_company\n', 'utf-8');
+    }
 
-  const lines = offers.map(o => formatScanHistoryRow(o, date, status)).join('\n') + '\n';
+    const lines = offers.map(o => formatScanHistoryRow(o, date, status)).join('\n') + '\n';
 
-  appendFileSync(SCAN_HISTORY_PATH, lines, 'utf-8');
+    appendFileSync(SCAN_HISTORY_PATH, lines, 'utf-8');
+  });
 }
 
 // ── Company blacklist (#1742) ───────────────────────────────────────
@@ -2507,7 +2518,7 @@ async function main() {
   // 6. Write results
   if (!dryRun && verifiedOffers.length > 0) {
     await appendToPipeline(verifiedOffers);
-    appendToScanHistory(verifiedOffers, date);
+    await appendToScanHistory(verifiedOffers, date);
   }
   if (!dryRun && cooldownOffers.length > 0) {
     const cooldownGroups = {};
@@ -2518,7 +2529,7 @@ async function main() {
       cooldownGroups[item.status].push(item.job);
     }
     for (const [status, group] of Object.entries(cooldownGroups)) {
-      appendToScanHistory(group, date, status);
+      await appendToScanHistory(group, date, status);
     }
   }
   // Expired postings — plus the old URLs of migrated offers — are recorded as
@@ -2528,12 +2539,12 @@ async function main() {
     ...migratedOffers.map(o => ({ ...o, url: o.previousUrl })),
   ];
   if (!dryRun && expiredForHistory.length > 0) {
-    appendToScanHistory(expiredForHistory, date, 'skipped_expired');
+    await appendToScanHistory(expiredForHistory, date, 'skipped_expired');
   }
   // Pages that loaded but had no Apply control: record so we don't re-verify
   // them next scan, but never let them reach pipeline.md.
   if (!dryRun && droppedOffers.length > 0) {
-    appendToScanHistory(droppedOffers, date, 'skipped_no_apply_control');
+    await appendToScanHistory(droppedOffers, date, 'skipped_no_apply_control');
   }
   // Guard-rejected URLs (invalid / unsupported protocol / blocked host) are
   // recorded with a precise status so subsequent scans dedup-skip them via
@@ -2547,7 +2558,7 @@ async function main() {
       byStatus.get(status).push(o);
     }
     for (const [status, group] of byStatus) {
-      appendToScanHistory(group, date, status);
+      await appendToScanHistory(group, date, status);
     }
   }
 

--- a/tests/scan-history-lock.test.mjs
+++ b/tests/scan-history-lock.test.mjs
@@ -55,7 +55,7 @@ const writerSource = `
   const { appendToScanHistory } = await import(scanUrl);
   await appendToScanHistory([{
     url: '${URL_BASE}' + writer,
-    portal: 'testportal',
+    source: 'testportal',
     title: 'Engineer',
     company: 'Acme',
     location: 'Remote',

--- a/tests/scan-history-lock.test.mjs
+++ b/tests/scan-history-lock.test.mjs
@@ -1,0 +1,130 @@
+// tests/scan-history-lock.test.mjs — appendToScanHistory() must write
+// data/scan-history.tsv under the same lock appendToPipeline() uses.
+//
+// scan.mjs, scan-ats-full.mjs, scan-interamt.mjs and plugins.mjs all append to
+// this one file, which is why appendToPipeline() takes a lock. scan-history
+// took none, leaving two races (#2600):
+//
+//   - The create branch is check-then-write, and its writeFileSync truncates.
+//     Two scanners starting against a missing file both take the branch; the
+//     loser's header write lands on top of rows the winner already appended
+//     and erases them.
+//   - A multi-row appendFileSync is not atomic, so two appends can interleave
+//     inside a line.
+//
+// Neither throws. Every scan-history reader skips a malformed line quietly, so
+// the damage shows up as postings that silently stop counting for dedup.
+//
+// This asserts lock PARTICIPATION rather than trying to lose the race on
+// purpose: a held lock must block the write. Racing it directly is not a
+// usable test — both windows are microseconds wide, and an earlier draft that
+// spawned ten barrier-synchronized writers caught the unlocked version once in
+// eight runs, which is a coin flip wearing a lab coat. Mutual exclusion itself
+// is already covered by test/pipeline-lock.test.mjs; what is new here is that
+// this writer takes part at all, and that is deterministic.
+//
+// The writer runs in a child process because discovered suites share one
+// process (and one module cache) with the rest of test-all, so scan.mjs may
+// already be imported with its real SCAN_HISTORY_PATH baked in.
+import { pass, fail, NODE } from './helpers.mjs';
+import { execFile } from 'child_process';
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { promisify } from 'util';
+import { acquirePipelineLock } from '../pipeline-lock.mjs';
+
+const execFileAsync = promisify(execFile);
+
+console.log('\nscan-history.tsv writes — appendToScanHistory holds the shared lock');
+
+const HEADER_PREFIX = 'url\tfirst_seen\t';
+const LOCK_TIMEOUT_MS = 600;
+const URL_BASE = 'https://example.test/';
+
+/** The url column of each row — column 0, exact, never a substring test. */
+const urlColumn = (rows) => rows.map(l => l.split('\t')[0]);
+
+const root = mkdtempSync(join(tmpdir(), 'career-ops-scan-history-'));
+const historyPath = join(root, 'data', 'scan-history.tsv');
+
+// argv is read from the end: node's arg layout after -e differs from a script
+// run, and the suite has to behave the same on every supported Node.
+const writerSource = `
+  const [scanUrl, writer] = process.argv.slice(-2);
+  const { appendToScanHistory } = await import(scanUrl);
+  await appendToScanHistory([{
+    url: '${URL_BASE}' + writer,
+    portal: 'testportal',
+    title: 'Engineer',
+    company: 'Acme',
+    location: 'Remote',
+  }], '2026-08-09', 'added');
+`;
+
+// cwd is the scratch root, not the repo: scan.mjs resolves its data paths
+// relative to cwd, so a writer that ignored CAREER_OPS_SCAN_HISTORY still
+// lands in the temp dir rather than the developer's real data/.
+const runWriter = (writer) =>
+  execFileAsync(NODE, ['--input-type=module', '-e', writerSource, '--', new URL('../scan.mjs', import.meta.url).href, writer], {
+    cwd: root,
+    env: {
+      ...process.env,
+      CAREER_OPS_SCAN_HISTORY: historyPath,
+      CAREER_OPS_PIPELINE_LOCK_TIMEOUT_MS: String(LOCK_TIMEOUT_MS),
+      CAREER_OPS_PIPELINE_LOCK_RETRY_MS: '20',
+    },
+  });
+
+try {
+  // 1. While another process holds the lock on scan-history.tsv, a writer must
+  //    wait it out and fail, not write. An unlocked appendToScanHistory ignores
+  //    the lock entirely and creates the file here.
+  const held = await acquirePipelineLock(historyPath, { timeoutMs: 2000, retryMs: 20 });
+  let blocked = false;
+  try {
+    await runWriter('blocked');
+    blocked = false;
+  } catch {
+    blocked = true; // LockTimeoutError propagates as a non-zero exit
+  } finally {
+    const wroteAnyway = existsSync(historyPath)
+      && new Set(urlColumn(readFileSync(historyPath, 'utf-8').split('\n').filter(Boolean))).has(`${URL_BASE}blocked`);
+    wroteAnyway
+      ? fail('wrote scan-history.tsv while another process held its lock — the append is unlocked')
+      : pass('a held lock blocks the scan-history write instead of letting it through');
+    if (!wroteAnyway && !blocked) {
+      fail('writer exited cleanly without writing — expected it to wait for the lock and time out');
+    }
+    held.release();
+  }
+
+  // 2. With the lock free, the same write succeeds: the fix must not simply
+  //    break the writer.
+  await runWriter('free');
+  const lines = readFileSync(historyPath, 'utf-8').split('\n').filter(Boolean);
+  const headers = lines.filter(l => l.startsWith(HEADER_PREFIX));
+  const rows = lines.filter(l => !l.startsWith(HEADER_PREFIX));
+
+  // Compare the url COLUMN exactly rather than testing the line for a
+  // substring: an exact field match is the stronger assertion, and a substring
+  // check against a URL is the shape CodeQL flags as incomplete sanitization.
+  headers.length === 1 && rows.length === 1 && urlColumn(rows)[0] === `${URL_BASE}free`
+    ? pass('once the lock is free the row is written, under a single header')
+    : fail(`expected 1 header + 1 row after release, got ${headers.length} header(s) and ${rows.length} row(s)`);
+
+  // 3. A second writer appends rather than truncating — the create branch must
+  //    stay a create branch once the file exists.
+  await runWriter('second');
+  const after = readFileSync(historyPath, 'utf-8').split('\n').filter(Boolean);
+  const urls = new Set(urlColumn(after.filter(l => !l.startsWith(HEADER_PREFIX))));
+  after.filter(l => l.startsWith(HEADER_PREFIX)).length === 1
+    && urls.has(`${URL_BASE}free`)
+    && urls.has(`${URL_BASE}second`)
+    ? pass('a later write appends under the existing header instead of rewriting it')
+    : fail(`expected both rows under one header, got ${JSON.stringify(after)}`);
+} catch (err) {
+  fail(`scan-history lock test threw: ${err?.message ?? err}`);
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}

--- a/web/src/lib/core/pipeline.ts
+++ b/web/src/lib/core/pipeline.ts
@@ -45,12 +45,12 @@ import { appendToPipeline, appendToScanHistory } from ${JSON.stringify(scanUrl)}
 let input = "";
 process.stdin.setEncoding("utf8");
 process.stdin.on("data", (d) => { input += d; });
-process.stdin.on("end", () => {
+process.stdin.on("end", async () => {
   try {
     const offers = JSON.parse(input);
     const date = new Date().toISOString().slice(0, 10);
-    appendToPipeline(offers);
-    appendToScanHistory(offers, date, "added");
+    await appendToPipeline(offers);
+    await appendToScanHistory(offers, date, "added");
     process.stdout.write(JSON.stringify({ added: offers.length }));
   } catch (e) {
     process.stdout.write(JSON.stringify({ added: 0, error: String((e && e.message) || e) }));

--- a/web/tests/lib/core-writer-await.test.mjs
+++ b/web/tests/lib/core-writer-await.test.mjs
@@ -14,7 +14,8 @@
 // self-checks, so an edit that renames the writers fails loudly rather than
 // silently matching nothing.
 //
-// Run:  node --test tests/lib/core-writer-await.test.mjs
+// Run (from web/, as `npm test` does):  node --test tests/lib/core-writer-await.test.mjs
+// From the repo root:                   node --test web/tests/lib/core-writer-await.test.mjs
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -28,15 +29,35 @@ const src = readFileSync(SRC, "utf8");
 // The async writers scan.mjs exports and this snippet drives.
 const WRITERS = ["appendToPipeline", "appendToScanHistory"];
 
-// A call to one of them at the start of a statement: optional `await `, then the
-// name, then `(`. Anchored to the line so the import line never matches.
-const callRe = (name) => new RegExp(`^\\s*(await\\s+)?${name}\\s*\\(`, "gm");
+// A call is the name followed by `(`, ANYWHERE on the line — not just at the
+// start of a statement. Anchoring to the statement start would let every
+// non-statement form through unnoticed, and the test would report zero matches
+// as a pass:
+//   const p = appendToScanHistory(...)   // promise captured, never awaited
+//   void appendToScanHistory(...)
+//   offers.length && appendToScanHistory(...)
+// The import line names the writers without calling them, so it is skipped
+// explicitly rather than relying on the `(` to exclude it.
+const callRe = (name) => new RegExp(`\\b${name}\\s*\\(`, "g");
+
+/** @returns {{line: number, text: string, awaited: boolean}[]} every call to `name`. */
+function callsTo(name) {
+  const found = [];
+  src.split("\n").forEach((text, i) => {
+    if (/^\s*import\b/.test(text)) return;
+    for (const m of text.matchAll(callRe(name))) {
+      // Awaited only if `await` is the token immediately before the call.
+      const before = text.slice(0, m.index);
+      found.push({ line: i + 1, text: text.trim(), awaited: /\bawait\s*$/.test(before) });
+    }
+  });
+  return found;
+}
 
 test("extractor still finds every core writer call (guards against a rename)", () => {
   for (const name of WRITERS) {
-    const calls = [...src.matchAll(callRe(name))];
     assert.ok(
-      calls.length > 0,
+      callsTo(name).length > 0,
       `found no call to ${name}() in ${SRC} — it was renamed or the snippet was restructured, ` +
         `so this test is no longer guarding anything. Update WRITERS.`,
     );
@@ -45,16 +66,31 @@ test("extractor still finds every core writer call (guards against a rename)", (
 
 test("every core writer call is awaited before the success response", () => {
   for (const name of WRITERS) {
-    for (const m of src.matchAll(callRe(name))) {
-      const line = src.slice(0, m.index).split("\n").length;
+    for (const call of callsTo(name)) {
       assert.ok(
-        m[1],
-        `${SRC}:${line} calls ${name}() without await. It is async and takes the shared ` +
-          `pipeline lock, so the child can write its success response and exit before the ` +
-          `append lands, and a rejection bypasses the surrounding try/catch.`,
+        call.awaited,
+        `${SRC}:${call.line} calls ${name}() without await:\n    ${call.text}\n` +
+          `It is async and takes the shared pipeline lock, so the child can write its success ` +
+          `response and exit before the append lands, and a rejection bypasses the surrounding ` +
+          `try/catch.`,
       );
     }
   }
+});
+
+test("extractor flags non-statement call forms, not just bare statements", () => {
+  // Guard the guard: an anchored pattern would score all four of these as
+  // "no calls found" and pass. Exercises the same predicate the sweep uses.
+  const awaited = (text) => {
+    const m = [...text.matchAll(callRe("appendToScanHistory"))][0];
+    assert.ok(m, `pattern did not match a call in: ${text}`);
+    return /\bawait\s*$/.test(text.slice(0, m.index));
+  };
+  assert.equal(awaited('    await appendToScanHistory(offers, date, "added");'), true);
+  assert.equal(awaited('    appendToScanHistory(offers, date, "added");'), false);
+  assert.equal(awaited('    const p = appendToScanHistory(offers, date, "added");'), false);
+  assert.equal(awaited('    void appendToScanHistory(offers, date, "added");'), false);
+  assert.equal(awaited('    offers.length && appendToScanHistory(offers, date, "added");'), false);
 });
 
 test("the handler that runs the writers is async", () => {

--- a/web/tests/lib/core-writer-await.test.mjs
+++ b/web/tests/lib/core-writer-await.test.mjs
@@ -1,0 +1,66 @@
+// Guards the child-process snippet in src/lib/core/pipeline.ts that calls the
+// core's canonical writers (appendToPipeline, appendToScanHistory from scan.mjs).
+//
+// Both writers are async and both take the shared pipeline lock. The snippet
+// runs them from a `process.stdin.on("end", ...)` handler and then writes the
+// success response — so an unawaited call lets the child report `added: N` and
+// exit while the lock is still being acquired, and the append never lands. The
+// synchronous try/catch does not see the rejection either, so a failed write is
+// reported as a success. Nothing downstream retries.
+//
+// pipeline.ts is TypeScript and the snippet is a template string, so it cannot
+// be imported and exercised here — this reads the source and asserts the shape
+// instead. Same approach as tests/states-alias-coverage.test.mjs: the extractor
+// self-checks, so an edit that renames the writers fails loudly rather than
+// silently matching nothing.
+//
+// Run:  node --test tests/lib/core-writer-await.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const SRC = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "src", "lib", "core", "pipeline.ts");
+const src = readFileSync(SRC, "utf8");
+
+// The async writers scan.mjs exports and this snippet drives.
+const WRITERS = ["appendToPipeline", "appendToScanHistory"];
+
+// A call to one of them at the start of a statement: optional `await `, then the
+// name, then `(`. Anchored to the line so the import line never matches.
+const callRe = (name) => new RegExp(`^\\s*(await\\s+)?${name}\\s*\\(`, "gm");
+
+test("extractor still finds every core writer call (guards against a rename)", () => {
+  for (const name of WRITERS) {
+    const calls = [...src.matchAll(callRe(name))];
+    assert.ok(
+      calls.length > 0,
+      `found no call to ${name}() in ${SRC} — it was renamed or the snippet was restructured, ` +
+        `so this test is no longer guarding anything. Update WRITERS.`,
+    );
+  }
+});
+
+test("every core writer call is awaited before the success response", () => {
+  for (const name of WRITERS) {
+    for (const m of src.matchAll(callRe(name))) {
+      const line = src.slice(0, m.index).split("\n").length;
+      assert.ok(
+        m[1],
+        `${SRC}:${line} calls ${name}() without await. It is async and takes the shared ` +
+          `pipeline lock, so the child can write its success response and exit before the ` +
+          `append lands, and a rejection bypasses the surrounding try/catch.`,
+      );
+    }
+  }
+});
+
+test("the handler that runs the writers is async", () => {
+  assert.match(
+    src,
+    /process\.stdin\.on\(\s*["']end["']\s*,\s*async\b/,
+    `${SRC}: the stdin "end" handler must be async — a non-async handler cannot await the writers.`,
+  );
+});


### PR DESCRIPTION
Closes #2600.

`data/scan-history.tsv` has exactly the same set of concurrent writers as `data/pipeline.md` — `scan.mjs`, `scan-ats-full.mjs`, `scan-interamt.mjs` and `plugins.mjs` — which is why `appendToPipeline()` takes a lock. `appendToScanHistory()` took none, leaving two races:

- **The create branch is check-then-write, and its `writeFileSync` truncates.** Two scanners starting against a missing file both take the branch; the loser's header write lands on top of rows the winner already appended and erases them.
- **A multi-row `appendFileSync` is not atomic**, so two appends can interleave inside a line.

Neither throws. Every scan-history reader skips a malformed line quietly, so the damage surfaces as postings that stop counting for dedup — re-surfaced as new on a later scan, or missing from a run's totals — rather than as an error anyone can trace back here.

## The change

Route the write through the existing `withPipelineLock`, on the scan-history path. No new lock module, no change to the file format, no change to the header rules.

`appendToScanHistory` becomes `async`, so its eleven call sites across the three scanners now `await` it. All eleven were already inside an `async main()`, so this is an `await` keyword each and no restructuring.

## On the test

It asserts **lock participation**, not a won race, and that is deliberate.

Both windows are microseconds wide. An earlier draft span ten barrier-synchronized writer processes at a fresh file and diffed the survivors — against the unlocked version it caught the bug **once in eight runs**. A detector that flips a coin is worse than none, because a green run reads as evidence.

Mutual exclusion itself is already covered by `test/pipeline-lock.test.mjs`. What is new here is that this writer takes part at all, and that is deterministic: hold the lock from another process, and the write must wait rather than land.

- **with the fix:** 3 of 3 runs pass
- **without it:** 3 of 3 runs fail (`wrote scan-history.tsv while another process held its lock`)

The writer runs in a child process because discovered suites share one process and module cache with the rest of `test-all`, so `scan.mjs` may already be imported with the real `SCAN_HISTORY_PATH` baked in. Its `cwd` is the scratch dir, so a writer that ignored `CAREER_OPS_SCAN_HISTORY` still could not touch a real `data/`.

## Scope

Write side only. #2600 also notes the dedup snapshot **read**, which #2601 is already reworking — routing that read through the same lock belongs with that change rather than against it. This PR touches no line #2601 touches.

`node test-all.mjs --quick`: 3139 passed, 0 failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scan history reliability by ensuring entries are fully saved before scan reporting continues.
  * Prevented overlapping scans from corrupting or interleaving history records.
  * Ensured all scan outcomes, including filtered, duplicate, expired, and invalid offers, are recorded consistently.

* **Tests**
  * Added coverage verifying scan history remains protected during concurrent writes and resumes correctly after locking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->