### PR TITLE
fix: render numeric year/date scalars in the CV instead of dropping them

### DIFF
--- a/build-cv-html.mjs
+++ b/build-cv-html.mjs
@@ -64,8 +64,12 @@ const DEFAULT_SECTION_TITLES = {
 // (e.g. "R&D", "scaled 10x < budget", 'the "north star" metric') render as
 // literal text instead of breaking the document or injecting tags.
 function escapeHtml(text) {
-  if (typeof text !== 'string') return '';
-  return text
+  // Blank out only truly absent/structural values. A number or boolean scalar
+  // (e.g. a payload with `year: 2024` instead of `"2024"`) must render its value,
+  // not vanish: the old `typeof text !== 'string' → ''` guard silently dropped
+  // numeric years/dates from the CV while `present` stayed true.
+  if (text === null || text === undefined || typeof text === 'object') return '';
+  return String(text)
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')

--- a/tests/cv-numeric-scalars.test.mjs
+++ b/tests/cv-numeric-scalars.test.mjs
@@ -1,0 +1,60 @@
+// tests/cv-numeric-scalars.test.mjs — a numeric scalar in the CV payload must
+// render its value, not be silently dropped.
+//
+// escapeHtml() used to `return ''` for anything that was not a string, so a
+// machine-authored payload with `year: 2024` (a number, not "2024") rendered an
+// EMPTY edu-year / cert-year / job-period while `present` stayed true — the CV
+// shipped with employment dates and graduation/certification years missing, and
+// the builder still exited 0 with `"valid": true`. Coercing scalars via String()
+// fixes it. End-to-end through the real builder and the shipped default template,
+// because build-cv-html.mjs exports nothing.
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { pass, fail, run, NODE, ROOT, lastRunFailure } from './helpers.mjs';
+
+console.log('\nbuild-cv-html.mjs — numeric year/date scalars render instead of vanishing');
+
+// Numbers on purpose: year and dates as JSON numbers, not strings.
+const PAYLOAD = {
+  lang: 'en',
+  page_format: 'letter',
+  candidate: { name: 'Numeric Scalars', email: 'num@example.com' },
+  summary: 'Summary.',
+  competencies: ['Competency'],
+  experience: [{ company: 'Corp', role: 'Engineer', dates: 2024, bullets: ['Did a thing'] }],
+  education: [{ title: 'BSc Computing', year: 2019 }],
+  certifications: [{ title: 'AWS SAA', year: 2025 }],
+};
+
+const dir = mkdtempSync(join(tmpdir(), 'cv-numeric-'));
+try {
+  const input = join(dir, 'num.json');
+  const output = join(dir, 'num.html');
+  writeFileSync(input, JSON.stringify(PAYLOAD));
+
+  if (run(NODE, [join(ROOT, 'build-cv-html.mjs'), input, output]) === null) {
+    const f = lastRunFailure();
+    fail(`build-cv-html.mjs crashed (exit ${f?.status}) - ${(f?.stderr || '').trim().split('\n').pop()}`);
+  } else if (!existsSync(output)) {
+    fail('build-cv-html.mjs exited 0 but wrote no output file');
+  } else {
+    const html = readFileSync(output, 'utf-8');
+    const cell = (cls) => {
+      const m = html.match(new RegExp(`<span class="${cls}">([\\s\\S]*?)</span>|<div class="${cls}">([\\s\\S]*?)</div>`));
+      return m ? (m[1] ?? m[2] ?? '').trim() : null;
+    };
+    const cases = [
+      ['edu-year', '2019'],
+      ['cert-year', '2025'],
+      ['job-period', '2024'],
+    ];
+    for (const [cls, want] of cases) {
+      const got = cell(cls);
+      if (got === want) pass(`${cls} renders ${want} from a numeric payload value`);
+      else fail(`${cls}: expected "${want}", got ${got === null ? '(no such cell)' : `"${got}"`}`);
+    }
+  }
+} finally {
+  try { rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+}


### PR DESCRIPTION
## The bug

A CV payload with a numeric scalar (`year: 2024` instead of `"2024"`) renders with the value missing. `escapeHtml()` in `build-cv-html.mjs` returns `''` for any non-string, so a bare number hits the typeof guard and comes out as an empty `edu-year` / `cert-year` / `job-period`. The `present` flag stays true, so the block still renders, and the CV ships with graduation years, certification years and employment dates blank while the builder exits 0 with `"valid": true`. The unresolved-placeholder guard can't catch this one: the placeholder was replaced, just with an empty string.

Hand-written YAML rarely triggers it because people quote their dates without thinking. Anything machine-authored does: a YAML emitter round-tripping the payload, or an agent writing the file, will produce `year: 2024` unquoted, and YAML parses that as a number.

## The fix

Coerce scalars through `String()` and blank out only `null`/`undefined`/objects, so numbers and booleans render their value. Two-line change in the escape path.

Regression test drives the real builder with numeric year/date fields and asserts the values appear in the rendered HTML. Fails on main, passes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Numeric and boolean values now render correctly in generated CVs instead of being omitted.
  * Null, undefined, and unsupported object values continue to be excluded from output.

* **Tests**
  * Added end-to-end coverage for numeric dates and years in experience, education, and certification sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->