### PR TITLE
feat(scan): record failed runs in scan-runs.tsv so trends exclude survivorship bias

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -2357,8 +2357,10 @@ async function main() {
   const emptyTargets = [];
 
   // Arm the failure-path row (#2643) now that the sweep is about to start and
-  // every counter it reads is in scope. new_added stays 0 on a failed run:
-  // the sweep hadn't reached the point where that count is final.
+  // every counter it reads is in scope. new_added is hardcoded 0 on a failed
+  // run even if the sweep added postings before dying (the count isn't settled
+  // mid-sweep). Excluded from trend averages so it can't skew them, but a
+  // raw-TSV reader should treat that 0 as a sentinel, not a true count.
   if (!dryRun) {
     registerRunFailureSnapshot(() => ({
       timestamp: new Date().toISOString(),

--- a/scan.mjs
+++ b/scan.mjs
@@ -1887,11 +1887,36 @@ const SCAN_RUNS_PATH = 'data/scan-runs.tsv';
 
 // One row of run counters per non-dry scan — today these numbers are printed
 // once in the summary and lost when the terminal scrolls. Full ISO timestamp
-// (two scans in one day must not collapse). `status` is reserved: always
-// 'completed' in v1; a follow-up wires failure-path writes so trend stats can
-// exclude survivorship bias. Consumers MUST parse by header name, never by
-// position — columns may be appended in later versions.
+// (two scans in one day must not collapse). `status` is 'completed' for a
+// finished run; a run that dies after the sweep starts records 'failed' via
+// writeRunFailureRow (#2643) so trend stats can exclude survivorship bias.
+// Consumers MUST parse by header name, never by position — columns may be
+// appended in later versions.
 export const SCAN_RUNS_HEADER = 'timestamp\tstatus\tcompanies\tboards\tfound\tfiltered_title\tfiltered_tier\tfiltered_location\tfiltered_posting_age\tfiltered_salary\tfiltered_content\tfiltered_cooldown\tdupes\tnew_added\terrors\tfiltered_blacklist\tfiltered_visa\tfiltered_posted_date\tfiltered_country_eligibility\n';
+
+// Failure-path writes (#2643). main() registers a snapshot closure once the
+// sweep's counters exist (never on --dry-run, never before the sweep starts —
+// a config error is not a run). The fatal catch and the SIGINT handler both
+// call writeRunFailureRow; the snapshot is consumed on first use so the two
+// signals can never double-write. Best-effort by design: a failure to record
+// the failure must not mask the original error, so everything is swallowed.
+let runFailureSnapshot = null;
+
+export function registerRunFailureSnapshot(fn) {
+  runFailureSnapshot = typeof fn === 'function' ? fn : null;
+}
+
+export function writeRunFailureRow(status = 'failed', filePath = SCAN_RUNS_PATH) {
+  const snapshot = runFailureSnapshot;
+  runFailureSnapshot = null;
+  if (!snapshot) return false;
+  try {
+    appendScanRunSummary({ ...snapshot(), status }, filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 export function appendScanRunSummary(c, filePath = SCAN_RUNS_PATH) {
   if (!existsSync(filePath)) writeFileSync(filePath, SCAN_RUNS_HEADER, 'utf-8');
@@ -2330,6 +2355,30 @@ async function main() {
   const newOffers = [];
   const errors = [...resolveErrors];
   const emptyTargets = [];
+
+  // Arm the failure-path row (#2643) now that the sweep is about to start and
+  // every counter it reads is in scope. new_added stays 0 on a failed run:
+  // the sweep hadn't reached the point where that count is final.
+  if (!dryRun) {
+    registerRunFailureSnapshot(() => ({
+      timestamp: new Date().toISOString(),
+      companies: targets.filter(t => !t._isBoard).length,
+      boards: targets.filter(t => t._isBoard).length,
+      found: totalFound, filteredTitle: totalFilteredTitle, filteredTier: totalFilteredTier,
+      filteredLocation: totalFilteredLocation, filteredPostingAge: totalFilteredPostingAge,
+      filteredSalary: totalFilteredSalary, filteredContent: totalFilteredContent,
+      filteredCooldown: totalFilteredCooldown, dupes: totalDupes, newAdded: 0,
+      errors: errors.length, filteredBlacklist: totalFilteredBlacklist,
+      filteredVisa: totalFilteredVisa, filteredPostedDate: totalFilteredPostedDate,
+      filteredCountryEligibility: totalFilteredCountryEligibility,
+    }));
+    // Ctrl-C mid-sweep is the common abort. Best effort: record, then die
+    // with the conventional SIGINT code.
+    process.once('SIGINT', () => {
+      writeRunFailureRow('failed');
+      process.exit(130);
+    });
+  }
 
   const tasks = targets.map(company => async () => {
     let provider = company._provider;
@@ -2770,6 +2819,8 @@ async function main() {
       filteredCountryEligibility: totalFilteredCountryEligibility,
     });
   }
+  // The run completed (or was a dry run) — disarm the failure row.
+  registerRunFailureSnapshot(null);
 
   console.log(`\n→ Run /career-ops pipeline to evaluate new offers.`);
   console.log('→ Share results and get help: https://discord.gg/8pRpHETxa4');
@@ -2797,6 +2848,7 @@ async function main() {
 if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
   main().catch(err => {
     console.error('Fatal:', err.message);
+    writeRunFailureRow('failed');
     process.exit(1);
   });
 }

--- a/stats.mjs
+++ b/stats.mjs
@@ -391,6 +391,13 @@ export function computeRunStats(content) {
   // status a future scan.mjs writes is excluded from trend averages until
   // this aggregator learns what it means. Rows from pre-status files default
   // to 'completed' above, so old data keeps counting.
+  //
+  // No-op on today's data: scan.mjs only ever writes 'completed' or 'failed',
+  // and both predicates ('!== failed' vs '=== completed') agree on those two.
+  // The switch is a guard for a future third status (e.g. 'aborted'), not a
+  // behavior change now. One edge is reachable only by hand-editing the TSV:
+  // an explicitly empty status flips from counted to failedRuns, since
+  // appendScanRunSummary always writes a non-empty status.
   const completed = rows.filter((r) => r.status === 'completed');
   const sum = (arr, k) => arr.reduce((a, r) => a + r[k], 0);
   return {

--- a/stats.mjs
+++ b/stats.mjs
@@ -387,7 +387,11 @@ export function computeRunStats(content) {
     });
   }
   if (rows.length === 0) return null;
-  const completed = rows.filter((r) => r.status !== 'failed');
+  // Inclusion by 'completed', not exclusion by known failure names: any
+  // status a future scan.mjs writes is excluded from trend averages until
+  // this aggregator learns what it means. Rows from pre-status files default
+  // to 'completed' above, so old data keeps counting.
+  const completed = rows.filter((r) => r.status === 'completed');
   const sum = (arr, k) => arr.reduce((a, r) => a + r[k], 0);
   return {
     totalRuns: rows.length,

--- a/tests/scan-run-failure.test.mjs
+++ b/tests/scan-run-failure.test.mjs
@@ -1,0 +1,81 @@
+// Failure-path writes for scan-runs.tsv (#2643): a run that dies after the
+// sweep has started must leave a `failed` row carrying the counters
+// accumulated so far, so stats.mjs trends can exclude it instead of never
+// seeing it (survivorship bias). Dry runs and pre-sweep exits register no
+// snapshot, so they keep leaving no trace.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const scan = await import(pathToFileURL(join(ROOT, 'scan.mjs')).href);
+const stats = await import(pathToFileURL(join(ROOT, 'stats.mjs')).href);
+
+const COUNTERS = {
+  timestamp: '2026-08-09T10:00:00Z',
+  companies: 40, boards: 2, found: 123,
+  filteredTitle: 5, filteredTier: 0, filteredLocation: 1, filteredPostingAge: 0,
+  filteredSalary: 0, filteredContent: 0, filteredCooldown: 0,
+  dupes: 7, newAdded: 0, errors: 3,
+  filteredBlacklist: 0, filteredVisa: 0, filteredPostedDate: 0,
+  filteredCountryEligibility: 0,
+};
+
+test('writeRunFailureRow appends a failed row from the registered snapshot, once', () => {
+  const file = join(mkdtempSync(join(tmpdir(), 'scanruns-')), 'scan-runs.tsv');
+  scan.registerRunFailureSnapshot(() => ({ ...COUNTERS }));
+  assert.equal(scan.writeRunFailureRow('failed', file), true);
+
+  const lines = readFileSync(file, 'utf-8').trim().split('\n');
+  assert.equal(lines.length, 2, 'header + exactly one row');
+  const header = lines[0].split('\t');
+  const cols = lines[1].split('\t');
+  const cell = (name) => cols[header.indexOf(name)];
+  assert.equal(cell('status'), 'failed');
+  assert.equal(cell('found'), '123');
+  assert.equal(cell('new_added'), '0');
+  assert.equal(cell('errors'), '3');
+
+  // The snapshot is consumed: a second failure signal (e.g. SIGINT handler
+  // followed by the fatal catch) must not double-write.
+  assert.equal(scan.writeRunFailureRow('failed', file), false);
+  assert.equal(readFileSync(file, 'utf-8').trim().split('\n').length, 2);
+});
+
+test('writeRunFailureRow is a no-op when no snapshot is registered', () => {
+  const file = join(mkdtempSync(join(tmpdir(), 'scanruns-')), 'scan-runs.tsv');
+  assert.equal(scan.writeRunFailureRow('failed', file), false);
+  assert.equal(existsSync(file), false, 'no file created for an unregistered run');
+});
+
+test('clearing the snapshot (success path) disarms the failure write', () => {
+  const file = join(mkdtempSync(join(tmpdir(), 'scanruns-')), 'scan-runs.tsv');
+  scan.registerRunFailureSnapshot(() => ({ ...COUNTERS }));
+  scan.registerRunFailureSnapshot(null);
+  assert.equal(scan.writeRunFailureRow('failed', file), false);
+  assert.equal(existsSync(file), false);
+});
+
+test('a throwing snapshot never masks the original failure', () => {
+  const file = join(mkdtempSync(join(tmpdir(), 'scanruns-')), 'scan-runs.tsv');
+  scan.registerRunFailureSnapshot(() => { throw new Error('counters gone'); });
+  assert.equal(scan.writeRunFailureRow('failed', file), false, 'best-effort: swallowed');
+  assert.equal(existsSync(file), false);
+});
+
+test('computeRunStats excludes any non-completed status from averages, counts it in failedRuns', () => {
+  const tsv = [
+    'timestamp\tstatus\tcompanies\tboards\tfound\tfiltered_title\tdupes\tnew_added\terrors',
+    '2026-08-01T09:00:00Z\tcompleted\t40\t2\t100\t10\t5\t8\t0',
+    '2026-08-02T09:00:00Z\tfailed\t40\t2\t3\t0\t0\t0\t1',
+    '2026-08-03T09:00:00Z\taborted\t40\t2\t7\t0\t0\t0\t0',
+  ].join('\n') + '\n';
+  const r = stats.computeRunStats(tsv);
+  assert.equal(r.totalRuns, 3);
+  assert.equal(r.failedRuns, 2, 'failed AND aborted both count as non-completed');
+  assert.equal(r.avgFoundPerRun, 100, 'averages over completed rows only');
+  assert.equal(r.avgNewPerRun, 8);
+});


### PR DESCRIPTION
Closes #2643 — the follow-up the `status` column was reserved for in #1606.

## What changes

`scan.mjs` arms a failure snapshot at the moment the sweep's counters come into scope, and only there: a `--dry-run` never arms it, and a config error before the sweep isn't a run, so neither leaves a trace. From that point on, a run that dies writes one row with `status: failed` carrying whatever the counters had accumulated. Two signals can trigger it, the fatal `main().catch` and a SIGINT handler (ctrl-C at company 40 of 45 being the common abort), and the snapshot is consumed on first use so they can never double-write. Everything in the write path is swallowed on purpose: failing to record the failure must not mask the original error. `new_added` is a hardcoded 0 on a failed row even when the sweep added postings before dying (the count isn't settled mid-sweep) — harmless to trends since failed rows are excluded from averages, but a raw-TSV reader should read that 0 as a sentinel, not a true count.

On the success path the snapshot is disarmed right after the `completed` row is appended, same guard as before.

`stats.mjs` already excluded failed rows from trend averages and reported `failedRuns`; the one change is selection by `status === 'completed'` instead of exclusion by the known failure name. This is a **no-op on what scan.mjs writes today** (only `completed`/`failed`, which both predicates agree on) — it's a guard so any status a *future* scan writes is excluded from trends until the aggregator learns what it means, not a behavior change now. Rows from pre-status files still default to `completed`, so old data keeps counting. One edge reachable only by hand-editing the TSV: an explicitly empty status flips from counted to `failedRuns`, since `appendScanRunSummary` always writes a non-empty status.

No schema change — the header reserved the column, and consumers parse by name.

## Coverage (honest limits)

Only two death paths write a `failed` row: the fatal `main().catch` and the `SIGINT` handler. **SIGTERM and `unhandledRejection` leave no row** — a `kill` or an unhandled async rejection still vanishes from the trend, same as before this PR. This narrows the survivorship gap for the common cases (crash, ctrl-C); it does not close it entirely.

## Tests

`tests/scan-run-failure.test.mjs`: failed row carries accumulated counters; snapshot consumed on first use (no double-write); no-op when unarmed; disarm on success; a throwing snapshot is swallowed; `computeRunStats` counts `failed` and any unknown status in `failedRuns` while averaging over completed rows only.

Suite: 3654 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scan runs now preserve failure records when interrupted or terminated by a fatal error.
  * Failure records are written only once and do not affect successful or dry-run scans.

* **Bug Fixes**
  * Run statistics now calculate averages using completed runs only.
  * Failed and other incomplete runs are excluded from completion metrics, while legacy records remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->