### PR TITLE
fix: correct eval-runner output so evaluations are usable

### DIFF
--- a/ollama-eval.mjs
+++ b/ollama-eval.mjs
@@ -248,7 +248,7 @@ LEGITIMACY: <High Confidence | Proceed with Caution | Suspicious>
 // ---------------------------------------------------------------------------
 // Call Ollama
 // ---------------------------------------------------------------------------
-const endpoint = `${baseUrl}/v1/chat/completions`;
+const endpoint = `${baseUrl}/api/chat`;
 const timeoutMs = parseInt(process.env.OLLAMA_TIMEOUT_MS || '300000', 10);
 if (Number.isNaN(timeoutMs) || timeoutMs <= 0) {
   console.error(`❌  Invalid OLLAMA_TIMEOUT_MS: "${process.env.OLLAMA_TIMEOUT_MS}" — must be a positive integer (milliseconds).`);
@@ -269,10 +269,12 @@ try {
         { role: 'user',   content: `JOB DESCRIPTION TO EVALUATE:\n\n${jdText}` },
       ],
       stream: false,
-      // Ollama's /api/chat reads generation params from `options` only — a
-      // top-level `temperature` is silently ignored, so the eval was running at
-      // Ollama's default (0.8) instead of the intended 0.4. Keep it deterministic
-      // (matching the openai/gemini engines) by putting it where Ollama reads it.
+      // Ollama's native /api/chat reads generation params from `options` only.
+      // This call targets that endpoint (NOT the OpenAI-compatible /v1 route,
+      // which ignores `options` and has no num_ctx equivalent), so both the
+      // deterministic temperature and the enlarged context window actually take
+      // effect. Without num_ctx here Ollama defaults to a 2048-token context and
+      // silently truncates the prompt; without temperature it runs at 0.8.
       options: { temperature: 0.4, num_ctx: 32768 },
     }),
     signal: AbortSignal.timeout(timeoutMs),
@@ -286,8 +288,14 @@ try {
   }
 
   const data = await res.json();
-  evaluationText = data.choices?.[0]?.message?.content?.trim();
-  const usage = normalizeOpenAIUsage(data.usage);
+  evaluationText = data.message?.content?.trim();
+  // Native /api/chat reports tokens as prompt_eval_count / eval_count, not an
+  // OpenAI-shaped `usage` object; map them through the shared normalizer.
+  const usage = normalizeOpenAIUsage({
+    prompt_tokens: data.prompt_eval_count,
+    completion_tokens: data.eval_count,
+    total_tokens: (data.prompt_eval_count ?? 0) + (data.eval_count ?? 0),
+  });
   tracker.record('evaluation', usage);
   if (!evaluationText) {
     console.error('❌  Ollama returned an empty response.');

--- a/openrouter-runner.mjs
+++ b/openrouter-runner.mjs
@@ -677,7 +677,12 @@ async function cmdEvaluate(input, ctx) {
     const reportLink  = `[${numStr}](reports/${numStr}-${slug}-${today}.md)`;
     const tsvLine     = `${num}\t${today}\t${companyName}\t(see report)\tEvaluated\t${scoreStr}\t❌\t${reportLink}\t\n`;
     const tsvFile     = `batch/tracker-additions/or-${numStr}-${slug}.tsv`;
-    writeFile(tsvFile, `num\tdate\tcompany\trole\tstatus\tscore\tpdf\treport\tnotes\n${tsvLine}`);
+    // AGENTS.md: a tracker-addition TSV is a SINGLE data line of 9 tab-separated
+    // columns. merge-tracker.mjs reads the whole file as ONE record (no line
+    // splitting), so a leading header row makes parts[4]/parts[5] the literal
+    // "status"/"score" and the evaluation is skipped ("cannot tell score from
+    // status"). Write only the data line.
+    writeFile(tsvFile, tsvLine);
 
     console.log(`\n✅ Report saved: ${relPath}`);
     console.log('\n─── EVALUATION ──────────────────────────────────────\n');

--- a/tests/ollama-eval-endpoint.test.mjs
+++ b/tests/ollama-eval-endpoint.test.mjs
@@ -1,0 +1,61 @@
+// tests/ollama-eval-endpoint.test.mjs — ollama-eval must call the native
+// /api/chat endpoint and send generation params where that endpoint reads them.
+//
+// The request was POSTed to the OpenAI-compatible /v1/chat/completions route,
+// which ignores the `options` object and has no num_ctx equivalent, so NEITHER
+// temperature: 0.4 NOR num_ctx: 32768 reached the model — every eval ran at the
+// server default temperature and a 2048-token context that silently truncated
+// the prompt. This drives the real CLI against a mock Ollama that captures the
+// request, asserting the endpoint and the params, and that the native response
+// shape ({message:{content}}) is parsed.
+import { createServer } from 'http';
+import { execFile } from 'child_process';
+import { join } from 'path';
+import { pass, fail, NODE, ROOT } from './helpers.mjs';
+
+console.log('\nollama-eval.mjs — calls native /api/chat with options (temperature + num_ctx)');
+
+const captured = { path: null, body: null };
+const server = createServer((req, res) => {
+  let raw = '';
+  req.on('data', (c) => (raw += c));
+  req.on('end', () => {
+    captured.path = req.url;
+    try { captured.body = JSON.parse(raw); } catch { captured.body = null; }
+    // Native /api/chat shape (NOT OpenAI choices[]).
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      model: 'test',
+      message: { role: 'assistant', content: 'Evaluation.\nVERDICT: 4/5 — solid fit' },
+      done: true,
+      prompt_eval_count: 1234,
+      eval_count: 56,
+    }));
+  });
+});
+
+await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+const port = server.address().port;
+
+const done = new Promise((resolve) => {
+  execFile(
+    NODE,
+    [join(ROOT, 'ollama-eval.mjs'), '--url', `http://127.0.0.1:${port}`, '--no-save', 'Some job description text.'],
+    { timeout: 30000 },
+    (err, stdout, stderr) => resolve({ err, stdout, stderr }),
+  );
+});
+const { stdout, stderr } = await done;
+server.close();
+
+if (captured.path === '/api/chat') pass('POSTs to the native /api/chat endpoint');
+else fail(`expected /api/chat, got ${captured.path}`);
+
+const opts = captured.body?.options ?? {};
+if (opts.num_ctx === 32768) pass('sends options.num_ctx = 32768');
+else fail(`options.num_ctx missing/wrong: ${JSON.stringify(opts)}`);
+if (opts.temperature === 0.4) pass('sends options.temperature = 0.4');
+else fail(`options.temperature missing/wrong: ${JSON.stringify(opts)}`);
+
+if (/VERDICT:\s*4\/5/.test(stdout + stderr)) pass('parses the native {message:{content}} response');
+else fail(`native response not parsed. tail: ${(stdout + stderr).trim().split('\n').pop()}`);

--- a/tests/openrouter-tracker-tsv.test.mjs
+++ b/tests/openrouter-tracker-tsv.test.mjs
@@ -1,0 +1,92 @@
+// tests/openrouter-tracker-tsv.test.mjs — an openrouter-produced tracker-addition
+// TSV must merge into applications.md.
+//
+// openrouter-runner wrote a "num\tdate\t…\n" HEADER line ahead of the data row.
+// merge-tracker.mjs reads the whole addition file as ONE record (no line split),
+// so with a header present parts[4]/parts[5] are the literal "status"/"score",
+// resolveScoreStatus returns null, and EVERY openrouter evaluation was skipped
+// with "cannot tell score from status". AGENTS.md specifies the file as a single
+// 9-column data line. This test merges the exact line openrouter emits and
+// asserts the row lands, and guards the source against reintroducing the header.
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { execFileSync } from 'child_process';
+import { pass, fail, NODE, ROOT } from './helpers.mjs';
+
+console.log('\nopenrouter-runner.mjs — tracker-addition TSV merges (no header row)');
+
+const TRACKER_HEADER = [
+  '# Applications Tracker',
+  '',
+  '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |',
+  '|---|------|---------|------|-------|--------|-----|--------|-------|',
+  '',
+].join('\n');
+
+// The exact shape openrouter-runner writes (openrouter-runner.mjs `tsvLine`):
+// num, date, company, "(see report)", status, score, pdf, report-link, notes.
+const num = 35, today = '2026-08-09', slug = 'acme-corp';
+const company = slug.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+const link = `[0${num}](reports/0${num}-${slug}-${today}.md)`;
+const dataLine = `${num}\t${today}\t${company}\t(see report)\tEvaluated\t4.0/5\t❌\t${link}\t\n`;
+
+const work = mkdtempSync(join(tmpdir(), 'cops-or-tsv-'));
+try {
+  const tracker = join(work, 'applications.md');
+  const addsDir = join(work, 'adds');
+  mkdirSync(addsDir, { recursive: true });
+  writeFileSync(tracker, TRACKER_HEADER);
+  writeFileSync(join(addsDir, `or-0${num}-${slug}.tsv`), dataLine);
+
+  let output = '';
+  try {
+    output = execFileSync(NODE, [join(ROOT, 'merge-tracker.mjs')], {
+      encoding: 'utf-8', timeout: 30000, stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, CAREER_OPS_TRACKER: tracker, CAREER_OPS_ADDITIONS: addsDir },
+    });
+  } catch (e) {
+    output = String(e.stdout ?? '') + String(e.stderr ?? '');
+  }
+
+  const merged = readFileSync(tracker, 'utf-8');
+  const row = merged.split('\n').find((l) => /^\|\s*35\s*\|/.test(l));
+  if (row && /Acme Corp/.test(row) && /Evaluated/.test(row) && /4\.0\/5/.test(row)) {
+    pass('openrouter TSV row merged into the tracker with score + status intact');
+  } else {
+    fail(`row not merged. output: ${output.trim().split('\n').pop()} | tracker row: ${row ?? '(none)'}`);
+  }
+
+  // Root-cause demonstration: the OLD header-prefixed content is skipped, not
+  // merged — a second isolated run with the header in front of the same row.
+  const work2 = mkdtempSync(join(tmpdir(), 'cops-or-hdr-'));
+  try {
+    const t2 = join(work2, 'applications.md');
+    const a2 = join(work2, 'adds');
+    mkdirSync(a2, { recursive: true });
+    writeFileSync(t2, TRACKER_HEADER);
+    writeFileSync(join(a2, `or-0${num}-${slug}.tsv`), `num\tdate\tcompany\trole\tstatus\tscore\tpdf\treport\tnotes\n${dataLine}`);
+    let out2 = '';
+    try {
+      out2 = execFileSync(NODE, [join(ROOT, 'merge-tracker.mjs')], {
+        encoding: 'utf-8', timeout: 30000, stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...process.env, CAREER_OPS_TRACKER: t2, CAREER_OPS_ADDITIONS: a2 },
+      });
+    } catch (e) { out2 = String(e.stdout ?? '') + String(e.stderr ?? ''); }
+    const merged2 = readFileSync(t2, 'utf-8');
+    if (!/^\|\s*35\s*\|/m.test(merged2)) pass('header-prefixed TSV is correctly skipped (the original bug)');
+    else fail('header-prefixed TSV merged unexpectedly — the root-cause assumption is wrong');
+  } finally {
+    try { rmSync(work2, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+
+  // Guard: the source must not prepend a header to the tracker-addition write.
+  const src = readFileSync(join(ROOT, 'openrouter-runner.mjs'), 'utf-8');
+  if (/num\\tdate\\tcompany\\trole\\tstatus/.test(src)) {
+    fail('openrouter-runner.mjs still writes a header row into the tracker-addition TSV');
+  } else {
+    pass('openrouter-runner.mjs writes only the data line (no header)');
+  }
+} finally {
+  try { rmSync(work, { recursive: true, force: true }); } catch { /* best effort */ }
+}


### PR DESCRIPTION
Two independent defects in the non-Claude eval engines. Each silently produces wrong or unmergeable output, so the runs look like they worked.

## openrouter-runner: every evaluation skipped at merge time

The tracker-addition TSV was written with a `num\tdate\t…` header line ahead of the data row. `merge-tracker.mjs` reads the whole addition file as one record, no line splitting, so the header made `parts[4]`/`parts[5]` the literal strings `status`/`score`, `resolveScoreStatus` returned null, and every openrouter evaluation was skipped with "cannot tell score from status". AGENTS.md specifies the file as a single 9-column data line; now only that line is written.

## ollama-eval: options never reached the model

The request went to the OpenAI-compatible `/v1/chat/completions` route, which ignores Ollama's `options` object and has no `num_ctx` equivalent. Neither `temperature: 0.4` nor `num_ctx: 32768` ever reached the model, so every eval ran at the server default temperature with a 2048-token context that silently truncated the prompt — long JDs lost their tail and the eval scored a fragment. The call now targets the native `/api/chat` endpoint (where `options` is honored), parses its `{message:{content}}` response shape, and maps `prompt_eval_count`/`eval_count` through the shared usage normalizer.

## Tests

An openrouter TSV round-trips through the real `merge-tracker.mjs` (and the old header-prefixed form is shown to be skipped, pinning the failure mode); a mock Ollama server asserts the endpoint choice, the options payload, and native-response parsing.

Suite: 3144 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
