### PR TITLE
fix(liveness): api.lever.co 404 is not authoritative for live-but-unlisted postings

### DIFF
--- a/liveness-api.mjs
+++ b/liveness-api.mjs
@@ -54,6 +54,9 @@ function isSafeValue(v) {
 //   `timeoutMs`  — override the default fetch timeout (slow/rate-limited APIs).
 //   `interpret`  — read the 200 response body to decide liveness (org-level APIs
 //                  where a 200 alone doesn't prove THIS posting is live).
+//   `api404Authoritative` — defaults to true (a 404/410 means gone). Set to
+//                  false when the provider's public API can 404 a posting that
+//                  is still genuinely live elsewhere (see the `lever` entry).
 const ATS_PROVIDERS = [
   {
     id: 'greenhouse',
@@ -75,6 +78,13 @@ const ATS_PROVIDERS = [
       return m ? { apiHost: `api.${host[1]}`, slug: m[1], id: m[2] } : null;
     },
     api: ({ apiHost, slug, id }) => `https://${apiHost}/v0/postings/${slug}/${id}`,
+    // Lever's Confidential/Internal Postings feature explicitly excludes some
+    // live postings from the public v0/postings API while the direct
+    // jobs.lever.co page keeps serving them normally. Real-world repro
+    // (2026-08-09): api.lever.co 404s two postings whose jobs.lever.co pages
+    // return 200 with the real job title and a working Apply control. A 404
+    // here is NOT proof of removal — fall through to Playwright instead.
+    api404Authoritative: false,
   },
   {
     id: 'ashby',
@@ -159,7 +169,7 @@ export function classifyAshbyBoard(json, jobId) {
  * Map a posting URL to its ATS API URL, or null if it isn't a known ATS posting
  * (or any extracted segment fails the strict charset). Pure + deterministic.
  * @param {string} rawUrl
- * @returns {{ ats: string, apiUrl: string, parts: Record<string, string>, timeoutMs?: number, interpret?: (res: Response, parts: Record<string, string>) => Promise<{ result: 'active' | 'expired', code: string, reason: string } | null> } | null}
+ * @returns {{ ats: string, apiUrl: string, parts: Record<string, string>, timeoutMs?: number, interpret?: (res: Response, parts: Record<string, string>) => Promise<{ result: 'active' | 'expired', code: string, reason: string } | null>, api404Authoritative: boolean } | null}
  */
 export function resolveAtsApi(rawUrl) {
   let u;
@@ -176,7 +186,14 @@ export function resolveAtsApi(rawUrl) {
     // most providers, or (Workday) a slash-separated sequence of safe segments.
     // isSafeValue enforces the same charset + no-".." rule either way.
     if (!Object.values(parts).every(isSafeValue)) return null;
-    return { ats: provider.id, apiUrl: provider.api(parts), parts, timeoutMs: provider.timeoutMs, interpret: provider.interpret };
+    return {
+      ats: provider.id,
+      apiUrl: provider.api(parts),
+      parts,
+      timeoutMs: provider.timeoutMs,
+      interpret: provider.interpret,
+      api404Authoritative: provider.api404Authoritative !== false,
+    };
   }
   return null;
 }
@@ -195,7 +212,7 @@ export function isAtsPosting(url) {
 export async function checkLivenessViaApi(url) {
   const resolved = resolveAtsApi(url);
   if (!resolved) return null;
-  const { ats, apiUrl, parts, interpret, timeoutMs } = resolved;
+  const { ats, apiUrl, parts, interpret, timeoutMs, api404Authoritative } = resolved;
 
   // The timeout guards the whole classification (fetch + any `interpret` body read),
   // since aborting the shared signal also tears down an in-flight res.json().
@@ -215,6 +232,7 @@ export async function checkLivenessViaApi(url) {
     }
 
     if (res.status === 404 || res.status === 410) {
+      if (!api404Authoritative) return null; // inconclusive → let Playwright check the real page
       return { result: 'expired', code: `${ats}_api_gone`, reason: `ATS API ${res.status} — posting removed` };
     }
     if (res.status === 200) {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -699,6 +699,22 @@ try {
     const cvWdLive = await checkLivenessViaApi(wdUrl);
     globalThis.fetch = async () => ({ status: 404 });
     const cvWdGone = await checkLivenessViaApi(wdUrl);
+    // Lever: unlike Greenhouse/Workday, a 404 on the public postings API is NOT
+    // authoritative proof of removal. Lever's Confidential/Internal Postings
+    // feature explicitly excludes some live postings from the public API while
+    // the direct jobs.lever.co page keeps serving them (real-world repro:
+    // Simbe Robotics and Enable postings, 2026-08-09 — api.lever.co 404s, the
+    // live page renders the real title with a working Apply control). So a
+    // Lever 404/410 must fall through to Playwright (null), not conclude
+    // expired outright, the same "let the browser decide" treatment other
+    // ambiguous cases already get.
+    const lvUrl = 'https://jobs.lever.co/acme/abc-123-def';
+    globalThis.fetch = async () => ({ status: 200 });
+    const cvLvLive = await checkLivenessViaApi(lvUrl);
+    globalThis.fetch = async () => ({ status: 404 });
+    const cvLvGone = await checkLivenessViaApi(lvUrl);
+    globalThis.fetch = async () => ({ status: 410 });
+    const cvLvGone410 = await checkLivenessViaApi(lvUrl);
     if (cvAshbyLive?.result === 'active' && cvAshbyLive?.code === 'ashby_api_ok'
         && cvAshbyGone?.result === 'expired' && cvAshbyGone?.code === 'ashby_api_unlisted'
         && cvAshbyMalformed === null
@@ -710,6 +726,13 @@ try {
       pass('checkLivenessViaApi: 200→interpret (Ashby), malformed→null, greenhouse/workday 200→active, 404→expired, fetch error→null');
     } else {
       fail(`checkLivenessViaApi wrong: ashbyLive=${JSON.stringify(cvAshbyLive)} ashbyGone=${JSON.stringify(cvAshbyGone)} malformed=${JSON.stringify(cvAshbyMalformed)} ghLive=${JSON.stringify(cvGhLive)} gone=${JSON.stringify(cvGone)} err=${JSON.stringify(cvErr)} wdLive=${JSON.stringify(cvWdLive)} wdGone=${JSON.stringify(cvWdGone)}`);
+    }
+    if (cvLvLive?.result === 'active' && cvLvLive?.code === 'lever_api_ok'
+        && cvLvGone === null
+        && cvLvGone410 === null) {
+      pass('checkLivenessViaApi: Lever 200→active, 404/410→null (inconclusive, unlike Greenhouse/Workday — Confidential Postings can 404 on the public API while still live)');
+    } else {
+      fail(`checkLivenessViaApi (Lever) wrong: live=${JSON.stringify(cvLvLive)} gone404=${JSON.stringify(cvLvGone)} gone410=${JSON.stringify(cvLvGone410)}`);
     }
   } finally {
     globalThis.fetch = origFetch;


### PR DESCRIPTION
## Summary

Closes #2648. Lever's Confidential/Internal Postings feature can exclude a genuinely live posting from the public `v0/postings` API while `jobs.lever.co` keeps serving the direct page normally to anonymous visitors. The Lever provider in `liveness-api.mjs` treated a 404/410 there the same as Greenhouse and Workday — instant, confident `expired` — which is wrong for this one case.

Real-world repro (still live as of this writing): `api.lever.co/v0/postings/SimbeRobotics/3da4ce33-555d-4c8b-87fd-e0fda8891028` 404s, while `jobs.lever.co/SimbeRobotics/3da4ce33-555d-4c8b-87fd-e0fda8891028` returns 200 with the real title (`Simbe Robotics - Head of Demand Generation & ABM`) and a working Apply control. Same story for an Enable posting.

## Scope

Scoped to Lever only, not applied blanket to every per-job-API provider. Before writing this I sampled the other providers' existing "ATS API 404" verdicts in a live tracker against the real rendered page (Playwright, not raw curl — `job-boards.greenhouse.io` is a client-rendered SPA, so a bare HTTP status check would have been misleading there too):

| Provider | Sampled | Genuinely dead | False negatives |
|---|---|---|---|
| Lever | 6 | 4 | 2 |
| Greenhouse | 5 | 5 | 0 |
| Workday | 1 | 1 | 0 |
| Ashby | 1 | 1 | 0 |

Every non-Lever posting either redirected to the board with no trace of the role, or showed an explicit not-found page. None share Lever's public-API-excludes-a-still-live-posting behavior, so their existing 404-is-authoritative fast path stays untouched — adding an unneeded Playwright fallback there would only slow down something that's already correct.

## Fix

`api404Authoritative` (defaults to `true`) lets a provider opt out of treating its own 404/410 as proof of removal. Set to `false` on the Lever entry only. When false, `checkLivenessViaApi` returns `null` on 404/410 so the caller falls through to the Playwright check — the same inconclusive treatment already given to network errors, timeouts, and a malformed Ashby board response.

Same bug class as #1372 (Ashby false-expired), different mechanism: there the API rung was missing entirely; here it exists but isn't authoritative on 404 for this one provider.

## Test plan

- [x] New regression test in `test-all.mjs`: Lever 200 → active, 404/410 → `null` (inconclusive), asserted against a mocked `fetch` following the existing `checkLivenessViaApi` test pattern
- [x] Confirmed the new test fails against the pre-fix code (404/410 → `expired`) before applying the fix
- [x] `node test-all.mjs` — 3138 pass / 0 fail after the fix
- [x] Every pre-existing Lever-specific test in the suite still passes (provider detection, SSRF redirect guard, `prepare-application.mjs` field builder, `scan.md`/`verify-portals` slug parsing) — the change is additive, not a behavior regression elsewhere

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job listing availability checks for providers whose APIs may return outdated 404 or 410 responses.
  * Listings are now verified through the public job page before being classified as expired when API results are inconclusive.

* **Tests**
  * Added regression coverage for active listings and temporary API removals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->