### PR TITLE
fix(deps): make js-yaml imports work on both 4.x and 5.x

### DIFF
--- a/browser-extract.mjs
+++ b/browser-extract.mjs
@@ -34,7 +34,7 @@
 import { readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { LIVENESS_CONTEXT_OPTIONS, rejectPrivateOrInvalid } from './liveness-browser.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));

--- a/check-table-freshness.mjs
+++ b/check-table-freshness.mjs
@@ -53,7 +53,7 @@
 import { readFileSync, readdirSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { flagValue } from './lib/cli-flags.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));

--- a/company-history.mjs
+++ b/company-history.mjs
@@ -44,7 +44,7 @@
 import { readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 
 import { parseScanHistory, detectReposts } from './detect-reposts.mjs';
 import { normalizeCompany, resolveTrackerPath } from './tracker-utils.mjs';

--- a/cv-templates.mjs
+++ b/cv-templates.mjs
@@ -7,7 +7,7 @@
 import { readdirSync, readFileSync, existsSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_TEMPLATES_DIR = resolve(__dirname, 'templates');

--- a/discover-ats.mjs
+++ b/discover-ats.mjs
@@ -34,7 +34,7 @@
 import { readFileSync, existsSync, writeFileSync, renameSync } from 'fs';
 import { dirname, join, resolve } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 
 import { makeHttpCtx } from './providers/_http.mjs';
 import greenhouse from './providers/greenhouse.mjs';

--- a/discover-ats.test.mjs
+++ b/discover-ats.test.mjs
@@ -29,7 +29,7 @@ import {
   buildWorkdayCandidates,
   resolveCompany,
 } from './discover-ats.mjs';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';

--- a/doctor.mjs
+++ b/doctor.mjs
@@ -8,7 +8,7 @@
 import { copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import dotenv from 'dotenv';
 import { discoverPlugins, pluginRoots, pluginStatus } from './plugins/_engine.mjs';
 import { resolveExtractorMode } from './browser-extract.mjs';

--- a/followup-cadence.mjs
+++ b/followup-cadence.mjs
@@ -14,7 +14,7 @@
 import { readFileSync, existsSync } from 'fs';
 import { join, dirname, relative, sep } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));

--- a/funnel-velocity.mjs
+++ b/funnel-velocity.mjs
@@ -37,7 +37,7 @@
 import { readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { computeFunnel, computeTrackerStats } from './stats.mjs';
 import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 import { resolveTrackerPath, loadCanonicalStates, resolveCanonicalState } from './tracker-utils.mjs';

--- a/openai-tailor.mjs
+++ b/openai-tailor.mjs
@@ -19,7 +19,7 @@
 import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'fs';
 import { join, dirname, basename } from 'path';
 import { fileURLToPath } from 'url';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 
 try {
   const { config } = await import('dotenv');

--- a/openrouter-runner.mjs
+++ b/openrouter-runner.mjs
@@ -22,7 +22,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import readline from 'node:readline';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { outputLanguageInstruction, parseOutputLanguage } from './profile-language.mjs';
 import {
   formatReportNumber, releaseReportNumbers, reserveReportNumbers,

--- a/plugins.mjs
+++ b/plugins.mjs
@@ -19,7 +19,7 @@
 import path from 'path';
 import { existsSync, readFileSync, writeFileSync, rmSync, mkdirSync } from 'fs';
 import { fileURLToPath } from 'url';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 
 import {
   discoverPlugins, pluginRoots, loadPluginConfig, pluginStatus,

--- a/plugins/_engine.mjs
+++ b/plugins/_engine.mjs
@@ -110,8 +110,13 @@ export async function loadPluginConfig(root) {
   const file = pluginsConfigPath(root);
   if (!existsSync(file)) return {};
   try {
-    const yaml = (await import('js-yaml')).default;
-    const parsed = yaml.load(readFileSync(file, 'utf8'));
+    // Named, not `.default`: js-yaml 5 ships a native ESM build with no default
+    // export, so `.default` is undefined there and `yaml.load` throws straight
+    // into the catch below. That catch fails OPEN — it returns {}, so every
+    // configured plugin silently stops loading and the only trace is one ⚠️ line
+    // that reads like a malformed config. The named form resolves on 4.x and 5.x.
+    const { load } = await import('js-yaml');
+    const parsed = load(readFileSync(file, 'utf8'));
     return parsed && typeof parsed === 'object' ? parsed : {};
   } catch (err) {
     warnSkip('config/plugins.yml', `unreadable, ignoring — ${err.message}`);

--- a/plugins/notion/_notion.mjs
+++ b/plugins/notion/_notion.mjs
@@ -16,7 +16,7 @@
 import { readFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 
 const DIR = dirname(fileURLToPath(import.meta.url));
 const STATES_PATH = join(DIR, '..', '..', 'templates', 'states.yml');

--- a/profile-language.mjs
+++ b/profile-language.mjs
@@ -1,4 +1,4 @@
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 
 const DEFAULT_OUTPUT_LANGUAGE = 'en';
 

--- a/providers/_profile-keywords.mjs
+++ b/providers/_profile-keywords.mjs
@@ -16,7 +16,7 @@
 // would require changing the Provider.fetch(entry, ctx) contract itself.
 
 import { existsSync, readFileSync } from 'fs';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 
 // Matches the CAREER_OPS_PROFILE override already honored by scan.mjs,
 // cv-templates.mjs, followup-cadence.mjs, plugins/_engine.mjs, and

--- a/rejection-latency.mjs
+++ b/rejection-latency.mjs
@@ -48,7 +48,7 @@
 import { readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 
 import { parseActiveInterviews } from './process-quality.mjs';
 import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';

--- a/salary-gap.mjs
+++ b/salary-gap.mjs
@@ -30,7 +30,7 @@
 import { readFileSync, existsSync, readdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const OBS_PATH = join(CAREER_OPS, 'data/salary-observations.tsv');

--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -34,7 +34,7 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync, statSync, renameSyn
 import { pathToFileURL } from 'url';
 import { createHash } from 'crypto';
 import path from 'path';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 
 import { makeHttpCtx, fetchJson } from './providers/_http.mjs';
 import { isResolverFailure, dnsPacingStats } from './providers/_dns-cache.mjs';

--- a/scan-interamt.mjs
+++ b/scan-interamt.mjs
@@ -19,7 +19,7 @@
 
 import { chromium } from 'playwright';
 import { readFileSync, existsSync, mkdirSync } from 'fs';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { appendToPipeline, appendToScanHistory, loadSeenUrls } from './scan.mjs';
 
 // ── Config ───────────────────────────────────────────────────────────

--- a/scan.mjs
+++ b/scan.mjs
@@ -34,7 +34,7 @@
 import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync } from 'fs';
 import { pathToFileURL, fileURLToPath } from 'url';
 import path from 'path';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 
 import { makeHttpCtx } from './providers/_http.mjs';
 import { buildTrustValidator } from './providers/_trust-validator.mjs';

--- a/stats.mjs
+++ b/stats.mjs
@@ -21,7 +21,7 @@
 import { readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 import { normalizeStatus, analyzeFromContent } from './followup-cadence.mjs';
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -30,7 +30,7 @@ import { join, dirname, basename, delimiter } from 'path';
 import { tmpdir } from 'os';
 import { promisify } from 'util';
 import { fileURLToPath, pathToFileURL } from 'url';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { pass, fail, warn, run, lastRunFailure, formatRunFailure, fileExists, finish, ROOT, QUICK, NODE, getBash, toBashPath } from './tests/helpers.mjs';
 import { flagValue, hasFlag } from './lib/cli-flags.mjs';
 

--- a/tests/js-yaml-import-form.test.mjs
+++ b/tests/js-yaml-import-form.test.mjs
@@ -59,12 +59,29 @@ function sourceFiles() {
 //
 // Anchored at a statement start (allowing indentation) so the fixture STRING in
 // test-all.mjs — `"import yaml from 'js-yaml';"`, quoted mid-line — does not match.
-const DEFAULT_BINDING = String.raw`[A-Za-z_$][\w$]*(?:\s*,\s*(?:\{[^}]*\}|\*\s+as\s+[A-Za-z_$][\w$]*))?\s+from`;
+// Token separator: whitespace, or a block comment, or both. `import /* c */ yaml
+// from 'js-yaml'` is a legal default import, and a plain `\s+` would step over it
+// and report the file clean — the one failure direction that is silent.
+const SEP = String.raw`(?:\s|/\*[\s\S]*?\*/)+`;
+const IDENT = String.raw`[A-Za-z_$][\w$]*`;
+const DEFAULT_BINDING = String.raw`${IDENT}(?:\s*,\s*(?:\{[^}]*\}|\*${SEP}as${SEP}${IDENT}))?${SEP}from`;
 const NAMED_DEFAULT = String.raw`\{[^}]*\bdefault\b[^}]*\}\s*from`;
 const STATIC_DEFAULT = new RegExp(
-  String.raw`^\s*import\s+(?:${DEFAULT_BINDING}|${NAMED_DEFAULT})\s*['"]js-yaml['"]`,
+  String.raw`^[^\S\n]*import${SEP}(?:${DEFAULT_BINDING}|${NAMED_DEFAULT})\s*['"]js-yaml['"]`,
   'm',
 );
+
+// KNOWN LIMIT — this is a text scan, not a parse. A line inside a template
+// literal or a block comment that happens to *look* like a default import is
+// reported as an offender (test-all.mjs's quoted single-line fixture is already
+// handled; a multi-line one would not be). That direction is loud and
+// self-correcting: CI goes red, a human reads the path, and the fixture gets an
+// exemption. The dangerous direction is the silent one — a real import the sweep
+// walks past — and that is what SEP above and the fail-closed branches below
+// exist to prevent. Making this syntax-aware would mean parsing 138 .ts/.tsx
+// files, so a TypeScript parser as a root dependency for one guard; every other
+// source scan in test-all.mjs is text-based too. Not worth it unless a real
+// fixture actually trips it.
 const DYNAMIC_DEFAULT = /import\(\s*['"]js-yaml['"]\s*\)\s*\)?\s*\.default/;
 
 const offenders = [];
@@ -114,6 +131,8 @@ const fires = STATIC_DEFAULT.test("import yaml from 'js-yaml';")
   && STATIC_DEFAULT.test("import yaml, * as ns from 'js-yaml';")
   && STATIC_DEFAULT.test("import { default as yaml } from 'js-yaml';")
   && STATIC_DEFAULT.test('import { default as yaml, load } from "js-yaml";')
+  && STATIC_DEFAULT.test("import /* keep 4.x */ yaml from 'js-yaml';")
+  && STATIC_DEFAULT.test("import yaml /* the default */ from 'js-yaml';")
   && DYNAMIC_DEFAULT.test("const yaml = (await import('js-yaml')).default;");
 // The namespace form and a plain named import are the two legal shapes; if either
 // started matching, the sweep would fail on a correctly-written file.

--- a/tests/js-yaml-import-form.test.mjs
+++ b/tests/js-yaml-import-form.test.mjs
@@ -14,56 +14,93 @@
 // while that conversion sat in review — which is exactly why the rule needs a
 // guard rather than a one-time sweep.
 //
-// Scoped to source: node_modules is third-party and free to import however it
-// likes, and a string LITERAL containing the pattern (test-all.mjs uses one as an
-// import-parser fixture) is not an import.
+// Scoped to TRACKED source, enumerated with `git ls-files`. A recursive walk with
+// a skip-list cannot work here: it also reads whatever untracked scratch the tree
+// happens to be carrying — a killed test-all.mjs run leaves a `.tmp-script-test-*`
+// copy of the whole repo behind, and every pre-conversion file in it reports as an
+// offender. Those paths are gitignored and ship to nobody, so the rule does not
+// apply to them. `git ls-files` is exactly the set that ships; it needs no
+// skip-list to maintain, never descends a symlinked directory, and cannot wander
+// outside the repo.
+//
+// A string LITERAL containing the pattern (test-all.mjs uses one as an
+// import-parser fixture) is not an import and must not match.
 
 import { pass, fail, ROOT } from './helpers.mjs';
-import { readFileSync, readdirSync, statSync } from 'fs';
+import { readFileSync } from 'fs';
+import { execFileSync } from 'child_process';
 import { join, relative } from 'path';
 
 console.log('\njs-yaml must never be imported via its (nonexistent) default export');
 
-const SKIP_DIRS = new Set(['node_modules', '.git', '.next', 'dist', 'build', 'coverage', 'out']);
 const EXTS = ['.mjs', '.js', '.ts', '.tsx'];
 
-/** @returns {string[]} every source file under `dir`, recursively. */
-function walk(dir) {
-  const found = [];
-  for (const entry of readdirSync(dir)) {
-    if (SKIP_DIRS.has(entry)) continue;
-    const full = join(dir, entry);
-    let st;
-    try { st = statSync(full); } catch { continue; }
-    if (st.isDirectory()) found.push(...walk(full));
-    else if (EXTS.some((e) => entry.endsWith(e))) found.push(full);
-  }
-  return found;
+/** @returns {string[]} every tracked source file in the repo. */
+function sourceFiles() {
+  // -z: NUL-separated, so a path containing a newline or quote cannot split a
+  // record and silently drop a file from the sweep.
+  const out = execFileSync('git', ['-C', ROOT, 'ls-files', '-z'], {
+    encoding: 'utf-8',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return out
+    .split('\0')
+    .filter((p) => p && EXTS.some((e) => p.endsWith(e)))
+    .map((p) => join(ROOT, p));
 }
 
+// Every way to bind js-yaml's nonexistent default export:
+//   import yaml from 'js-yaml'                    — the plain form
+//   import yaml, { load } from 'js-yaml'          — default plus a named clause
+//   import yaml, * as ns from 'js-yaml'           — default plus a namespace
+//   import { default as yaml } from 'js-yaml'     — the same binding, written long
+// All four fail to link on 5.x identically. `import * as yaml` and a bare named
+// import (`{ load, dump }`) are the legal forms and must NOT match.
+//
 // Anchored at a statement start (allowing indentation) so the fixture STRING in
 // test-all.mjs — `"import yaml from 'js-yaml';"`, quoted mid-line — does not match.
-const STATIC_DEFAULT = /^\s*import\s+[A-Za-z_$][\w$]*\s*(?:,|from)\s*['"]js-yaml['"]/m;
+const DEFAULT_BINDING = String.raw`[A-Za-z_$][\w$]*(?:\s*,\s*(?:\{[^}]*\}|\*\s+as\s+[A-Za-z_$][\w$]*))?\s+from`;
+const NAMED_DEFAULT = String.raw`\{[^}]*\bdefault\b[^}]*\}\s*from`;
+const STATIC_DEFAULT = new RegExp(
+  String.raw`^\s*import\s+(?:${DEFAULT_BINDING}|${NAMED_DEFAULT})\s*['"]js-yaml['"]`,
+  'm',
+);
 const DYNAMIC_DEFAULT = /import\(\s*['"]js-yaml['"]\s*\)\s*\)?\s*\.default/;
 
 const offenders = [];
+// A file that cannot be read is not a file that passes. Anything unreadable is
+// reported as its own failure rather than skipped, so the sweep cannot go green
+// while silently covering less of the tree than it claims.
+const unreadable = [];
 // This file is exempt from its own sweep: it necessarily CONTAINS both offending
 // forms, as the literals the detector self-check below is built from. Exempting
 // it by exact path (not by a name pattern) keeps the exemption from widening to
 // any other file that happens to look similar.
 const SELF = join(ROOT, 'tests', 'js-yaml-import-form.test.mjs');
 
-for (const file of walk(ROOT)) {
+const scanned = sourceFiles();
+for (const file of scanned) {
   if (file === SELF) continue;
   let text;
-  try { text = readFileSync(file, 'utf-8'); } catch { continue; }
+  try {
+    text = readFileSync(file, 'utf-8');
+  } catch (err) {
+    unreadable.push(`${relative(ROOT, file)} (${err.code || err.message})`);
+    continue;
+  }
   if (!text.includes('js-yaml')) continue;
   if (STATIC_DEFAULT.test(text)) offenders.push(`${relative(ROOT, file)} (static default import)`);
   else if (DYNAMIC_DEFAULT.test(text)) offenders.push(`${relative(ROOT, file)} (dynamic .default)`);
 }
 
-if (offenders.length === 0) {
-  pass('every js-yaml import uses the namespace form, which works on 4.x and 5.x');
+// An empty file list means `git ls-files` returned nothing usable — a clean sweep
+// over zero files is the failure mode this whole test exists to prevent.
+if (scanned.length === 0) {
+  fail('git ls-files produced no source files — the js-yaml sweep scanned nothing');
+} else if (unreadable.length > 0) {
+  fail(`could not read ${unreadable.length} tracked source file(s), so the js-yaml sweep is incomplete: ${unreadable.join(', ')}`);
+} else if (offenders.length === 0) {
+  pass(`every js-yaml import in ${scanned.length} tracked source files uses the namespace form, which works on 4.x and 5.x`);
 } else {
   fail(`js-yaml default import(s) — these break on js-yaml 5, use \`import * as yaml\`: ${offenders.join(', ')}`);
 }
@@ -73,10 +110,18 @@ if (offenders.length === 0) {
 // stays exempt.
 const fires = STATIC_DEFAULT.test("import yaml from 'js-yaml';")
   && STATIC_DEFAULT.test('  import yaml from "js-yaml";')
+  && STATIC_DEFAULT.test("import yaml, { load } from 'js-yaml';")
+  && STATIC_DEFAULT.test("import yaml, * as ns from 'js-yaml';")
+  && STATIC_DEFAULT.test("import { default as yaml } from 'js-yaml';")
+  && STATIC_DEFAULT.test('import { default as yaml, load } from "js-yaml";')
   && DYNAMIC_DEFAULT.test("const yaml = (await import('js-yaml')).default;");
-const exempt = !STATIC_DEFAULT.test(`      "import yaml from 'js-yaml';",`);
+// The namespace form and a plain named import are the two legal shapes; if either
+// started matching, the sweep would fail on a correctly-written file.
+const exempt = !STATIC_DEFAULT.test(`      "import yaml from 'js-yaml';",`)
+  && !STATIC_DEFAULT.test("import * as yaml from 'js-yaml';")
+  && !STATIC_DEFAULT.test("import { load, dump } from 'js-yaml';");
 if (fires && exempt) {
-  pass('the detector still matches both offending forms and ignores a quoted fixture');
+  pass('the detector matches every default-import form and ignores the namespace, named, and quoted-fixture forms');
 } else {
   fail(`detector broken: fires=${fires} exempt=${exempt} — it would report a clean sweep regardless of the tree`);
 }

--- a/tests/js-yaml-import-form.test.mjs
+++ b/tests/js-yaml-import-form.test.mjs
@@ -1,0 +1,82 @@
+// tests/js-yaml-import-form.test.mjs — no source file may import js-yaml's default
+// export.
+//
+// js-yaml 5 ships a native ESM build with NO default export, so
+// `import yaml from 'js-yaml'` fails to LINK on 5.x — the module never evaluates
+// and the process dies before any of its code runs. The dynamic form is worse:
+// `(await import('js-yaml')).default` is `undefined` rather than an error, so the
+// first `yaml.load(...)` throws inside whatever try/catch surrounds it. In
+// plugins/_engine.mjs that catch fails open by design, which turned an unreadable
+// plugin config into a silent empty config.
+//
+// The repo was converted to `import * as yaml` wholesale, but a conversion only
+// holds until the next file. rejection-latency.mjs landed with the default form
+// while that conversion sat in review — which is exactly why the rule needs a
+// guard rather than a one-time sweep.
+//
+// Scoped to source: node_modules is third-party and free to import however it
+// likes, and a string LITERAL containing the pattern (test-all.mjs uses one as an
+// import-parser fixture) is not an import.
+
+import { pass, fail, ROOT } from './helpers.mjs';
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join, relative } from 'path';
+
+console.log('\njs-yaml must never be imported via its (nonexistent) default export');
+
+const SKIP_DIRS = new Set(['node_modules', '.git', '.next', 'dist', 'build', 'coverage', 'out']);
+const EXTS = ['.mjs', '.js', '.ts', '.tsx'];
+
+/** @returns {string[]} every source file under `dir`, recursively. */
+function walk(dir) {
+  const found = [];
+  for (const entry of readdirSync(dir)) {
+    if (SKIP_DIRS.has(entry)) continue;
+    const full = join(dir, entry);
+    let st;
+    try { st = statSync(full); } catch { continue; }
+    if (st.isDirectory()) found.push(...walk(full));
+    else if (EXTS.some((e) => entry.endsWith(e))) found.push(full);
+  }
+  return found;
+}
+
+// Anchored at a statement start (allowing indentation) so the fixture STRING in
+// test-all.mjs — `"import yaml from 'js-yaml';"`, quoted mid-line — does not match.
+const STATIC_DEFAULT = /^\s*import\s+[A-Za-z_$][\w$]*\s*(?:,|from)\s*['"]js-yaml['"]/m;
+const DYNAMIC_DEFAULT = /import\(\s*['"]js-yaml['"]\s*\)\s*\)?\s*\.default/;
+
+const offenders = [];
+// This file is exempt from its own sweep: it necessarily CONTAINS both offending
+// forms, as the literals the detector self-check below is built from. Exempting
+// it by exact path (not by a name pattern) keeps the exemption from widening to
+// any other file that happens to look similar.
+const SELF = join(ROOT, 'tests', 'js-yaml-import-form.test.mjs');
+
+for (const file of walk(ROOT)) {
+  if (file === SELF) continue;
+  let text;
+  try { text = readFileSync(file, 'utf-8'); } catch { continue; }
+  if (!text.includes('js-yaml')) continue;
+  if (STATIC_DEFAULT.test(text)) offenders.push(`${relative(ROOT, file)} (static default import)`);
+  else if (DYNAMIC_DEFAULT.test(text)) offenders.push(`${relative(ROOT, file)} (dynamic .default)`);
+}
+
+if (offenders.length === 0) {
+  pass('every js-yaml import uses the namespace form, which works on 4.x and 5.x');
+} else {
+  fail(`js-yaml default import(s) — these break on js-yaml 5, use \`import * as yaml\`: ${offenders.join(', ')}`);
+}
+
+// Guard the guard: a regex that stopped matching would report a clean sweep
+// forever. Prove both patterns still fire, and that the quoted-fixture case
+// stays exempt.
+const fires = STATIC_DEFAULT.test("import yaml from 'js-yaml';")
+  && STATIC_DEFAULT.test('  import yaml from "js-yaml";')
+  && DYNAMIC_DEFAULT.test("const yaml = (await import('js-yaml')).default;");
+const exempt = !STATIC_DEFAULT.test(`      "import yaml from 'js-yaml';",`);
+if (fires && exempt) {
+  pass('the detector still matches both offending forms and ignores a quoted fixture');
+} else {
+  fail(`detector broken: fires=${fires} exempt=${exempt} — it would report a clean sweep regardless of the tree`);
+}

--- a/theme-style.mjs
+++ b/theme-style.mjs
@@ -18,7 +18,7 @@
  * Pure + dependency-light (js-yaml only) so it's unit-testable without Playwright.
  */
 import { readFileSync, existsSync } from 'fs';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 
 // Recognized style tokens → the CSS custom property each maps to. Anything not
 // listed here is ignored, so a typo or an unrelated `style:` key is inert.

--- a/tracker-utils.mjs
+++ b/tracker-utils.mjs
@@ -12,7 +12,7 @@ import { readFileSync, writeFileSync, renameSync, rmSync, mkdirSync, statSync, e
 import { join, dirname, basename, resolve, relative, isAbsolute, sep } from 'path';
 import { createHash, randomUUID } from 'crypto';
 import { tmpdir } from 'os';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { normalizeTextKey } from './tracker-parse.mjs';
 
 /**

--- a/tracker.mjs
+++ b/tracker.mjs
@@ -38,7 +38,7 @@ import { readFileSync, copyFileSync, existsSync, mkdirSync, statSync } from 'fs'
 import { createHash } from 'crypto';
 import { dirname, resolve, join } from 'path';
 import { pathToFileURL } from 'url';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { resolveColumns } from './tracker-parse.mjs';
 import {
   canonicalizeTrackerPath, openTrackerTransaction, writeFileAtomic,

--- a/validate-portals.mjs
+++ b/validate-portals.mjs
@@ -13,7 +13,7 @@ import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSy
 import { join, dirname, resolve } from 'path';
 import { tmpdir } from 'os';
 import { fileURLToPath, pathToFileURL } from 'url';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { flagValue, hasFlag } from './lib/cli-flags.mjs';
 
 const ROOT = dirname(fileURLToPath(import.meta.url));

--- a/verify-portals.mjs
+++ b/verify-portals.mjs
@@ -28,7 +28,7 @@
 import { existsSync, readFileSync } from 'fs';
 import { dirname, resolve } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 
 import { fetchJson as defaultFetchJson, makeHttpCtx } from './providers/_http.mjs';
 import { loadProviders, resolveProvider } from './providers/_registry.mjs';

--- a/web/src/app/api/followups/cadence/route.ts
+++ b/web/src/app/api/followups/cadence/route.ts
@@ -1,7 +1,7 @@
 import { execFile } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import { careerOpsRoot, rootScript } from "@/lib/career-ops";
 import { atomicWriteWithBackup } from "@/lib/core/safe-write";
 import { PROFILE_CADENCE_KEYS, type ProfileCadenceKey } from "@/lib/followups";

--- a/web/src/app/api/portals/route.ts
+++ b/web/src/app/api/portals/route.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import { careerOpsRoot } from "@/lib/career-ops";
 import { atomicWriteWithBackup } from "@/lib/core/safe-write";
 

--- a/web/src/app/api/profile/route.ts
+++ b/web/src/app/api/profile/route.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import { careerOpsRoot } from "@/lib/career-ops";
 import { atomicWriteWithBackup } from "@/lib/core/safe-write";
 

--- a/web/src/lib/core/portals.ts
+++ b/web/src/lib/core/portals.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import { careerOpsRoot } from "@/lib/career-ops";
 import { DEFAULT_FILTERS, cleanChips, type ExploreFilters } from "@/lib/explore";
 

--- a/web/src/lib/core/states.ts
+++ b/web/src/lib/core/states.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import { careerOpsRoot } from "@/lib/career-ops";
 
 /**

--- a/web/src/lib/pdf-paths.mjs
+++ b/web/src/lib/pdf-paths.mjs
@@ -8,7 +8,7 @@
  */
 import fs from "node:fs";
 import path from "node:path";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 
 /**
  * Lowercase, non-alphanumeric runs -> single hyphen, trimmed.

--- a/weekly-digest.mjs
+++ b/weekly-digest.mjs
@@ -40,7 +40,7 @@
 import { readFileSync, existsSync, readdirSync, mkdtempSync, writeFileSync, rmSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_SESSIONS_DIR = join(CAREER_OPS, 'interview-prep', 'sessions');


### PR DESCRIPTION
## The problem

js-yaml 5 ships a native ESM build with **no default export**. Every `import yaml from 'js-yaml'` in the repo fails to link under 5.x, so on a tree that resolves 5.x the test runner does not even start:

```
$ node test-all.mjs --quick
import yaml from 'js-yaml';
       ^^^^
SyntaxError: The requested module 'js-yaml' does not provide an export named 'default'
```

## The one that actually bites

`plugins/_engine.mjs` → `loadPluginConfig` did:

```js
const yaml = (await import('js-yaml')).default;   // undefined on 5.x
const parsed = yaml.load(readFileSync(file, 'utf8'));
```

inside a try/catch that **fails open by design**. On 5.x `yaml.load` throws, the catch returns `{}`, and **every configured plugin silently stops loading**. The only trace is a single line that reads like a malformed config:

```
⚠️  config/plugins.yml: skipping — unreadable, ignoring — Cannot read properties of undefined (reading 'load')
```

Fail-open is the right posture for a bad config file; it is the wrong posture for "the YAML parser is missing", because the two are indistinguishable to the user.

## The change

- 33 files: `import yaml from 'js-yaml'` → `import * as yaml from 'js-yaml'`. Resolves identically on 4.x and 5.x; every `yaml.load` / `yaml.dump` call site is untouched. One line per file, nothing else.
- `plugins/_engine.mjs`: destructure `{ load }` from the lazy import instead of reaching for `.default`.

**This deliberately does not bump the declared range.** `package.json` still says `^4.1.1` and nothing here needs 5.x — the change only removes the hard block for anyone whose tree resolves 5.x. Whether to move to 5 stays your call.

## Verification

`node test-all.mjs --quick` against both majors:

| js-yaml | result |
|---|---|
| **4.1.1** (the declared version) | 3137 passed, 0 failed |
| **5.2.2** | 3137 passed, 0 failed |

and confirmed the unpatched tree cannot load the runner at all under 5.2.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized YAML module usage across application workflows and tools.
  * Preserved existing YAML loading, parsing, and error-handling behavior.

* **Tests**
  * Aligned test imports with the updated YAML module usage.
  * Added automated checks to detect unsupported YAML import patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->