### PR TITLE
fix(jd-similarity): the seniority gate fired on JD boilerplate and on any CV showing progression

### DIFF
--- a/jd-similarity.mjs
+++ b/jd-similarity.mjs
@@ -48,14 +48,71 @@ export function jaccardSimilarity(left, right) {
   return intersection / (a.size + b.size - intersection);
 }
 
-/** Detect the first recognized seniority level in text, or -1 when absent. */
-function levelOf(text) {
+/**
+ * Level words that are also ordinary English, mapped to the words that follow
+ * them in their NON-seniority sense. JD boilerplate is full of these: "Principal
+ * responsibilities" means "main duties", "mid-market" is a customer segment, and
+ * "lead" is usually a verb. Matching them as job levels made the gate below fire
+ * on postings of identical seniority.
+ *
+ * Only the trailing word is inspected: "Principal Engineer" and "Lead Engineer"
+ * stay levels because `engineer` is not in any of these lists.
+ */
+const NON_LEVEL_FOLLOWERS = {
+  principal: ['responsibilities', 'responsibility', 'duties', 'accountabilities', 'objectives', 'purpose', 'tasks', 'activities'],
+  lead: ['to', 'the', 'a', 'an', 'our', 'and', 'or', 'by', 'on', 'in', 'for', 'with', 'from', 'mentoring', 'projects'],
+  mid: ['market', 'size', 'sized', 'cap', 'tier', 'funnel', 'term', 'sized-company'],
+};
+
+/** Whether a level word at `index` reads as a job level rather than plain English. */
+function readsAsLevel(word, normalized, index) {
+  const followers = NON_LEVEL_FOLLOWERS[word];
+  if (!followers) return true;
+  const after = normalized.slice(index + word.length).match(/^[^a-z0-9]*([a-z0-9-]+)/);
+  return !after || !followers.includes(after[1]);
+}
+
+/**
+ * Every distinct seniority level named in the text, as LEVELS indices.
+ *
+ * Returns ALL of them rather than the first: a document may name several (a CV
+ * showing career progression names each rank it held), and `findIndex` used to
+ * collapse that to whichever appeared earliest in the LEVELS table — reading a
+ * junior-to-senior CV as junior.
+ */
+function levelsIn(text) {
   const normalized = String(text ?? '').toLowerCase();
-  return LEVELS.findIndex(words => words.some(word => {
-    if (/^[\p{Script=Han}]+$/u.test(word)) return normalized.includes(word);
-    const escaped = word.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    return new RegExp(`(?:^|[^a-z0-9])${escaped}(?=$|[^a-z0-9])`, 'i').test(normalized);
-  }));
+  const found = new Set();
+  LEVELS.forEach((words, level) => {
+    for (const word of words) {
+      if (/^[\p{Script=Han}]+$/u.test(word)) {
+        if (normalized.includes(word)) { found.add(level); break; }
+        continue;
+      }
+      const escaped = word.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const pattern = new RegExp(`(?:^|[^a-z0-9])(${escaped})(?=$|[^a-z0-9])`, 'gi');
+      let match;
+      while ((match = pattern.exec(normalized)) !== null) {
+        if (readsAsLevel(word, normalized, match.index + match[0].length - word.length)) {
+          found.add(level);
+          break;
+        }
+      }
+      if (found.has(level)) break;
+    }
+  });
+  return found;
+}
+
+/**
+ * Detect the seniority level of a document, or -1 when it has no single
+ * unambiguous one. Naming several levels counts as ambiguous, NOT as the lowest
+ * one: the gate below exists to catch a clear level difference, and a guess is
+ * worse than standing down and letting the similarity score decide.
+ */
+function levelOf(text) {
+  const levels = levelsIn(text);
+  return levels.size === 1 ? [...levels][0] : -1;
 }
 
 /** Return whether the new JD and previous document have different seniority levels. */

--- a/tests/jd-similarity-seniority.test.mjs
+++ b/tests/jd-similarity-seniority.test.mjs
@@ -1,0 +1,96 @@
+// tests/jd-similarity-seniority.test.mjs — the seniority gate in jd-similarity.mjs.
+//
+// recommendCvReuse refuses to recommend reuse when the two documents describe
+// different seniority levels (`reason: 'level-mismatch'`). That gate OVERRIDES
+// the similarity score, so a false positive silently turns a good reuse
+// candidate into a full regeneration. The two ways it used to misfire:
+//
+//   1. Ordinary English that happens to contain a level word — "Principal
+//      responsibilities", "you will lead", "mid-market" — was read as a job
+//      level. JD boilerplate is full of these.
+//   2. A document naming SEVERAL levels resolved to whichever came first in the
+//      LEVELS table, not to the role's actual level. Any CV showing career
+//      progression ("Junior Developer ... Senior Developer") reads as junior.
+//
+// The gate must stay strict about REAL level differences, so every relaxation
+// below is paired with an assertion that a genuine mismatch still fires.
+import { pass, fail, ROOT } from './helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\njd-similarity.mjs — the seniority gate only fires on real level differences');
+
+try {
+  const { recommendCvReuse, hardMismatch, jaccardSimilarity } = await import(
+    pathToFileURL(join(ROOT, 'jd-similarity.mjs')).href
+  );
+
+  const check = (label, actual, expected) => {
+    if (actual === expected) pass(label);
+    else fail(`${label} => ${JSON.stringify(actual)}, expected ${JSON.stringify(expected)}`);
+  };
+
+  // ── 1. A real level difference must still be caught ──────────────────────
+  check(
+    'a genuine level difference still blocks reuse',
+    recommendCvReuse('Senior Backend Engineer. Django, PostgreSQL, Redis.',
+                     'Junior Backend Engineer. Django, PostgreSQL, Redis.').reason,
+    'level-mismatch',
+  );
+  check(
+    'intern vs staff still blocks reuse',
+    hardMismatch('Engineering Intern, summer programme.', 'Staff Engineer, platform group.'),
+    true,
+  );
+
+  // ── 2. Ordinary English is not a job level ───────────────────────────────
+  // "Principal responsibilities" = "main duties"; "lead" here is a verb.
+  const boilerplateJd =
+    'Backend Engineer. Principal responsibilities: build payment infrastructure with ' +
+    'Django, PostgreSQL and Redis, design REST APIs, improve reliability, and lead ' +
+    'mentoring for teammates. Remote friendly.';
+  const seniorJd =
+    'Senior Backend Engineer. We build payment infrastructure with Django, PostgreSQL ' +
+    'and Redis. You will design REST APIs, improve reliability and mentor teammates. ' +
+    'Remote friendly.';
+  check('"Principal responsibilities" / verb "lead" is not a seniority level',
+    hardMismatch(seniorJd, boilerplateJd), false);
+  // The gate no longer overrides the score, so the score decides. Guard the
+  // fixture too: if it ever drifts below the medium threshold this assertion
+  // would pass for the wrong reason.
+  const boilerplateScore = jaccardSimilarity(seniorJd, boilerplateJd);
+  check('the fixture stays above the medium-similarity threshold',
+    boilerplateScore >= 0.45 && boilerplateScore < 0.72, true);
+  check('...so the recommendation follows the score instead of regenerating',
+    recommendCvReuse(seniorJd, boilerplateJd).decision, 'reuse-with-edits');
+
+  check('"mid-market" is a segment, not a seniority level',
+    hardMismatch('Backend Engineer for our mid-market segment. Django, PostgreSQL.',
+                 'Senior Backend Engineer. Django, PostgreSQL.'), false);
+
+  // A level word that DOES qualify the role must keep working, including the
+  // titles built from the very words excluded above.
+  check('"Lead Engineer" is still a level', hardMismatch('Lead Engineer, platform.', 'Junior Engineer, platform.'), true);
+  check('"Principal Engineer" is still a level',
+    hardMismatch('Principal Engineer, platform.', 'Junior Engineer, platform.'), true);
+  check('"Mid-level Engineer" is still a level',
+    hardMismatch('Mid-level Engineer, platform.', 'Intern Engineer, platform.'), true);
+
+  // ── 3. Several levels in one document = ambiguous, never a hard mismatch ──
+  const progressionCv =
+    'Experience: Junior Developer 2019-2021. Senior Developer 2021-2026. ' +
+    'Django, PostgreSQL, React.';
+  check('a CV naming several levels does not resolve to the first one',
+    hardMismatch('Senior Developer. Django, PostgreSQL, React.', progressionCv), false);
+  const cvScore = jaccardSimilarity('Senior Developer. Django, PostgreSQL, React.', progressionCv);
+  check('the CV fixture stays above the medium-similarity threshold', cvScore >= 0.45, true);
+  check('...so a progression CV is recommended for reuse, not regeneration',
+    recommendCvReuse('Senior Developer. Django, PostgreSQL, React.', progressionCv).decision,
+    'reuse-with-edits');
+
+  // Ambiguity on EITHER side is enough to stand down.
+  check('an ambiguous new JD also stands the gate down',
+    hardMismatch(progressionCv, 'Intern Developer. Django.'), false);
+} catch (error) {
+  fail(`jd-similarity.mjs seniority tests could not run: ${error.message}`);
+}


### PR DESCRIPTION
`recommendCvReuse` refuses to recommend reuse when the two documents describe different seniority levels. That gate **overrides the similarity score**, so a false positive turns a good reuse candidate into a full regeneration — the exact outcome the module exists to avoid.

It misfires two ways. Both are measured below against `main`.

## 1. Ordinary English read as a job level

`levelOf` matched a bare keyword anywhere in the text. `lead`, `principal` and `mid` are ordinary English, and JD boilerplate is full of them.

Two near-duplicate postings for the same seniority — the second just spells out "Principal responsibilities" and uses "lead" as a verb:

```
A: Senior Backend Engineer. We build payment infrastructure with Django, PostgreSQL
   and Redis. You will design REST APIs, improve reliability and mentor teammates.
B: Backend Engineer. Principal responsibilities: build payment infrastructure with
   Django, PostgreSQL and Redis, design REST APIs, improve reliability, and lead
   mentoring for teammates.
```

`main` → `{"decision":"regenerate","score":0.696,"reason":"level-mismatch"}`
The 0.696 score alone means `reuse-with-edits`; the gate discarded it.

Same with a customer segment: `mid-market` vs a senior posting → `regenerate` at score 0.571.

## 2. A document naming several levels collapsed to the earliest one

`LEVELS.findIndex(...)` returns the first index in the **LEVELS table**, not the level the document is about. Any CV showing career progression names every rank it held — and `jd-similarity.mjs`'s own usage line is `<new-jd.txt> <previous-jd-or-cv.txt>`, so a CV is an expected input.

```
CV: Experience: Junior Developer 2019-2021. Senior Developer 2021-2026. Django, PostgreSQL, React.
JD: Senior Developer. Django, PostgreSQL, React.
```

`main` reads that CV as **junior** → `{"decision":"regenerate","score":0.556,"reason":"level-mismatch"}`.

## The fix

- **`NON_LEVEL_FOLLOWERS`** — `principal` / `lead` / `mid` stop counting as levels when the following word puts them in their ordinary sense (`principal responsibilities`, `mid-market`, `lead the`). Only the trailing word is inspected, so `Principal Engineer`, `Lead Engineer` and `Mid-level Engineer` remain levels.
- **`levelsIn` returns every distinct level; `levelOf` resolves only when there is exactly one.** Several levels = ambiguous = the gate stands down and the similarity score decides. Guessing is worse than standing down: the gate exists to catch a *clear* difference.

Deliberately conservative in one more place — a JD saying "Senior Engineer reporting to the Principal Engineer" is now ambiguous and no longer blocks reuse. Losing a hard block is recoverable (the score still ranks it); a false block is not, because the recommendation never surfaces.

Behaviour is unchanged for every unambiguous pair: `Senior` vs `Junior`, `Intern` vs `Staff` and the CJK level words still block reuse.

## Test plan

`jd-similarity.mjs` had **no test file** (it was one of seven core scripts with zero test references). This adds `tests/jd-similarity-seniority.test.mjs`, picked up by `test-all.mjs` auto-discovery.

The relaxations are each paired with an assertion that a genuine mismatch still fires, and the two "recommendation follows the score" assertions are guarded by an explicit check that the fixture sits in the medium band — otherwise they would pass for the wrong reason if a fixture ever drifted.

- [x] 6 of the 13 assertions verified RED on `main`; the 7 guard assertions pass both before and after, which is what makes them guards.
- [x] `node test-all.mjs --only jd-similarity-seniority` — 13 passed, 0 failed.
- [x] `node test-all.mjs` — 3150 passed, 0 failed (the single warning is the pre-existing `Dashboard build skipped — go compiler not in env`).

## Out of scope, noted while measuring

`tokenize` never segments CJK: `'负责后端服务开发，具备Python经验'` yields whole clauses as single tokens, so two near-identical Chinese JDs score 0.500. A side effect is that the ten Chinese entries in `STOP_WORDS` are unreachable — they can only match a standalone token, which CJK text never produces. Fixing that means real segmentation (`Intl.Segmenter`) and it would move every CJK similarity score, so it does not belong in this PR. Happy to open it separately if you want it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved seniority-level detection in job-description matching.
  * Prevented ordinary terms such as “principal responsibilities,” “lead,” and “mid-market” from being misclassified as seniority levels.
  * Documents mentioning multiple seniority levels are now treated as ambiguous, reducing incorrect reuse or mismatch decisions.
  * Preserved blocking behavior for genuine seniority mismatches.

* **Tests**
  * Added coverage for seniority detection, similarity thresholds, reuse decisions, boilerplate, and career-progression scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->