### PR TITLE
fix(ollama): include profile context in evaluations

### DIFF
--- a/ollama-eval.mjs
+++ b/ollama-eval.mjs
@@ -30,6 +30,7 @@ import {
   formatReportNumber, releaseReportNumbers, reserveReportNumbers,
 } from './reserve-report-num.mjs';
 import { TokenAccumulator, formatBreakdown, normalizeOpenAIUsage } from './utils/token-tracker.mjs';
+import { buildBudgetedPrompt } from './lib/context-budget.mjs';
 
 const tracker = new TokenAccumulator();
 tracker.recordZeroToken('scan');
@@ -49,6 +50,7 @@ const PATHS = {
   shared:  join(ROOT, 'modes', '_shared.md'),
   oferta:  join(ROOT, 'modes', 'oferta.md'),
   cv:      join(ROOT, 'cv.md'),
+  profile: join(ROOT, 'modes', '_profile.md'),
   profileYml: join(ROOT, 'config', 'profile.yml'),
   reports: join(ROOT, 'reports'),
 };
@@ -199,31 +201,41 @@ console.log('\n📂  Loading context files...');
 const sharedContext = readFile(PATHS.shared, 'modes/_shared.md');
 const ofertaLogic   = readFile(PATHS.oferta, 'modes/oferta.md');
 const cvContent     = readFile(PATHS.cv,     'cv.md');
+const profileContent = readFile(PATHS.profile, 'modes/_profile.md');
 const profileYml    = readFile(PATHS.profileYml, 'config/profile.yml');
 const languageInstruction = outputLanguageInstruction(parseOutputLanguage(profileYml));
 
 // ---------------------------------------------------------------------------
-// Build system prompt
+// Build system prompt with token budget management
 // ---------------------------------------------------------------------------
+const { contextBody, budgetReport } = buildBudgetedPrompt({
+  sharedContent: sharedContext,
+  ofertaContent: ofertaLogic,
+  cvContent,
+  profileYml,
+  profileContent,
+  jdText,
+  maxTokens: 32_768, // matches options.num_ctx below
+});
+
+if (budgetReport.compressed) {
+  console.log(`📊  Token budget: ${budgetReport.beforeTokens} → ${budgetReport.afterTokens} tokens (saved ${budgetReport.beforeTokens - budgetReport.afterTokens})`);
+  console.log(`    Trimmed sections: ${budgetReport.removed.join(', ')}`);
+  if (budgetReport.overBudget) {
+    console.log(`    ⚠️  Still ${budgetReport.afterTokens - budgetReport.budget} tokens over budget after compression`);
+  }
+} else if (budgetReport.overBudget) {
+  console.log(`⚠️  Token budget: ${budgetReport.totalTokens} tokens exceeds ${budgetReport.budget} limit by ${budgetReport.totalTokens - budgetReport.budget}`);
+} else {
+  console.log(`📊  Token budget: ${budgetReport.totalTokens} tokens (within ${budgetReport.budget} limit)`);
+}
+
 const systemPrompt = `You are career-ops, an AI-powered job search assistant.
 You evaluate job offers against the user's CV using a structured A-G scoring system.
 
 Your evaluation methodology is defined below. Follow it exactly.
 
-═══════════════════════════════════════════════════════
-SYSTEM CONTEXT (_shared.md)
-═══════════════════════════════════════════════════════
-${sharedContext}
-
-═══════════════════════════════════════════════════════
-EVALUATION MODE (oferta.md)
-═══════════════════════════════════════════════════════
-${ofertaLogic}
-
-═══════════════════════════════════════════════════════
-CANDIDATE RESUME (cv.md)
-═══════════════════════════════════════════════════════
-${cvContent}
+${contextBody}
 
 ═══════════════════════════════════════════════════════
 IMPORTANT OPERATING RULES FOR THIS SESSION

--- a/tests/ollama-profile-context.test.mjs
+++ b/tests/ollama-profile-context.test.mjs
@@ -75,14 +75,18 @@ const server = createServer((req, res) => {
       capturedSystemPrompt = '';
     }
 
-    // Include both response shapes so this test stays compatible with #2647.
-    res.end(JSON.stringify({
-      choices: [{ message: { content: responseText } }],
-      message: { role: 'assistant', content: responseText },
-      usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
-      prompt_eval_count: 10,
-      eval_count: 5,
-    }));
+    if (req.url === '/api/chat') {
+      res.end(JSON.stringify({
+        message: { role: 'assistant', content: responseText },
+        prompt_eval_count: 10,
+        eval_count: 5,
+      }));
+    } else {
+      res.end(JSON.stringify({
+        choices: [{ message: { content: responseText } }],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      }));
+    }
   });
 });
 

--- a/tests/ollama-profile-context.test.mjs
+++ b/tests/ollama-profile-context.test.mjs
@@ -1,0 +1,121 @@
+// tests/ollama-profile-context.test.mjs — Ollama receives both profile sources (#2488).
+//
+// Run the real CLI from an isolated fixture root and capture its request with a
+// mock Ollama server. This proves profile content reaches the model without
+// touching a contributor's local career-ops data.
+import { execFile } from 'node:child_process';
+import { createServer } from 'node:http';
+import {
+  copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { pass, fail, NODE, ROOT } from './helpers.mjs';
+
+console.log('\nollama-eval — includes profile.yml and _profile.md in model context (#2488)');
+
+const fixtureRoot = mkdtempSync(join(ROOT, '.tmp-script-test-ollama-profile-context-'));
+const copyIntoFixture = (relativePath) => {
+  const destination = join(fixtureRoot, relativePath);
+  mkdirSync(dirname(destination), { recursive: true });
+  copyFileSync(join(ROOT, relativePath), destination);
+};
+
+for (const relativePath of [
+  'ollama-eval.mjs',
+  'profile-language.mjs',
+  'reserve-report-num.mjs',
+  'tracker-aliases.json',
+  'tracker-parse.mjs',
+  'tracker-utils.mjs',
+  'lib/context-budget.mjs',
+  'utils/token-tracker.mjs',
+]) {
+  copyIntoFixture(relativePath);
+}
+
+mkdirSync(join(fixtureRoot, 'config'), { recursive: true });
+mkdirSync(join(fixtureRoot, 'modes'), { recursive: true });
+writeFileSync(join(fixtureRoot, 'config', 'profile.yml'), [
+  'language:',
+  '  output: en',
+  'north_star: PROFILE_YML_SENTINEL_REMOTE_ONLY',
+  '',
+].join('\n'));
+writeFileSync(join(fixtureRoot, 'modes', '_profile.md'), 'PROFILE_MD_SENTINEL_REMOTE_ONLY\n');
+writeFileSync(join(fixtureRoot, 'modes', '_shared.md'), 'SHARED CONTEXT\n');
+writeFileSync(join(fixtureRoot, 'modes', 'oferta.md'), 'EVALUATION MODE\n');
+writeFileSync(join(fixtureRoot, 'cv.md'), 'CANDIDATE CV\n');
+
+let capturedSystemPrompt = '';
+const responseText = [
+  'Evaluation complete.',
+  '---SCORE_SUMMARY---',
+  'COMPANY: Example',
+  'ROLE: Engineer',
+  'SCORE: 4.0',
+  'ARCHETYPE: Builder',
+  'LEGITIMACY: High Confidence',
+  '---END_SUMMARY---',
+].join('\n');
+
+const server = createServer((req, res) => {
+  let raw = '';
+  req.on('data', (chunk) => { raw += chunk; });
+  req.on('end', () => {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    if (req.url === '/api/tags') {
+      res.end(JSON.stringify({ models: [] }));
+      return;
+    }
+
+    try {
+      const body = JSON.parse(raw);
+      capturedSystemPrompt = body.messages?.find((message) => message.role === 'system')?.content ?? '';
+    } catch {
+      capturedSystemPrompt = '';
+    }
+
+    // Include both response shapes so this test stays compatible with #2647.
+    res.end(JSON.stringify({
+      choices: [{ message: { content: responseText } }],
+      message: { role: 'assistant', content: responseText },
+      usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      prompt_eval_count: 10,
+      eval_count: 5,
+    }));
+  });
+});
+
+try {
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const port = server.address().port;
+  const result = await new Promise((resolve) => {
+    execFile(
+      NODE,
+      [join(fixtureRoot, 'ollama-eval.mjs'), '--url', `http://127.0.0.1:${port}`, '--no-save', 'On-site role.'],
+      { timeout: 30000 },
+      (error, stdout, stderr) => resolve({ error, stdout, stderr }),
+    );
+  });
+
+  if (result.error) {
+    fail(`Ollama fixture run failed: ${(result.stderr || result.error.message).trim().split('\n').pop()}`);
+  } else {
+    pass('runs the real Ollama evaluator against the isolated mock server');
+  }
+
+  if (capturedSystemPrompt.includes('PROFILE_YML_SENTINEL_REMOTE_ONLY')) {
+    pass('sends config/profile.yml content to Ollama');
+  } else {
+    fail('config/profile.yml content is missing from the Ollama system prompt');
+  }
+
+  if (capturedSystemPrompt.includes('PROFILE_MD_SENTINEL_REMOTE_ONLY')) {
+    pass('sends modes/_profile.md content to Ollama');
+  } else {
+    fail('modes/_profile.md content is missing from the Ollama system prompt');
+  }
+} finally {
+  await new Promise((resolve) => server.close(resolve));
+  rmSync(fixtureRoot, { recursive: true, force: true });
+}


### PR DESCRIPTION
## What does this PR do?

Routes `ollama-eval.mjs` through the shared `buildBudgetedPrompt()` path so local Ollama evaluations receive both `config/profile.yml` and `modes/_profile.md`, alongside the existing shared mode, evaluation mode, CV, and JD context.

Adds an isolated behavior test that runs the real CLI against a mock Ollama server and proves both profile sources reach the system prompt without touching local user data. The mock accepts both the current response shape and the native shape proposed in #2647.

## Related issue

Fixes #2488

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

## Verification

- Before the implementation, the behavior test completed the mock CLI run but failed both profile-presence assertions.
- After the implementation, the targeted suite reports `3 passed, 0 failed, 0 warnings`.
- Full `node test-all.mjs`: `3137 passed, 0 failed, 3 warnings`.
- The warnings are clean-clone/environment warnings; `.21` has no Go compiler, so the dashboard build was skipped. GitHub CI remains the full build gate.
- `node --check ollama-eval.mjs` and `node --check tests/ollama-profile-context.test.mjs` pass.
- `git diff --check` passes.
- `git merge-tree` reports no conflict with #2647.

Assisted by Codex; the behavior change and full Node suite were verified on the remote development host.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Profile content is now included in evaluation context alongside configuration and job details.
  - Evaluation prompts are automatically managed within the available token budget, compressing content when necessary.
  - The evaluator now reports compression activity, removed sections, and any remaining budget overages.

- **Tests**
  - Added integration coverage verifying that profile configuration and profile content are correctly sent to the evaluation service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->