### PR TITLE
fix(web): derive company matching keys from the core, not an ASCII-only copy

### DIFF
--- a/web/src/app/api/whats-new/route.ts
+++ b/web/src/app/api/whats-new/route.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { careerOpsRoot, readApplications } from "@/lib/career-ops";
+import { getNormalizeTextKey } from "@/lib/core/text-key";
 import type { DiscoveredOffer } from "@/lib/explore";
 
 export const runtime = "nodejs";
@@ -11,7 +12,10 @@ export const dynamic = "force-dynamic";
 // evaluated yet. No scan runs here — it reads the history a past scan already
 // wrote, so the home stays instant + free (directly answers the #1 token-cost
 // complaint). cols: url, first_seen, portal, title, company, status, location.
-const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+// Company matching keys come from the CORE (see lib/core/text-key.ts), never a
+// local reimplementation. The previous ASCII-only key deleted every non-Latin
+// letter, so "Škoda" collided with "Koda" — suppressing a real offer as
+// "already evaluated" — and "日本電産" keyed to the empty string (#2666).
 
 export async function GET(req: Request) {
   const days = Math.min(30, Math.max(1, Number(new URL(req.url).searchParams.get("days")) || 7));
@@ -24,6 +28,8 @@ export async function GET(req: Request) {
   }
 
   // Companies already evaluated → don't resurface as "new".
+  const normalizeTextKey = await getNormalizeTextKey();
+  const norm = (s: string) => normalizeTextKey(s, " ");
   const evaluated = new Set(readApplications().map((a) => norm(a.company)).filter(Boolean));
 
   const toOffer = (c: string[]): DiscoveredOffer | null => {

--- a/web/src/lib/core/text-key.ts
+++ b/web/src/lib/core/text-key.ts
@@ -1,0 +1,75 @@
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { careerOpsRoot } from "@/lib/career-ops";
+
+/**
+ * ACL for the core's `normalizeTextKey` (tracker-parse.mjs) — the shared
+ * matching/dedup key helper that scan.mjs and tracker-parse.mjs use (#2569).
+ *
+ * DERIVED, NOT COPIED (#2369, #2666). The web used to reimplement this with
+ * `[^a-z0-9]`, which deletes every non-ASCII letter: "Nestlé" keyed to "nestl",
+ * "Škoda" to "koda" and "日本電産" to the empty string. Two companies could then
+ * collide after stripping and a genuinely new offer got suppressed as "already
+ * evaluated" — a job the user never saw, with no signal.
+ *
+ * We can't `import` it statically: the core lives in the USER's checkout,
+ * resolved at runtime via careerOpsRoot(), and is not a build dependency of this
+ * app. So we import it dynamically per resolved root and cache the module —
+ * keyed by path, and NEVER caching a failure (the lesson from #2590, where a
+ * cached fallback pinned stale definitions for the process lifetime).
+ *
+ * Consequence, by design: the web keys with the normalizeTextKey of the user's
+ * OWN core, so web dedup always matches their CLI dedup. Version skew is
+ * semantic, and that's the correct behaviour — not a bug to paper over.
+ */
+
+type NormalizeTextKey = (value: unknown, separator?: string) => string;
+
+const modCache = new Map<string, NormalizeTextKey>();
+
+/**
+ * Last-resort key when the core is absent (a partial checkout, or a data-only
+ * install). This IS a copy, and we say so rather than pretending otherwise —
+ * but it degrades toward the LEAST destructive shape: Unicode-aware, so it can
+ * never reproduce the #2666 bug of silently dropping non-Latin names. Worst
+ * case it disagrees with the core about some exotic separator; it will never
+ * turn a company name into "".
+ */
+function fallbackKey(value: unknown, separator = ""): string {
+  return String(value ?? "")
+    .normalize("NFKC")
+    .toLowerCase()
+    .replace(/[^\p{L}\p{M}\p{N}]+/gu, separator)
+    .trim();
+}
+
+let warned = false;
+
+/** Resolve the core's normalizeTextKey for the current root, or the fallback. */
+export async function getNormalizeTextKey(): Promise<NormalizeTextKey> {
+  const file = path.join(careerOpsRoot(), "tracker-parse.mjs");
+  const hit = modCache.get(file);
+  if (hit) return hit;
+  try {
+    const mod = await import(/* webpackIgnore: true */ pathToFileURL(file).href);
+    const fn = mod?.normalizeTextKey;
+    if (typeof fn === "function") {
+      modCache.set(file, fn); // only successes are cached (#2590)
+      return fn;
+    }
+    if (!warned) {
+      warned = true;
+      console.warn(
+        `[career-ops] ${file} has no normalizeTextKey export — company matching falls back to a local Unicode-safe key. Update career-ops to keep web dedup identical to CLI dedup.`,
+      );
+    }
+  } catch {
+    if (!warned) {
+      warned = true;
+      console.warn(
+        `[career-ops] could not load ${file} — company matching falls back to a local Unicode-safe key. Update career-ops to keep web dedup identical to CLI dedup.`,
+      );
+    }
+  }
+  return fallbackKey;
+}


### PR DESCRIPTION
Server half of #2666.

## The bug

`whats-new` keyed companies with a local `[^a-z0-9]` normalizer, which deletes every non-Latin letter. That key decides **which offers get suppressed as already-evaluated**, so it had two live failure modes:

- **Silent loss:** a tracked `Koda` swallows a genuinely new `Škoda` offer — the user never sees it, with no signal.
- **Never matches:** `日本電産` keys to `""`, gets dropped by `.filter(Boolean)`, and resurfaces forever.

career-ops ships German, French, Japanese, Turkish and Arabic modes and scans EU/JP boards, so this hit the markets it most needed to serve.

## The fix

Keys come from the core's `normalizeTextKey` (#2569) through a new ACL, `lib/core/text-key.ts`.

It **can't be a static import**: the core lives in the *user's* checkout, resolved at runtime via `careerOpsRoot()`, and isn't a build dependency of this app. So the ACL imports it dynamically, caches per resolved path, and **never caches a failure** — the #2590 lesson, where a cached fallback pinned stale definitions for a whole process lifetime.

**By design:** the web keys with the user's *own* core, so web dedup always matches their CLI dedup. Version skew becomes semantic, which is the correct behaviour.

**The fallback is a copy, and the code says so** rather than hiding it — but a Unicode-aware one. Worst case it disagrees with the core about an exotic separator; it can never turn a company name into `""`.

## Verification

Ran the failing scenario live. With `Koda` already in the tracker:

| | |
|---|---|
| `Škoda` offer | ✅ surfaces (previously swallowed by `Koda`) |
| `日本電産` offer | ✅ surfaces (previously keyed to `""`) |
| `Koda` itself | ✅ still correctly suppressed |

Also exercised the fallback path: importing the core **throws catchably** on a partial checkout — `tracker-parse.mjs` loads `tracker-aliases.json` at module scope — and the ACL degrades instead of 500ing. Worth knowing generally: deriving from the core means inheriting its load-time file dependencies.

typecheck + `next build` green.

## Not in this PR

The **client half**: `explorer-view.tsx` must stop normalizing entirely and compare server-provided keys. A `"use client"` component can't reach the core at all, so the cure there is moving the computation server-side rather than importing. Follows separately, and it's the shape the maintainer's structural freeze will check (server derives / client doesn't normalize).

Refs #2666, #2369.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved company-name matching in the “What’s New” experience.
  * Company names containing non-Latin characters are now preserved and handled correctly.
  * Prevented distinct company names from being incorrectly treated as identical when filtering evaluated offers.
  * Added a reliable fallback for text matching when the shared text-normalization service is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->