### PR TITLE
fix(web): finish Unicode company keys for explore + registry (#2666)

### DIFF
--- a/web/src/app/actions/registry.ts
+++ b/web/src/app/actions/registry.ts
@@ -10,6 +10,7 @@
 
 import type { Application, InboxJob } from "@/lib/career-ops";
 import type { Job } from "@/components/jobs/job-store";
+import { normalizeTextKey } from "@/lib/core/normalize-text-key.mjs";
 
 export const AUTO_FIRE_MAX = 3; // fire ≤3 evaluations silently; confirm above that
 export const BATCH_CAP = 12; // hard ceiling on a single fan-out
@@ -84,7 +85,8 @@ export type DispatchResult =
 
 // ── helpers ──────────────────────────────────────────────────────────────
 const isStr = (v: unknown): v is string => typeof v === "string" && v.length > 0;
-const normCompany = (s: string) => s.toLowerCase().replace(/\s+/g, " ").trim();
+// Same shape as core normalizeTextKey(s, " ") — keeps accents/CJK, strips punct (#2666).
+const normCompany = (s: string) => normalizeTextKey(s, " ");
 
 // Allow only in-app routes (with optional :segment and ?query). Blocks anything
 // that isn't one of the app's own sections — the model can't navigate offsite.

--- a/web/src/components/explore/explorer-view.tsx
+++ b/web/src/components/explore/explorer-view.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { cn } from "@/lib/cn";
 import { instrumentSerif } from "@/lib/fonts";
 import type { Application, InboxJob } from "@/lib/career-ops";
+import { normalizeTextKey } from "@/lib/core/normalize-text-key.mjs";
 import { paramsToFilters, paramsToAi, type ExploreFilters } from "@/lib/explore";
 import { FilterBuilder } from "./filter-builder";
 import { DiscoveringState } from "./discovering-state";
@@ -15,7 +16,8 @@ import { AiSearchBox } from "./ai-search-box";
 import { ResultsList, type EnrichedOffer } from "./results-list";
 import { useExplore } from "./explore-provider";
 
-const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+// Same shape as core normalizeTextKey(s, " ") — never [^a-z0-9] (#2666).
+const norm = (s: string) => normalizeTextKey(s, " ");
 const CLI_NAMES: Record<string, string> = {
   claude: "Claude Code",
   codex: "Codex",

--- a/web/src/lib/core/normalize-text-key.mjs
+++ b/web/src/lib/core/normalize-text-key.mjs
@@ -1,0 +1,33 @@
+/**
+ * Unicode-safe company/role matching key — algorithm mirror of the core's
+ * `normalizeTextKey` in tracker-parse.mjs (#2569 / #2666).
+ *
+ * Plain .mjs (same pattern as clean-chips.mjs) so node:test and client bundles
+ * can import it without a TS runner or Node-only deps.
+ *
+ * WHY A COPY EXISTS AT ALL: the live core lives in the user's career-ops
+ * checkout and is resolved at runtime via careerOpsRoot() — unavailable in the
+ * browser. Server code prefers the live export through getNormalizeTextKey()
+ * in text-key.ts; this file is for (a) client components and (b) the last-resort
+ * fallback when the core module can't be loaded.
+ *
+ * Keep the body byte-for-byte aligned with tracker-parse.mjs `normalizeTextKey`
+ * (nullish → '', NFKC, lower, \p{L}\p{M}\p{N}, separator). The parity test in
+ * tests/lib/normalize-text-key.test.mjs fails the build if they drift.
+ *
+ * Never reinstate [^a-z0-9]: that deleted every non-ASCII letter ("Škoda"→"koda",
+ * "日本電産"→""), which both suppressed real offers and resurfaced evaluated ones.
+ */
+
+/**
+ * @param {unknown} value
+ * @param {string} [separator='']
+ * @returns {string}
+ */
+export function normalizeTextKey(value, separator = "") {
+  return String(value ?? "")
+    .normalize("NFKC")
+    .toLowerCase()
+    .replace(/[^\p{L}\p{M}\p{N}]+/gu, separator)
+    .trim();
+}

--- a/web/src/lib/core/text-key.ts
+++ b/web/src/lib/core/text-key.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { careerOpsRoot } from "@/lib/career-ops";
+import { normalizeTextKey as fallbackKey } from "./normalize-text-key.mjs";
 
 /**
  * ACL for the core's `normalizeTextKey` (tracker-parse.mjs) — the shared
@@ -21,27 +22,15 @@ import { careerOpsRoot } from "@/lib/career-ops";
  * Consequence, by design: the web keys with the normalizeTextKey of the user's
  * OWN core, so web dedup always matches their CLI dedup. Version skew is
  * semantic, and that's the correct behaviour — not a bug to paper over.
+ *
+ * Client components cannot use this ACL (Node-only). They import the Unicode-safe
+ * mirror from normalize-text-key.mjs instead — same algorithm, parity-tested
+ * against the core so [^a-z0-9] cannot creep back in.
  */
 
 type NormalizeTextKey = (value: unknown, separator?: string) => string;
 
 const modCache = new Map<string, NormalizeTextKey>();
-
-/**
- * Last-resort key when the core is absent (a partial checkout, or a data-only
- * install). This IS a copy, and we say so rather than pretending otherwise —
- * but it degrades toward the LEAST destructive shape: Unicode-aware, so it can
- * never reproduce the #2666 bug of silently dropping non-Latin names. Worst
- * case it disagrees with the core about some exotic separator; it will never
- * turn a company name into "".
- */
-function fallbackKey(value: unknown, separator = ""): string {
-  return String(value ?? "")
-    .normalize("NFKC")
-    .toLowerCase()
-    .replace(/[^\p{L}\p{M}\p{N}]+/gu, separator)
-    .trim();
-}
 
 let warned = false;
 

--- a/web/tests/lib/normalize-text-key.test.mjs
+++ b/web/tests/lib/normalize-text-key.test.mjs
@@ -1,0 +1,67 @@
+// Parity + regression tests for the web's Unicode-safe normalizeTextKey mirror.
+// Imports the core and the web copy side-by-side so they can never drift (#2369/#2666).
+//
+// Run:  node --test tests/lib/normalize-text-key.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { pathToFileURL } from "node:url";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { normalizeTextKey as webKey } from "../../src/lib/core/normalize-text-key.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const { normalizeTextKey: coreKey } = await import(
+  pathToFileURL(join(ROOT, "tracker-parse.mjs")).href
+);
+
+const CASES = [
+  ["Nestlé", "nestlé"],
+  ["Zürich Re", "zürich re"],
+  ["Ação Digital", "ação digital"],
+  ["Škoda", "škoda"],
+  ["日本電産", "日本電産"],
+  ["Acme, Inc.", "acme inc"],
+  ["Koda", "koda"],
+];
+
+test("web mirror matches core for accented / CJK / punctuation cases", () => {
+  for (const [input, expected] of CASES) {
+    assert.equal(webKey(input, " "), expected, `web: ${input}`);
+    assert.equal(coreKey(input, " "), expected, `core: ${input}`);
+    assert.equal(webKey(input, " "), coreKey(input, " "), `parity: ${input}`);
+  }
+});
+
+test("Škoda does not collide with Koda (the silent-suppression bug)", () => {
+  assert.notEqual(webKey("Škoda", " "), webKey("Koda", " "));
+  assert.equal(webKey("Škoda", " "), coreKey("Škoda", " "));
+});
+
+test("CJK company names stay non-empty (the forever-duplicate bug)", () => {
+  assert.ok(webKey("日本電産", " "));
+  assert.equal(webKey("日本電産", " "), "日本電産");
+});
+
+test("null/undefined key to empty string (not 'null'/'undefined')", () => {
+  assert.equal(webKey(null, " "), "");
+  assert.equal(webKey(undefined, " "), "");
+  assert.equal(webKey(null, " "), coreKey(null, " "));
+  assert.equal(webKey(undefined), coreKey(undefined));
+});
+
+test("default separator stays solid-key (opt-in space only)", () => {
+  assert.equal(webKey("Acme, Inc."), "acmeinc");
+  assert.equal(webKey("Acme, Inc."), coreKey("Acme, Inc."));
+  assert.equal(webKey("Acme, Inc.", " "), "acme inc");
+});
+
+test("ASCII-only [^a-z0-9] shape must not return (regression lock)", () => {
+  // The pre-#2666 web norm produced these broken keys. If anyone reintroduces
+  // that regex, these assertions fail loudly.
+  assert.notEqual(webKey("Nestlé", " "), "nestl");
+  assert.notEqual(webKey("Zürich Re", " "), "z rich re");
+  assert.notEqual(webKey("Ação Digital", " "), "a o digital");
+  assert.notEqual(webKey("Škoda", " "), "koda");
+  assert.notEqual(webKey("日本電産", " "), "");
+});


### PR DESCRIPTION
## Summary
- Completes #2666 after #2667: replace the remaining ASCII-only `norm` in `explorer-view` and the divergent `normCompany` in `registry` with a shared Unicode-safe `normalizeTextKey` mirror.
- Server routes still prefer live core via `getNormalizeTextKey()`; client uses the parity-tested `.mjs` mirror (core isn't available in the browser).
- Adds tests that lock Nestlé / Škoda≠Koda / 日本電産 / nullish against `tracker-parse.mjs`.
## Test plan
- [X] `cd web && node --test tests/lib/normalize-text-key.test.mjs`
- [X] `cd web && npm run typecheck`
- [X] Spot-check Explore enrichment: tracked Nestlé/Škoda/日本電産 rows match without false suppressions or empty-key resurfacing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text and company-name matching for accented characters, CJK text, punctuation, and other Unicode content.
  * Reduced key collisions and prevented empty keys for supported non-Latin text.
  * Standardized handling of missing values and separators.

* **Tests**
  * Added coverage for Unicode normalization, separators, nullish values, and previous normalization edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->