### PR TITLE
fix(reply-matcher): require corroboration for partial role-title matches

### DIFF
--- a/reply-matcher.mjs
+++ b/reply-matcher.mjs
@@ -43,26 +43,63 @@ export function checkCompanyMatch(text, company) {
   return false;
 }
 
-export function checkRoleMatch(text, role) {
+// Generic recruiting/HR vocabulary. These words are common enough in unrelated
+// senders' signatures, job titles, and boilerplate (e.g. "Talent Acquisition &
+// Diversity" in a recruiter's signature for a *different* company/role) that
+// they must never, by themselves, count as a "significant word" match against
+// a tracker role title — regardless of length (see #2671).
+const GENERIC_ROLE_WORDS = new Set([
+  'talent', 'acquisition', 'specialist', 'coordinator', 'operations',
+  'recruiter', 'recruiting', 'human', 'resources', 'people'
+]);
+
+// A role title that is a single word and that word is generic recruiting
+// vocabulary (e.g. role === "Recruiter") degenerates a "whole role" substring
+// check into exactly the same bare-word check the stoplist exists to block —
+// there is no multi-word phrase for the match to be specific about.
+function isBareGenericRole(role) {
+  const parts = role.split(/[\s_\\/()-]+/).filter(Boolean);
+  return parts.length === 1 && GENERIC_ROLE_WORDS.has(parts[0].toLowerCase());
+}
+
+// True only when the *entire* role title (or its Chinese, symbol-stripped form)
+// appears in the text as one contiguous substring. This is specific enough to
+// stand on its own, with no need for a corroborating company/domain signal —
+// unless the role is nothing but a single generic word (see isBareGenericRole).
+export function checkRoleMatchExact(text, role) {
   if (!role || !text) return false;
-  
+  if (isBareGenericRole(role)) return false;
+
   const tNorm = normalizeStr(text);
   const rNorm = normalizeStr(role);
   if (tNorm.includes(rNorm)) return true;
 
+  // Handle Chinese role titles ignoring symbols
+  const cleanRole = role.replace(/[\s_\\/()-]+/g, '');
+  if (cleanRole.length > 2 && tNorm.includes(cleanRole.toLowerCase())) return true;
+
+  return false;
+}
+
+export function checkRoleMatch(text, role) {
+  if (!role || !text) return false;
+
+  if (checkRoleMatchExact(text, role)) return true;
+
+  const tNorm = normalizeStr(text);
+
   // Sometimes role has extra descriptors, we check if a significant part matches
-  // Like "PY01_python开发工程师" vs "python开发工程师"
+  // Like "PY01_python开发工程师" vs "python开发工程师". Generic recruiting words
+  // (see GENERIC_ROLE_WORDS) are excluded no matter how long they are — a bare
+  // "Talent" or "Specialist" match is exactly the false-positive pattern from
+  // #2671, not evidence of a real match.
   const roleParts = role.split(/[\s_\\/()-]+/);
   for (const part of roleParts) {
-    if (part.length > 3 && tNorm.includes(normalizeStr(part))) {
+    if (part.length > 3 && !GENERIC_ROLE_WORDS.has(part.toLowerCase()) && tNorm.includes(normalizeStr(part))) {
       return true; // partial match on a significant word
     }
   }
 
-  // Handle Chinese role titles ignoring symbols
-  const cleanRole = role.replace(/[\s_\\/()-]+/g, '');
-  if (cleanRole.length > 2 && tNorm.includes(cleanRole.toLowerCase())) return true;
-  
   return false;
 }
 
@@ -181,14 +218,7 @@ export function matchCandidates(candidates, apps, followups = []) {
         signals.push('company-name');
         companyHint = app.company;
       }
-      
-      const isRoleMatch = checkRoleMatch(textContext, app.role);
-      if (isRoleMatch) {
-        score += 1.5;
-        signals.push('role-title');
-        roleHint = app.role;
-      }
-      
+
       let hasDomainMatch = false;
       if (fromDomain) {
         const appDomains = getAppDomains(app, followups);
@@ -198,6 +228,22 @@ export function matchCandidates(candidates, apps, followups = []) {
           signals.push('sender-domain');
           companyHint = companyHint || app.company;
         }
+      }
+
+      // A role match on the *entire* role title is specific enough to stand on
+      // its own. A match on just one "significant word" of the role (e.g. the
+      // role split into descriptor parts) is not — those partial matches must be
+      // corroborated by a company-name or sender-domain signal, otherwise a
+      // generic multi-word title (e.g. "Talent Acquisition Specialist") lets any
+      // unrelated email that happens to contain one of those words falsely
+      // attribute itself to this application (#2671).
+      const isRoleExactMatch = checkRoleMatchExact(textContext, app.role);
+      const isRolePartialMatch = !isRoleExactMatch && checkRoleMatch(textContext, app.role);
+      const isRoleMatch = isRoleExactMatch || (isRolePartialMatch && (isCompanyMatch || hasDomainMatch));
+      if (isRoleMatch) {
+        score += 1.5;
+        signals.push('role-title');
+        roleHint = app.role;
       }
 
       const postAppKeywords = ['interview', 'offer', 'rejection', '邀您面试', '简历通过', 'next steps', 'update on your application'];

--- a/reply-matcher.mjs
+++ b/reply-matcher.mjs
@@ -53,22 +53,33 @@ const GENERIC_ROLE_WORDS = new Set([
   'recruiter', 'recruiting', 'human', 'resources', 'people'
 ]);
 
-// A role title that is a single word and that word is generic recruiting
-// vocabulary (e.g. role === "Recruiter") degenerates a "whole role" substring
-// check into exactly the same bare-word check the stoplist exists to block —
-// there is no multi-word phrase for the match to be specific about.
-function isBareGenericRole(role) {
+// Matches any CJK ideograph. Chinese role titles are normally written with no
+// whitespace/underscore separators at all ("python开发工程师" is one semantic
+// phrase, not one "word"), so the single-word rule below must not treat them
+// as a bare single word the way it does for Latin-script titles.
+const CJK_RE = /[一-鿿㐀-䶿]/;
+
+// A role title that reduces to a single word — whether that word is generic
+// recruiting vocabulary ("Recruiter") or a specific one ("Engineer") — is not
+// specific enough to stand alone as an "exact" match: checking it as a whole-
+// role substring degenerates into exactly the same bare-word check the
+// corroboration requirement exists to gate. Such roles fall through to the
+// partial-match path in checkRoleMatch(), which requires company/domain
+// corroboration in matchCandidates(). Chinese compound titles are exempted:
+// they carry no separators to split on, so "single part" doesn't mean
+// "single word" for them.
+function isSingleWordRole(role) {
   const parts = role.split(/[\s_\\/()-]+/).filter(Boolean);
-  return parts.length === 1 && GENERIC_ROLE_WORDS.has(parts[0].toLowerCase());
+  return parts.length === 1 && !CJK_RE.test(parts[0]);
 }
 
 // True only when the *entire* role title (or its Chinese, symbol-stripped form)
 // appears in the text as one contiguous substring. This is specific enough to
 // stand on its own, with no need for a corroborating company/domain signal —
-// unless the role is nothing but a single generic word (see isBareGenericRole).
+// unless the role is nothing but a single word (see isSingleWordRole).
 export function checkRoleMatchExact(text, role) {
   if (!role || !text) return false;
-  if (isBareGenericRole(role)) return false;
+  if (isSingleWordRole(role)) return false;
 
   const tNorm = normalizeStr(text);
   const rNorm = normalizeStr(role);

--- a/reply-matcher.mjs
+++ b/reply-matcher.mjs
@@ -83,6 +83,12 @@ export function checkRoleMatchExact(text, role) {
 
   const tNorm = normalizeStr(text);
   const rNorm = normalizeStr(role);
+  // A whitespace-only role normalizes to '' (normalizeStr strips whitespace),
+  // and String.prototype.includes('') is always true — without this guard a
+  // blank role would "exactly" match any text at all, bypassing corroboration
+  // entirely. isSingleWordRole doesn't catch this: splitting a whitespace-only
+  // string on separators yields zero parts, not one.
+  if (!rNorm) return false;
   if (tNorm.includes(rNorm)) return true;
 
   // Handle Chinese role titles ignoring symbols

--- a/reply-matcher.test.mjs
+++ b/reply-matcher.test.mjs
@@ -67,6 +67,20 @@ test('checkRoleMatchExact - only a full contiguous role-title match counts', () 
   // A genuinely specific, non-generic partial word is not "exact" either —
   // checkRoleMatchExact only credits the whole role string.
   assert.equal(checkRoleMatchExact('邀请您参加python开发工程师的面试', 'PY01_python开发工程师'), false);
+  // Chinese compound titles have no separators to split on, so a "single part"
+  // Chinese role is still a whole-role match, not a bare single word.
+  assert.ok(checkRoleMatchExact('邀请您参加python开发工程师的面试', 'python开发工程师'));
+});
+
+test('checkRoleMatchExact - a single-word role, even a specific one, never counts standalone (CodeRabbit #2672)', () => {
+  // "Engineer" is not generic-recruiting vocabulary, but a single word gives a
+  // "whole role" check no more specificity than a bare-word check — it must
+  // fall through to the partial-match path and require corroboration, same as
+  // any other single significant word.
+  assert.equal(checkRoleMatchExact('We are excited to have you interview as an Engineer.', 'Engineer'), false);
+  // checkRoleMatch (the boolean convenience wrapper) still reports a match via
+  // the partial-word path; matchCandidates is what enforces corroboration.
+  assert.ok(checkRoleMatch('We are excited to have you interview as an Engineer.', 'Engineer'));
 });
 
 test('getAppDomains - drops prose tokens and filenames, keeps real hostnames', () => {
@@ -336,6 +350,39 @@ test('matchCandidates - a partial role-word match corroborated by company name s
   assert.equal(results[0].application_num, 31);
   assert.ok(results[0].signals.includes('company-name'));
   assert.ok(results[0].signals.includes('role-title'));
+  assert.equal(results[0].confidence, 'high');
+});
+
+test('matchCandidates - a partial role-word match corroborated by sender domain alone still matches (CodeRabbit #2672)', () => {
+  const apps = [
+    {
+      num: 32,
+      company: 'Fabrikam Systems',
+      role: 'PY01_Senior Backend Engineer',
+      notes: 'Recruiter contact: talent@fabrikam-careers.example'
+    }
+  ];
+
+  const candidates = [
+    {
+      message_id: 'msg10',
+      // Sender domain matches the recruiter contact domain in notes via
+      // getAppDomains. Neither "Fabrikam" nor "Fabrikam Systems" appears
+      // anywhere in the message text, so company-name matching cannot fire —
+      // the only corroboration available is the sender domain.
+      from: 'jane@fabrikam-careers.example',
+      subject: 'Backend Engineer — next steps',
+      body_snippet: 'We would like to invite you to interview.',
+      signal: 'interview_invite'
+    }
+  ];
+
+  const results = matchCandidates(candidates, apps, []);
+
+  assert.equal(results[0].application_num, 32);
+  assert.ok(results[0].signals.includes('sender-domain'));
+  assert.ok(results[0].signals.includes('role-title'));
+  assert.ok(!results[0].signals.includes('company-name'));
   assert.equal(results[0].confidence, 'high');
 });
 

--- a/reply-matcher.test.mjs
+++ b/reply-matcher.test.mjs
@@ -83,6 +83,16 @@ test('checkRoleMatchExact - a single-word role, even a specific one, never count
   assert.ok(checkRoleMatch('We are excited to have you interview as an Engineer.', 'Engineer'));
 });
 
+test('checkRoleMatchExact - a whitespace-only role never matches (CodeRabbit #2672)', () => {
+  // normalizeStr(' ') === '', and ''.includes('') === true for any text, so a
+  // blank role must be explicitly rejected — otherwise it would "exactly"
+  // match arbitrary text and bypass corroboration entirely. isSingleWordRole
+  // doesn't catch this: splitting a whitespace-only string on separators
+  // yields zero parts, not one.
+  assert.equal(checkRoleMatchExact('Completely unrelated message about anything at all.', '   '), false);
+  assert.equal(checkRoleMatchExact('Completely unrelated message about anything at all.', ' '), false);
+});
+
 test('getAppDomains - drops prose tokens and filenames, keeps real hostnames', () => {
   const app = {
     num: 68,

--- a/reply-matcher.test.mjs
+++ b/reply-matcher.test.mjs
@@ -4,6 +4,7 @@ import {
   extractDomain,
   checkCompanyMatch,
   checkRoleMatch,
+  checkRoleMatchExact,
   getAppDomains,
   matchCandidates,
   classifyReply
@@ -43,6 +44,29 @@ test('checkRoleMatch', () => {
   // Chinese role matches
   assert.ok(checkRoleMatch('邀请您参加PY01_python开发工程师的面试', 'python开发工程师'));
   assert.ok(checkRoleMatch('邀请您参加python开发工程师的面试', 'PY01_python开发工程师'));
+});
+
+test('checkRoleMatch - generic recruiting words never match alone (#2671)', () => {
+  // A signature line from an unrelated recruiter ("Talent Acquisition & Diversity")
+  // must not satisfy a role match against a "Talent Acquisition Specialist"
+  // tracker row just because "Talent" and "Acquisition" both appear >3 chars long.
+  assert.equal(
+    checkRoleMatch('Jane Doe, Talent Acquisition & Diversity, Contoso Inc.', 'Talent Acquisition Specialist'),
+    false
+  );
+  assert.equal(checkRoleMatch('Our People Operations team will be in touch.', 'People Operations Coordinator'), false);
+  assert.equal(checkRoleMatch('Please reach out to our recruiter for next steps.', 'Recruiter'), false);
+});
+
+test('checkRoleMatchExact - only a full contiguous role-title match counts', () => {
+  assert.ok(checkRoleMatchExact('Update for Software Engineer role', 'Software Engineer'));
+  assert.equal(
+    checkRoleMatchExact('Jane Doe, Talent Acquisition & Diversity, Contoso Inc.', 'Talent Acquisition Specialist'),
+    false
+  );
+  // A genuinely specific, non-generic partial word is not "exact" either —
+  // checkRoleMatchExact only credits the whole role string.
+  assert.equal(checkRoleMatchExact('邀请您参加python开发工程师的面试', 'PY01_python开发工程师'), false);
 });
 
 test('getAppDomains - drops prose tokens and filenames, keeps real hostnames', () => {
@@ -264,6 +288,77 @@ test('matchCandidates - a shared ATS domain in one application does not capture 
     !results[0].signals.includes('sender-domain'),
     'a shared ATS sender must not score a domain match against an unrelated application'
   );
+});
+
+test('matchCandidates - a generic role-title word from an unrelated sender does not match (#2671)', () => {
+  const apps = [
+    { num: 30, company: 'Contoso', role: 'Talent Acquisition Specialist', notes: '' }
+  ];
+
+  const candidates = [
+    {
+      message_id: 'msg7',
+      // Different company, different domain, no company-name mention. The only
+      // overlap with the tracker row is the generic "Talent Acquisition" phrase
+      // inside an unrelated recruiter's signature line, from a different thread
+      // about a different role entirely.
+      from: 'jane.doe@fabrikam.example',
+      subject: 'Following up on your application to Fabrikam',
+      body_snippet: 'Best,\nJane Doe\nTalent Acquisition & Diversity, Fabrikam',
+      signal: null
+    }
+  ];
+
+  const results = matchCandidates(candidates, apps, []);
+
+  assert.equal(results.length, 1);
+  assert.equal(results[0].application_num, null, 'a bare generic-word overlap must not be attributed to the tracker row');
+  assert.ok(!results[0].signals.includes('role-title'));
+});
+
+test('matchCandidates - a partial role-word match corroborated by company name still matches', () => {
+  const apps = [
+    { num: 31, company: 'Northwind Traders', role: 'PY01_Senior Backend Engineer', notes: '' }
+  ];
+
+  const candidates = [
+    {
+      message_id: 'msg8',
+      from: 'careers@northwindtraders.example',
+      subject: 'Interview with Northwind Traders — Backend Engineer role',
+      body_snippet: 'We would like to invite you to interview.',
+      signal: 'interview_invite'
+    }
+  ];
+
+  const results = matchCandidates(candidates, apps, []);
+
+  assert.equal(results[0].application_num, 31);
+  assert.ok(results[0].signals.includes('company-name'));
+  assert.ok(results[0].signals.includes('role-title'));
+  assert.equal(results[0].confidence, 'high');
+});
+
+test('matchCandidates - a genuinely specific role match still works standalone', () => {
+  // Regression guard: exact/near-exact and non-generic role matches must keep
+  // working without corroboration, per the existing "high confidence" fixture.
+  const apps = [
+    { num: 1, company: 'Acme Corp', role: 'Software Engineer', notes: '' }
+  ];
+
+  const candidates = [
+    {
+      message_id: 'msg9',
+      from: 'no-reply@unrelated.example',
+      subject: 'Update for Software Engineer role',
+      body_snippet: '',
+      signal: null
+    }
+  ];
+
+  const results = matchCandidates(candidates, apps, []);
+  assert.equal(results[0].application_num, 1);
+  assert.ok(results[0].signals.includes('role-title'));
 });
 
 test('classifyReply - high confidence interview fixtures', () => {


### PR DESCRIPTION
## Summary
- `checkRoleMatch()` treated any role-title word longer than 3 characters as sufficient evidence of a match on its own, with no requirement that a second signal (company name or sender domain) also corroborate it. A tracker row titled e.g. "Talent Acquisition Specialist" splits into `["Talent","Acquisition","Specialist"]`, and any unrelated email containing just one of those words anywhere — such as a different recruiter's signature line ("Talent Acquisition & Diversity") for a completely different company — satisfied the match and got misattributed to that application.
- Adds `checkRoleMatchExact()`, which only credits a match on the *entire* role title (or its Chinese, symbol-stripped form) as one contiguous substring. That's specific enough to stand alone. A role that's a single generic word (e.g. `role: "Recruiter"`) is excluded from this path too, since a whole-role check degenerates into a bare-word check when there's no multi-word phrase to be specific about.
- `matchCandidates()` now only counts a partial (significant-word) role match when it's corroborated by `checkCompanyMatch` or the sender-domain match, both already computed per-application in that loop.
- `checkRoleMatch()` also gains `GENERIC_ROLE_WORDS`, a stoplist of generic recruiting/HR vocabulary (talent, acquisition, specialist, coordinator, operations, recruiter, recruiting, human, resources, people) that never counts as a significant word by itself, regardless of length — these are exactly the words most likely to collide with unrelated senders' signatures/titles.

## Non-goals / guarantees preserved
- `checkCompanyMatch`, exact/near-exact role matches, and Chinese role-title handling are unchanged.
- No new match-confidence tiers beyond what's needed: an uncorroborated partial role match now simply doesn't count as a role-title signal, same as any other absent signal — it falls through to the existing `no-match`/`ambiguous-match` handling in `matchCandidates`.

## Test plan
- [x] `node --test reply-matcher.test.mjs` — all passing, including new regression coverage:
  - `checkRoleMatch - generic recruiting words never match alone (#2671)`
  - `checkRoleMatchExact - only a full contiguous role-title match counts`
  - `matchCandidates - a generic role-title word from an unrelated sender does not match (#2671)`
  - `matchCandidates - a partial role-word match corroborated by company name still matches`
  - `matchCandidates - a genuinely specific role match still works standalone`
- [x] `node test-all.mjs` — 3276 passed, 0 failed (1 pre-existing warning, unrelated to this change)

Closes #2671

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved role matching by distinguishing exact job titles from generic recruiting language.
  * Prevented unrelated messages from matching based solely on broad recruiting terms.
  * Partial role matches now require supporting company or sender-domain evidence.
  * Preserved valid matches for exact titles and specific company-correlated roles.

* **Tests**
  * Added coverage for exact titles, generic terms, unrelated messages, and company-supported partial matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->