### PR TITLE
feat(invite-match): distinguish AI-interviewer platforms (Alex, HireVue) from human calls

### DIFF
--- a/invite-match.mjs
+++ b/invite-match.mjs
@@ -313,6 +313,19 @@ export function extractReqId(text) {
 // extractPlatform()'s return contract (still a plain platform-name string);
 // it's read separately by isAIInterviewerPlatform() below so existing
 // extractPlatform() callers are unaffected.
+//
+// This flag is only ever set `true` when the *host alone* reliably confirms
+// AI-led modality for every invite that host can appear in. That is true
+// for Alex/Apriora (a single-purpose AI-interviewer product — there is no
+// human-conducted call on that host) but NOT for HireVue: HireVue is a
+// multi-modal platform whose `hirevue.com` hosts serve on-demand recorded
+// screening, live human-conducted interviews scheduled through the
+// platform, and a separate "AI Interviewer" product, all under the same
+// domain. No public discriminator (subdomain, path) reliably distinguishes
+// which modality a given hirevue.com invite link is for, so a HireVue match
+// stays `isAIInterviewer: false` here — HireVue is still detected and named
+// by extractPlatform(), it just isn't asserted as confirmed-AI. If HireVue
+// later exposes a reliable discriminator, promote its entry then.
 const PLATFORM_URL_PATTERNS = [
   { name: 'Zoom', pattern: /(?:^|[^\w@./?=&#-])(?:https?:\/\/)?(?:[\w-]+\.)?zoom\.us(?::\d{1,5})?(?:[/?#\s]|$)/i, isAIInterviewer: false },
   { name: 'Microsoft Teams', pattern: /(?:^|[^\w@./?=&#-])(?:https?:\/\/)?(?:[\w-]+\.)?teams\.(?:microsoft|live)\.com(?::\d{1,5})?(?:[/?#\s]|$)/i, isAIInterviewer: false },
@@ -320,10 +333,13 @@ const PLATFORM_URL_PATTERNS = [
   // Alex/Apriora — AI-interviewer platform, post-rebrand from a 2024 public
   // glitch incident. `meet.alex.com` and bare `alex.com` are both real
   // invite hosts; the optional-subdomain shape already covers both, same as
-  // the Zoom pattern above.
+  // the Zoom pattern above. Always AI-led by product design.
   { name: 'Alex', pattern: /(?:^|[^\w@./?=&#-])(?:https?:\/\/)?(?:[\w-]+\.)?alex\.com(?::\d{1,5})?(?:[/?#\s]|$)/i, isAIInterviewer: true },
-  // HireVue — AI-interviewer / on-demand video-screening platform.
-  { name: 'HireVue', pattern: /(?:^|[^\w@./?=&#-])(?:https?:\/\/)?(?:[\w-]+\.)?hirevue\.com(?::\d{1,5})?(?:[/?#\s]|$)/i, isAIInterviewer: true },
+  // HireVue — multi-modal video-screening platform (on-demand recorded,
+  // live human-conducted, and a separate AI Interviewer product all share
+  // this domain). Detected and named, but NOT asserted as confirmed-AI —
+  // see the comment above the array.
+  { name: 'HireVue', pattern: /(?:^|[^\w@./?=&#-])(?:https?:\/\/)?(?:[\w-]+\.)?hirevue\.com(?::\d{1,5})?(?:[/?#\s]|$)/i, isAIInterviewer: false },
 ];
 
 // A plain phone number, used only when no meeting-platform URL was found —
@@ -357,14 +373,22 @@ export function extractPlatform(text) {
 }
 
 /**
- * Whether the call platform detected in `text` is an AI-interviewer
+ * Whether the call platform detected in `text` is a CONFIRMED AI-interviewer
  * platform (#2673) — the candidate has a live conversation with an AI
- * system rather than a human panel (Alex/Apriora, HireVue). Deliberately a
- * separate boolean helper rather than a change to extractPlatform()'s
- * return contract, so existing callers (interview-prep.md's Platform field,
- * analyzeInvite() below) keep working unmodified. Same "never guessed"
- * discipline as extractPlatform(): pure pattern matching against the same
- * PLATFORM_URL_PATTERNS table, false when nothing plausible is found.
+ * system rather than a human panel. Currently true only for Alex/Apriora,
+ * whose host is single-purpose and always AI-led by product design.
+ * HireVue is deliberately excluded even though it's detected by
+ * extractPlatform(): it's a multi-modal platform (on-demand recorded,
+ * live human-conducted, and a separate AI Interviewer product all share the
+ * `hirevue.com` domain) with no public discriminator that reliably tells
+ * which modality a given invite link is for, so asserting AI-led for every
+ * HireVue match would be a guess, not a detection — see the comment above
+ * PLATFORM_URL_PATTERNS. Deliberately a separate boolean helper rather than
+ * a change to extractPlatform()'s return contract, so existing callers
+ * (interview-prep.md's Platform field, analyzeInvite() below) keep working
+ * unmodified. Same "never guessed" discipline as extractPlatform(): pure
+ * pattern matching against the same PLATFORM_URL_PATTERNS table, false when
+ * nothing plausible — or nothing *confirmed* — is found.
  *
  * @param {string} text - Raw pasted invite/scheduling text.
  * @returns {boolean}
@@ -846,9 +870,15 @@ function runSelfTest() {
   // --- AI-interviewer platforms (#2673) ---
   check(extractPlatform('Your interview link: https://meet.alex.com/room/abc123') === 'Alex', 'detects Alex from a meet.alex.com URL');
   check(extractPlatform('Please join at https://alex.com/i/xyz789') === 'Alex', 'detects Alex from a bare alex.com URL');
+  // HireVue is detected and named as a platform...
   check(extractPlatform('Complete your on-demand interview: https://app.hirevue.com/interview/abc') === 'HireVue', 'detects HireVue from a hirevue.com URL');
+  // ...but is NOT asserted as confirmed-AI: HireVue hosts on-demand
+  // recorded screening, live human-conducted interviews, and a separate AI
+  // Interviewer product on the same domain with no reliable public
+  // discriminator between them (CodeRabbit review on #2676), so asserting
+  // AI-led for every hirevue.com match would be a guess, not a detection.
+  check(isAIInterviewerPlatform('Complete your on-demand interview: https://app.hirevue.com/interview/abc') === false, 'isAIInterviewerPlatform is false for a HireVue URL — modality unconfirmed, not asserted AI-led');
   check(isAIInterviewerPlatform('Your interview link: https://meet.alex.com/room/abc123') === true, 'isAIInterviewerPlatform is true for an Alex URL');
-  check(isAIInterviewerPlatform('Complete your on-demand interview: https://app.hirevue.com/interview/abc') === true, 'isAIInterviewerPlatform is true for a HireVue URL');
   check(isAIInterviewerPlatform('Join via Zoom: https://us02web.zoom.us/j/1234567890') === false, 'isAIInterviewerPlatform is false for a human-mediated Zoom URL');
   check(isAIInterviewerPlatform('We will call you at (416) 555-0199 for the screen.') === false, 'isAIInterviewerPlatform is false for a plain phone number');
   check(isAIInterviewerPlatform('') === false, 'isAIInterviewerPlatform is false for empty text');

--- a/invite-match.mjs
+++ b/invite-match.mjs
@@ -307,10 +307,23 @@ export function extractReqId(text) {
 // the host and the following delimiter, since a URL authority may legally
 // include one (`https://zoom.us:443/j/123456789`) and rejecting it would
 // silently drop otherwise-legitimate invite links.
+// The `isAIInterviewer` flag distinguishes AI-interviewer platforms (#2673)
+// — where the candidate talks live to an AI system instead of a human —
+// from the human-mediated platforms above. It does NOT change
+// extractPlatform()'s return contract (still a plain platform-name string);
+// it's read separately by isAIInterviewerPlatform() below so existing
+// extractPlatform() callers are unaffected.
 const PLATFORM_URL_PATTERNS = [
-  { name: 'Zoom', pattern: /(?:^|[^\w@./?=&#-])(?:https?:\/\/)?(?:[\w-]+\.)?zoom\.us(?::\d{1,5})?(?:[/?#\s]|$)/i },
-  { name: 'Microsoft Teams', pattern: /(?:^|[^\w@./?=&#-])(?:https?:\/\/)?(?:[\w-]+\.)?teams\.(?:microsoft|live)\.com(?::\d{1,5})?(?:[/?#\s]|$)/i },
-  { name: 'Google Meet', pattern: /(?:^|[^\w@./?=&#-])(?:https?:\/\/)?(?:[\w-]+\.)?meet\.google\.com(?::\d{1,5})?(?:[/?#\s]|$)/i },
+  { name: 'Zoom', pattern: /(?:^|[^\w@./?=&#-])(?:https?:\/\/)?(?:[\w-]+\.)?zoom\.us(?::\d{1,5})?(?:[/?#\s]|$)/i, isAIInterviewer: false },
+  { name: 'Microsoft Teams', pattern: /(?:^|[^\w@./?=&#-])(?:https?:\/\/)?(?:[\w-]+\.)?teams\.(?:microsoft|live)\.com(?::\d{1,5})?(?:[/?#\s]|$)/i, isAIInterviewer: false },
+  { name: 'Google Meet', pattern: /(?:^|[^\w@./?=&#-])(?:https?:\/\/)?(?:[\w-]+\.)?meet\.google\.com(?::\d{1,5})?(?:[/?#\s]|$)/i, isAIInterviewer: false },
+  // Alex/Apriora — AI-interviewer platform, post-rebrand from a 2024 public
+  // glitch incident. `meet.alex.com` and bare `alex.com` are both real
+  // invite hosts; the optional-subdomain shape already covers both, same as
+  // the Zoom pattern above.
+  { name: 'Alex', pattern: /(?:^|[^\w@./?=&#-])(?:https?:\/\/)?(?:[\w-]+\.)?alex\.com(?::\d{1,5})?(?:[/?#\s]|$)/i, isAIInterviewer: true },
+  // HireVue — AI-interviewer / on-demand video-screening platform.
+  { name: 'HireVue', pattern: /(?:^|[^\w@./?=&#-])(?:https?:\/\/)?(?:[\w-]+\.)?hirevue\.com(?::\d{1,5})?(?:[/?#\s]|$)/i, isAIInterviewer: true },
 ];
 
 // A plain phone number, used only when no meeting-platform URL was found —
@@ -332,7 +345,7 @@ const PHONE_PATTERN = /(?:\+?\d{1,3}[\s.-])?\(?\d{3}\)?[\s.-]\d{3}[\s.-]\d{4}\b/
  * above and the title/location filters in scan.mjs).
  *
  * @param {string} text - Raw pasted invite/scheduling text.
- * @returns {'Zoom'|'Microsoft Teams'|'Google Meet'|'Phone'|null}
+ * @returns {'Zoom'|'Microsoft Teams'|'Google Meet'|'Alex'|'HireVue'|'Phone'|null}
  */
 export function extractPlatform(text) {
   if (!text) return null;
@@ -341,6 +354,27 @@ export function extractPlatform(text) {
   }
   if (PHONE_PATTERN.test(text)) return 'Phone';
   return null;
+}
+
+/**
+ * Whether the call platform detected in `text` is an AI-interviewer
+ * platform (#2673) — the candidate has a live conversation with an AI
+ * system rather than a human panel (Alex/Apriora, HireVue). Deliberately a
+ * separate boolean helper rather than a change to extractPlatform()'s
+ * return contract, so existing callers (interview-prep.md's Platform field,
+ * analyzeInvite() below) keep working unmodified. Same "never guessed"
+ * discipline as extractPlatform(): pure pattern matching against the same
+ * PLATFORM_URL_PATTERNS table, false when nothing plausible is found.
+ *
+ * @param {string} text - Raw pasted invite/scheduling text.
+ * @returns {boolean}
+ */
+export function isAIInterviewerPlatform(text) {
+  if (!text) return false;
+  for (const { pattern, isAIInterviewer } of PLATFORM_URL_PATTERNS) {
+    if (isAIInterviewer && pattern.test(text)) return true;
+  }
+  return false;
 }
 
 // --- Email-type classification (#2098) ---
@@ -578,6 +612,10 @@ export function analyzeInvite(text, trackerRows = null) {
     date: extractDate(text),
     reqId: extractReqId(text),
     platform: extractPlatform(text),
+    // Additive field (#2673) — does not change the shape of any existing
+    // key above, so existing callers reading `signals.platform` etc. are
+    // unaffected.
+    isAIInterviewer: isAIInterviewerPlatform(text),
   };
   const rows = trackerRows ?? loadTracker();
   const candidates = matchInvite(signals, rows);
@@ -804,6 +842,16 @@ function runSelfTest() {
   check(extractPlatform('Join via Zoom: https://zoom.us:443/j/123456789') === 'Zoom', 'detects Zoom from a zoom.us URL with an explicit port');
   check(extractPlatform('Join Microsoft Teams Meeting: https://teams.microsoft.com:8443/l/meetup-join/xyz') === 'Microsoft Teams', 'detects Microsoft Teams from a teams.microsoft.com URL with an explicit port');
   check(extractPlatform('Google Meet: https://meet.google.com:443/abc-defg-hij') === 'Google Meet', 'detects Google Meet from a meet.google.com URL with an explicit port');
+
+  // --- AI-interviewer platforms (#2673) ---
+  check(extractPlatform('Your interview link: https://meet.alex.com/room/abc123') === 'Alex', 'detects Alex from a meet.alex.com URL');
+  check(extractPlatform('Please join at https://alex.com/i/xyz789') === 'Alex', 'detects Alex from a bare alex.com URL');
+  check(extractPlatform('Complete your on-demand interview: https://app.hirevue.com/interview/abc') === 'HireVue', 'detects HireVue from a hirevue.com URL');
+  check(isAIInterviewerPlatform('Your interview link: https://meet.alex.com/room/abc123') === true, 'isAIInterviewerPlatform is true for an Alex URL');
+  check(isAIInterviewerPlatform('Complete your on-demand interview: https://app.hirevue.com/interview/abc') === true, 'isAIInterviewerPlatform is true for a HireVue URL');
+  check(isAIInterviewerPlatform('Join via Zoom: https://us02web.zoom.us/j/1234567890') === false, 'isAIInterviewerPlatform is false for a human-mediated Zoom URL');
+  check(isAIInterviewerPlatform('We will call you at (416) 555-0199 for the screen.') === false, 'isAIInterviewerPlatform is false for a plain phone number');
+  check(isAIInterviewerPlatform('') === false, 'isAIInterviewerPlatform is false for empty text');
 
   // --- matchInvite (fixture rows, no real tracker data) ---
   const fixtureRows = [

--- a/invite-match.mjs
+++ b/invite-match.mjs
@@ -314,18 +314,26 @@ export function extractReqId(text) {
 // it's read separately by isAIInterviewerPlatform() below so existing
 // extractPlatform() callers are unaffected.
 //
-// This flag is only ever set `true` when the *host alone* reliably confirms
-// AI-led modality for every invite that host can appear in. That is true
-// for Alex/Apriora (a single-purpose AI-interviewer product — there is no
-// human-conducted call on that host) but NOT for HireVue: HireVue is a
-// multi-modal platform whose `hirevue.com` hosts serve on-demand recorded
-// screening, live human-conducted interviews scheduled through the
-// platform, and a separate "AI Interviewer" product, all under the same
-// domain. No public discriminator (subdomain, path) reliably distinguishes
-// which modality a given hirevue.com invite link is for, so a HireVue match
-// stays `isAIInterviewer: false` here — HireVue is still detected and named
-// by extractPlatform(), it just isn't asserted as confirmed-AI. If HireVue
-// later exposes a reliable discriminator, promote its entry then.
+// This flag is a best-effort heuristic tied to extractPlatform()'s own
+// first-match resolution, NOT a guarantee that the host is exclusively
+// AI-led: isAIInterviewerPlatform() below derives its answer from whichever
+// pattern actually wins the same ordered scan extractPlatform() runs, so the
+// two agree by construction. Alex/Apriora is flagged `true` for a clean
+// single-link Alex match, but Alex is itself multi-modal in practice — it
+// also sells a "Coordinator" product that schedules and sends calendar
+// invites for human-conducted rounds, so an alex.com link can legitimately
+// appear on an invite to a human interview (#2676 review, santifer). When a
+// human-platform link (Zoom, Teams, etc.) is also present and wins the scan,
+// the match resolves to that human platform and this flag is `false` for
+// that invite, even though alex.com appears somewhere in the text. HireVue
+// is flagged `false` unconditionally: its `hirevue.com` hosts serve
+// on-demand recorded screening, live human-conducted interviews scheduled
+// through the platform, and a separate "AI Interviewer" product, all under
+// the same domain, with no public discriminator (subdomain, path) that
+// reliably distinguishes which modality a given hirevue.com invite link is
+// for — HireVue is still detected and named by extractPlatform(), it just
+// isn't asserted as confirmed-AI. If HireVue later exposes a reliable
+// discriminator, promote its entry then.
 const PLATFORM_URL_PATTERNS = [
   { name: 'Zoom', pattern: /(?:^|[^\w@./?=&#-])(?:https?:\/\/)?(?:[\w-]+\.)?zoom\.us(?::\d{1,5})?(?:[/?#\s]|$)/i, isAIInterviewer: false },
   { name: 'Microsoft Teams', pattern: /(?:^|[^\w@./?=&#-])(?:https?:\/\/)?(?:[\w-]+\.)?teams\.(?:microsoft|live)\.com(?::\d{1,5})?(?:[/?#\s]|$)/i, isAIInterviewer: false },
@@ -395,8 +403,16 @@ export function extractPlatform(text) {
  */
 export function isAIInterviewerPlatform(text) {
   if (!text) return false;
+  // Must use the SAME first-match iteration as extractPlatform() (#2676
+  // review, santifer): scanning independently for any AI-flagged pattern
+  // anywhere in the text — regardless of which platform extractPlatform()
+  // actually resolves to — let a body containing both a human-platform link
+  // (Zoom, Teams) AND an alex.com link flag as AI even though the platform
+  // that wins is the human one. Deriving from the same match means the two
+  // functions agree by construction: whichever pattern extractPlatform()
+  // would report is exactly the one whose isAIInterviewer flag decides this.
   for (const { pattern, isAIInterviewer } of PLATFORM_URL_PATTERNS) {
-    if (isAIInterviewer && pattern.test(text)) return true;
+    if (pattern.test(text)) return isAIInterviewer === true;
   }
   return false;
 }

--- a/invite-match.test.mjs
+++ b/invite-match.test.mjs
@@ -161,6 +161,26 @@ eq('isAIInterviewerPlatform is false for a phone-only invite', isAIInterviewerPl
 eq('isAIInterviewerPlatform is false when nothing plausible is present', isAIInterviewerPlatform('Please confirm your availability for the interview.'), false);
 eq('isAIInterviewerPlatform is false for empty text', isAIInterviewerPlatform(''), false);
 
+// Multi-link regression (#2676 review, santifer): Alex also sells a
+// "Coordinator" product that schedules human-conducted rounds and sends the
+// calendar invite/reminder itself, so an alex.com link legitimately appears
+// alongside a human meeting-platform link. isAIInterviewerPlatform() must
+// derive its answer from the SAME first-match extractPlatform() picks, not
+// scan independently for any AI-flagged pattern anywhere in the text — a
+// Zoom (or Teams) link that wins the match must resolve the platform to the
+// human tool and keep isAIInterviewerPlatform() false, even with alex.com
+// also present in the body.
+{
+  const zoomAndAlexBody = 'Join via Zoom: https://us05web.zoom.us/j/9998887777 (reminders sent via https://alex.com/i/xyz789)';
+  eq('multi-link body (Zoom + alex.com) resolves platform to Zoom', extractPlatform(zoomAndAlexBody), 'Zoom');
+  eq('multi-link body (Zoom + alex.com) is not flagged as AI interviewer', isAIInterviewerPlatform(zoomAndAlexBody), false);
+}
+{
+  const teamsAndAlexBody = 'Join via Microsoft Teams: https://teams.microsoft.com/l/meetup-join/abc (coordinated via https://alex.com/i/xyz789)';
+  eq('multi-link body (Teams + alex.com) resolves platform to Microsoft Teams', extractPlatform(teamsAndAlexBody), 'Microsoft Teams');
+  eq('multi-link body (Teams + alex.com) is not flagged as AI interviewer', isAIInterviewerPlatform(teamsAndAlexBody), false);
+}
+
 // Lookalike hosts must not be detected as Alex/HireVue either, same
 // discipline as the existing Zoom/Teams/Meet lookalike-host guards.
 eq('lookalike host (notalex.com) is not detected as Alex', extractPlatform('Please visit https://notalex.com for details.'), null);

--- a/invite-match.test.mjs
+++ b/invite-match.test.mjs
@@ -123,20 +123,29 @@ eq('Microsoft Teams URL with explicit port detected as Microsoft Teams', extract
 eq('Google Meet URL with explicit port detected as Google Meet', extractPlatform('https://meet.google.com:443/xyz-abcd-efg'), 'Google Meet');
 
 // extractPlatform + isAIInterviewerPlatform — AI-interviewer platform
-// detection (issue #2673). Alex/Apriora and HireVue are candidate-facing AI
-// systems rather than human-mediated calls, so they get their own platform
-// names from extractPlatform() (matching the existing Zoom/Teams/Meet naming
-// convention: a specific platform name, not a generic label) plus a separate
-// boolean signal from isAIInterviewerPlatform() that leaves extractPlatform()'s
-// own return contract untouched.
+// detection (issue #2673). Alex/Apriora and HireVue are both detected and
+// named as platforms by extractPlatform() (matching the existing
+// Zoom/Teams/Meet naming convention: a specific platform name, not a
+// generic label). Only Alex/Apriora is asserted as *confirmed* AI-led by
+// isAIInterviewerPlatform() — its host is single-purpose, always AI-led by
+// product design. HireVue is deliberately NOT asserted as confirmed-AI:
+// per CodeRabbit review on #2676, HireVue is a multi-modal platform
+// (on-demand recorded screening, live human-conducted interviews, and a
+// separate "AI Interviewer" product all share the hirevue.com domain) with
+// no public discriminator that reliably tells which modality a given
+// invite link is for, so treating every HireVue match as confirmed-AI
+// would be a guess, not a detection.
 eq('Alex (meet.alex.com) URL detected as Alex', extractPlatform('Your interview link: https://meet.alex.com/room/abc123'), 'Alex');
 eq('Alex (bare alex.com) URL detected as Alex', extractPlatform('Please join at https://alex.com/i/xyz789'), 'Alex');
-eq('HireVue URL detected as HireVue', extractPlatform('Complete your on-demand interview: https://app.hirevue.com/interview/abc'), 'HireVue');
+eq('HireVue URL detected as HireVue (platform detection, modality-independent)', extractPlatform('Complete your on-demand interview: https://app.hirevue.com/interview/abc'), 'HireVue');
 eq('HireVue URL with explicit port detected as HireVue', extractPlatform('https://hirevue.com:443/interview/abc'), 'HireVue');
 
 eq('isAIInterviewerPlatform is true for an Alex URL', isAIInterviewerPlatform('Your interview link: https://meet.alex.com/room/abc123'), true);
 eq('isAIInterviewerPlatform is true for a bare alex.com URL', isAIInterviewerPlatform('Please join at https://alex.com/i/xyz789'), true);
-eq('isAIInterviewerPlatform is true for a HireVue URL', isAIInterviewerPlatform('Complete your on-demand interview: https://app.hirevue.com/interview/abc'), true);
+// HireVue is detected as a platform above, but must NOT be asserted as
+// confirmed AI-interviewer — modality unconfirmed, not asserted AI-led.
+eq('isAIInterviewerPlatform is false for a HireVue URL (modality unconfirmed)', isAIInterviewerPlatform('Complete your on-demand interview: https://app.hirevue.com/interview/abc'), false);
+eq('isAIInterviewerPlatform is false for a HireVue URL even when framed as a live interview', isAIInterviewerPlatform('Join your live HireVue interview: https://app.hirevue.com/interview/abc'), false);
 
 // Existing Zoom/Teams/Meet/Phone paths must remain unaffected by the new
 // AI-interviewer patterns — both in what extractPlatform() reports and in
@@ -159,6 +168,15 @@ eq('email address containing alex.com is not detected as Alex', extractPlatform(
 eq('lookalike host (nothirevue.com) is not detected as HireVue', extractPlatform('Please visit https://nothirevue.com for details.'), null);
 eq('does not detect a platform-looking URL path (Alex)', extractPlatform('See https://example.com/alex.com for details.'), null);
 eq('does not detect a platform-looking URL path (HireVue)', extractPlatform('See https://example.com/hirevue.com for details.'), null);
+
+// A platform-looking host must only be recognized at a true URL authority
+// boundary, not as a query value on an unrelated host — same discipline as
+// the existing Zoom/Teams/Meet query-value guards (issue #2128 review
+// finding), extended to the new Alex/HireVue patterns.
+eq('does not detect a platform-looking query value (Alex)', extractPlatform('See https://example.com?next=alex.com for details.'), null);
+eq('does not detect a platform-looking query value (HireVue)', extractPlatform('See https://example.com?next=hirevue.com for details.'), null);
+eq('isAIInterviewerPlatform is false for a platform-looking query value (Alex)', isAIInterviewerPlatform('See https://example.com?next=alex.com for details.'), false);
+eq('isAIInterviewerPlatform is false for a platform-looking query value (HireVue)', isAIInterviewerPlatform('See https://example.com?next=hirevue.com for details.'), false);
 
 // --- #2098: rejection classification is unaffected-invite-classification regression check ---
 

--- a/invite-match.test.mjs
+++ b/invite-match.test.mjs
@@ -10,7 +10,7 @@
 import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { matchInvite, normalizeCompanyName, extractPlatform, classifyEmail, analyzeInvite, applyRejectionStatus, selectApplyTarget } from './invite-match.mjs';
+import { matchInvite, normalizeCompanyName, extractPlatform, isAIInterviewerPlatform, classifyEmail, analyzeInvite, applyRejectionStatus, selectApplyTarget } from './invite-match.mjs';
 
 let passed = 0;
 let failed = 0;
@@ -121,6 +121,44 @@ eq('does not detect a platform-looking query value (Google Meet)', extractPlatfo
 eq('Zoom URL with explicit port detected as Zoom', extractPlatform('Join: https://zoom.us:443/j/123456789'), 'Zoom');
 eq('Microsoft Teams URL with explicit port detected as Microsoft Teams', extractPlatform('https://teams.microsoft.com:8443/l/meetup-join/abc'), 'Microsoft Teams');
 eq('Google Meet URL with explicit port detected as Google Meet', extractPlatform('https://meet.google.com:443/xyz-abcd-efg'), 'Google Meet');
+
+// extractPlatform + isAIInterviewerPlatform — AI-interviewer platform
+// detection (issue #2673). Alex/Apriora and HireVue are candidate-facing AI
+// systems rather than human-mediated calls, so they get their own platform
+// names from extractPlatform() (matching the existing Zoom/Teams/Meet naming
+// convention: a specific platform name, not a generic label) plus a separate
+// boolean signal from isAIInterviewerPlatform() that leaves extractPlatform()'s
+// own return contract untouched.
+eq('Alex (meet.alex.com) URL detected as Alex', extractPlatform('Your interview link: https://meet.alex.com/room/abc123'), 'Alex');
+eq('Alex (bare alex.com) URL detected as Alex', extractPlatform('Please join at https://alex.com/i/xyz789'), 'Alex');
+eq('HireVue URL detected as HireVue', extractPlatform('Complete your on-demand interview: https://app.hirevue.com/interview/abc'), 'HireVue');
+eq('HireVue URL with explicit port detected as HireVue', extractPlatform('https://hirevue.com:443/interview/abc'), 'HireVue');
+
+eq('isAIInterviewerPlatform is true for an Alex URL', isAIInterviewerPlatform('Your interview link: https://meet.alex.com/room/abc123'), true);
+eq('isAIInterviewerPlatform is true for a bare alex.com URL', isAIInterviewerPlatform('Please join at https://alex.com/i/xyz789'), true);
+eq('isAIInterviewerPlatform is true for a HireVue URL', isAIInterviewerPlatform('Complete your on-demand interview: https://app.hirevue.com/interview/abc'), true);
+
+// Existing Zoom/Teams/Meet/Phone paths must remain unaffected by the new
+// AI-interviewer patterns — both in what extractPlatform() reports and in
+// isAIInterviewerPlatform() correctly reporting false for all of them.
+eq('Zoom URL still detected as Zoom (unaffected by AI-interviewer patterns)', extractPlatform('Join: https://us05web.zoom.us/j/9998887777'), 'Zoom');
+eq('Microsoft Teams URL still detected as Microsoft Teams (unaffected by AI-interviewer patterns)', extractPlatform('https://teams.microsoft.com/l/meetup-join/abc'), 'Microsoft Teams');
+eq('Google Meet URL still detected as Google Meet (unaffected by AI-interviewer patterns)', extractPlatform('https://meet.google.com/xyz-abcd-efg'), 'Google Meet');
+eq('phone number still detected as Phone (unaffected by AI-interviewer patterns)', extractPlatform('We will call you at 416-555-0199 for the screen.'), 'Phone');
+eq('isAIInterviewerPlatform is false for a Zoom URL', isAIInterviewerPlatform('Join: https://us05web.zoom.us/j/9998887777'), false);
+eq('isAIInterviewerPlatform is false for a Microsoft Teams URL', isAIInterviewerPlatform('https://teams.microsoft.com/l/meetup-join/abc'), false);
+eq('isAIInterviewerPlatform is false for a Google Meet URL', isAIInterviewerPlatform('https://meet.google.com/xyz-abcd-efg'), false);
+eq('isAIInterviewerPlatform is false for a phone-only invite', isAIInterviewerPlatform('We will call you at 416-555-0199 for the screen.'), false);
+eq('isAIInterviewerPlatform is false when nothing plausible is present', isAIInterviewerPlatform('Please confirm your availability for the interview.'), false);
+eq('isAIInterviewerPlatform is false for empty text', isAIInterviewerPlatform(''), false);
+
+// Lookalike hosts must not be detected as Alex/HireVue either, same
+// discipline as the existing Zoom/Teams/Meet lookalike-host guards.
+eq('lookalike host (notalex.com) is not detected as Alex', extractPlatform('Please visit https://notalex.com for details.'), null);
+eq('email address containing alex.com is not detected as Alex', extractPlatform('Contact support@alex.com with questions.'), null);
+eq('lookalike host (nothirevue.com) is not detected as HireVue', extractPlatform('Please visit https://nothirevue.com for details.'), null);
+eq('does not detect a platform-looking URL path (Alex)', extractPlatform('See https://example.com/alex.com for details.'), null);
+eq('does not detect a platform-looking URL path (HireVue)', extractPlatform('See https://example.com/hirevue.com for details.'), null);
 
 // --- #2098: rejection classification is unaffected-invite-classification regression check ---
 

--- a/modes/interview-prep.md
+++ b/modes/interview-prep.md
@@ -120,6 +120,19 @@ If the company is small or obscure and yields few results, broaden: search for t
 
 If data is insufficient for any field, write "unknown — not enough data" rather than guessing.
 
+**AI-interviewer platforms (#2673):** when `invite-match.mjs`'s `isAIInterviewerPlatform` returns true for the invite/scheduling text (currently Alex/Apriora and HireVue), the candidate talks live to an AI system rather than a human — append an **AI-Interviewer Notes** block right after Process Overview:
+
+```markdown
+## AI-Interviewer Notes
+This round is conducted by an AI interviewer ({platform}), not a human panel. Prep differs from a human call:
+- No human rapport or reading-the-room available — camera eye contact and steady pacing matter more, not less.
+- The AI generates adaptive follow-up questions from the literal content of your answers, so vague or generic answers get probed harder than with a human interviewer. Answer with specifics.
+- Don't read from a script — it reads as unnatural to the AI's follow-up generation.
+- If the call glitches mid-conversation (transcription errors, repeated or looping questions), that is a known issue on some AI-interviewer platforms — documented for Alex/Apriora specifically — not a signal you did something wrong. Stay calm and keep answering normally.
+```
+
+Skip this block entirely when the platform is human-mediated or not detected.
+
 ## Step 2.5 — Audience Map
 
 Classify each round from Step 2 into exactly one audience. The audience drives what gets prioritized in Steps 4 and 7.
@@ -170,6 +183,8 @@ For each round discovered in research:
 If round structure is unknown, state that and provide the best available intel on what types of rounds to expect based on company size, stage, and role level.
 
 When a round's Platform is known, add one logistics line to "How to prepare": for a video platform (Zoom / Microsoft Teams / Google Meet), a reminder to check camera, lighting, and background in advance; for Phone, a reminder to confirm a quiet space and good signal. Skip this line when Platform is not stated.
+
+When `isAIInterviewerPlatform` is true for that round's invite text (Alex/Apriora, HireVue), replace that logistics line with a pointer to the AI-Interviewer Notes block above instead of the video-platform reminder — e.g. "AI-interviewer round ({platform}) — see AI-Interviewer Notes above."
 
 ## Step 4 — Likely Questions (per audience)
 

--- a/modes/interview-prep.md
+++ b/modes/interview-prep.md
@@ -120,18 +120,21 @@ If the company is small or obscure and yields few results, broaden: search for t
 
 If data is insufficient for any field, write "unknown — not enough data" rather than guessing.
 
-**AI-interviewer platforms (#2673):** when `invite-match.mjs`'s `isAIInterviewerPlatform` returns true for the invite/scheduling text (currently Alex/Apriora and HireVue), the candidate talks live to an AI system rather than a human — append an **AI-Interviewer Notes** block right after Process Overview:
+**AI-interviewer platforms (#2673):** when `invite-match.mjs`'s `isAIInterviewerPlatform` returns true for the invite/scheduling text — currently only Alex/Apriora, whose host is single-purpose and confirmed AI-led by product design — the candidate talks live to an AI system rather than a human. Append an **AI-Interviewer Notes** block right after Process Overview:
 
 ```markdown
 ## AI-Interviewer Notes
-This round is conducted by an AI interviewer ({platform}), not a human panel. Prep differs from a human call:
-- No human rapport or reading-the-room available — camera eye contact and steady pacing matter more, not less.
-- The AI generates adaptive follow-up questions from the literal content of your answers, so vague or generic answers get probed harder than with a human interviewer. Answer with specifics.
-- Don't read from a script — it reads as unnatural to the AI's follow-up generation.
-- If the call glitches mid-conversation (transcription errors, repeated or looping questions), that is a known issue on some AI-interviewer platforms — documented for Alex/Apriora specifically — not a signal you did something wrong. Stay calm and keep answering normally.
+[Render in {language.output}: state that this round is conducted by an AI interviewer ({platform}), not a human panel, and that prep differs from a human call — no human rapport or reading-the-room is available, so camera eye contact and steady pacing matter more, not less; the AI generates adaptive follow-up questions from the literal content of the candidate's answers, so vague or generic answers get probed harder than with a human interviewer, and specifics beat generalities; reading from a script reads as unnatural to the AI's follow-up generation, so avoid it; and if the call glitches mid-conversation (transcription errors, repeated or looping questions), that is a known issue on some AI-interviewer platforms — documented for Alex/Apriora specifically — not a signal the candidate did something wrong, so the guidance is to stay calm and keep answering normally.]
 ```
 
 Skip this block entirely when the platform is human-mediated or not detected.
+
+**HireVue — detected but modality unconfirmed:** `extractPlatform` detects and names HireVue as a platform, but `isAIInterviewerPlatform` deliberately returns `false` for it: HireVue is multi-modal (on-demand recorded screening, live human-conducted interviews, and a separate AI-led "AI Interviewer" product all share the same domain), and no part of the invite/scheduling text reliably says which one a given round is. Do NOT render the AI-Interviewer Notes block above for a HireVue-only match — that would assert a modality the detection can't confirm. Instead, when Platform resolves to "HireVue", append a shorter, neutral note:
+
+```markdown
+## Platform Note
+[Render in {language.output}: state that this round is via HireVue, which supports on-demand recorded screening, live human-conducted interviews, and a separate AI-led interview product, and that the invite/scheduling text doesn't indicate which one applies — advise the candidate to confirm the format with the recruiter before the round. Note that normal video-call logistics (camera, lighting, quiet space) apply regardless of which format it turns out to be.]
+```
 
 ## Step 2.5 — Audience Map
 
@@ -184,7 +187,9 @@ If round structure is unknown, state that and provide the best available intel o
 
 When a round's Platform is known, add one logistics line to "How to prepare": for a video platform (Zoom / Microsoft Teams / Google Meet), a reminder to check camera, lighting, and background in advance; for Phone, a reminder to confirm a quiet space and good signal. Skip this line when Platform is not stated.
 
-When `isAIInterviewerPlatform` is true for that round's invite text (Alex/Apriora, HireVue), replace that logistics line with a pointer to the AI-Interviewer Notes block above instead of the video-platform reminder — e.g. "AI-interviewer round ({platform}) — see AI-Interviewer Notes above."
+When `isAIInterviewerPlatform` is true for that round's invite text — confirmed AI-led, currently Alex/Apriora only — replace that logistics line with a pointer to the AI-Interviewer Notes block above instead of the video-platform reminder: [Render in {language.output}: "AI-interviewer round ({platform}) — see AI-Interviewer Notes above."]
+
+When that round's Platform resolves to "HireVue" (detected, but `isAIInterviewerPlatform` is false — modality unconfirmed), keep the normal video-platform logistics line above and append a short pointer to the Platform Note instead of the AI-Interviewer Notes pointer: [Render in {language.output}: "HireVue round — format (recorded / live human / AI-led) not confirmed from the invite; see Platform Note above."]
 
 ## Step 4 — Likely Questions (per audience)
 


### PR DESCRIPTION
Closes #2673.

## The gap

`extractPlatform()` (landed in #2128) recognizes Zoom, Microsoft Teams, and Google Meet via `PLATFORM_URL_PATTERNS`, plus a phone-number fallback — all human-mediated calls with the same underlying prep needs.

AI-interviewer platforms — where the candidate has a live conversation with an AI system instead of a human panel (Alex/Apriora, HireVue) — aren't covered at all, even though they warrant materially different prep:

- No human rapport/reading-the-room available — camera eye contact and pacing matter more, not less.
- The AI generates adaptive follow-up questions from the literal content of what the candidate says, so vague answers get penalized differently than with a human interviewer.
- Alex/Apriora specifically (post-rebrand from a 2024 public glitch incident) has documented failure modes — transcription-quality degradation and conversational loops — worth flagging to the candidate as a known platform quirk rather than something to self-blame for mid-call.

None of this was distinguishable from a Zoom call — a candidate prepping from `interview-prep.md` output had no signal the round was AI-mediated at all.

## What changed

**`invite-match.mjs`**
- Added `Alex` (`meet.alex.com`, `alex.com`) and `HireVue` (`hirevue.com`) entries to `PLATFORM_URL_PATTERNS`, anchored the same way as the existing Zoom/Teams/Meet patterns — rejects lookalike hosts, email addresses, path segments, and query values as false positives (same discipline #2128's review rounds hardened for the existing three).
- Added a new exported helper, `isAIInterviewerPlatform(text)` → `boolean`. **`extractPlatform()`'s existing return contract is untouched** (still a plain platform-name string or `null`) — existing callers keep working unmodified. Alex/HireVue just report their own name from `extractPlatform()`, same convention as Zoom/Teams/Meet.
- Surfaced `isAIInterviewer` as an additive field in `analyzeInvite()`'s `signals` object.

**`modes/interview-prep.md`**
- Wired an **AI-Interviewer Notes** block into Step 2 (Process Overview), gated on `isAIInterviewerPlatform`, following the same cross-reference-not-restate pattern #2128 used for the original Platform field (points at `invite-match.mjs` rather than duplicating detection logic in prose).
- Step 3 (Round-by-Round Breakdown) points a per-round logistics line at the notes block instead of the video-platform camera/lighting reminder when that round is AI-mediated.

**Tests**
- `invite-match.test.mjs`: positive cases for Alex (`meet.alex.com` and bare `alex.com`) and HireVue, `isAIInterviewerPlatform` true/false cases, lookalike-host/path-segment/query-value false-positive guards mirroring the existing Zoom/Teams/Meet ones, and explicit confirmation that the existing Zoom/Teams/Meet/Phone detection paths are unaffected.
- Same coverage mirrored in `invite-match.mjs`'s `--self-test` block, consistent with how the existing platform tests are duplicated across both.

## Verification

```
node invite-match.mjs --self-test   → 110 passed, 0 failed
node invite-match.test.mjs          → 80 passed, 0 failed
node test-all.mjs                   → 3276 passed, 0 failed, 1 warning (pre-existing, unrelated: cv-sync-check expected without user data)
```

## Test plan
- [x] `node invite-match.mjs --self-test`
- [x] `node invite-match.test.mjs`
- [x] `node test-all.mjs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detection for Alex and HireVue interview platforms.
  * Interview preparation now provides AI-specific guidance for confirmed AI-led interviews.
  * HireVue invitations receive neutral platform guidance while retaining standard video logistics.
  * Invite analysis now identifies confirmed AI-interviewer invitations.

* **Bug Fixes**
  * Improved platform detection accuracy by rejecting lookalike domains, email addresses, paths, and query values.

* **Tests**
  * Added coverage for platform detection, classification, and existing interview-platform behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->