### PR TITLE
fix(oraclecloud): accept Oracle's numbered tenant apexes (oraclecloud1-99.com)

### DIFF
--- a/providers/oraclecloud.mjs
+++ b/providers/oraclecloud.mjs
@@ -10,6 +10,14 @@
 //   <tenant>.fa.oraclecloud.com
 //   <tenant>.fa.<region>.oraclecloud.com   (e.g. us2)
 //   <tenant>.fa.ocs.oraclecloud.com
+//   ...and the same three shapes on the numbered apex `oraclecloud<NN>.com`
+//   that Oracle issues to newer tenants (observed live: a Fusion board on
+//   `<tenant>.fa.ocs.oraclecloud26.com` whose unnumbered `oraclecloud.com`
+//   sibling host does not resolve at all).
+//
+// The numeric suffix is BOUNDED (1-99), not open-ended: this regex exists to
+// PIN the host before every fetch, so it enumerates a finite apex family and
+// never degrades into `oraclecloud<anything>.com`.
 //
 // Career page URL:
 //   https://<host>/hcmUI/CandidateExperience/<lang>/sites/<siteNumber>/jobs
@@ -36,7 +44,10 @@
 import { decodeEntities } from './_html-entities.mjs';
 import { BROWSER_LIKE_USER_AGENT } from './_http.mjs';
 
-const ORACLE_HOST_RE = /^[a-z0-9-]+\.fa\.(?:[a-z0-9-]+\.)?(?:ocs\.)?oraclecloud\.com$/i;
+// `oraclecloud(?:[1-9][0-9]?)?` = oraclecloud.com plus oraclecloud1.com …
+// oraclecloud99.com. No leading zero, at most two digits — a bounded family,
+// so this stays a host pin and never becomes a wildcard apex match.
+const ORACLE_HOST_RE = /^[a-z0-9-]+\.fa\.(?:[a-z0-9-]+\.)?(?:ocs\.)?oraclecloud(?:[1-9][0-9]?)?\.com$/i;
 
 const PAGE_SIZE = 200;
 const MAX_PAGES = 25;             // safety cap (~5000 jobs); hard ceiling like workday
@@ -58,7 +69,7 @@ function assertOracleUrl(url) {
   }
   if (parsed.protocol !== 'https:') throw new Error(`oraclecloud: URL must use HTTPS: ${url}`);
   if (!ORACLE_HOST_RE.test(parsed.hostname)) {
-    throw new Error(`oraclecloud: untrusted hostname "${parsed.hostname}" — must match *.fa[.<region>][.ocs].oraclecloud.com`);
+    throw new Error(`oraclecloud: untrusted hostname "${parsed.hostname}" — must match *.fa[.<region>][.ocs].oraclecloud[1-99].com`);
   }
   return url;
 }

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -632,9 +632,11 @@ search_queries:
 #   amazon          amazon.jobs           (global board; provider: amazon + an amazon: filter block, see below)
 #   successfactors  *.successfactors.(eu|com) / *.jobs2web.com  (SAP SF Recruiting Marketing / RMK boards;
 #                   branded hosts like jobs.<company>.com need provider: successfactors + api: <board origin>)
-#   oraclecloud     <tenant>.fa[.<region>][.ocs].oraclecloud.com/hcmUI/CandidateExperience/.../sites/<siteNumber>/jobs
+#   oraclecloud     <tenant>.fa[.<region>][.ocs].oraclecloud[1-99].com/hcmUI/CandidateExperience/.../sites/<siteNumber>/jobs
 #                   (Oracle Recruiting Cloud / Fusion CX — JPMorgan, Oracle, BNY, Amex, Honeywell; siteNumber
-#                   auto-derived from the URL, override with provider: oraclecloud + siteNumber: / optional locationId:)
+#                   auto-derived from the URL, override with provider: oraclecloud + siteNumber: / optional locationId:.
+#                   Newer tenants are issued a NUMBERED apex, e.g. <tenant>.fa.ocs.oraclecloud26.com — same shapes,
+#                   same provider; just use whichever host the employer's careers link actually points at.)
 #   gem             jobs.gem.com/<boardId>
 #   join            join.com/companies/<slug>  (SSR __NEXT_DATA__ parse, no separate API)
 #
@@ -708,7 +710,8 @@ search_queries:
 #
 # - name: Example Oracle Recruiting Cloud Co
 #   # Oracle Recruiting Cloud / Fusion Candidate Experience. Auto-detects any
-#   # <tenant>.fa[.<region>][.ocs].oraclecloud.com host and derives siteNumber
+#   # <tenant>.fa[.<region>][.ocs].oraclecloud[1-99].com host (the numbered apex,
+#   # e.g. oraclecloud26.com, is what newer tenants get) and derives siteNumber
 #   # from the /sites/<siteNumber>/ path segment (default CX_1).
 #   careers_url: https://exampleco.fa.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1/jobs
 #   max_pages: 25          # optional page cap (200 jobs/page, default 25 ≈ 5000 jobs, max 25)

--- a/tests/providers/oraclecloud.test.mjs
+++ b/tests/providers/oraclecloud.test.mjs
@@ -55,6 +55,75 @@ try {
     fail(`ocs variant returned ${JSON.stringify(ocsHit)}`);
   }
 
+  // ── numbered apex (oraclecloud<NN>.com) ─────────────────────────────
+  // Oracle issues newer tenants a numbered apex; the same three host shapes
+  // exist there. Before this was accepted, detect() returned null and the
+  // board scanned as zero jobs with no error.
+  const numberedShapes = [
+    ['plain', 'https://acme.fa.oraclecloud26.com/hcmUI/CandidateExperience/en/sites/CX_1/jobs', 'acme.fa.oraclecloud26.com'],
+    ['<region>', 'https://acme.fa.us2.oraclecloud26.com/hcmUI/CandidateExperience/en/sites/CX_1/jobs', 'acme.fa.us2.oraclecloud26.com'],
+    ['.ocs.', 'https://acme.fa.ocs.oraclecloud26.com/hcmUI/CandidateExperience/en/sites/CX_1/jobs', 'acme.fa.ocs.oraclecloud26.com'],
+  ];
+  const numberedBad = numberedShapes.filter(([, url, host]) => {
+    const r = oc.detect({ name: 'X', careers_url: url });
+    return !(r && hostOf(r.url) === host);
+  });
+  if (numberedBad.length === 0) {
+    pass('oraclecloud.detect() handles the numbered apex (oraclecloud26.com) on all three host shapes');
+  } else {
+    fail(`numbered apex rejected for shape(s): ${numberedBad.map(([n]) => n).join(', ')}`);
+  }
+
+  // bounded family: 1..99 in, everything outside out. The regex is an SSRF
+  // pin — it must enumerate a finite apex set, never `oraclecloud<any>.com`.
+  const apexUrl = (apex) => `https://acme.fa.ocs.${apex}.com/hcmUI/CandidateExperience/en/sites/CX_1/jobs`;
+  const acceptedApexes = ['oraclecloud', 'oraclecloud1', 'oraclecloud9', 'oraclecloud26', 'oraclecloud99'];
+  const rejectedApexes = ['oraclecloud0', 'oraclecloud01', 'oraclecloud100', 'oraclecloud26x', 'oraclecloudabc'];
+  const apexMisses = [
+    ...acceptedApexes.filter((a) => oc.detect({ name: 'X', careers_url: apexUrl(a) }) === null),
+    ...rejectedApexes.filter((a) => oc.detect({ name: 'X', careers_url: apexUrl(a) }) !== null),
+  ];
+  if (apexMisses.length === 0) {
+    pass('oraclecloud host pin is a BOUNDED apex family (1-99 accepted; 0, 01, 100, suffixed → null)');
+  } else {
+    fail(`apex boundary wrong for: ${apexMisses.join(', ')}`);
+  }
+
+  // numbered apex as a LABEL inside a hostile host → null (suffix spoof)
+  if (oc.detect({ name: 'Spoof3', careers_url: 'https://x.fa.ocs.oraclecloud26.evil.example/hcmUI/CandidateExperience/en/sites/CX_1/jobs' }) === null) {
+    pass('oraclecloud.detect() rejects a numbered apex used as a label of a hostile host');
+  } else {
+    fail('oraclecloud.detect() must reject oraclecloud26.<evil-domain>');
+  }
+
+  // numbered apex in the PATH, not the host → null
+  if (oc.detect({ name: 'Spoof4', careers_url: 'https://evil.example/x.fa.ocs.oraclecloud26.com/sites/CX_1/jobs' }) === null) {
+    pass('oraclecloud.detect() rejects a numbered apex placed in the path');
+  } else {
+    fail('oraclecloud.detect() must reject a path-spoofed numbered apex');
+  }
+
+  // numbered apex in USERINFO (before the @) → real host is evil → null
+  if (oc.detect({ name: 'Spoof5', careers_url: 'https://acme.fa.ocs.oraclecloud26.com@evil.example/hcmUI/CandidateExperience/en/sites/CX_1/jobs' }) === null) {
+    pass('oraclecloud.detect() rejects a numbered apex hidden in URL userinfo');
+  } else {
+    fail('oraclecloud.detect() must reject a userinfo-spoofed numbered apex');
+  }
+
+  // right label, wrong TLD → null
+  if (oc.detect({ name: 'Spoof6', careers_url: 'https://acme.fa.ocs.oraclecloud26.net/hcmUI/CandidateExperience/en/sites/CX_1/jobs' }) === null) {
+    pass('oraclecloud.detect() rejects the numbered apex on a non-.com TLD');
+  } else {
+    fail('oraclecloud.detect() must reject oraclecloud26.net');
+  }
+
+  // plaintext numbered apex → null (HTTPS-only, same as the unnumbered apex)
+  if (oc.detect({ name: 'X', careers_url: 'http://acme.fa.ocs.oraclecloud26.com/hcmUI/CandidateExperience/en/sites/CX_1/jobs' }) === null) {
+    pass('oraclecloud.detect() rejects a plaintext numbered-apex URL');
+  } else {
+    fail('oraclecloud.detect() must reject http:// on the numbered apex');
+  }
+
   // default siteNumber CX_1 when no /sites/<n>/ in the path
   const noSite = oc.detect({ name: 'X', careers_url: 'https://acme.fa.oraclecloud.com/hcmUI/CandidateExperience/en/' });
   if (noSite && noSite.url.includes('siteNumber=CX_1,')) {


### PR DESCRIPTION
## What does this PR do?

`ORACLE_HOST_RE` in `providers/oraclecloud.mjs` only matches the `oraclecloud.com` apex. Oracle issues newer Fusion tenants a **numbered** apex (`oraclecloud26.com` is live in the wild), so those boards fail `detect()` and the scanner returns **zero jobs with no error and no warning** — the worst kind of failure, because the board looks empty rather than broken.

This widens the host pin to a **bounded** apex family and adds tests for the new shapes and their spoofs.

## The fix

```diff
-const ORACLE_HOST_RE = /^[a-z0-9-]+\.fa\.(?:[a-z0-9-]+\.)?(?:ocs\.)?oraclecloud\.com$/i;
+const ORACLE_HOST_RE = /^[a-z0-9-]+\.fa\.(?:[a-z0-9-]+\.)?(?:ocs\.)?oraclecloud(?:[1-9][0-9]?)?\.com$/i;
```

`oraclecloud(?:[1-9][0-9]?)?` = the unnumbered apex plus `oraclecloud1.com` … `oraclecloud99.com`. **No leading zero, at most two digits.**

This is deliberately *not* `oraclecloud\d*\.com` or anything wildcard-ish. That regex is an SSRF pin — it is the only thing standing between a `portals.yml` entry and an arbitrary outbound fetch — so it stays an enumeration of a finite host family. `oraclecloud0`, `oraclecloud01`, `oraclecloud100` and `oraclecloudanything` are all still rejected, and there are tests asserting each.

## Verification

Ran the provider's real `fetch()` against four live tenants, once with the current `main` provider and once with the patched one. Same harness, same run:

| tenant | `main` | patched |
| --- | --- | --- |
| `*.fa.ocs.oraclecloud.com` (A) | 7 jobs | 7 jobs |
| `*.fa.ocs.oraclecloud.com` (B, `CX_3001`) | 3 jobs | 3 jobs |
| `*.fa.ocs.oraclecloud.com` (C) | 23 jobs | 23 jobs |
| `*.fa.ocs.oraclecloud26.com` | **`detect()` → null, 0 jobs** | **13 jobs** |

No change on the unnumbered apex; the numbered tenant goes from silently empty to its real 13 postings. (Tenant hostnames are from my own `portals.yml` so I've left them out of a public body — happy to send them if you want to re-run it.)

Negative control per the usual discipline: the two new assertions were run against unpatched `main` first and fail there —

```
❌ numbered apex rejected for shape(s): plain, <region>, .ocs.
❌ apex boundary wrong for: oraclecloud1, oraclecloud9, oraclecloud26, oraclecloud99
📊 Results: 37 passed, 2 failed
```

— and pass with the fix (39/0).

## Tests added

In `tests/providers/oraclecloud.test.mjs` (existing file, auto-discovered):

- the numbered apex across **all three** existing host shapes: `<tenant>.fa.`, `<tenant>.fa.<region>.`, `<tenant>.fa.ocs.`
- the 1–99 boundary: `oraclecloud`, `1`, `9`, `26`, `99` accepted; `0`, `01`, `100`, `26x`, `abc` rejected
- numbered apex used as a **label of a hostile host** (`x.fa.ocs.oraclecloud26.evil.example`) → null
- numbered apex in the **path** rather than the host → null
- numbered apex in URL **userinfo** (before the `@`) → null
- right label, **wrong TLD** (`oraclecloud26.net`) → null
- **plaintext** `http://` on the numbered apex → null

## Docs

`templates/portals.example.yml` documented the host pattern in two places (the provider index and the ORC example block); both now show `oraclecloud[1-99].com` and note that newer tenants get the numbered apex.

Unrelated gap I noticed but left alone to keep this scoped: `docs/SUPPORTED_JOB_BOARDS.md` has no Oracle Recruiting Cloud row at all. Happy to add one in a separate PR if useful.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass — **3280 passed, 0 failed** (2 warnings, both pre-existing "expected without user data" fixture notes)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Oracle Cloud hostname validation now supports numbered domains from `oraclecloud1.com` through `oraclecloud99.com`.
  - Site-number detection and manual overrides continue to work for numbered domains.

- **Bug Fixes**
  - Improved hostname rejection for unsupported, spoofed, malformed, or insecure Oracle Cloud addresses.

- **Documentation**
  - Updated Oracle Cloud setup guidance with examples of numbered domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->