### PR TITLE
fix(shared): let _profile.md define the archetypes, and allow "none of these"

### DIFF
--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -165,6 +165,20 @@ Forcing it into the nearest available label — or into a "hybrid" of two —
 manufactures a confident fit narrative for a job the user is not applying for,
 which is worse than a low score because it reads as analysis.
 
+**A match against the default table below is not a match against the user's
+targets.** Where `_profile.md` defines archetypes, "targeted" means one of
+those. An offer that lands cleanly on a default row and on nothing in
+`_profile.md` is still an unmatched offer: name the default archetype if it
+helps explain the role, and score North Star as unmatched anyway. Reading the
+fallback as a target is the exact failure this section exists to stop — it is
+how a program-management req came back as "Technical AI PM / AI Transformation
+Lead (hybrid)" for a candidate who targets neither.
+
+On the number: `modes/ofertas.md` already anchors this dimension at
+`5 = exact target role, 1 = unrelated`. Unmatched sits at the bottom of that
+scale, not in the middle — the offer is not one the user is looking for, and a
+mid score reads as a partial fit that does not exist.
+
 | Archetype | Key signals in JD |
 |-----------|-------------------|
 | AI Platform / LLMOps | "observability", "evals", "pipelines", "monitoring", "reliability" |

--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -148,7 +148,22 @@ When a JD publishes a salary figure, distinguish advertised range, likely guaran
 
 ## Archetype Detection
 
-Classify every offer into one of these types (or hybrid of 2):
+Classify the offer by archetype. `modes/_profile.md` → *Your Target Roles* is
+authoritative: where it defines archetypes, detect against **that** table and
+use the one below only as a fallback for what it does not cover. This mirrors
+the precedence already stated above — user customizations in `_profile.md`
+override the defaults in this file.
+
+The table below is a default, not a closed set. It reflects one particular
+search (see AGENTS.md → Origin) and will not describe every user's field: a
+silicon design-verification engineer, a quant, a clinician have no archetype
+here at all.
+
+**If an offer matches no archetype the user actually targets, say so plainly
+and score North Star alignment low.** That is a real and useful signal.
+Forcing it into the nearest available label — or into a "hybrid" of two —
+manufactures a confident fit narrative for a job the user is not applying for,
+which is worse than a low score because it reads as analysis.
 
 | Archetype | Key signals in JD |
 |-----------|-------------------|

--- a/modes/oferta.md
+++ b/modes/oferta.md
@@ -41,7 +41,19 @@ If deeper company research is useful, recommend running `/career-ops deep` separ
 
 ## Step 0 — Archetype Detection
 
-Classify the job into one of the 6 archetypes (see `_shared.md`). If it is a hybrid, indicate the 2 closest ones. This determines:
+Classify the job against the archetypes in `_shared.md` — which means the user's
+own, from `modes/_profile.md` → *Your Target Roles*, where those exist. If it is
+a hybrid of two of the user's targets, indicate both.
+
+**"None of these" is a valid outcome and must be reported as one.** If the role
+matches nothing the user targets, do not pick the nearest label and do not call
+it a hybrid: say so, score North Star at the bottom of its scale, and continue
+the evaluation on the other dimensions — the rest of the report is still worth
+having, and a low alignment score with an honest reason is more useful than a
+confident fit narrative for a job the user is not applying for. A match against
+`_shared.md`'s default table alone is not a match against the user's targets.
+
+This determines:
 - Which proof points to prioritize in block B
 - How to rewrite the summary in block E
 - Which STAR stories to prepare in block F
@@ -530,6 +542,14 @@ Save full evaluation in `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`.
 **URL:**
 **Via:** {agency/recruiter firm, or — for direct applications}
 **Archetype:** {detected}
+<!-- When the role matches one of the user's targets, name it. When it matches
+     none, this field is NOT left blank and NOT hedged — an empty field reads as
+     the tool failing, and "possibly a hybrid of X and Y" is the coercion this
+     is meant to prevent. Write one of:
+       Not a target — closest default: {row from _shared.md's table}
+       Not a target — no close match
+     Naming the default row still helps the reader place the role; what it must
+     not do is stand in for a target the user actually has. -->
 **Score:** {X/5}
 **Legitimacy:** {High Confidence | Proceed with Caution | Suspicious}
 **Work Auth:** {✅ Sponsors | ➖ Not needed | ⚠️ Unstated | ⛔ No sponsorship}


### PR DESCRIPTION
## The problem

`modes/_shared.md` says:

> Classify every offer into one of these types (or hybrid of 2)

That makes six archetypes a **closed set**, in the one file every mode reads.
They are the archetypes of the search this tool came out of (`AGENTS.md` →
*Origin* says as much), and they cover a narrow slice: a silicon
design-verification engineer, a quant, a clinician have no archetype in that
table at all.

The next line already says to read `_profile.md` — but only *afterwards*, for
framing. So detection happens against the author's taxonomy and the user's own
targeting arrives too late to affect it.

**Observed:** an ML-systems / inference engineer's evaluation of a
program-management req came back as *"Technical AI PM / AI Transformation Lead
(hybrid)"* — a faithful execution of "or hybrid of 2", and a fit narrative for
a career the candidate does not have.

The hybrid clause makes it worse: with no way to conclude *none*, the nearest
two labels always produce an answer.

## The change

This changes the table's **status**, not its contents.

- `_profile.md`'s archetypes take precedence where defined; the table becomes
  the fallback for what it does not cover. That is only this file's own stated
  rule — *"User customizations in `_profile.md` override defaults here"* —
  applied to the section that was ignoring it.
- An explicit **"matches nothing the user targets"** outcome, scored low on
  North Star alignment. A manufactured fit is worse than a low score, because
  it reads as analysis.

**Not a single table row changes**, so a user without a customized
`_profile.md` sees identical behaviour — the out-of-the-box path is untouched.

## Testing

`node test-all.mjs` → 3138 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Archetype detection now prioritizes profile guidance for more accurate classification.
  - Clarified that the default archetype table is non-exhaustive.
  - Hybrid classifications are limited to the user’s specified target archetypes.
  - Offers without a matching target archetype can be identified as “None of these” and receive the lowest North Star alignment score.
  - Removed the requirement to force every offer into a listed archetype or hybrid.
  - Reports now explain non-target roles using the closest matching archetype or note when no close match exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->