### PR TITLE
fix(ci): skip the upgrade leg when nothing managed changed, instead of failing

### DIFF
--- a/upgrade-tests.mjs
+++ b/upgrade-tests.mjs
@@ -76,8 +76,18 @@ function pickOracle(mirror, oldTag, targetSha, systemPaths) {
     if (!managed(f)) return false;
     try { git(mirror, 'cat-file', '-e', `${targetSha}:${f}`); return true; } catch { return false; }
   });
-  if (!candidate) throw new Error(`No changed system file between ${oldTag} and target — nothing to upgrade, leg would be vacuous`);
-  return candidate;
+  // No managed file changed. That is NOT a failure by itself: a web-only PR
+  // (web/ is deliberately outside SYSTEM_PATHS) legitimately changes nothing
+  // `apply` manages, so there is nothing to qualify. Returning null lets the
+  // caller SKIP. Throwing here made the gate red for every web-only PR, which
+  // on 11-ago blocked three at once — including the fix for a HIGH severity
+  // advisory. "I cannot test this" and "this is broken" must not share an exit.
+  //
+  // The caller still fails loudly when ROOT files changed and none is managed:
+  // that shape means the SYSTEM_PATHS read is probably wrong, which is exactly
+  // what this oracle exists to catch.
+  if (!candidate) return { oracle: null, changed };
+  return { oracle: candidate, changed };
 }
 
 function isAncestor(cwd, tag, sha) {
@@ -102,7 +112,15 @@ export function runLeg({ oldTag, targetSha, label = oldTag, mutateMirror = null 
     if (!sysMatch) throw new Error(`Could not locate SYSTEM_PATHS in the target's update-system.mjs (constant renamed?) — refusing to run a leg with no managed-path set`);
     const targetSystemPaths = Array.from(sysMatch[1].matchAll(/['"]([^'"]+)['"]/g), (m) => m[1]);
 
-    const oracle = pickOracle(mirror, oldTag, targetSha, targetSystemPaths);
+    const { oracle, changed } = pickOracle(mirror, oldTag, targetSha, targetSystemPaths);
+    if (!oracle) {
+      const rootChanged = changed.filter((f) => !f.includes('/'));
+      if (rootChanged.length > 0) {
+        throw new Error(`Root files changed (${rootChanged.join(', ')}) but none is in SYSTEM_PATHS — refusing to skip: the managed-path set may be wrong`);
+      }
+      console.log(`  SKIP [${label}] no SYSTEM_PATHS file changed between ${oldTag} and target (${changed.length} file(s) changed, all outside the managed set) — nothing to qualify`);
+      return { failures: [], skipped: true };
+    }
     const oracleBlob = git(mirror, 'rev-parse', `${targetSha}:${oracle}`);
 
     const install = join(work, 'install');
@@ -200,8 +218,11 @@ function prGate() {
   const newestOld = newestAncestorTag(targetSha);
   if (!newestOld) { console.error('No release tag is an ancestor of HEAD — fetch tags first (CI: fetch-depth: 0)'); process.exit(1); }
   console.log(`PR gate: ${newestOld} -> ${targetSha.slice(0, 8)}`);
-  const { failures } = runLeg({ oldTag: newestOld, targetSha });
-  console.log(failures.length ? `RED: ${failures.length} failure(s)` : 'GREEN');
+  const { failures, skipped } = runLeg({ oldTag: newestOld, targetSha });
+  // THREE states, never two: a skipped leg qualified nothing, so calling it
+  // GREEN would report a pass that never ran.
+  console.log(skipped ? 'SKIPPED: nothing in the managed set changed — this leg qualified nothing'
+    : failures.length ? `RED: ${failures.length} failure(s)` : 'GREEN');
   process.exit(failures.length ? 1 : 0);
 }
 

--- a/upgrade-tests.mjs
+++ b/upgrade-tests.mjs
@@ -70,7 +70,7 @@ function writeGitConfig(work, mirror) {
  *  the target and the leg would go spuriously RED. */
 function pickOracle(mirror, oldTag, targetSha, systemPaths) {
   const changed = git(mirror, 'diff', '--name-only', `${oldTag}..${targetSha}`).split('\n').filter(Boolean);
-  if (changed.includes('update-system.mjs')) return 'update-system.mjs';
+  if (changed.includes('update-system.mjs')) return { oracle: 'update-system.mjs', changed };
   const managed = (f) => systemPaths.some((p) => (p.endsWith('/') ? f.startsWith(p) : f === p));
   const candidate = changed.find((f) => {
     if (!managed(f)) return false;


### PR DESCRIPTION
## The bug

`upgrade-tests.mjs` throws when no `SYSTEM_PATHS` file changed between the last tag and the target:

```
Error: No changed system file between career-ops-v1.26.0 and target — nothing to upgrade, leg would be vacuous
```

The reasoning behind that check is right — a leg with no managed file to qualify proves nothing. **Treating it as a FAILURE is the bug.** `web/` is deliberately outside `SYSTEM_PATHS`, so a web-only PR legitimately changes nothing `apply` manages, and the gate goes red on a PR that is not broken in any way.

Measured on 11 Aug: **three PRs blocked at once** — #2665 (the fix for a HIGH severity advisory: js-yaml 4.3.0 → 4.3.1), #2668 and #2654. A security fix could not land because the gate could not test it.

## The fix

`pickOracle` returns `null` instead of throwing; the caller skips the leg and says so. **"I cannot test this" and "this is broken" must not share an exit code.**

Two things kept deliberately:

1. **The skip is not a pass.** `--pr-gate` now prints three states, never two: `GREEN` / `SKIPPED: nothing in the managed set changed — this leg qualified nothing` / `RED`. A skipped leg reported as GREEN would be a pass that never ran, which is the exact shape this suite exists to catch elsewhere.
2. **A suspicious shape still fails.** If root-level files changed and *none* is managed, that likely means the `SYSTEM_PATHS` read is wrong (a renamed constant, a bad parse) — so it throws rather than skipping.

## Verified by running all three paths

| case | expected | result |
|---|---|---|
| web-only change (#2665's branch) | skip, exit 0 | `SKIP … (1 file changed, all outside the managed set)`, exit 0 |
| managed file changed (`scan.mjs`) | run the leg | 0 skips, full leg, `GREEN` |
| only an unmanaged root file | fail loudly | exit 1, `Root files changed (probe-unmanaged.txt) but none is in SYSTEM_PATHS — refusing to skip` |

`node test-all.mjs` → 3276 passed, 0 failed.

Credit where due: the gate itself (#2642) is good work and the non-vacuity oracle is the right idea — this only changes what happens when the oracle legitimately finds nothing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of changes that do not affect managed files.
  - Web-only and otherwise unmanaged changes are now skipped appropriately.
  - Changes to unsupported root files still correctly fail validation.
  - Validation results now clearly distinguish **SKIPPED**, **RED**, and **GREEN** outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->