### PR TITLE
fix(deps): patch both HIGH advisories in web (js-yaml 4.3.1, nanoid 3.3.18)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1653,9 +1653,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -2826,9 +2826,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Closes both open HIGH-severity Dependabot advisories on `web/package-lock.json`. Lockfile only — no source change, no behaviour change.

| alert | package | installed | patched | now |
|---|---|---|---|---|
| #14 | js-yaml | 4.3.0 | 4.3.1 | **4.3.1** |
| #15 | nanoid | 3.3.16 | 3.3.17 | **3.3.18** |

- **#14** — quadratic CPU consumption resolving `!!omap`. The 4.x branch is patched at 4.3.1, so the major bump to 5.x (#2631) is not required to clear it.
- **#15** — custom generators can loop indefinitely when size is zero. Reached transitively via `postcss` → `next`; nothing in the repo imports it directly.

Generated with `npm audit fix --package-lock-only`, which reports `found 0 vulnerabilities` afterwards.

**Verified:** `npm ci` clean · `npm test` 123 pass / 0 fail · `npm run typecheck` clean · `npm run build` succeeds.

Note: #2665 (Renovate) carries the js-yaml half of this on its own. Either can land — this one closes both alerts in a single lockfile state, which is how npm resolves it anyway.
