### PR TITLE
test(web-contract): freeze the company-key parity and its source per surface

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -12969,6 +12969,120 @@ try {
       }
     }
   }
+
+  // 55.7 The company/role matching key: core vs the web's declared mirror (#2666).
+  //
+  // The browser cannot reach the user's checkout, so web/src/lib/core/
+  // normalize-text-key.mjs is a COPY by necessity, declared as such. A conscious
+  // copy without an assertion is exactly the failure this repo has now hit five
+  // times (states.ts, CADENCE_DEFAULTS, doctor prereqs, the #2590 cache, and the
+  // three divergent company norms of #2666 itself).
+  //
+  // Compare CORE vs MIRROR, not core vs the derived path: the derived path
+  // imports the core, so it CANNOT diverge — asserting on it would guard the one
+  // thing that cannot break while ignoring the one that can. The mirror is also
+  // the path nobody exercises in normal operation (it only runs on a partial
+  // checkout), which is precisely why it needs a test rather than usage.
+  //
+  // Expected values are DERIVED from the core, never hand-written: a hand-written
+  // expectation would freeze today's answer and stop tracking the source.
+  const corpusPath = join(ROOT, 'tests', 'fixtures', 'company-key-corpus.json');
+  const mirrorPath = join(ROOT, 'web', 'src', 'lib', 'core', 'normalize-text-key.mjs');
+  if (!existsSync(join(ROOT, 'web', 'src'))) {
+    warn('web/ not present in this checkout — skipping the company-key parity freeze (#2666)');
+  } else if (!existsSync(corpusPath) || !existsSync(mirrorPath)) {
+    // web/ IS here, so a missing file is a move, not an absence. Failing rather
+    // than skipping: a skip is how this freeze would quietly stop guarding.
+    fail(`web/ exists but ${!existsSync(corpusPath) ? 'tests/fixtures/company-key-corpus.json' : 'web/src/lib/core/normalize-text-key.mjs'} is missing — the #2666 key parity cannot verify (moved?)`);
+  } else {
+    try {
+      const corpus = JSON.parse(readFileSync(corpusPath, 'utf-8'));
+      const core = await import(pathToFileURL(join(ROOT, 'tracker-parse.mjs')).href);
+      const mirror = await import(pathToFileURL(mirrorPath).href);
+      const coreFn = core.normalizeTextKey, mirrorFn = mirror.normalizeTextKey;
+      if (typeof coreFn !== 'function' || typeof mirrorFn !== 'function') {
+        fail('normalizeTextKey is not exported by the core and/or the web mirror — the #2666 parity cannot verify');
+      } else {
+        // undefined cannot be written in JSON but is a real input (a missing
+        // cell), and it is half of the null/undefined bug — so it is appended here.
+        const inputs = [...corpus.cases.map((c) => c.input), undefined];
+        const drift = [];
+        for (const sep of ['', ' ']) {
+          for (const input of inputs) {
+            const a = coreFn(input, sep), b = mirrorFn(input, sep);
+            if (a !== b) drift.push(`${JSON.stringify(input)} sep=${JSON.stringify(sep)}: core=${JSON.stringify(a)} mirror=${JSON.stringify(b)}`);
+          }
+        }
+        if (drift.length === 0) {
+          pass(`web company-key mirror matches the core on all ${inputs.length} corpus cases x2 separators (#2666)`);
+        } else {
+          fail(`web company-key mirror DRIFTED from the core — ${drift.length} case(s): ${drift.slice(0, 3).join(' | ')}`);
+        }
+        // Guard of the guard, in TWO directions, because each covers a hole the
+        // other cannot see:
+        //  (a) the RULES could regress in the core itself, and
+        //  (b) the CORPUS could be thinned until the comparison above passes
+        //      vacuously — "matches on all 0 cases" is a green that proves nothing.
+        // (b) was found by mutation: deleting Škoda and 日本電産 from the corpus
+        // left every check green, because (a) queries the core directly.
+        const inputStrings = corpus.cases.map((c) => String(c.input));
+        const mustCarry = ['Škoda', 'Koda', '日本電産', 'Nestlé'];
+        const missing = mustCarry.filter((m) => !inputStrings.includes(m));
+        const rulesHold = coreFn('Škoda', ' ') !== coreFn('Koda', ' ') && coreFn('日本電産', ' ') !== '';
+        if (missing.length === 0 && corpus.cases.length >= 10 && rulesHold) {
+          pass(`company-key corpus still carries its teeth (${corpus.cases.length} cases incl. the collision pair, rules hold) (#2666)`);
+        } else if (!rulesHold) {
+          fail('the company-key rules regressed: Škoda now collides with Koda and/or CJK keys to empty — this is the #2666 data-loss bug returning');
+        } else {
+          fail(`the company-key corpus lost its teeth: ${missing.length ? `missing ${missing.join(', ')}` : `only ${corpus.cases.length} cases left`} — the parity check above would pass without exercising the failure it exists for`);
+        }
+      }
+    } catch (err) {
+      fail(`company-key parity check could not run (${err.message}) — treat as unverified, not as passing (#2666)`);
+    }
+  }
+
+  // 55.8 Where the key comes from, per surface (#2666, structural half).
+  //
+  // Shapes are NOT interchangeable: the server can reach the user's live core
+  // (dynamic import via careerOpsRoot) and must derive from it; a "use client"
+  // component physically cannot, so it imports the shared mirror. What none of
+  // them may do is define a normalizer of its own — that is how three divergent
+  // company keys shipped in the first place.
+  //
+  // The ASCII-class check is scoped to THESE THREE FILES on purpose. A repo-wide
+  // grep for [^a-z0-9] measured 71% false positives (domain slugs, filename
+  // slugs, a regex boundary class — all legitimate), and a check that shouts at
+  // correct code gets silenced. Here the same expression would be the bug.
+  const keySurfaces = [
+    { file: join(ROOT, 'web', 'src', 'app', 'api', 'whats-new', 'route.ts'), needs: 'getNormalizeTextKey', how: 'derive from the live core' },
+    { file: join(ROOT, 'web', 'src', 'components', 'explore', 'explorer-view.tsx'), needs: 'normalize-text-key', how: 'import the shared mirror (client cannot reach the core)' },
+    { file: join(ROOT, 'web', 'src', 'app', 'actions', 'registry.ts'), needs: 'normalize-text-key', how: 'import the shared mirror' },
+  ];
+  if (existsSync(join(ROOT, 'web', 'src'))) {
+    for (const { file, needs, how } of keySurfaces) {
+      const name = file.slice(ROOT.length + 1);
+      if (!existsSync(file)) { fail(`${name} is missing — the #2666 key-source freeze cannot verify (moved?)`); continue; }
+      const src = readFileSync(file, 'utf-8');
+      if (!src.includes(needs)) {
+        fail(`${name} no longer references ${needs} — it must ${how}, never key company names on its own (#2666)`);
+      } else if (src.split('\n')
+        // Comment lines are stripped first: the honest fix for this bug ships a
+        // comment WARNING against the pattern ("never [^a-z0-9]"), and flagging
+        // that would punish the file for documenting its own trap. Measured:
+        // this exact false positive fired on explorer-view.tsx the first time
+        // this check ran. Line-level is proportionate here — the scope is three
+        // known files, and a full JS parse to catch a block comment would be
+        // more machinery than the risk deserves.
+        .filter((l) => { const t = l.trimStart(); return !t.startsWith('//') && !t.startsWith('*') && !t.startsWith('/*'); })
+        .some((l) => /\[\^a-z0-9\]/i.test(l))) {
+        fail(`${name} contains an ASCII-only character class — that is the exact key that made "Škoda" collide with "Koda" and emptied CJK names (#2666)`);
+      } else {
+        pass(`${name} takes its matching key from the right place (#2666)`);
+      }
+    }
+  }
+
 } catch (e) {
   fail(`core↔web contract freeze section crashed: ${e.message}`);
 }

--- a/tests/fixtures/company-key-corpus.json
+++ b/tests/fixtures/company-key-corpus.json
@@ -1,0 +1,21 @@
+{
+  "_why": "Shared corpus for the company/role matching key (#2666). The core's normalizeTextKey (tracker-parse.mjs) is the source of truth; web/src/lib/core/normalize-text-key.mjs is a declared copy that exists because the browser cannot reach the user's checkout. This file is the single list both sides are checked against — two lists would drift, which is the whole failure this corpus guards.",
+  "_separator": " ",
+  "_note": "Expected values are NOT hand-written: the assertion derives them from the core and compares the mirror against that. The strings below are the cases; the core decides the answers.",
+  "cases": [
+    { "input": "Nestlé", "why": "accented Latin — the plain case the ASCII-only key destroyed (nestl)" },
+    { "input": "Nestlé", "why": "same name in NFD (macOS stores filenames decomposed) — must key identically to the NFC form" },
+    { "input": "Zürich Re", "why": "umlaut plus a second word" },
+    { "input": "Škoda", "why": "the collision that started this: the old key made it 'koda', matching a different company called Koda and hiding a real opening" },
+    { "input": "Ação", "why": "Portuguese cedilla and tilde" },
+    { "input": "日本電産", "why": "CJK — the old key emptied it, so it never matched and duplicated forever" },
+    { "input": "Koda", "why": "the counterpart of the collision: must stay DISTINCT from Škoda" },
+    { "input": "ＡＣＭＥ", "why": "fullwidth Latin, routine in Japanese-sourced data — NFKC folds it to acme" },
+    { "input": "ﬁnance", "why": "fi ligature — NFKC decomposes it" },
+    { "input": "İstanbul Tekstil", "why": "Turkish dotted capital I. toLowerCase yields i + U+0307 and the combining mark survives, so this does NOT match 'Istanbul Tekstil'. That is the CURRENT INTENDED behaviour (consistent with keeping accents: Škoda != Skoda), pinned here on purpose. A targeted fix exists and is verified — stripping U+0307 after lowercasing matches İstanbul/Istanbul while leaving Škoda, Nestlé and Zürich untouched — but it is not applied: this key is a frozen contract surface the web derives from. If you are changing this case, you are changing a decision, not fixing an oversight." },
+    { "input": "Acme Corp", "why": "plain ASCII control — must be unaffected by any of the above" },
+    { "input": null, "why": "nullish must key to empty string, not the literal 'null' (which made null and undefined match each other)" },
+    { "input": "", "why": "empty stays empty" },
+    { "input": "  Acme  ,  Inc.  ", "why": "runs of separators and surrounding whitespace collapse and trim" }
+  ]
+}


### PR DESCRIPTION
The last piece of #2666. The bug is fixed in three surfaces; this is what stops it coming back.

## Why an assertion at all

`web/src/lib/core/normalize-text-key.mjs` is a **copy by necessity** — the browser cannot reach the user's checkout, so a client component can't import the core. It is declared as a copy and documented as one. But a conscious copy with no assertion behind it is exactly what this repo has now shipped five times: `states.ts`, `CADENCE_DEFAULTS`, the doctor prereqs, the #2590 cache, and the three divergent company keys of #2666 itself.

## 55.7 — parity: core vs the mirror

Compares `normalizeTextKey` from `tracker-parse.mjs` against the web mirror over a shared 15-case corpus × 2 separators.

Two deliberate choices:

- **Core vs MIRROR, not core vs the derived path.** The server path imports the core, so it *cannot* diverge — asserting on it would guard the one thing that can't break while ignoring the one that can. The mirror is also the path nobody exercises in normal use (it only runs on a partial checkout), which is why it needs a test rather than usage.
- **Expected values are derived from the core, never hand-written.** A hand-written expectation freezes today's answer and stops tracking the source.

The corpus (`tests/fixtures/company-key-corpus.json`) is one shared file rather than a list on each side, since two lists drift — the failure this whole thread is about.

## 55.8 — where each surface gets its key

Shapes are not interchangeable: the server can reach the live core and must derive from it; a `"use client"` component physically cannot and imports the shared mirror. What none of them may do is roll its own normalizer.

The ASCII-class check is scoped to those three files on purpose: a repo-wide grep for `[^a-z0-9]` measures **71% false positives** here (domain slugs, filename slugs, a regex boundary class — all legitimate), and a check that shouts at correct code gets silenced. It also skips comment lines, because the honest fix ships a comment *warning against* the pattern — that false positive fired on the first run.

## Verified by mutation, not by reading

| mutation | result |
|---|---|
| mirror reverted to `[^a-z0-9]` | RED — 14 cases, e.g. `core="nestlé" mirror="nestl"` |
| client defines its own `norm` again | RED — names the file and what it must do instead |
| corpus thinned (Škoda + CJK removed) | RED — *"the parity check above would pass without exercising the failure it exists for"* |

That third one was a real hole found by mutating: the original guard-of-the-guard queried the core directly, so an emptied corpus passed vacuously. It now checks both directions — the rules AND the corpus.

`node test-all.mjs` → 3281 passed, 0 failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated checks to ensure consistent company and role matching across core and web implementations.
  * Added regression coverage for accented, Unicode, CJK, fullwidth, ligature, casing, control-character, empty, and nullish inputs.
  * Added validation that required web surfaces use the correct normalization logic and support the documented character ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->