### PR TITLE
fix(detect-reposts): concurrent openings were reported as reposts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,7 @@ AI-powered, CLI-agnostic job search automation: pipeline tracking, offer evaluat
 | `company-history.mjs` | Read-only per-company evidence card joining the tracker, follow-ups, scan history and the status-log (JSON or `--summary`) |
 | `followup-cadence.mjs` | Follow-up cadence calculator (JSON) |
 | `followup-seed.mjs` | Seeds `data/follow-ups.md` with a pinned first follow-up date when a row turns Applied (JSON) |
-| `detect-reposts.mjs` | Flags roles re-listed 2+ times in 90 days from `scan-history.tsv` (JSON or `--summary`) |
+| `detect-reposts.mjs` | Flags roles re-listed 2+ times in 90 days from `scan-history.tsv` — requires 2+ distinct URLs seen on 2+ distinct scan dates (`--min-span`) with the same title identity, so concurrent per-city/country/segment openings are not mistaken for reposts (JSON or `--summary`) |
 | `check-table-freshness.mjs` | Staleness validator for jurisdiction data tables — flags `expired` rows (past `next_effective` without re-verification, exit 1) and `review-due` rows (`as_of` older than 12 months, soft); discovers any `templates/*.yml` with `as_of` rows automatically (JSON or `--summary` table output) |
 | `process-quality.mjs` | Per-company recruiting-friction rate from `[process-friction]` tags in `data/active-interviews.md` Notes (JSON or `--summary`) |
 | `rejection-latency.mjs` | Post-interview response-latency signal — flags companies still in `Interview` state whose silence since the last `data/active-interviews.md` round exceeds a courtesy (30d default, configurable) threshold, with a ready-to-copy `data/blacklist.md` suggestion row; suggestion-only, never writes (JSON or `--summary` table output) |

--- a/company-history.mjs
+++ b/company-history.mjs
@@ -12,6 +12,11 @@
  *     response — it is an answer, not silence.
  *   - postingChurn: does this company repost the same role repeatedly
  *     (evergreen requisition / re-opened search), per detect-reposts.mjs?
+ *     "The same role, later" is the whole claim: a company running several
+ *     openings side by side — one per city, country, language or segment — is
+ *     not reposting, and detect-reposts.mjs enforces that with a minimum span
+ *     and a title-identity rule. Before it did, this axis reported
+ *     `reposts-detected` for companies that had never reposted anything.
  *
  * This script deliberately reports FACTS, not verdicts. It never uses the
  * words "ghost"/"ghosted" or "risk" — high-volume inboxes, evergreen

--- a/detect-reposts.mjs
+++ b/detect-reposts.mjs
@@ -97,12 +97,21 @@ const selfTestMode = args.includes('--self-test');
 // Tested against Number()/Number.isInteger() as well: Number('') is 0, so an
 // empty value (`--min-span=`) would read as a deliberate zero and disable the
 // floor. A total regex has no such hole.
+// The regex is not sufficient on its own: it happily accepts a 400-digit run of
+// nines, which Number() turns into Infinity. That reproduces this file's
+// original defect in a new place — an infinite floor rejects every cluster, an
+// infinite window is unbounded, and JSON.stringify writes Infinity as `null`,
+// so metadata reports a value that is not the one in effect. A merely UNSAFE
+// integer is the quiet version of the same thing: 9007199254740993 silently
+// becomes ...992. isSafeInteger rejects both.
 const intFlag = (flag, fallback) => {
   const raw = flagValue(args, flag);
   if (raw === undefined) return fallback;
   const text = String(raw).trim();
   if (!/^\d+$/.test(text)) return fallback;
-  return Number(text);
+  const parsed = Number(text);
+  if (!Number.isSafeInteger(parsed)) return fallback;
+  return parsed;
 };
 const windowDays = intFlag('--window', DEFAULT_WINDOW_DAYS);
 const minSpanDays = intFlag('--min-span', MIN_REPOST_SPAN_DAYS);

--- a/detect-reposts.mjs
+++ b/detect-reposts.mjs
@@ -84,13 +84,25 @@ const summaryMode = args.includes('--summary');
 const selfTestMode = args.includes('--self-test');
 // Both numeric flags read through flagValue, so `--min-span=7` behaves exactly
 // like `--min-span 7` — the defect lib/cli-flags.mjs exists to keep the next
-// script from rediscovering. An absent or unparseable value falls back to the
-// default, which is the behaviour --window already had.
+// script from rediscovering. Anything that is not a plain non-negative integer
+// falls back to the default, which is the behaviour --window already had for an
+// unparseable value.
+//
+// The whole string must match, and it must not be negative. parseInt() alone
+// satisfies neither: it reads "7abc" as 7, and it reads "-5" as -5 — and a
+// negative floor silently disables the very guard --min-span exists to set,
+// reporting concurrent openings as reposts again with no indication that the
+// value was rejected. A negative --window likewise rejects every cluster.
+//
+// Tested against Number()/Number.isInteger() as well: Number('') is 0, so an
+// empty value (`--min-span=`) would read as a deliberate zero and disable the
+// floor. A total regex has no such hole.
 const intFlag = (flag, fallback) => {
   const raw = flagValue(args, flag);
   if (raw === undefined) return fallback;
-  const parsed = parseInt(raw, 10);
-  return Number.isNaN(parsed) ? fallback : parsed;
+  const text = String(raw).trim();
+  if (!/^\d+$/.test(text)) return fallback;
+  return Number(text);
 };
 const windowDays = intFlag('--window', DEFAULT_WINDOW_DAYS);
 const minSpanDays = intFlag('--min-span', MIN_REPOST_SPAN_DAYS);

--- a/detect-reposts.mjs
+++ b/detect-reposts.mjs
@@ -2,10 +2,10 @@
 /**
  * detect-reposts.mjs — Repost Detector for career-ops
  *
- * Reads data/scan-history.tsv, groups rows by company, fuzzy-matches role
- * titles with roleFuzzyMatch from role-matcher.mjs, and flags any
- * company+role that appears 2+ times with different URLs within a 90-day
- * window. Such clusters are almost certainly the same opening being
+ * Reads data/scan-history.tsv, groups rows by company, groups role titles by
+ * title identity (see titleIdentityKey), and flags any company+role that
+ * appears 2+ times with different URLs, on 2+ distinct scan dates, within a
+ * 90-day window. Such clusters are almost certainly the same opening being
  * re-listed by the employer — useful for tracking stale pipelines and
  * ghost postings.
  *
@@ -13,9 +13,34 @@
  * status (`skipped_expired`, `skipped_invalid_url`, `skipped_blocked_host`)
  * describe dead postings, not reposts, and are skipped.
  *
+ * TWO CONSTRAINTS SEPARATE A REPOST FROM A SIBLING REQUISITION. Both were
+ * added after the detector reported `reposts-detected` for three companies
+ * that had never reposted anything:
+ *
+ *   1. MINIMUM SPAN. `first_seen` is when the SCANNER first saw a URL, not
+ *      when the employer posted it. A whole company is swept at once, so two
+ *      URLs sharing a first_seen date were listed CONCURRENTLY — that is the
+ *      signature of parallel openings, and the exact opposite of a repost,
+ *      which requires the role to reappear later. A cluster whose members all
+ *      come from one sweep therefore spans 0 days and cannot be evidence of
+ *      reposting at all. See MIN_REPOST_SPAN_DAYS / --min-span.
+ *
+ *   2. TITLE IDENTITY, not title similarity. This used to group titles with
+ *      roleFuzzyMatch, which merges any two titles clearing a 0.6 Jaccard
+ *      ratio. Per-region and per-segment variants of one job land exactly on
+ *      that boundary — "Commercial Solutions Engineer - Munich" vs "- Berlin"
+ *      share 3 of 5 tokens — so a company that fans one opening out across
+ *      cities read as a company reposting. Those are distinct requisitions
+ *      hiring distinct headcount, and merging them is a fabricated signal.
+ *      Membership now requires the same SET of title words, which still
+ *      tolerates word-order and punctuation churn between two listings of one
+ *      role but never merges titles that differ by a city, country, language,
+ *      segment or seniority word.
+ *
  * Run: node detect-reposts.mjs             (JSON to stdout)
  *      node detect-reposts.mjs --summary   (human-readable table)
  *      node detect-reposts.mjs --window 60 (override 90-day window)
+ *      node detect-reposts.mjs --min-span 7 (override 1-day minimum span)
  *      node detect-reposts.mjs --self-test
  *      node detect-reposts.mjs --help
  *
@@ -26,13 +51,20 @@ import { readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 
-import { roleFuzzyMatch, roleTokens, BASELINE_TOKENS } from './role-matcher.mjs';
 import { normalizeCompanyName } from './invite-match.mjs';
 import { flagValue, validateFlags } from './lib/cli-flags.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const SCAN_HISTORY_PATH = join(CAREER_OPS, 'data/scan-history.tsv');
 const DEFAULT_WINDOW_DAYS = 90;
+
+// Smallest first_seen span a cluster may have and still count as a repost.
+// 1, not a larger figure: scans run on an irregular cadence (this history has
+// gaps of 1 to 13 days), so a genuine repost caught on two consecutive scan
+// days spans exactly 1 and must survive. The load-bearing part is that 0 is
+// excluded — see constraint 1 in the header. --min-span raises it for anyone
+// whose sweeps straddle midnight and land one company on two dates.
+const MIN_REPOST_SPAN_DAYS = 1;
 
 // --- CLI args ---
 
@@ -43,16 +75,25 @@ const USAGE = `Usage:
   node detect-reposts.mjs                       # full JSON repost clusters to stdout
   node detect-reposts.mjs --summary             # human-readable table
   node detect-reposts.mjs --window 60           # override the default 90-day window
+  node detect-reposts.mjs --min-span 7          # override the default 1-day minimum span
   node detect-reposts.mjs --self-test           # run the in-memory test suite
   node detect-reposts.mjs --help                # print this usage block and exit`;
 
 const args = process.argv.slice(2);
 const summaryMode = args.includes('--summary');
 const selfTestMode = args.includes('--self-test');
-const windowValue = flagValue(args, '--window');
-const windowDays = windowValue !== undefined
-  ? (Number.isNaN(parseInt(windowValue, 10)) ? DEFAULT_WINDOW_DAYS : parseInt(windowValue, 10))
-  : DEFAULT_WINDOW_DAYS;
+// Both numeric flags read through flagValue, so `--min-span=7` behaves exactly
+// like `--min-span 7` — the defect lib/cli-flags.mjs exists to keep the next
+// script from rediscovering. An absent or unparseable value falls back to the
+// default, which is the behaviour --window already had.
+const intFlag = (flag, fallback) => {
+  const raw = flagValue(args, flag);
+  if (raw === undefined) return fallback;
+  const parsed = parseInt(raw, 10);
+  return Number.isNaN(parsed) ? fallback : parsed;
+};
+const windowDays = intFlag('--window', DEFAULT_WINDOW_DAYS);
+const minSpanDays = intFlag('--min-span', MIN_REPOST_SPAN_DAYS);
 
 // --- Date helpers ---
 function parseDate(dateStr) {
@@ -118,6 +159,55 @@ export function companyKey(row) {
   return stored || normalizeCompanyName(raw) || raw.toLowerCase();
 }
 
+// Canonical identity of a role TITLE, for deciding whether two listings are the
+// same opening. The key is the title's set of words: accent-folded, lowercased,
+// stripped of punctuation, deduplicated and sorted.
+//
+// Set equality is the whole point, and it is chosen against the two
+// alternatives on either side of it:
+//
+//   - Raw string equality is too tight. One opening re-listed months later
+//     routinely comes back with the words reordered or repunctuated
+//     ("Forward Deployed Engineer - Sweden" -> "Forward Deployed Engineer,
+//     Sweden"), and a detector that misses those misses real reposts.
+//
+//   - roleFuzzyMatch (what this used to use) is too loose. It merges titles
+//     that merely overlap enough, which is precisely how a family of sibling
+//     requisitions — same job, one per city/country/language/segment/level —
+//     collapses into a phantom repost cluster.
+//
+// Set equality sits exactly between them: every word must be accounted for on
+// both sides, so any city, country, language or seniority word present in one
+// title and absent from the other splits the two apart, while their ORDER and
+// punctuation are free to drift.
+//
+// No length or stopword filtering, deliberately. roleTokens drops words of 3
+// characters or fewer, which would erase the only thing distinguishing "…
+// Engineer - UK" from "… Engineer - US" and merge two countries' openings.
+//
+// Word splitting is script-preserving: it keeps any Unicode letter or number
+// and treats everything else as a separator, following the same reasoning as
+// #2429 for company names. Restricting to [a-z0-9] would fold every Japanese
+// or Cyrillic title to the empty string, and every such title at one company
+// would then share a key. A CJK title has no spaces to split on, so it stays a
+// single word and matches only its exact self — no over-clustering either way.
+//
+// A title that folds to nothing (all punctuation) falls back to its lowercased
+// raw text, the same guard companyKey uses.
+export function titleIdentityKey(title) {
+  const raw = String(title ?? '').trim();
+  const words = raw
+    .normalize('NFD')
+    .replace(/\p{Mn}/gu, '')
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+  if (words.length === 0) return raw.toLowerCase();
+  return [...new Set(words)].sort().join(' ');
+}
+
 function loadScanHistory(path = SCAN_HISTORY_PATH) {
   if (!existsSync(path)) return [];
   return parseScanHistory(readFileSync(path, 'utf-8'));
@@ -125,14 +215,14 @@ function loadScanHistory(path = SCAN_HISTORY_PATH) {
 
 // --- Core detection ---
 //
-// Group rows by company (case-insensitive), then within each company group
-// compare all pairs of titles via roleFuzzyMatch. Build clusters of matching
-// rows with union-find, then keep a cluster only if (a) it contains 2+ rows,
-// (b) at least two rows have different URLs, and (c) the cluster's first_seen
-// dates all fall within `windowDays` of each other.
+// Group rows by company (case-insensitive), then within each company group by
+// title identity (titleIdentityKey). Keep a cluster only if (a) it contains 2+
+// rows, (b) at least two rows have different URLs, (c) the cluster's first_seen
+// dates all fall within `windowDays` of each other, and (d) those dates span at
+// least `minSpanDays` — see constraint 1 in the header.
 //
 // Exported so external tests can call detectReposts() directly on a row list.
-export function detectReposts(rows, windowDays = DEFAULT_WINDOW_DAYS) {
+export function detectReposts(rows, windowDays = DEFAULT_WINDOW_DAYS, minSpan = MIN_REPOST_SPAN_DAYS) {
   if (!Array.isArray(rows)) return [];
   const valid = rows
     .filter(r =>
@@ -166,17 +256,17 @@ export function detectReposts(rows, windowDays = DEFAULT_WINDOW_DAYS) {
   const clusters = [];
   for (const [, groupRows] of byCompany) {
     if (groupRows.length < 2) continue;
-    clusters.push(...detectRepostsInGroup(groupRows, windowDays));
+    clusters.push(...detectRepostsInGroup(groupRows, windowDays, minSpan));
   }
   return clusters.sort((a, b) => (a.lastSeen < b.lastSeen ? 1 : -1));
 }
 
 // Cluster rows in a single company group. Rows are first grouped by title
-// (exact or fuzzy match), then each title group is sorted by date and a
-// sliding window finds sub-clusters within the windowDays span. This two-phase
-// approach prevents non-matching roles (e.g. a Product Manager between two
-// Backend Engineer postings) from breaking a valid repost cluster.
-function detectRepostsInGroup(rows, windowDays) {
+// identity, then each title group is sorted by date and a sliding window finds
+// sub-clusters within the windowDays span. This two-phase approach prevents
+// non-matching roles (e.g. a Product Manager between two Backend Engineer
+// postings) from breaking a valid repost cluster.
+function detectRepostsInGroup(rows, windowDays, minSpan = MIN_REPOST_SPAN_DAYS) {
   const titleGroups = groupRowsByTitle(rows);
 
   const results = [];
@@ -201,7 +291,7 @@ function detectRepostsInGroup(rows, windowDays) {
         // valid overlapping repost pairs that would otherwise be dropped
         // (e.g. Jan 1 + Mar 15 sealed, but Mar 15 + Jun 10 also valid).
         if (cluster.length >= 2) {
-          const result = buildRepostCluster(cluster, windowDays);
+          const result = buildRepostCluster(cluster, windowDays, minSpan);
           if (result) results.push(result);
         }
         cluster = cluster.filter(c => daysBetween(c.date, row.date) <= windowDays);
@@ -209,164 +299,64 @@ function detectRepostsInGroup(rows, windowDays) {
       }
     }
     if (cluster.length >= 2) {
-      const result = buildRepostCluster(cluster, windowDays);
+      const result = buildRepostCluster(cluster, windowDays, minSpan);
       if (result) results.push(result);
     }
   }
   return results;
 }
 
-// Group one company's rows into title groups: a seed row plus every later row
-// whose title matches it (exact, case-insensitively, or via roleFuzzyMatch).
+// Group one company's rows into title groups: all rows sharing a
+// titleIdentityKey land in one group.
 //
-// The obvious implementation is a nested loop over rows, and that is what this
-// used to be. It degrades badly on the shape scan-history.tsv actually grows
-// into: the file is append-only with one row per scanned posting, so a large
-// employer accumulates thousands of DISTINCT titles. Nothing collapses, every
-// pair pays a full roleFuzzyMatch (which re-tokenizes both strings on every
-// call), and the run goes quadratic with a very expensive constant (#2383).
+// This is a single O(N) bucketing pass. It replaced a nested loop that compared
+// every pair of titles with roleFuzzyMatch, and then an inverted token index
+// built to make that nested loop affordable (#2383) on the shape
+// scan-history.tsv actually grows into — the file is append-only with one row
+// per scanned posting, so a large employer accumulates thousands of DISTINCT
+// titles and nothing collapses. Deciding membership by an equality key instead
+// of by pairwise similarity removes the quadratic term outright, so the index
+// that existed to prune it has nothing left to prune.
 //
-// Two structures replace the nested loop without changing what it computes:
+// The correctness reason for the change, rather than the speed one, is in
+// constraint 2 of the header: pairwise similarity merged sibling requisitions.
 //
-//   1. Rows are bucketed by their lowercased title in one pass. Every row in a
-//      bucket matches every other by the exact-title arm of the old condition,
-//      so a bucket is atomic: a seed either takes the whole bucket or none of
-//      it. Exact reposts (the overwhelming majority of real ones) therefore
-//      collapse in O(N) with no fuzzy calls at all, and toLowerCase() runs once
-//      per row instead of once per comparison.
-//
-//   2. Fuzzy matching then runs over DISTINCT buckets only, and even there is
-//      gated by an inverted index over non-baseline tokens. roleFuzzyMatch can
-//      only return true for two non-identical titles when their deduped token
-//      sets share at least two tokens, at least one of which is not a
-//      BASELINE_TOKENS word, and their Jaccard ratio is >= 0.6. All three are
-//      necessary conditions and all three are checked exactly here, so any
-//      bucket pair the gate drops is one roleFuzzyMatch would have rejected
-//      anyway. The gate filters calls, never verdicts: every surviving pair is
-//      still decided by roleFuzzyMatch itself.
-//
-// Ordering is preserved exactly, because it is load-bearing downstream. The
-// date sort in detectRepostsInGroup uses a comparator that returns 1 (not 0)
-// for equal dates, so same-date rows keep their input order only if the group
-// arrives in input order; buildRepostCluster also reads clusterRows[0].company.
-// Groups are therefore emitted in seed order and their rows re-sorted by
-// original array position, which is what the nested loop produced: the seed is
-// always the first not-yet-used row, and the inner loop appended the rest in
-// array order.
+// Ordering is load-bearing downstream and is preserved. The date sort in
+// detectRepostsInGroup uses a comparator returning 1 (not 0) for equal dates,
+// so same-date rows keep their input order only if the group arrives in input
+// order; buildRepostCluster also reads clusterRows[0].company. Groups are
+// therefore emitted in first-appearance order of their key, and rows within a
+// group stay in input order.
 function groupRowsByTitle(rows) {
-  // Pass 1 — bucket by lowercased title, remembering each row's original
-  // position so groups can be rebuilt in input order later.
-  const buckets = [];
-  const bucketOfKey = new Map();
-  for (let i = 0; i < rows.length; i++) {
-    const key = rows[i].title.toLowerCase();
-    let idx = bucketOfKey.get(key);
-    if (idx === undefined) {
-      idx = buckets.length;
-      bucketOfKey.set(key, idx);
-      // The representative title is the FIRST row's raw title, which is also
-      // the row the nested loop would have used as the seed. Other rows in the
-      // bucket differ from it only in case, and every decision roleFuzzyMatch
-      // makes runs on lowercased text, so the choice cannot change a verdict.
-      buckets.push({ title: rows[i].title, rowIdx: [], tokens: null, tokenSet: null });
-    }
-    buckets[idx].rowIdx.push(i);
-  }
-
-  // Single distinct title: the nested loop would have made one group of
-  // everything. Skip the index entirely.
-  if (buckets.length === 1) return [buckets[0].rowIdx.map(i => rows[i])];
-
-  // Pass 2 — tokenize each distinct title once, then index DISCRIMINATING
-  // token -> buckets. Baseline tokens are deliberately left out of the index:
-  // words like "engineer" or "platform" appear in most titles at a company, so
-  // indexing them would build one enormous posting list that has to be walked
-  // for every seed and can never, on its own, justify a match.
-  const postings = new Map();
-  for (let b = 0; b < buckets.length; b++) {
-    const tokens = [...new Set(roleTokens(buckets[b].title))];
-    buckets[b].tokens = tokens;
-    buckets[b].tokenSet = new Set(tokens);
-    for (const token of tokens) {
-      if (BASELINE_TOKENS.has(token)) continue;
-      let list = postings.get(token);
-      if (!list) { list = []; postings.set(token, list); }
-      list.push(b);
-    }
-  }
-
-  // Pass 3 — seed buckets in first-appearance order, gathering matches.
-  const used = new Uint8Array(buckets.length);
-  const seen = new Uint8Array(buckets.length);
-  const candidates = [];
   const groups = [];
-
-  for (let seed = 0; seed < buckets.length; seed++) {
-    if (used[seed]) continue;
-    used[seed] = 1;
-    const members = [seed];
-    const seedTokens = buckets[seed].tokens;
-
-    // Collect every bucket sharing at least one discriminating token with the
-    // seed. A bucket that shares none cannot match: roleFuzzyMatch requires a
-    // non-baseline word in the overlap, so it would return false without ever
-    // being asked.
-    for (const token of seedTokens) {
-      const list = postings.get(token);
-      if (!list) continue;
-      for (const b of list) {
-        if (b === seed || used[b] || seen[b]) continue;
-        seen[b] = 1;
-        candidates.push(b);
-      }
+  const groupOfKey = new Map();
+  for (const row of rows) {
+    const key = titleIdentityKey(row.title);
+    let idx = groupOfKey.get(key);
+    if (idx === undefined) {
+      idx = groups.length;
+      groupOfKey.set(key, idx);
+      groups.push([]);
     }
-
-    // Ascending bucket order keeps the candidate walk deterministic. It cannot
-    // change the outcome — each candidate is tested against the seed alone —
-    // but it makes the traversal reproducible run to run.
-    candidates.sort((a, b) => a - b);
-    for (const b of candidates) {
-      seen[b] = 0;
-      // Exact overlap over the deduped token sets, then the exact Jaccard
-      // ratio |A n B| / |A u B| with |A u B| = |A| + |B| - |A n B|. Both are
-      // the same numbers roleFuzzyMatch computes; failing either is a verdict
-      // it would have reached itself.
-      const candSet = buckets[b].tokenSet;
-      let overlap = 0;
-      for (const token of seedTokens) if (candSet.has(token)) overlap += 1;
-      if (overlap < 2) continue;
-      const union = seedTokens.length + buckets[b].tokens.length - overlap;
-      if (overlap / union < 0.6) continue;
-      if (roleFuzzyMatch(buckets[seed].title, buckets[b].title)) {
-        used[b] = 1;
-        members.push(b);
-      }
-    }
-    candidates.length = 0;
-
-    if (members.length === 1) {
-      groups.push(buckets[seed].rowIdx.map(i => rows[i]));
-      continue;
-    }
-    // Appended one index at a time rather than spread: a pathological history
-    // can put a very large number of rows into a single bucket, and a spread
-    // that wide overflows the argument stack.
-    const merged = [];
-    for (const b of members) for (const i of buckets[b].rowIdx) merged.push(i);
-    merged.sort((a, b) => a - b);
-    groups.push(merged.map(i => rows[i]));
+    groups[idx].push(row);
   }
-
   return groups;
 }
 
-// A fuzzy-matched cluster becomes a repost cluster only when (a) at least two
-// distinct URLs are present (same URL means a dedup hit, not a repost), and
-// (b) every row's first_seen date falls within windowDays of every other row.
-// We enforce the window by requiring max-min span <= windowDays. Rows sharing
-// the same URL are collapsed (only the earliest sighting is kept) so a URL
-// seen on multiple scan dates doesn't inflate the repost count.
-function buildRepostCluster(clusterRows, windowDays) {
+// A title-identity cluster becomes a repost cluster only when (a) at least two
+// distinct URLs are present (same URL means a dedup hit, not a repost), (b)
+// every row's first_seen date falls within windowDays of every other row, and
+// (c) the span between the earliest and latest first_seen is at least
+// minSpan days. We enforce the window by requiring max-min span <= windowDays.
+// Rows sharing the same URL are collapsed (only the earliest sighting is kept)
+// so a URL seen on multiple scan dates doesn't inflate the repost count.
+//
+// (c) is what keeps concurrent openings out. Two URLs first seen on the same
+// date were listed side by side in one sweep — that is a company running two
+// requisitions at once, which is the opposite of re-listing one requisition
+// later, and it is the single largest source of false positives in a real
+// history (165 of 252 clusters when it was missing). See header constraint 1.
+function buildRepostCluster(clusterRows, windowDays, minSpan = MIN_REPOST_SPAN_DAYS) {
   const byUrl = new Map();
   for (const row of clusterRows) {
     if (!byUrl.has(row.url) || row.date < byUrl.get(row.url).date) {
@@ -382,6 +372,7 @@ function buildRepostCluster(clusterRows, windowDays) {
   const last = sorted[sorted.length - 1];
   const span = daysBetween(first.date, last.date);
   if (span > windowDays) return null;
+  if (span < minSpan) return null;
 
   const role = last.title;
   const appearances = sorted.map(r => ({ url: r.url, date: r.dateStr, title: r.title }));
@@ -401,7 +392,7 @@ function buildRepostCluster(clusterRows, windowDays) {
 function printSummary(clusters) {
   console.log(`\n${'='.repeat(78)}`);
   console.log('  Repost Detector — career-ops');
-  console.log(`  window: ${windowDays} days | clusters: ${clusters.length}`);
+  console.log(`  window: ${windowDays} days | min span: ${minSpanDays} day(s) | clusters: ${clusters.length}`);
   console.log(`${'='.repeat(78)}\n`);
 
   if (clusters.length === 0) {
@@ -487,6 +478,103 @@ function runSelfTest() {
   check(detectReposts([], DEFAULT_WINDOW_DAYS).length === 0, 'empty input should return no clusters');
   check(detectReposts(baseRows.filter(r => r.status !== 'added'), DEFAULT_WINDOW_DAYS).length === 0, 'only-skipped rows should return no clusters');
 
+  // --- Regression fixtures for the three phantom-repost shapes found in a
+  // real scan-history. Company names and URLs are synthetic; only the SHAPE is
+  // reproduced, which is the part that matters. ---
+  const scanRow = (url, dateStr, title, company) =>
+    ({ url, date: parseDate(dateStr), dateStr, title, company, status: 'added', portal: 'ashby-full', location: '' });
+
+  // Shape 1 — one sweep, sibling per-city variants of one role. Both
+  // constraints reject it independently, so assert each one on its own too.
+  const perCity = [
+    scanRow('https://jobs.example.com/acme/a', '2026-01-10', 'Commercial Solutions Engineer - Munich', 'Acme'),
+    scanRow('https://jobs.example.com/acme/b', '2026-01-10', 'Commercial Solutions Engineer - Berlin', 'Acme'),
+    scanRow('https://jobs.example.com/acme/c', '2026-01-10', 'Commercial Solutions Engineer - EMEA', 'Acme'),
+  ];
+  check(detectReposts(perCity, DEFAULT_WINDOW_DAYS).length === 0, 'per-city variants seen in one sweep are not reposts');
+  check(
+    detectReposts(perCity, DEFAULT_WINDOW_DAYS, 0).length === 0,
+    'per-city variants are rejected on title identity even with the span floor disabled',
+  );
+
+  // Shape 2 — the exact same title twice in one sweep: two concurrent
+  // requisitions. Only the span floor can reject this one; title identity
+  // holds, which is precisely why the floor is needed as well.
+  const sameSweep = [
+    scanRow('https://jobs.example.com/globex/r1', '2026-01-10', 'Regional Sales Engineer (Remote, CHE)', 'Globex'),
+    scanRow('https://jobs.example.com/globex/r2', '2026-01-10', 'Regional Sales Engineer (Remote, CHE)', 'Globex'),
+  ];
+  check(detectReposts(sameSweep, DEFAULT_WINDOW_DAYS).length === 0, 'two concurrent requisitions in one sweep are not a repost');
+  check(
+    detectReposts(sameSweep, DEFAULT_WINDOW_DAYS, 0).length === 1,
+    'the same-sweep fixture is rejected by the span floor specifically (it survives with the floor disabled)',
+  );
+
+  // Shape 3 — two countries' requisitions in one sweep, titles differing only
+  // by a trailing country. This is exactly what roleFuzzyMatch used to merge.
+  const perCountry = [
+    scanRow('https://jobs.example.com/initech/1', '2026-01-10', 'Channel Account Manager', 'Initech'),
+    scanRow('https://jobs.example.com/initech/2', '2026-01-10', 'Channel Account Manager - Spain', 'Initech'),
+  ];
+  check(detectReposts(perCountry, DEFAULT_WINDOW_DAYS).length === 0, 'two countries\' requisitions are not a repost');
+  check(
+    detectReposts(perCountry, DEFAULT_WINDOW_DAYS, 0).length === 0,
+    'a trailing country word splits the titles even with the span floor disabled',
+  );
+
+  // --- The positive control these constraints must not break: the same role,
+  // different URL, seen on two different scan dates. ---
+  const genuine = [
+    scanRow('https://jobs.example.com/umbrella/4066969101', '2026-01-08', 'Senior Customer Success Manager', 'Umbrella'),
+    scanRow('https://jobs.example.com/umbrella/4948414101', '2026-02-11', 'Senior Customer Success Manager', 'Umbrella'),
+  ];
+  const genuineClusters = detectReposts(genuine, DEFAULT_WINDOW_DAYS);
+  check(genuineClusters.length === 1, 'genuine repost across two scan dates is still flagged');
+  check(genuineClusters[0]?.daysSpan === 34, 'genuine repost keeps its real 34-day span');
+
+  // A repost re-listed with the words reordered/repunctuated is still one role.
+  const reworded = [
+    scanRow('https://jobs.example.com/hooli/a', '2026-01-28', 'Forward Deployed Engineer - Sweden', 'Hooli'),
+    scanRow('https://jobs.example.com/hooli/b', '2026-02-11', 'Forward Deployed Engineer, Sweden', 'Hooli'),
+  ];
+  check(detectReposts(reworded, DEFAULT_WINDOW_DAYS).length === 1, 'punctuation-only retitling still counts as the same role');
+
+  // A same-day sighting must not be able to drag a real repost pair's span down
+  // to 0 and suppress it.
+  const mixedSpan = [
+    ...genuine,
+    scanRow('https://jobs.example.com/umbrella/4948414102', '2026-02-11', 'Senior Customer Success Manager', 'Umbrella'),
+  ];
+  const mixedClusters = detectReposts(mixedSpan, DEFAULT_WINDOW_DAYS);
+  check(mixedClusters.length === 1 && mixedClusters[0].repostCount === 3, 'a same-day third sighting joins the real cluster rather than suppressing it');
+
+  // titleIdentityKey contract.
+  check(
+    titleIdentityKey('Forward Deployed Engineer - Sweden') === titleIdentityKey('Forward Deployed Engineer, Sweden'),
+    'titleIdentityKey ignores punctuation',
+  );
+  check(
+    titleIdentityKey('Senior Backend Engineer Payments') === titleIdentityKey('Backend Engineer Payments Senior'),
+    'titleIdentityKey ignores word order',
+  );
+  check(
+    titleIdentityKey('Solutions Engineer - UK') !== titleIdentityKey('Solutions Engineer - US'),
+    'titleIdentityKey keeps short country words that roleTokens would have dropped',
+  );
+  check(
+    titleIdentityKey('Operations Manager') !== titleIdentityKey('Senior Operations Manager'),
+    'titleIdentityKey keeps seniority words distinct',
+  );
+  check(titleIdentityKey('—') === '—', 'a title that folds to nothing falls back to its raw text rather than an empty key');
+  check(
+    titleIdentityKey('シニアエンジニア') !== titleIdentityKey('データアナリスト'),
+    'non-Latin titles keep distinct keys instead of both folding to empty (#2429 reasoning)',
+  );
+  check(
+    titleIdentityKey('Ingénieur Données') === titleIdentityKey('Ingenieur Donnees'),
+    'titleIdentityKey folds accents, so a re-listing that drops them is still the same role',
+  );
+
   console.log(`\n  detect-reposts self-test: ${pass} passed, ${fail} failed\n`);
   process.exit(fail > 0 ? 1 : 0);
 }
@@ -509,7 +597,7 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
   }
 
   const rows = loadScanHistory();
-  const clusters = detectReposts(rows, windowDays);
+  const clusters = detectReposts(rows, windowDays, minSpanDays);
 
   if (summaryMode) {
     printSummary(clusters);
@@ -517,6 +605,7 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
     console.log(JSON.stringify({
       metadata: {
         windowDays,
+        minSpanDays,
         totalRows: rows.length,
         clusters: clusters.length,
       },

--- a/detect-reposts.mjs
+++ b/detect-reposts.mjs
@@ -68,8 +68,14 @@ const MIN_REPOST_SPAN_DAYS = 1;
 
 // --- CLI args ---
 
-const KNOWN_FLAGS = ['--window', '--summary', '--self-test', '--help', '-h'];
-const VALUE_FLAGS = ['--window'];
+// ADDING A FLAG: add it to BOTH lists below, and to USAGE. validateFlags reads
+// these, not the code that consumes the flag, so a new flag wired up everywhere
+// else still exits 1 with "unrecognized flag(s)". Appending to a list is also
+// the shape git merges most willingly: two branches can each add a flag here and
+// merge without a conflict, leaving whichever landed second working in every
+// file except this one. That is how --min-span arrived rejected (#2919).
+const KNOWN_FLAGS = ['--window', '--min-span', '--summary', '--self-test', '--help', '-h'];
+const VALUE_FLAGS = ['--window', '--min-span'];
 
 const USAGE = `Usage:
   node detect-reposts.mjs                       # full JSON repost clusters to stdout

--- a/detect-reposts.test.mjs
+++ b/detect-reposts.test.mjs
@@ -1263,6 +1263,43 @@ const badSpanOut = execFileSync('node', [scriptPath, '--min-span', 'abc'], {
 });
 eq('--min-span abc falls back to 1', JSON.parse(badSpanOut).metadata.minSpanDays, 1);
 
+// Anything that is not a plain non-negative integer falls back rather than
+// being half-read. The negative case is the dangerous one: it silently DISABLES
+// the guard --min-span exists to set, so concurrent openings would be reported
+// as reposts again with nothing to indicate the value was rejected. "7abc" is
+// the same class — parseInt() reads it as 7 and runs with a number nobody typed.
+const flagFallbackCases = [
+  ['--min-span', '-5', 'minSpanDays', 1, 'negative --min-span falls back (never disables the floor)'],
+  ['--min-span', '7abc', 'minSpanDays', 1, 'partially numeric --min-span falls back (not read as 7)'],
+  ['--min-span', '1.5', 'minSpanDays', 1, 'non-integer --min-span falls back'],
+  ['--window', '-1', 'windowDays', 90, 'negative --window falls back (never rejects every cluster)'],
+  ['--window', '60abc', 'windowDays', 90, 'partially numeric --window falls back'],
+];
+for (const [flag, value, field, expected, label] of flagFallbackCases) {
+  const out = execFileSync('node', [scriptPath, flag, value], {
+    encoding: 'utf-8', timeout: 10000,
+    cwd: dirname(scriptPath),
+  });
+  eq(label, JSON.parse(out).metadata[field], expected);
+}
+
+// `--min-span=` supplies an EMPTY value, which must fall back too. Number('')
+// is 0, so a validator written with Number()/Number.isInteger() would read this
+// as a deliberate zero and quietly disable the floor.
+const emptySpanOut = execFileSync('node', [scriptPath, '--min-span='], {
+  encoding: 'utf-8', timeout: 10000,
+  cwd: dirname(scriptPath),
+});
+eq('--min-span= (empty value) falls back to 1, not 0', JSON.parse(emptySpanOut).metadata.minSpanDays, 1);
+
+// 0 remains a legitimate explicit value on both flags — the fallback rules must
+// not swallow it, or the floor could never be switched off on purpose.
+const zeroSpanOut = execFileSync('node', [scriptPath, '--min-span', '0'], {
+  encoding: 'utf-8', timeout: 10000,
+  cwd: dirname(scriptPath),
+});
+eq('--min-span 0 is honoured as an explicit zero', JSON.parse(zeroSpanOut).metadata.minSpanDays, 0);
+
 // Test -h flag
 const hOut = execFileSync('node', [scriptPath, '-h'], {
   encoding: 'utf-8', timeout: 10000,

--- a/detect-reposts.test.mjs
+++ b/detect-reposts.test.mjs
@@ -1197,6 +1197,23 @@ const windowJson = JSON.parse(windowOut);
 ok('--window produces valid JSON output', typeof windowJson === 'object' && 'metadata' in windowJson);
 eq('--window sets windowDays in metadata', windowJson.metadata.windowDays, 30);
 
+// Test --min-span flag.
+//
+// This asserts on the VALUE reaching metadata, not merely on a zero exit,
+// because the failure this guards against exits non-zero for a reason that has
+// nothing to do with the flag's logic: validateFlags reads KNOWN_FLAGS, which
+// lives in a different block from every line that consumes --min-span. Adding
+// the flag everywhere else and forgetting that list produces "unrecognized
+// flag(s): --min-span" from code that is otherwise complete and correct — and
+// two branches can each append to that list and merge without git ever
+// reporting a conflict, so nothing outside a running CLI catches it.
+const minSpanOut = execFileSync('node', [scriptPath, '--min-span', '3'], {
+  encoding: 'utf-8', timeout: 10000,
+  cwd: dirname(scriptPath),
+});
+const minSpanJson = JSON.parse(minSpanOut);
+eq('--min-span sets minSpanDays in metadata', minSpanJson.metadata.minSpanDays, 3);
+
 // Test --summary flag
 const summaryOut = execFileSync('node', [scriptPath, '--summary'], {
   encoding: 'utf-8', timeout: 10000,

--- a/detect-reposts.test.mjs
+++ b/detect-reposts.test.mjs
@@ -1300,6 +1300,36 @@ const zeroSpanOut = execFileSync('node', [scriptPath, '--min-span', '0'], {
 });
 eq('--min-span 0 is honoured as an explicit zero', JSON.parse(zeroSpanOut).metadata.minSpanDays, 0);
 
+// All-digits is not enough on its own. A long digit run converts to Infinity,
+// which is this file's original defect in a new place: an infinite floor
+// rejects every cluster, an infinite window is unbounded, and JSON.stringify
+// writes Infinity as `null` — so metadata would report a value that is not the
+// one in effect. An UNSAFE integer is the quiet version: 9007199254740993
+// silently becomes ...992, a number nobody typed.
+const overflowCases = [
+  ['--min-span', '9'.repeat(400), 'minSpanDays', 1, 'overflow --min-span falls back (never becomes an infinite floor)'],
+  ['--window', '9'.repeat(400), 'windowDays', 90, 'overflow --window falls back (never becomes an unbounded window)'],
+  ['--min-span', '9007199254740993', 'minSpanDays', 1, 'unsafe-integer --min-span falls back rather than losing precision'],
+];
+for (const [flag, value, field, expected, label] of overflowCases) {
+  const out = execFileSync('node', [scriptPath, flag, value], {
+    encoding: 'utf-8', timeout: 10000,
+    cwd: dirname(scriptPath),
+  });
+  const meta = JSON.parse(out).metadata;
+  eq(label, meta[field], expected);
+}
+
+// The metadata block must always round-trip a real number, since it is what a
+// consumer reads to learn which rules produced the clusters. `null` there means
+// an Infinity got through.
+const metaSanity = JSON.parse(execFileSync('node', [scriptPath, '--min-span', '9'.repeat(400)], {
+  encoding: 'utf-8', timeout: 10000,
+  cwd: dirname(scriptPath),
+})).metadata;
+ok('metadata.minSpanDays is always a finite number, never null', Number.isFinite(metaSanity.minSpanDays));
+ok('metadata.windowDays is always a finite number, never null', Number.isFinite(metaSanity.windowDays));
+
 // Test -h flag
 const hOut = execFileSync('node', [scriptPath, '-h'], {
   encoding: 'utf-8', timeout: 10000,

--- a/detect-reposts.test.mjs
+++ b/detect-reposts.test.mjs
@@ -17,8 +17,7 @@
  * Run: node detect-reposts.test.mjs
  */
 
-import { detectReposts, parseScanHistory, companyKey } from './detect-reposts.mjs';
-import { roleFuzzyMatch } from './role-matcher.mjs';
+import { detectReposts, parseScanHistory, companyKey, titleIdentityKey } from './detect-reposts.mjs';
 import { readFileSync, writeFileSync, unlinkSync, existsSync, mkdtempSync, rmSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -380,11 +379,22 @@ eq('91 days -> NOT flagged', detectReposts([
   row({ url: 'https://x.com/2', date: d('2026-04-02'), dateStr: '2026-04-02' }),
 ], 90).length, 0);
 
-// Window = 0: same-day only
-eq('window=0, same day, different URL -> flagged', detectReposts([
+// Window = 0 admits same-day clusters only, which the default 1-day span floor
+// then rejects — the two bounds have no overlap, so --window 0 can no longer
+// return anything. Asserted so the degenerate combination is a documented
+// outcome rather than a surprise.
+eq('window=0 with the default span floor -> nothing can be flagged', detectReposts([
   row({ url: 'https://x.com/1', date: d('2026-01-01'), dateStr: '2026-01-01' }),
   row({ url: 'https://x.com/2', date: d('2026-01-01'), dateStr: '2026-01-01' }),
-], 0).length, 1);
+], 0).length, 0);
+
+// The same rows with the floor lowered: this keeps coverage of the window=0
+// path itself, and proves the assertion above is the FLOOR talking rather than
+// the window silently dropping same-day rows for some other reason.
+eq('window=0, same day, different URL, span floor 0 -> flagged', detectReposts([
+  row({ url: 'https://x.com/1', date: d('2026-01-01'), dateStr: '2026-01-01' }),
+  row({ url: 'https://x.com/2', date: d('2026-01-01'), dateStr: '2026-01-01' }),
+], 0, 0).length, 1);
 
 eq('window=0, 1 day apart -> NOT flagged', detectReposts([
   row({ url: 'https://x.com/1', date: d('2026-01-01'), dateStr: '2026-01-01' }),
@@ -482,10 +492,22 @@ eq('unsorted input dates -> still works (sorted internally)', unsortedResult.len
 eq('unsorted: firstSeen = 2026-01-01', unsortedResult[0]?.firstSeen, '2026-01-01');
 eq('unsorted: lastSeen = 2026-03-01', unsortedResult[0]?.lastSeen, '2026-03-01');
 
-// Same date, different URLs
-eq('same date, different URLs -> flagged', detectReposts([
+// Same date, different URLs — two openings listed side by side in one sweep,
+// not one opening re-listed. `first_seen` is a SCANNER observation date, so a
+// zero-day span means both URLs were already live when the scanner arrived and
+// carries no evidence about re-listing at all. This was the defect behind three
+// companies reading as `reposts-detected` on 2026-08-11.
+eq('same date, different URLs -> NOT flagged (concurrent, not reposted)', detectReposts([
   row({ url: 'https://x.com/1', date: d('2026-01-01'), dateStr: '2026-01-01' }),
   row({ url: 'https://x.com/2', date: d('2026-01-01'), dateStr: '2026-01-01' }),
+], 90).length, 0);
+
+// One day apart is the smallest real signal and must survive, so the rule above
+// reads as "a zero span is not evidence" rather than "close sightings are
+// suspicious".
+eq('one day apart, different URLs -> flagged', detectReposts([
+  row({ url: 'https://x.com/1', date: d('2026-01-01'), dateStr: '2026-01-01' }),
+  row({ url: 'https://x.com/2', date: d('2026-01-02'), dateStr: '2026-01-02' }),
 ], 90).length, 1);
 
 // ============================================================================
@@ -846,18 +868,25 @@ eq('SW: distinct roles not grouped', detectReposts([
 // ============================================================================
 console.log('\n--- 10.6 grouping equivalence (#2383) ---');
 
-// #2383 replaced the nested title loop in detectRepostsInGroup with a
-// bucket-by-lowercased-title Map plus an inverted token index. That was a pure
-// speed change, so the only thing worth testing is that it is in fact pure:
-// the clusters coming out must be byte-identical to what the old loop produced,
-// including their order and the order of appearances inside them.
+// A second, independently written implementation of the whole detector. The
+// clusters coming out of detect-reposts.mjs must be byte-identical to what this
+// one produces, including their order and the order of appearances inside them.
 //
-// The reference below is the pre-#2383 file, copied verbatim. It is frozen on
-// purpose. If detect-reposts.mjs ever changes what it computes (window rules,
-// cluster shape, dedup policy) rather than how fast it computes it, this copy
-// must be updated in the same commit. A silent divergence failing here is the
-// intended behaviour, not a nuisance.
-function legacyBuildRepostCluster(clusterRows, windowDays) {
+// Its history: it began as the pre-#2383 file copied verbatim, guarding a pure
+// speed change (a nested title loop became a bucket Map plus an inverted token
+// index). It is no longer a frozen copy of anything — the phantom-repost fix
+// changed what the detector COMPUTES, so this reference was updated in the same
+// commit, exactly as the note here has always required. What it still buys is a
+// second opinion on the parts most easily broken by accident: grouping order,
+// same-date input order, URL dedup, and the two date bounds. It is deliberately
+// written in the straightforward nested-loop style rather than mirroring the
+// real file's structure, so a shared bug has to be reasoned into both.
+//
+// If detect-reposts.mjs ever changes what it computes (window rules, span
+// rules, cluster shape, dedup policy, title identity) rather than how fast it
+// computes it, this copy must be updated in the same commit. A silent
+// divergence failing here is the intended behaviour, not a nuisance.
+function legacyBuildRepostCluster(clusterRows, windowDays, minSpan) {
   const byUrl = new Map();
   for (const r of clusterRows) {
     if (!byUrl.has(r.url) || r.date < byUrl.get(r.url).date) byUrl.set(r.url, r);
@@ -869,6 +898,7 @@ function legacyBuildRepostCluster(clusterRows, windowDays) {
   const last = sorted[sorted.length - 1];
   const span = daysBetween(first.date, last.date);
   if (span > windowDays) return null;
+  if (span < minSpan) return null;
   return {
     company: clusterRows[0].company,
     role: last.title,
@@ -880,9 +910,10 @@ function legacyBuildRepostCluster(clusterRows, windowDays) {
   };
 }
 
-function legacyDetectRepostsInGroup(rows, windowDays) {
-  // The quadratic loop this change removed: every row is compared against every
-  // other row with a fresh toLowerCase() and a fresh roleFuzzyMatch().
+function legacyDetectRepostsInGroup(rows, windowDays, minSpan) {
+  // Grouping by title identity, written as the naive quadratic scan: every row
+  // is compared against every other with a freshly recomputed key. The real
+  // file does this with a single-pass Map; agreeing here is the point.
   const titleGroups = [];
   const used = new Set();
   for (const r of rows) {
@@ -891,7 +922,7 @@ function legacyDetectRepostsInGroup(rows, windowDays) {
     used.add(r);
     for (const other of rows) {
       if (used.has(other)) continue;
-      if (r.title.toLowerCase() === other.title.toLowerCase() || roleFuzzyMatch(r.title, other.title)) {
+      if (titleIdentityKey(r.title) === titleIdentityKey(other.title)) {
         group.push(other);
         used.add(other);
       }
@@ -911,7 +942,7 @@ function legacyDetectRepostsInGroup(rows, windowDays) {
         cluster.push(r);
       } else {
         if (cluster.length >= 2) {
-          const built = legacyBuildRepostCluster(cluster, windowDays);
+          const built = legacyBuildRepostCluster(cluster, windowDays, minSpan);
           if (built) results.push(built);
         }
         cluster = cluster.filter(cr => daysBetween(cr.date, r.date) <= windowDays);
@@ -919,14 +950,14 @@ function legacyDetectRepostsInGroup(rows, windowDays) {
       }
     }
     if (cluster.length >= 2) {
-      const built = legacyBuildRepostCluster(cluster, windowDays);
+      const built = legacyBuildRepostCluster(cluster, windowDays, minSpan);
       if (built) results.push(built);
     }
   }
   return results;
 }
 
-function legacyDetectReposts(rows, windowDays = 90) {
+function legacyDetectReposts(rows, windowDays = 90, minSpan = 1) {
   if (!Array.isArray(rows)) return [];
   const valid = rows
     .filter(r =>
@@ -949,7 +980,7 @@ function legacyDetectReposts(rows, windowDays = 90) {
   const clusters = [];
   for (const [, groupRows] of byCompany) {
     if (groupRows.length < 2) continue;
-    clusters.push(...legacyDetectRepostsInGroup(groupRows, windowDays));
+    clusters.push(...legacyDetectRepostsInGroup(groupRows, windowDays, minSpan));
   }
   return clusters.sort((a, b) => (a.lastSeen < b.lastSeen ? 1 : -1));
 }
@@ -957,8 +988,8 @@ function legacyDetectReposts(rows, windowDays = 90) {
 // Compares full cluster output, not just cluster counts: eq() stringifies, so
 // this catches a changed cluster order, a changed appearance order inside a
 // cluster, or a different `role`/`company` representative being picked.
-function sameAsLegacy(label, rows, windowDays = 90) {
-  eq(label, detectReposts(rows, windowDays), legacyDetectReposts(rows, windowDays));
+function sameAsLegacy(label, rows, windowDays = 90, minSpan = 1) {
+  eq(label, detectReposts(rows, windowDays, minSpan), legacyDetectReposts(rows, windowDays, minSpan));
 }
 
 // Compact row builder for the corpora below.
@@ -1075,7 +1106,12 @@ const mixedCorpus = Array.from({ length: 300 }, (_, i) => {
 });
 sameAsLegacy('equivalence: 300-row mixed corpus (seeded)', mixedCorpus);
 sameAsLegacy('equivalence: same mixed corpus at window=30', mixedCorpus, 30);
-sameAsLegacy('equivalence: same mixed corpus at window=0', mixedCorpus, 0);
+// window=0 needs the span floor lowered to 0 as well, or both sides return an
+// empty list and the comparison confirms nothing.
+sameAsLegacy('equivalence: same mixed corpus at window=0, span floor 0', mixedCorpus, 0, 0);
+// The span floor itself, compared against the reference on the full corpus.
+sameAsLegacy('equivalence: same mixed corpus at span floor 0', mixedCorpus, 90, 0);
+sameAsLegacy('equivalence: same mixed corpus at span floor 30', mixedCorpus, 90, 30);
 
 // The mixed corpus is only meaningful if it actually produces clusters — an
 // all-empty comparison would pass no matter what the grouping did.
@@ -1203,8 +1239,29 @@ const helpOut = execFileSync('node', [scriptPath, '--help'], {
 ok('--help prints usage', helpOut.includes('Usage:'));
 ok('--help documents --summary', helpOut.includes('--summary'));
 ok('--help documents --window', helpOut.includes('--window'));
+ok('--help documents --min-span', helpOut.includes('--min-span'));
 ok('--help documents --self-test', helpOut.includes('--self-test'));
 ok('--help documents --help', helpOut.includes('--help'));
+
+// --min-span in both accepted forms, since it reads through flagValue. The
+// `=` form is the one a hand-rolled indexOf() lookup drops silently.
+const spanEqOut = execFileSync('node', [scriptPath, '--min-span=30'], {
+  encoding: 'utf-8', timeout: 10000,
+  cwd: dirname(scriptPath),
+});
+eq('--min-span=30 is honoured (not silently dropped)', JSON.parse(spanEqOut).metadata.minSpanDays, 30);
+
+const spanSpaceOut = execFileSync('node', [scriptPath, '--min-span', '30'], {
+  encoding: 'utf-8', timeout: 10000,
+  cwd: dirname(scriptPath),
+});
+eq('--min-span 30 is honoured', JSON.parse(spanSpaceOut).metadata.minSpanDays, 30);
+
+const badSpanOut = execFileSync('node', [scriptPath, '--min-span', 'abc'], {
+  encoding: 'utf-8', timeout: 10000,
+  cwd: dirname(scriptPath),
+});
+eq('--min-span abc falls back to 1', JSON.parse(badSpanOut).metadata.minSpanDays, 1);
 
 // Test -h flag
 const hOut = execFileSync('node', [scriptPath, '-h'], {


### PR DESCRIPTION
## What does this PR do?

`detect-reposts.mjs` flagged concurrent openings as reposts, so `company-history.mjs` reported `postingChurn: reposts-detected` for companies that had never reposted anything. Two independent defects produced it; this fixes both and adds regression fixtures for each.

## Related issue

None — bug fix, sent straight in per the template.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

---

### Defect 1 — a zero-day span is not evidence of reposting

`first_seen` in `scan-history.tsv` is the **scanner's** observation date, not the employer's posting date, and a company is swept in one pass. Two URLs sharing a `first_seen` were therefore listed **concurrently** — the opposite of re-listing. Those clusters span 0 days and carry no information about reposting at all.

In a real 2341-row scan-history that was **165 of 252 clusters**.

Fixed with a minimum span (`MIN_REPOST_SPAN_DAYS = 1`, `--min-span` to override). 1 rather than something larger because scans run on an irregular cadence, so a genuine repost caught on two consecutive scan days spans exactly 1 and has to survive — the load-bearing part is only that 0 is excluded.

### Defect 2 — `roleFuzzyMatch` merged sibling requisitions

Title grouping used `roleFuzzyMatch`, which merges any two titles clearing a 0.6 Jaccard ratio. Per-region and per-segment variants of one job land **exactly** on that boundary — `Commercial Solutions Engineer - Munich` vs `- Berlin` share 3 of 5 tokens — so a company fanning one opening across cities read as a company reposting.

That was **39 further clusters** in the same history. I inspected all 39: every one was a false positive (per-country variants, per-city variants, `German speaking` vs `Dutch speaking`, `Technical Account Manager 3` vs `Technical Account Manager`, `Operations Manager` vs `Senior Operations Manager`). None was a genuine repost.

Replaced with `titleIdentityKey`: the set of a title's accent-folded, punctuation-stripped words. It sits deliberately between the two alternatives — raw string equality is too tight (a role re-listed months later comes back repunctuated, `… - Sweden` → `…, Sweden`), and fuzzy matching is too loose. Word order and punctuation may drift; a differing city, country, language, segment or seniority word now splits the titles.

Two details worth flagging:

- **No length/stopword filtering.** `roleTokens` drops words of 3 characters or fewer, which would erase the only thing distinguishing `… Engineer - UK` from `… Engineer - US`.
- **Script-preserving word splitting** (`\p{L}\p{N}`, not `[a-z0-9]`), for the reason #2429 gave for company names: the ASCII-only form folds every CJK or Cyrillic title to the empty string and they would all then share one key.

### Side effect: the #2389 token index is gone

Deciding membership by an equality key rather than pairwise similarity removes the quadratic term the inverted token index existed to prune. Grouping is now a single O(N) bucketing pass, so the index has nothing left to prune and is deleted with it. The #2389 performance guard (4000 distinct titles at one company) still passes.

## Result

On that 2341-row history: **252 clusters → 68**, with no span-0 and no mixed-identity clusters remaining, and genuine reposts (34d, 22d, 16d, 2d spans) still detected. The three companies that surfaced the defect now report `none-detected`, and `metadata.sources.scanHistory` is `true` in the same run — so those are real negatives, not a source that failed to load.

## Notes for reviewers

- **`--window 0` is now degenerate**, since the window and the span floor no longer overlap. Asserted in the tests so it is a documented outcome rather than a surprise, alongside a floor-disabled variant that keeps the `window=0` path itself covered.
- **The legacy-equivalence reference is updated in the same commit**, as its own note has always required. It is no longer a frozen pre-#2389 copy — it is now a second, independently written implementation, still guarding grouping order, same-date input order, URL dedup and both date bounds.
- **Each regression fixture isolates which constraint rejects it**, so none of them can pass for the wrong reason: the same-sweep fixture is asserted to *survive* with the span floor disabled (proving the floor rejects it), while the per-city and per-country fixtures are asserted rejected *even with the floor disabled* (proving title identity rejects them).
- Fixture company names and URLs are synthetic; only the shape is reproduced.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

On `test-all.mjs`: 3394 passed / 1 failed, and that single failure is identical on unmodified `main` on this machine — a Windows `node_modules` symlink issue in the `followup-cadence` temp-dir e2e, unrelated to this change. Verified by running the suite with the four changed files reverted to `origin/main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repost detection by distinguishing genuine reposts from concurrent listings across locations, languages, segments, countries, and seniority levels.
  * Added stricter title identity matching to reduce false positives from unrelated or reordered job postings.
  * Reposts must now appear across separate scan dates and meet a configurable minimum time span.
  * Added command-line configuration for the minimum repost span, including safer handling of invalid values.

* **Documentation**
  * Clarified repost-detection rules and posting-churn behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## Rebased onto current `main`, and one commit that is not about reposts

#2920 landed while this was open. It moved the four reporting CLIs onto `lib/cli-flags.mjs`, which rejects any flag absent from a per-file `KNOWN_FLAGS` list. This branch adds `--min-span`. The two changes merge without a textual conflict — both append to lists in different blocks — and the result was a flag parsed, documented, threaded through and unit-tested, refused at the door:

```
$ node detect-reposts.mjs --min-span 3 --summary
Error: unrecognized flag(s): --min-span. Valid flags: --window, --summary, …
exit 1
```

`--min-span` now appears in `KNOWN_FLAGS` and `VALUE_FLAGS`, and the block carries a comment saying to add both, because the next flag will arrive the same way. This is the case @abankar1 quotes in #2982; the marker comment is the cheap half of it, and a lint or a test that walks `USAGE` against `KNOWN_FLAGS` would be the durable half if you want one.

The regression test asserts the **value reaching metadata**, not a zero exit status: this failure exits non-zero for a reason unrelated to the flag's own logic, so an exit-code check would pass on a build where `--min-span` was silently dropped and the default used instead — the same false all-clear #2919 was about.

Re-verified after the rebase on the real 3226-row `scan-history.tsv`: the three companies that prompted this PR still report `none-detected`, and 254 assertions pass. The new guard was seen red by removing `--min-span` from `KNOWN_FLAGS`.
