### PR TITLE
fix(status): a Turkish tracker row normalizes three different ways — TUI, core and web all disagree

### DIFF
--- a/followup-cadence.mjs
+++ b/followup-cadence.mjs
@@ -15,7 +15,7 @@ import { readFileSync, existsSync } from 'fs';
 import { join, dirname, relative, sep } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import * as yaml from 'js-yaml';
-import { loadCanonicalStates } from './tracker-utils.mjs';
+import { loadCanonicalStates, foldStatusInput } from './tracker-utils.mjs';
 import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
@@ -106,9 +106,9 @@ function statusAliasMap() {
   try {
     for (const st of loadCanonicalStates(join(CAREER_OPS, 'templates', 'states.yml'))) {
       const id = st.id.toLowerCase();
-      map.set(id, id);
-      if (st.label) map.set(st.label.toLowerCase(), id);
-      for (const a of st.aliases) map.set(String(a).toLowerCase(), id);
+      map.set(foldStatusInput(id), id);
+      if (st.label) map.set(foldStatusInput(st.label), id);
+      for (const a of st.aliases) map.set(foldStatusInput(a), id);
     }
   } catch {
     // A missing/malformed states.yml is a broken install. Degrade to
@@ -122,8 +122,10 @@ function statusAliasMap() {
 const ACTIONABLE_STATUSES = ['applied', 'responded', 'interview'];
 
 export function normalizeStatus(raw) {
-  const clean = raw.replace(/\*\*/g, '').trim().toLowerCase()
-    .replace(/\s+\d{4}-\d{2}-\d{2}.*$/, '').trim();
+  // foldStatusInput, not a bare toLowerCase: JS lowercases the Turkish dotted
+  // capital `İ` to `i` + U+0307 and the mark survives, so every all-caps
+  // Turkish row missed every alias (#2704 review).
+  const clean = foldStatusInput(String(raw).replace(/\s+\d{4}-\d{2}-\d{2}.*$/, ''));
   return statusAliasMap().get(clean) || clean;
 }
 

--- a/followup-cadence.mjs
+++ b/followup-cadence.mjs
@@ -15,6 +15,7 @@ import { readFileSync, existsSync } from 'fs';
 import { join, dirname, relative, sep } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import * as yaml from 'js-yaml';
+import { loadCanonicalStates } from './tracker-utils.mjs';
 import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
@@ -82,31 +83,48 @@ export function resolveCadenceConfig({ profilePath = PROFILE_FILE, appliedDays =
 
 const CADENCE = resolveCadenceConfig();
 
-// --- Status normalization (mirrors verify-pipeline.mjs) ---
-const ALIASES = {
-  'evaluada': 'evaluated', 'condicional': 'evaluated', 'hold': 'evaluated',
-  'evaluar': 'evaluated', 'verificar': 'evaluated',
-  'aplicado': 'applied', 'enviada': 'applied', 'aplicada': 'applied',
-  'applied': 'applied', 'sent': 'applied',
-  'respondido': 'responded',
-  'entrevista': 'interview',
-  'oferta': 'offer',
-  // Hired aliases from templates/states.yml — without these, an "Accepted" or
-  // "Contratado" row normalizes to itself, so stats/funnel/company-history
-  // consumers looking for 'hired' silently drop the best outcome in the tracker.
-  'contratado': 'hired', 'contratada': 'hired', 'accepted': 'hired', 'accept': 'hired',
-  'rechazado': 'rejected', 'rechazada': 'rejected',
-  'descartado': 'discarded', 'descartada': 'discarded',
-  'cerrada': 'discarded', 'cancelada': 'discarded',
-  'no aplicar': 'skip', 'no_aplicar': 'skip', 'monitor': 'skip', 'geo blocker': 'skip',
-};
+// --- Status normalization ---
+//
+// DERIVED from templates/states.yml, not a hand-copy of it. The map that used
+// to live here was already missing every Turkish spelling the Go dashboard
+// recognises, so the same tracker row normalized three different ways: the TUI
+// read `Mülakat` as `interview`, this file left it as `mülakat` (matching no
+// ACTIONABLE/ADVANCED set, so the row silently vanished from the funnel), and
+// the web rejected it outright on writeback. tracker-utils already exposes the
+// loader for exactly this — its docstring says "a new state or alias lands in
+// one file and every consumer follows" — it just had no consumer here (#2704).
+//
+// Cached per process: these are short-lived CLI runs, so a single read is
+// correct. A long-running consumer must NOT copy this pattern — see #2590,
+// where caching states.yml for a server's lifetime pinned a stale roster.
+let aliasMapCache = null;
+
+/** alias/id/label (lowercased) → canonical lowercase id, from states.yml. */
+function statusAliasMap() {
+  if (aliasMapCache) return aliasMapCache;
+  const map = new Map();
+  try {
+    for (const st of loadCanonicalStates(join(CAREER_OPS, 'templates', 'states.yml'))) {
+      const id = st.id.toLowerCase();
+      map.set(id, id);
+      if (st.label) map.set(st.label.toLowerCase(), id);
+      for (const a of st.aliases) map.set(String(a).toLowerCase(), id);
+    }
+  } catch {
+    // A missing/malformed states.yml is a broken install. Degrade to
+    // identity-normalization rather than resurrecting a hardcoded table: a
+    // fallback copy is the same copy in disguise and drifts the same way.
+    return (aliasMapCache = new Map());
+  }
+  return (aliasMapCache = map);
+}
 
 const ACTIONABLE_STATUSES = ['applied', 'responded', 'interview'];
 
 export function normalizeStatus(raw) {
   const clean = raw.replace(/\*\*/g, '').trim().toLowerCase()
     .replace(/\s+\d{4}-\d{2}-\d{2}.*$/, '').trim();
-  return ALIASES[clean] || clean;
+  return statusAliasMap().get(clean) || clean;
 }
 
 // --- Date helpers ---

--- a/normalize-statuses.mjs
+++ b/normalize-statuses.mjs
@@ -16,7 +16,7 @@ import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import {
   openTrackerTransaction, rebuildRow, resolveTrackerPath,
-} from './tracker-utils.mjs';
+  loadCanonicalStates, resolveCanonicalState,} from './tracker-utils.mjs';
 import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
@@ -27,6 +27,18 @@ const DRY_RUN = process.argv.includes('--dry-run');
 mkdirSync(join(CAREER_OPS, 'data'), { recursive: true });
 
 // Canonical status mapping
+let statesCache = null;
+/** Canonical states from templates/states.yml, read once per CLI run. */
+function canonicalStates() {
+  if (statesCache) return statesCache;
+  try {
+    statesCache = loadCanonicalStates(join(CAREER_OPS, 'templates', 'states.yml'));
+  } catch {
+    statesCache = []; // broken install: fall through to "unknown", never a stale copy
+  }
+  return statesCache;
+}
+
 function normalizeStatus(raw) {
   // Strip markdown bold
   let s = raw.replace(/\*\*/g, '').trim();
@@ -78,15 +90,14 @@ function normalizeStatus(raw) {
     if (lower === c.toLowerCase()) return { status: c };
   }
 
-  // Spanish aliases → English canonicals
-  if (['evaluada'].includes(lower)) return { status: 'Evaluated' };
-  if (['aplicado', 'enviada', 'aplicada', 'applied', 'sent'].includes(lower)) return { status: 'Applied' };
-  if (['respondido'].includes(lower)) return { status: 'Responded' };
-  if (['entrevista'].includes(lower)) return { status: 'Interview' };
-  if (['oferta'].includes(lower)) return { status: 'Offer' };
-  if (['contratado', 'contratada', 'hired', 'accepted', 'accept'].includes(lower)) return { status: 'Hired' };
-  if (['cerrada', 'descartada'].includes(lower)) return { status: 'Discarded' };
-  if (['no aplicar', 'no_aplicar', 'skip'].includes(lower)) return { status: 'SKIP' };
+  // Every remaining alias comes from templates/states.yml, not a list here.
+  // The hand-written list this replaces had drifted: it carried the Spanish
+  // aliases and none of the Turkish ones, so a `Mülakat` row was reported as
+  // an unknown status by the very tool whose job is normalizing statuses
+  // (#2704). test-all already asserted states.yml ⊆ this function; deriving
+  // makes that hold by construction instead of by remembering.
+  const fromStates = resolveCanonicalState(lower, canonicalStates());
+  if (fromStates) return { status: fromStates };
 
   // Unknown — flag it
   return { status: null, unknown: true };

--- a/templates/states.yml
+++ b/templates/states.yml
@@ -57,6 +57,6 @@ states:
 
   - id: hired
     label: Hired
-    aliases: [contratado, contratada, hired, accepted, accept, "kabul edildi", kabul_edildi, "işe alındı", "ise alindi"]
+    aliases: [contratado, contratada, hired, accepted, accept, "kabul edildi", kabul_edildi, "işe alındı", "ise alindi", "işe alindi"]
     description: Offer accepted, job landed!
     dashboard_group: hired

--- a/templates/states.yml
+++ b/templates/states.yml
@@ -9,54 +9,54 @@
 states:
   - id: evaluated
     label: Evaluated
-    aliases: [evaluada, condicional, hold, evaluar, verificar]
+    aliases: [evaluada, condicional, hold, evaluar, verificar, değerlendirildi, degerlendirildi]
     description: Offer evaluated with report, pending decision
     dashboard_group: evaluated
 
   - id: applied
     label: Applied
-    aliases: [aplicado, enviada, aplicada, sent]
+    aliases: [aplicado, enviada, aplicada, sent, başvuruldu, basvuruldu]
     description: Application submitted
     dashboard_group: applied
 
   - id: responded
     label: Responded
-    aliases: [respondido]
+    aliases: [respondido, "yanıt verildi", yanıt_verildi, "yanit verildi", yanit_verildi]
     description: Company has responded (not yet interview)
     dashboard_group: responded
 
   - id: interview
     label: Interview
-    aliases: [entrevista]
+    aliases: [entrevista, mülakat, mulakat]
     description: Active interview process
     dashboard_group: interview
 
   - id: offer
     label: Offer
-    aliases: [oferta]
+    aliases: [oferta, teklif]
     description: Offer received
     dashboard_group: offer
 
   - id: rejected
     label: Rejected
-    aliases: [rechazado, rechazada]
+    aliases: [rechazado, rechazada, reddedildi]
     description: Rejected by company
     dashboard_group: rejected
 
   - id: discarded
     label: Discarded
-    aliases: [descartado, descartada, cerrada, cancelada]
+    aliases: [descartado, descartada, cerrada, cancelada, "iptal edildi", iptal_edildi, "ıptal edildi", ıptal_edildi]
     description: Discarded by candidate or offer closed
     dashboard_group: discarded
 
   - id: skip
     label: SKIP
-    aliases: [no_aplicar, no aplicar, skip, monitor, geo blocker, geo_blocker]
+    aliases: [no_aplicar, no aplicar, skip, monitor, geo blocker, geo_blocker, "uygun değil", uygun_değil, "uygun degil", uygun_degil]
     description: Doesn't fit, don't apply
     dashboard_group: skip
 
   - id: hired
     label: Hired
-    aliases: [contratado, contratada, hired, accepted, accept]
+    aliases: [contratado, contratada, hired, accepted, accept, "kabul edildi", kabul_edildi, "işe alındı", "ise alindi"]
     description: Offer accepted, job landed!
     dashboard_group: hired

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -7202,6 +7202,12 @@ try {
       copyFileSync(join(ROOT, 'followup-cadence.mjs'), join(e2eTmp, 'followup-cadence.mjs'));
       copyFileSync(join(ROOT, 'tracker-parse.mjs'), join(e2eTmp, 'tracker-parse.mjs'));
       copyFileSync(join(ROOT, 'tracker-aliases.json'), join(e2eTmp, 'tracker-aliases.json'));
+      // followup-cadence now derives its status aliases from templates/states.yml
+      // via tracker-utils, so the fixture has to carry both — same reason
+      // tracker-aliases.json is copied for tracker-parse.mjs (#2704).
+      copyFileSync(join(ROOT, 'tracker-utils.mjs'), join(e2eTmp, 'tracker-utils.mjs'));
+      mkdirSync(join(e2eTmp, 'templates'), { recursive: true });
+      copyFileSync(join(ROOT, 'templates', 'states.yml'), join(e2eTmp, 'templates', 'states.yml'));
       // 'junction' on Windows, not 'dir': a directory symlink needs
       // SeCreateSymbolicLinkPrivilege, which a normal shell lacks unless
       // Developer Mode is on, so this threw EPERM and failed the test on an
@@ -9665,6 +9671,52 @@ try {
   }
 } catch (e) {
   fail(`non-Latin via guard tests crashed: ${e.message}`);
+}
+
+// ── GO STATUS LITERALS MUST BE states.yml ALIASES (#2704) ─────────
+// The Go dashboard's NormalizeStatus grew its own, larger alias table: it knew
+// every Turkish spelling while states.yml did not, so ONE tracker row
+// normalized three different ways — the TUI read `Mülakat` as interview, the
+// core left it as `mülakat` (matching no ACTIONABLE/ADVANCED set, so the row
+// vanished from the funnel), and the web rejected it on writeback. We ship
+// modes/tr/, so this was live for Turkish users.
+//
+// Guard the direction that actually drifts: every status literal Go matches on
+// must be resolvable through states.yml. Go may still hold MORE matching logic
+// (it uses substring Contains for some), but it must not know a spelling the
+// source of truth has never heard of.
+console.log('\n🧪 Testing Go status literals against states.yml (#2704)...');
+try {
+  const { loadCanonicalStates } = await import(pathToFileURL(join(ROOT, 'tracker-utils.mjs')).href);
+  const states = loadCanonicalStates(join(ROOT, 'templates', 'states.yml'));
+  const known = new Set();
+  for (const st of states) {
+    known.add(st.id.toLowerCase());
+    if (st.label) known.add(st.label.toLowerCase());
+    for (const a of st.aliases) known.add(String(a).toLowerCase());
+  }
+
+  const goPath = join(ROOT, 'dashboard', 'internal', 'data', 'career.go');
+  if (!existsSync(goPath)) {
+    pass('dashboard/internal/data/career.go absent — Go status guard skipped');
+  } else {
+    const go = readFileSync(goPath, 'utf-8');
+    const fnStart = go.indexOf('func NormalizeStatus');
+    const body = fnStart === -1 ? '' : go.slice(fnStart, go.indexOf('\nfunc ', fnStart + 1));
+    // Only the literals used for status matching (== or Contains), not any
+    // other string in the function.
+    const literals = [...body.matchAll(/(?:s == |Contains\(s, )"([^"]+)"/g)].map((m) => m[1].toLowerCase());
+    const unknown = [...new Set(literals)].filter((l) => !known.has(l));
+    if (literals.length === 0) {
+      fail('could not extract any status literals from Go NormalizeStatus — the guard is not actually checking anything (#2704)');
+    } else if (unknown.length === 0) {
+      pass(`every Go status literal (${new Set(literals).size}) resolves through states.yml (#2704)`);
+    } else {
+      fail(`Go NormalizeStatus knows spellings states.yml does not — add them to templates/states.yml: ${unknown.join(', ')}`);
+    }
+  }
+} catch (e) {
+  fail(`Go status literal guard crashed: ${e.message}`);
 }
 
 // ── MERGE-TRACKER: DISTINCT NON-LATIN COMPANIES (#2429) ───────────

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -9764,6 +9764,30 @@ try {
     ? pass('the all-caps Turkish cases from the #2704 review resolve correctly')
     : fail(`all-caps Turkish still failing: ${wrong.map(([r, w]) => `${r}->${cadenceNorm(r)} (want ${w})`).join(', ')}`);
 
+  // PAIR SEMANTICS, not implementation. The assertions above prove the fold
+  // repairs Turkish; they say nothing about what else it reaches. 462d2765
+  // shipped this same fold as NFD -> strip -> NFC on the company key, which
+  // also decomposed the PRECOMPOSED dots of z-dot, e-dot and g-dot and
+  // collapsed Zubr/Zubr, Eme/Eme and Generali/Generali -- Polish, Lithuanian
+  // and Maltese losing a distinction with every existing test still green
+  // (undone in 5df43e7). The status fold carried the identical defect; these
+  // pin the OUTCOME rather than the implementation.
+  {
+    const pairs = [
+      ['TEKL\u0130F', 'teklif', true, 'Turkish dotted capital: the dot is a casing artifact'],
+      ['KABUL ED\u0130LD\u0130', 'kabul edildi', true, 'same artifact, multi-word'],
+      ['\u017Bubr', 'Zubr', false, 'Polish z-dot: the dot is a letter the user typed'],
+      ['\u0116m\u0117', 'Eme', false, 'Lithuanian e-dot: same class'],
+      ['\u0120enerali', 'Generali', false, 'Maltese g-dot'],
+      ['\u0160koda', 'Skoda', false, 'caron typed by the user'],
+      ['Nestl\u00E9', 'Nestle', false, 'accent typed by the user'],
+    ];
+    const wrong = pairs.filter(([a, b, mustMatch]) => (foldStatusInput(a) === foldStatusInput(b)) !== mustMatch);
+    wrong.length === 0
+      ? pass('foldStatusInput folds the casing artifact only - typed dots and accents still separate (#2704)')
+      : fail(`foldStatusInput pair semantics wrong: ${wrong.map(([a, b, m]) => `${a}/${b} expected ${m ? 'match' : 'differ'}`).join('; ')}`);
+  }
+
   foldStatusInput('TEKLİF') === 'teklif'
     ? pass('foldStatusInput strips the combining dot JS introduces (#2704)')
     : fail(`foldStatusInput('TEKLİF') = ${JSON.stringify(foldStatusInput('TEKLİF'))}, expected "teklif"`);

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -9719,6 +9719,58 @@ try {
   fail(`Go status literal guard crashed: ${e.message}`);
 }
 
+// ── TURKISH DOTTED-CAPITAL CASING (#2704 review) ──────────────────
+// JS lowercases `İ` (U+0130) to `i` + COMBINING DOT ABOVE (U+0307) and the mark
+// survives, so `TEKLİF` became `tekli\u0307f` and matched no alias. Uppercase
+// status words are ordinary in Turkish, so every all-caps Turkish row missed.
+// foldStatusInput drops U+0307 after lowercasing, which repairs 31 of the 32
+// affected spellings at once; the 32nd (`İŞE ALINDI`, where dotless `ı`
+// uppercases to `I` and lowercases back to dotted `i`) is covered by an alias.
+console.log('\n🧪 Testing Turkish uppercase status resolution (#2704)...');
+try {
+  const { loadCanonicalStates, foldStatusInput } = await import(pathToFileURL(join(ROOT, 'tracker-utils.mjs')).href);
+  const { normalizeStatus: cadenceNorm } = await import(pathToFileURL(join(ROOT, 'followup-cadence.mjs')).href);
+  const states = loadCanonicalStates(join(ROOT, 'templates', 'states.yml'));
+
+  // The fold must not be able to collapse two different states: no canonical
+  // id/label/alias may itself contain U+0307.
+  const marked = [];
+  for (const st of states) {
+    for (const v of [st.id, st.label, ...st.aliases]) {
+      if (String(v).normalize('NFD').includes('\u0307')) marked.push(`${st.id}:${v}`);
+    }
+  }
+  marked.length === 0
+    ? pass('no canonical state value carries U+0307, so the fold cannot merge two states (#2704)')
+    : fail(`a canonical value contains U+0307 — folding it could collapse states: ${marked.join(', ')}`);
+
+  // Every value, in every casing a user can produce, resolves to its own state.
+  const misses = [];
+  for (const st of states) {
+    for (const v of [st.id, st.label, ...st.aliases]) {
+      for (const typed of [String(v), String(v).toLocaleUpperCase('tr'), String(v).toUpperCase()]) {
+        if (cadenceNorm(typed) !== st.id) misses.push(`${JSON.stringify(typed)}->${cadenceNorm(typed)} (want ${st.id})`);
+      }
+    }
+  }
+  misses.length === 0
+    ? pass('every state resolves from its as-written, Turkish-uppercase and plain-uppercase spellings (#2704)')
+    : fail(`${misses.length} spelling(s) do not resolve: ${misses.slice(0, 6).join(', ')}`);
+
+  // The specific reproductions from the review.
+  const cases = [['TEKLİF', 'offer'], ['DEĞERLENDİRİLDİ', 'evaluated'], ['KABUL EDİLDİ', 'hired'], ['İŞE ALINDI', 'hired']];
+  const wrong = cases.filter(([raw, want]) => cadenceNorm(raw) !== want);
+  wrong.length === 0
+    ? pass('the all-caps Turkish cases from the #2704 review resolve correctly')
+    : fail(`all-caps Turkish still failing: ${wrong.map(([r, w]) => `${r}->${cadenceNorm(r)} (want ${w})`).join(', ')}`);
+
+  foldStatusInput('TEKLİF') === 'teklif'
+    ? pass('foldStatusInput strips the combining dot JS introduces (#2704)')
+    : fail(`foldStatusInput('TEKLİF') = ${JSON.stringify(foldStatusInput('TEKLİF'))}, expected "teklif"`);
+} catch (e) {
+  fail(`Turkish casing guard crashed: ${e.message}`);
+}
+
 // ── MERGE-TRACKER: DISTINCT NON-LATIN COMPANIES (#2429) ───────────
 // Sibling of the #1603 via guard, one column over. normalizeCompany() stripped
 // [^a-z0-9], so EVERY non-Latin company name folded to '' and compared equal to

--- a/tests/states-alias-coverage.test.mjs
+++ b/tests/states-alias-coverage.test.mjs
@@ -45,34 +45,32 @@ try {
     }
   }
 
-  // Rules of the second shape normalize-statuses.mjs also uses:
-  //   if (['evaluada'].includes(lower)) return { status: 'Evaluated' };
-  // A plain list-membership check against the already-lowercased `lower`,
-  // rather than an anchored regex. RULE_RE above never matches these, so
-  // without this pass a missing alias here (e.g. dropping 'evaluada' from
-  // states.yml) would sail through the test undetected.
-  const LIST_RULE_RE = /\[((?:'[^']*'|"[^"]*")(?:\s*,\s*(?:'[^']*'|"[^"]*"))*)\]\.includes\(lower\)\)\s*return\s*\{\s*status:\s*'([^']+)'/g;
-  const fromListRules = [];
-  for (const m of src.matchAll(LIST_RULE_RE)) {
-    for (const lit of m[1].matchAll(/'([^']*)'|"([^"]*)"/g)) {
-      const a = (lit[1] ?? lit[2] ?? '').trim();
-      if (a) fromListRules.push({ alias: a, expected: m[2] });
-    }
-  }
-  extracted.push(...fromListRules);
+  // normalize-statuses.mjs used to carry a SECOND rule shape — plain
+  // `['evaluada'].includes(lower)` alias lists — and this file extracted those
+  // too. Those lists are gone (#2704): the function now resolves the remaining
+  // aliases through states.yml itself, so there is no second vocabulary left to
+  // scrape. The assertion below inverted with it — instead of proving the lists
+  // are extractable, it proves they have not come back.
 
   // Each extractor is asserted separately on purpose. A combined
   // `extracted.length > 0` passes on the regex arm alone, so if
   // normalize-statuses.mjs reshapes its list rules and LIST_RULE_RE stops
   // matching, that arm silently checks nothing while the test stays green —
   // exactly the kind of quiet drift this file exists to catch.
-  extracted.length > fromListRules.length
-    ? pass(`extracted ${extracted.length - fromListRules.length} anchored alias rule(s) from normalize-statuses.mjs`)
+  extracted.length > 0
+    ? pass(`extracted ${extracted.length} anchored alias rule(s) from normalize-statuses.mjs`)
     : fail("extracted no anchored alias rules — RULE_RE no longer matches normalize-statuses.mjs and is checking nothing");
 
-  fromListRules.length > 0
-    ? pass(`extracted ${fromListRules.length} list-membership alias rule(s) from normalize-statuses.mjs`)
-    : fail("extracted no list-membership alias rules — LIST_RULE_RE no longer matches normalize-statuses.mjs and is checking nothing");
+  // Derivation guard, replacing the extractor that has nothing left to extract.
+  // Two halves, because either alone can go quietly wrong: the derivation must
+  // still be wired, and a hardcoded alias list must not reappear beside it.
+  const derives = /resolveCanonicalState\(/.test(src);
+  const hasListRule = /\]\.includes\(lower\)\)\s*return\s*\{\s*status:/.test(src);
+  derives && !hasListRule
+    ? pass('normalize-statuses derives its remaining aliases from states.yml rather than listing them (#2704)')
+    : fail(derives
+      ? 'a hardcoded alias list reappeared in normalize-statuses.mjs — resolve through states.yml instead (#2704)'
+      : 'normalize-statuses no longer calls resolveCanonicalState — the states.yml derivation was removed (#2704)');
 
   const orphans = extracted.filter(({ alias, expected }) => {
     const resolved = resolveCanonicalState(alias, states);

--- a/tracker-utils.mjs
+++ b/tracker-utils.mjs
@@ -559,8 +559,37 @@ export function loadCanonicalStates(statesPath) {
  * @param {{id:string,label:string,aliases:string[]}[]} states - From loadCanonicalStates().
  * @returns {string|null} Canonical label (e.g. "Applied"), or null when unknown.
  */
+/**
+ * Case-fold a status the way a HUMAN typed it, not the way JS lowercases it.
+ *
+ * JavaScript lowercases the Turkish dotted capital `İ` (U+0130) to `i` plus a
+ * COMBINING DOT ABOVE (U+0307), and the mark survives — so `TEKLİF` becomes
+ * `tekli\u0307f`, which equals no alias anyone would ever write. Turkish
+ * uppercase status words are ordinary, so every all-caps Turkish row missed.
+ *
+ * Dropping U+0307 after lowercasing repairs it for every alias at once, rather
+ * than listing the ~32 mark-bearing spellings the aliases would otherwise need
+ * — a list that would also have to carry `ski\u0307p` and `hi\u0307red`, and that
+ * would silently need extending on every future alias containing an `i`.
+ *
+ * No canonical state, label or alias legitimately contains U+0307, so this
+ * cannot collapse two different states together (asserted in test-all).
+ *
+ * @param {*} input - Raw status text.
+ * @returns {string} Lowercased, mark-folded, bold/whitespace-stripped status.
+ */
+export function foldStatusInput(input) {
+  return String(input ?? '')
+    .replace(/\*\*/g, '')
+    .trim()
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/\u0307/g, '')
+    .normalize('NFC');
+}
+
 export function resolveCanonicalState(input, states) {
-  const clean = String(input ?? '').replace(/\*\*/g, '').trim().toLowerCase();
+  const clean = foldStatusInput(input);
   if (!clean) return null;
   for (const s of states) {
     if (s.label.toLowerCase() === clean) return s.label;

--- a/tracker-utils.mjs
+++ b/tracker-utils.mjs
@@ -567,7 +567,7 @@ export function loadCanonicalStates(statesPath) {
  * `tekli\u0307f`, which equals no alias anyone would ever write. Turkish
  * uppercase status words are ordinary, so every all-caps Turkish row missed.
  *
- * Dropping U+0307 after lowercasing repairs it for every alias at once, rather
+ * Dropping U+0307 after an NFKC lowercase repairs it for every alias at once, rather
  * than listing the ~32 mark-bearing spellings the aliases would otherwise need
  * — a list that would also have to carry `ski\u0307p` and `hi\u0307red`, and that
  * would silently need extending on every future alias containing an `i`.
@@ -582,10 +582,15 @@ export function foldStatusInput(input) {
   return String(input ?? '')
     .replace(/\*\*/g, '')
     .trim()
+    .normalize('NFKC')
     .toLowerCase()
-    .normalize('NFD')
-    .replace(/\u0307/g, '')
-    .normalize('NFC');
+    // NO `NFD`, for the same structural reason normalizeTextKey documents:
+    // NFKC leaves ż, ė and ġ as SINGLE precomposed code points so this strip
+    // cannot reach their dots, while `i` + U+0307 (what lowercasing `İ`
+    // produces) has no precomposed form and stays exposed. Decomposing first
+    // looks equivalent and is not — it collapses Żubr/Zubr, Ėmė/Eme and
+    // Ġenerali/Generali, which is what 5df43e7 had to undo on the company key.
+    .replace(/\u0307/gu, '');
 }
 
 export function resolveCanonicalState(input, states) {


### PR DESCRIPTION
Closes #2704.

`states.yml` calls itself *"Source of truth for career-ops (writer) and dashboard (reader). Both systems MUST use these exact states."* It isn't — Go's `NormalizeStatus` carries **59 status literals** against states.yml's **23 aliases**, and the extra ones are the Turkish spellings.

One row, three answers:

| Tracker status | Go TUI | core `.mjs` | web |
|---|---|---|---|
| `Entrevista` (es) | `interview` | `interview` | `Interview` |
| `Mülakat` (tr) | **`interview`** | **`mülakat`** | **`null`** |
| `Teklif` (tr) | **`offer`** | **`teklif`** | **`null`** |
| `Başvuruldu` (tr) | **`applied`** | **`başvuruldu`** | **`null`** |

We ship `modes/tr/`, so for a Turkish user the TUI looks correct while `followup-cadence` returns the raw string — matching no `ACTIONABLE_STATUSES`/`ADVANCED_STATUSES` set, so the row silently leaves the follow-up queue and the funnel — `normalize-statuses` calls it unknown, and `POST /api/status` rejects it.

## Fix

**1. The SSOT was the side that was behind**, so the spellings move *into* `states.yml` and **Go needs no change at all**. That's the whole reason this is a small diff.

**2. Both core normalizers now derive.** `followup-cadence` and `normalize-statuses` each kept a private alias map. `tracker-utils` already exposes `loadCanonicalStates`/`resolveCanonicalState`, and its docstring already promises *"a new state or alias lands in one file and every consumer follows"* — it simply had no consumer in either file (only `set-status` and `funnel-velocity` used it).

After:

```
status            core          web
Mülakat           interview     Interview
Teklif            offer         Offer
Başvuruldu        applied       Applied
Kabul Edildi      hired         Hired
Değerlendirildi   evaluated     Evaluated
```

**3. A guard on the direction that drifts.** Every status literal Go matches on must resolve through `states.yml`. Go may keep *more* matching logic (it uses substring `Contains`), but it must not know a spelling the source of truth has never heard of. That guard immediately earned itself — it caught four `discarded` spellings (`iptal edildi` and variants) my own manual pass had missed.

## Two things I changed that weren't in the plan

- **`states-alias-coverage`'s `LIST_RULE_RE` arm** extracted the hardcoded lists this PR deletes, so it correctly reported it was checking nothing. Rather than delete it, I inverted it: it now asserts the derivation is wired **and** that a hardcoded list hasn't reappeared. Verified it fails in both directions.
- **The e2e cadence fixture** copies specific files into a temp dir; `followup-cadence` now needs `tracker-utils.mjs` and `templates/states.yml` there too, same reason `tracker-aliases.json` is already copied for `tracker-parse.mjs`.

## Known limitation, flagged not buried

Turkish dotted capital `İ` lowercases in JS to `i` + U+0307, so `İptal Edildi` still resolves to unknown while `iptal edildi` works. **Go has the same behaviour** — that's why its table carries both `iptal` and `ıptal`. Locale-aware casing is a separate problem and I'd rather name it than ship a half-fix.

`node test-all.mjs --quick` → **3400 passed, 0 failed**.

3 commits (states.yml → derivation → guards).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Status recognition now uses shared canonical definitions across tracking and normalization tools.
  * Added multilingual aliases, including Turkish variants, alternate spellings, and phrase forms.
  * Improved handling of capitalization, accents, bold formatting, and Unicode variations.
  * Status labels, identifiers, descriptions, and dashboard groupings remain unchanged.
* **Reliability**
  * Added validation for alias resolution, including Turkish uppercase variants.
  * Preserved safe fallback behavior when canonical status data cannot be loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->