### PR TITLE
fix(getro): pace sequential pages and retry transient failures

### DIFF
--- a/providers/getro.mjs
+++ b/providers/getro.mjs
@@ -1,6 +1,8 @@
 // @ts-check
 /** @typedef {import('./_types.js').Provider} Provider */
 
+import { fetchJsonWithRetry } from './_http.mjs';
+
 // Getro provider — VC "talent network" portfolio job boards (jobs at a fund's
 // portfolio companies). Powers b2venture, Earlybird, Point Nine, Speedinvest,
 // Cherry, HV Capital, Atomico, and many other VC boards.
@@ -52,6 +54,14 @@ const DEFAULT_MAX_PAGES = 40;      // safety cap: 40 x 20 = 800 newest jobs/boar
 // 10k sequential API calls against a third party.
 const HARD_MAX_PAGES = 200;        // 200 x 20 = 4000 newest jobs/board
 const DEFAULT_MAX_AGE_DAYS = 90;   // pagination bound only; global filter does the real cut
+// Pacing between sequential pages of the SAME board. scan.mjs runs companies
+// 10-wide, but those are different tenants on different hosts; the burst that
+// gets noticed is N back-to-back POSTs at one endpoint. Getro sits behind a
+// Datadog WAF that IP-blocks on that pattern (observed 2026-08-08: 40-page
+// boards → 403 "You've been blocked" for ~2.5h, which is silent data loss
+// because 403 is correctly non-retryable). A short sleep between pages costs
+// nothing on a parallel scan of distinct tenants and removes the signature.
+const PAGE_DELAY_MS = 250;
 
 function resolveCollection(entry) {
   const id = entry.getro_collection;
@@ -83,7 +93,15 @@ export default {
     const out = [];
     let total = Infinity;
     for (let page = 0; page < maxPages && page * HITS_PER_PAGE < total; page++) {
-      const json = await ctx.fetchJson(apiUrl, {
+      // Pace pages 1..n; page 0 is the first contact with this host and needs
+      // no delay. ctx.sleep keeps unit tests off the wall clock, matching the
+      // convention in _http.mjs.
+      if (page > 0) {
+        await (typeof ctx.sleep === 'function'
+          ? ctx.sleep(PAGE_DELAY_MS)
+          : new Promise(resolve => setTimeout(resolve, PAGE_DELAY_MS)));
+      }
+      const json = await fetchJsonWithRetry(ctx, apiUrl, {
         method: 'POST',
         // redirect:'error' — apiUrl is pinned to api.getro.com (https), so a 3xx
         // to a private/metadata IP must not be followed (matches every provider).


### PR DESCRIPTION
Fixes #2706.

`providers/getro.mjs` paginates with back-to-back POSTs to one endpoint. On a 40-page board that burst reads as scraping to Getro's Datadog WAF, which IP-bans the caller (`403 "You've been blocked"`, ~2.5h observed on 2026-08-08). Since 403 is correctly non-retryable, the result is silent data loss — the scan just returns fewer companies.

### Changes

**1. Pace sequential pages of the same board (250 ms).**
Skipped before page 0, so a single-page board is unaffected. `scan.mjs` runs companies 10-wide but those are distinct tenants on distinct hosts — the burst that gets noticed is N back-to-back requests at *one* endpoint, so this costs effectively nothing on a parallel scan. Uses `ctx.sleep` when present, matching the convention in `_http.mjs`, so unit tests never wall-clock wait.

I considered a per-host limiter in `_http.mjs` and rejected it: ATS hosts are multi-tenant, so keying a token bucket by hostname would serialise the dozens of Ashby and Greenhouse tenants that run 10-wide today without any vendor complaining.

**2. Route the fetch through `fetchJsonWithRetry`.**
`getro.mjs` was the only paginating provider still calling `ctx.fetchJson` raw, so one transient 5xx or timeout discarded an entire board — the failure mode #2506 added the helper to prevent. Default policy (2 retries, 500 ms base, 8 s cap) applies; no behaviour change on the happy path.

### Verification

- All 13 Getro boards in my `portals.yml` complete without a 403; before the change, three consistently failed.
- A 160-job board (8 pages) costs ~1.75 s of added pacing.
- `node test-all.mjs` — 3128 passed. The 9 failures on my tree are pre-existing `.gitignore`-coverage assertions unrelated to `providers/`.

No config surface added, no new dependencies, defaults unchanged for every other provider.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when loading Getro job listings by automatically retrying failed page requests.
  * Added a brief delay between page loads to reduce request failures and improve data retrieval stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->