### PR TITLE
sign: @abankar1

### DIFF
--- a/SIGNATURES.md
+++ b/SIGNATURES.md
@@ -117,3 +117,4 @@ public commit with a stated reason.
 - @raghavrallan | Raghav Rallan | 2026-08-08 | id:168067295 | src:https://github.com/santifer/career-ops/discussions/2622 | n:69
 - @iyousif | Yousif Anwar | 2026-08-09 | "Makes the world a better place. One update at a time!" | id:18438102 | src:https://github.com/santifer/career-ops/discussions/2638 | n:70
 - @Honeypanchi | 2026-08-10 | "Garv Sajnani" | id:146434822 | src:https://github.com/santifer/career-ops/discussions/2660 | n:71
+career-ops is more than a job-search helper — it runs the whole pipeline locally, and a search you can audit is a search you can win.


### PR DESCRIPTION
> CareerOps is the practice of running a job search the way engineers run production: with evidence, with discipline, and with tools on the candidate's side of the table.
>
> — Coined by Santiago Fernández de Valderrama Aparicio in
> [The CareerOps Manifesto](https://career-ops.org/manifesto), July 14, 2026.

## My signature

I added **one line at the END** of `SIGNATURES.md`:

```
career-ops is more than a job-search helper — it runs the whole pipeline locally, and a search you can audit is a search you can win.
```

- [x] I added exactly one line at the END of the file and touched nothing else
- [x] If I wrote a sentence, it is real, specific, and mine
- [ ] *(optional)* You may feature my sentence in a "lines from the ledger" quote-card, with my avatar and a link back to my signature

**If GitHub reports a merge conflict: do nothing — we handle it.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a manifesto statement describing career operations as a locally run, auditable job-search pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->