### PR TITLE
fix(web): record status changes in the transition ledger

### DIFF
--- a/web/src/app/api/status/route.ts
+++ b/web/src/app/api/status/route.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { careerOpsRoot } from "@/lib/career-ops";
 import { canonicalizeStatus } from "@/lib/core/states";
 import { atomicWrite } from "@/lib/core/safe-write";
+import { appendStatusTransition } from "@/lib/core/status-log.mjs";
 
 // Writeback: UPDATE the status cell of an EXISTING tracker row only. Never adds
 // rows — per the core data contract, new rows go through the TSV + merge flow.
@@ -52,12 +53,14 @@ export async function POST(req: Request) {
   }
 
   let changed = false;
+  let prevStatus = "";
   for (let i = 0; i < lines.length; i++) {
     if (!lines[i].trim().startsWith("|")) continue;
     const parts = lines[i].split("|");
     if (parts.length < 8) continue;
     if (parts[1].trim() !== String(n)) continue;
     if (statusIdx >= parts.length - 1) continue; // guard malformed row
+    prevStatus = parts[statusIdx].trim(); // captured before the overwrite, for the ledger
     parts[statusIdx] = ` ${canon} `;
     lines[i] = parts.join("|");
     changed = true;
@@ -70,5 +73,20 @@ export async function POST(req: Request) {
   } catch {
     return NextResponse.json({ error: "write failed" }, { status: 500 });
   }
-  return NextResponse.json({ ok: true, status: canon });
+
+  // Record the transition in the ledger set-status.mjs already writes, so the
+  // history is the same whether a row was moved from the CLI or from here.
+  // Canonicalize the previous value first: an aliased cell ("aplicado", "sent")
+  // must not read as a transition when it already means the new status.
+  // Observation-only — the tracker write above has committed, so a ledger
+  // failure is reported alongside the successful change, never as a failure.
+  const { logged } = appendStatusTransition({
+    trackerFile: file,
+    num: n,
+    from: canonicalizeStatus(prevStatus) ?? prevStatus,
+    to: canon,
+    source: "web",
+  });
+
+  return NextResponse.json({ ok: true, status: canon, statusLogged: logged });
 }

--- a/web/src/lib/core/status-log.mjs
+++ b/web/src/lib/core/status-log.mjs
@@ -1,0 +1,54 @@
+import fs from "node:fs";
+import path from "node:path";
+
+// The web half of the transition ledger (status-log.tsv). set-status.mjs has
+// written this file since #1695, and funnel-velocity.mjs and company-history.mjs
+// read it — but status changes made in the web UI never reached it, so for
+// anyone who works from the web app the ledger stays empty and both readers have
+// no data to work with.
+//
+// Contract is set-status.mjs's, byte for byte:
+//   {tracker#}\t{date}\t{from}\t{to}\t{source}\t
+// with the ledger a SIBLING of the tracker file, so a CAREER_OPS_TRACKER
+// redirect keeps the ledger next to the tracker it describes.
+//
+// Observation-only, exactly as the CLI treats it: the tracker remains the source
+// of truth for STATE, the ledger only records WHEN. A failed append is reported
+// to the caller and never thrown, because by the time this runs the status write
+// has already committed — turning a ledger problem into a failed status change
+// would be strictly worse than losing one history row.
+
+/** A field is safe when it cannot shift the columns of a TSV row. */
+const isSafeField = (v) => !/[\t\r\n]/.test(String(v));
+
+/**
+ * Append one transition to the ledger beside `trackerFile`.
+ *
+ * @param {object}  args
+ * @param {string}  args.trackerFile  Path to applications.md; the ledger is its sibling.
+ * @param {number|string} args.num    Tracker row number.
+ * @param {string}  args.from         Previous status (canonicalized by the caller).
+ * @param {string}  args.to           New status (canonicalized by the caller).
+ * @param {string} [args.source]      What performed the change. Defaults to "web".
+ * @param {string} [args.date]        Event date YYYY-MM-DD. Defaults to today.
+ * @returns {{logged: boolean, reason?: string}} Never throws.
+ */
+export function appendStatusTransition({ trackerFile, num, from, to, source = "web", date }) {
+  const eventDate = date ?? new Date().toISOString().slice(0, 10);
+
+  for (const field of [num, from, to, source, eventDate]) {
+    if (!isSafeField(field)) return { logged: false, reason: "invalid-field" };
+  }
+
+  // Re-selecting the current status is not a transition. Logging it would inflate
+  // every hop count funnel-velocity.mjs derives from this file.
+  if (from === to) return { logged: false, reason: "no-change" };
+
+  const logPath = path.join(path.dirname(trackerFile), "status-log.tsv");
+  try {
+    fs.appendFileSync(logPath, `${num}\t${eventDate}\t${from}\t${to}\t${source}\t\n`);
+    return { logged: true };
+  } catch (err) {
+    return { logged: false, reason: `error: ${err.message}` };
+  }
+}

--- a/web/src/lib/core/status-log.mjs
+++ b/web/src/lib/core/status-log.mjs
@@ -18,8 +18,23 @@ import path from "node:path";
 // has already committed — turning a ledger problem into a failed status change
 // would be strictly worse than losing one history row.
 
+// Not every value has a string form: a null-prototype object has no toString,
+// so String() on it throws rather than returning something to inspect. Both
+// checks below run before the try, so an unguarded conversion would leave the
+// helper by exception. Treat "cannot be converted" as "not writable".
+const asText = (v) => {
+  try {
+    return String(v);
+  } catch {
+    return null;
+  }
+};
+
 /** A field is safe when it cannot shift the columns of a TSV row. */
-const isSafeField = (v) => !/[\t\r\n]/.test(String(v));
+const isSafeField = (v) => {
+  const text = asText(v);
+  return text !== null && !/[\t\r\n]/.test(text);
+};
 
 // True only when YYYY-MM-DD names a day that exists. A shape check alone admits
 // "2026-02-30" and "2026-13-40", and every reader of the ledger treats whatever
@@ -30,9 +45,11 @@ const isSafeField = (v) => !/[\t\r\n]/.test(String(v));
 // A twin of isRealCalendarDate() in followup-cadence.mjs, not an import of it:
 // Turbopack's root is pinned to web/ (next.config.mjs) and refuses modules
 // outside it, so a repo-root module cannot be imported at build time here. That
-// is the same constraint tracker-table.mjs documents.
+// is the same constraint tracker-table.mjs documents. The one difference is the
+// typeof test, which stands in for the original's String() so that a value with
+// no string form is rejected rather than throwing.
 const isRealCalendarDate = (iso) => {
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(String(iso ?? ""))) return false;
+  if (typeof iso !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(iso)) return false;
   const [y, mo, d] = iso.split("-").map(Number);
   if (mo < 1 || mo > 12 || d < 1) return false;
   // setUTCFullYear rather than Date.UTC: Date.UTC maps years 0-99 onto

--- a/web/src/lib/core/status-log.mjs
+++ b/web/src/lib/core/status-log.mjs
@@ -21,6 +21,28 @@ import path from "node:path";
 /** A field is safe when it cannot shift the columns of a TSV row. */
 const isSafeField = (v) => !/[\t\r\n]/.test(String(v));
 
+// True only when YYYY-MM-DD names a day that exists. A shape check alone admits
+// "2026-02-30" and "2026-13-40", and every reader of the ledger treats whatever
+// is in the date column as a real date. Round-tripping through a UTC Date and
+// comparing the parts back catches out-of-range months as well as month-length
+// and leap-year violations, which a range check misses.
+//
+// A twin of isRealCalendarDate() in followup-cadence.mjs, not an import of it:
+// Turbopack's root is pinned to web/ (next.config.mjs) and refuses modules
+// outside it, so a repo-root module cannot be imported at build time here. That
+// is the same constraint tracker-table.mjs documents.
+const isRealCalendarDate = (iso) => {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(String(iso ?? ""))) return false;
+  const [y, mo, d] = iso.split("-").map(Number);
+  if (mo < 1 || mo > 12 || d < 1) return false;
+  // setUTCFullYear rather than Date.UTC: Date.UTC maps years 0-99 onto
+  // 1900-1999, which would reject a literal ISO year below 0100.
+  const dt = new Date(0);
+  dt.setUTCFullYear(y, mo - 1, d);
+  dt.setUTCHours(0, 0, 0, 0);
+  return dt.getUTCFullYear() === y && dt.getUTCMonth() === mo - 1 && dt.getUTCDate() === d;
+};
+
 /**
  * Append one transition to the ledger beside `trackerFile`.
  *
@@ -30,13 +52,25 @@ const isSafeField = (v) => !/[\t\r\n]/.test(String(v));
  * @param {string}  args.from         Previous status (canonicalized by the caller).
  * @param {string}  args.to           New status (canonicalized by the caller).
  * @param {string} [args.source]      What performed the change. Defaults to "web".
- * @param {string} [args.date]        Event date YYYY-MM-DD. Defaults to today.
+ * @param {string} [args.date]        Event date YYYY-MM-DD, a real calendar day. Defaults to today.
  * @returns {{logged: boolean, reason?: string}} Never throws.
  */
-export function appendStatusTransition({ trackerFile, num, from, to, source = "web", date }) {
+export function appendStatusTransition({ trackerFile, num, from, to, source = "web", date } = {}) {
   const eventDate = date ?? new Date().toISOString().slice(0, 10);
 
-  for (const field of [num, from, to, source, eventDate]) {
+  // Without this, a missing path throws out of path.dirname() below — outside
+  // the try, so no caller sees a result. "Never throws" has to hold for a
+  // caller's own mistake too, because by then the status write has committed.
+  if (typeof trackerFile !== "string" || !trackerFile) {
+    return { logged: false, reason: "invalid-field" };
+  }
+
+  // The date is held to its documented format rather than the generic check:
+  // it is the only column with one, and a date that cannot be parsed back is
+  // worse than an absent row because funnel-velocity.mjs still counts it.
+  if (!isRealCalendarDate(eventDate)) return { logged: false, reason: "invalid-field" };
+
+  for (const field of [num, from, to, source]) {
     if (!isSafeField(field)) return { logged: false, reason: "invalid-field" };
   }
 

--- a/web/tests/lib/status-log.test.mjs
+++ b/web/tests/lib/status-log.test.mjs
@@ -119,24 +119,22 @@ test("appendStatusTransition: defaults the date to today when none is given", ()
   assert.equal(date, new Date().toISOString().slice(0, 10));
 });
 
-test("appendStatusTransition: an unwritable ledger never throws", () => {
-  // Given a tracker whose directory cannot be written to
-  const tracker = fixture();
-  const dir = path.dirname(tracker);
-  fs.chmodSync(dir, 0o500);
+test("appendStatusTransition: a ledger that cannot be written never throws", () => {
+  // Given a tracker path inside a directory that does not exist, so the append
+  // cannot succeed. (Permissions are not used to provoke this: chmod does not
+  // restrict directory writes on Windows, so a mode-based fixture passes on
+  // POSIX and fails on CI.)
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "status-log-"));
+  const tracker = path.join(dir, "no-such-dir", "applications.md");
 
-  try {
-    // When the append fails
-    const res = appendStatusTransition({ trackerFile: tracker, num: 2, from: "Evaluated", to: "Applied" });
+  // When the append fails
+  const res = appendStatusTransition({ trackerFile: tracker, num: 2, from: "Evaluated", to: "Applied" });
 
-    // Then it reports the failure instead of raising — the status write has
-    // already committed, and a ledger problem must never surface as a failed
-    // status change
-    assert.equal(res.logged, false);
-    assert.match(res.reason, /^error:/);
-  } finally {
-    fs.chmodSync(dir, 0o700);
-  }
+  // Then it reports the failure instead of raising — the status write has
+  // already committed, and a ledger problem must never surface as a failed
+  // status change
+  assert.equal(res.logged, false);
+  assert.match(res.reason, /^error:/);
 });
 
 test("appendStatusTransition: values containing a tab or newline are rejected, not written", () => {

--- a/web/tests/lib/status-log.test.mjs
+++ b/web/tests/lib/status-log.test.mjs
@@ -137,6 +137,41 @@ test("appendStatusTransition: a ledger that cannot be written never throws", () 
   assert.match(res.reason, /^error:/);
 });
 
+test("appendStatusTransition: a call with missing arguments reports instead of throwing", () => {
+  // Given a caller that omits the arguments entirely, and one that omits only
+  // the tracker path
+
+  // When each is invoked
+  // Then both report the failure. "Never throws" has to hold for a caller bug
+  // too: the API route destructures the result after its tracker write has
+  // already committed, so an exception here would surface a completed status
+  // change as a 500.
+  assert.deepEqual(appendStatusTransition(), { logged: false, reason: "invalid-field" });
+  assert.deepEqual(appendStatusTransition({ num: 1, from: "Evaluated", to: "Applied" }), {
+    logged: false,
+    reason: "invalid-field",
+  });
+});
+
+test("appendStatusTransition: an impossible or malformed date is rejected, not written", () => {
+  // Given dates that pass a tab/newline check but do not name a real day —
+  // a rolled-over day, an out-of-range month, free text, and an empty string
+  for (const date of ["2026-02-30", "2026-13-40", "not-a-date", ""]) {
+    const tracker = fixture();
+
+    // When one is submitted
+    const res = appendStatusTransition({ trackerFile: tracker, num: 6, from: "Evaluated", to: "Applied", date });
+
+    // Then nothing is written. The ledger is the only record of WHEN a
+    // transition happened, and funnel-velocity.mjs measures elapsed time from
+    // this column — a date that cannot be parsed back is worse than a missing
+    // row, because it is counted as real.
+    assert.equal(res.logged, false, `expected ${JSON.stringify(date)} to be rejected`);
+    assert.equal(res.reason, "invalid-field");
+    assert.equal(fs.existsSync(ledgerFor(tracker)), false);
+  }
+});
+
 test("appendStatusTransition: values containing a tab or newline are rejected, not written", () => {
   // Given a status that would break the TSV row apart
   const tracker = fixture();

--- a/web/tests/lib/status-log.test.mjs
+++ b/web/tests/lib/status-log.test.mjs
@@ -172,6 +172,29 @@ test("appendStatusTransition: an impossible or malformed date is rejected, not w
   }
 });
 
+test("appendStatusTransition: a value with no primitive form is rejected, not thrown", () => {
+  // Given a value that cannot be converted to a string at all: a null-prototype
+  // object has no toString, so String() on it throws. Both the date check and
+  // the column check run before the try, so an unguarded conversion escapes the
+  // helper entirely, which is the one thing it promises not to do.
+  for (const field of ["date", "num", "from", "source"]) {
+    const tracker = fixture();
+
+    // When one is submitted in any of the inspected columns
+    const res = appendStatusTransition({
+      trackerFile: tracker,
+      num: 1,
+      from: "Evaluated",
+      to: "Applied",
+      [field]: Object.create(null),
+    });
+
+    // Then it comes back reported, like every other rejected input
+    assert.deepEqual(res, { logged: false, reason: "invalid-field" }, `field: ${field}`);
+    assert.equal(fs.existsSync(ledgerFor(tracker)), false);
+  }
+});
+
 test("appendStatusTransition: values containing a tab or newline are rejected, not written", () => {
   // Given a status that would break the TSV row apart
   const tracker = fixture();

--- a/web/tests/lib/status-log.test.mjs
+++ b/web/tests/lib/status-log.test.mjs
@@ -177,7 +177,7 @@ test("appendStatusTransition: a value with no primitive form is rejected, not th
   // object has no toString, so String() on it throws. Both the date check and
   // the column check run before the try, so an unguarded conversion escapes the
   // helper entirely, which is the one thing it promises not to do.
-  for (const field of ["date", "num", "from", "source"]) {
+  for (const field of ["date", "num", "from", "to", "source"]) {
     const tracker = fixture();
 
     // When one is submitted in any of the inspected columns

--- a/web/tests/lib/status-log.test.mjs
+++ b/web/tests/lib/status-log.test.mjs
@@ -1,0 +1,159 @@
+// Tests for the web-side transition-ledger append (status-log.tsv). Imports
+// directly from status-log.mjs, the single source of truth, so the test and the
+// production code cannot drift.
+//
+// The ledger is an observation trail: the tracker stays authoritative for STATE,
+// the ledger records WHEN a transition happened. Every case here is therefore
+// about not corrupting that trail and never letting a ledger problem turn a
+// successful status change into a failed one.
+//
+// Run:  node --test tests/lib/status-log.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { appendStatusTransition } from "../../src/lib/core/status-log.mjs";
+
+/** Fresh temp dir with a tracker file in it; returns the tracker path. */
+function fixture() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "status-log-"));
+  const tracker = path.join(dir, "applications.md");
+  fs.writeFileSync(tracker, "| # | Date | Company |\n", "utf8");
+  return tracker;
+}
+
+const ledgerFor = (tracker) => path.join(path.dirname(tracker), "status-log.tsv");
+
+test("appendStatusTransition: writes one line in the set-status.mjs format", () => {
+  // Given a tracker with no ledger beside it yet
+  const tracker = fixture();
+
+  // When a real transition is recorded
+  const res = appendStatusTransition({
+    trackerFile: tracker,
+    num: 42,
+    from: "Evaluated",
+    to: "Applied",
+    date: "2026-08-11",
+  });
+
+  // Then exactly one line lands, in the ledger format the CLI already writes:
+  // {tracker#}\t{date}\t{from}\t{to}\t{source}\t
+  assert.equal(res.logged, true);
+  const body = fs.readFileSync(ledgerFor(tracker), "utf8");
+  assert.equal(body, "42\t2026-08-11\tEvaluated\tApplied\tweb\t\n");
+});
+
+test("appendStatusTransition: creates the ledger next to the tracker, not in cwd", () => {
+  // Given a tracker in a directory of its own
+  const tracker = fixture();
+
+  // When a transition is recorded
+  appendStatusTransition({ trackerFile: tracker, num: 1, from: "Evaluated", to: "SKIP" });
+
+  // Then the ledger is a sibling of the tracker, so CAREER_OPS_TRACKER
+  // redirects keep the ledger next to the tracker it describes
+  assert.ok(fs.existsSync(ledgerFor(tracker)));
+});
+
+test("appendStatusTransition: a no-op re-select writes nothing", () => {
+  // Given a row already marked Applied
+  const tracker = fixture();
+
+  // When the same status is submitted again
+  const res = appendStatusTransition({
+    trackerFile: tracker,
+    num: 7,
+    from: "Applied",
+    to: "Applied",
+  });
+
+  // Then no ledger line is written — re-selecting a status is not a transition,
+  // and a ledger full of self-transitions would corrupt funnel velocity
+  assert.equal(res.logged, false);
+  assert.equal(res.reason, "no-change");
+  assert.equal(fs.existsSync(ledgerFor(tracker)), false);
+});
+
+test("appendStatusTransition: appends rather than overwriting", () => {
+  // Given one transition already recorded
+  const tracker = fixture();
+  appendStatusTransition({ trackerFile: tracker, num: 3, from: "Evaluated", to: "Applied", date: "2026-08-01" });
+
+  // When a second transition on the same row is recorded
+  appendStatusTransition({ trackerFile: tracker, num: 3, from: "Applied", to: "Rejected", date: "2026-08-09" });
+
+  // Then both survive, oldest first — the ledger is append-only history.
+  // Split on the newline only: trimming would eat the format's trailing tab.
+  const lines = fs.readFileSync(ledgerFor(tracker), "utf8").split("\n").slice(0, -1);
+  assert.equal(lines.length, 2);
+  assert.equal(lines[0], "3\t2026-08-01\tEvaluated\tApplied\tweb\t");
+  assert.equal(lines[1], "3\t2026-08-09\tApplied\tRejected\tweb\t");
+});
+
+test("appendStatusTransition: records the source so web and CLI rows stay distinguishable", () => {
+  // Given a caller that names a different source
+  const tracker = fixture();
+
+  // When it records a transition
+  appendStatusTransition({ trackerFile: tracker, num: 9, from: "Evaluated", to: "Applied", source: "set-status" });
+
+  // Then the source column carries it — a reader must be able to tell a
+  // web-originated transition from a CLI one
+  const body = fs.readFileSync(ledgerFor(tracker), "utf8");
+  assert.match(body, /\tset-status\t\n$/);
+});
+
+test("appendStatusTransition: defaults the date to today when none is given", () => {
+  // Given no explicit event date
+  const tracker = fixture();
+
+  // When a transition is recorded
+  appendStatusTransition({ trackerFile: tracker, num: 5, from: "Evaluated", to: "Applied" });
+
+  // Then today's date is stamped in ISO form, matching the CLI default
+  const [, date] = fs.readFileSync(ledgerFor(tracker), "utf8").split("\t");
+  assert.match(date, /^\d{4}-\d{2}-\d{2}$/);
+  assert.equal(date, new Date().toISOString().slice(0, 10));
+});
+
+test("appendStatusTransition: an unwritable ledger never throws", () => {
+  // Given a tracker whose directory cannot be written to
+  const tracker = fixture();
+  const dir = path.dirname(tracker);
+  fs.chmodSync(dir, 0o500);
+
+  try {
+    // When the append fails
+    const res = appendStatusTransition({ trackerFile: tracker, num: 2, from: "Evaluated", to: "Applied" });
+
+    // Then it reports the failure instead of raising — the status write has
+    // already committed, and a ledger problem must never surface as a failed
+    // status change
+    assert.equal(res.logged, false);
+    assert.match(res.reason, /^error:/);
+  } finally {
+    fs.chmodSync(dir, 0o700);
+  }
+});
+
+test("appendStatusTransition: values containing a tab or newline are rejected, not written", () => {
+  // Given a status that would break the TSV row apart
+  const tracker = fixture();
+
+  // When it is submitted
+  const res = appendStatusTransition({
+    trackerFile: tracker,
+    num: 4,
+    from: "Evaluated",
+    to: "Applied\tRejected",
+  });
+
+  // Then nothing is written — one malformed line silently shifts every column
+  // for every downstream reader
+  assert.equal(res.logged, false);
+  assert.equal(res.reason, "invalid-field");
+  assert.equal(fs.existsSync(ledgerFor(tracker)), false);
+});

--- a/web/tests/lib/status-log.test.mjs
+++ b/web/tests/lib/status-log.test.mjs
@@ -213,3 +213,60 @@ test("appendStatusTransition: values containing a tab or newline are rejected, n
   assert.equal(res.reason, "invalid-field");
   assert.equal(fs.existsSync(ledgerFor(tracker)), false);
 });
+
+// ── Round trip: the writer's output against the reader that consumes it ──────
+//
+// Every test above checks this writer against its own idea of the format, and
+// funnel-velocity.mjs's self-test checks that reader against its own. Both pass
+// while disagreeing with each other, which is exactly the gap that let the
+// source column diverge unnoticed. These parse the real written file with the
+// real reader.
+//
+// funnel-velocity.mjs is a root ESM module; importing it by relative path keeps
+// the two halves genuinely coupled rather than restating the format here.
+test("round trip: a written row parses back through funnel-velocity's reader", async () => {
+  const { parseStatusLog } = await import("../../../funnel-velocity.mjs");
+  const { loadCanonicalStates } = await import("../../../tracker-utils.mjs");
+  const states = loadCanonicalStates(path.join(import.meta.dirname, "../../../templates/states.yml"));
+
+  const tracker = fixture();
+  appendStatusTransition({
+    trackerFile: tracker,
+    num: 7,
+    from: "Evaluated",
+    to: "Applied",
+    source: "web",
+    date: "2026-06-01",
+  });
+  appendStatusTransition({
+    trackerFile: tracker,
+    num: 7,
+    from: "Applied",
+    to: "Responded",
+    source: "web",
+    date: "2026-06-08",
+  });
+
+  const parsed = parseStatusLog(fs.readFileSync(ledgerFor(tracker), "utf8"), states);
+
+  // Nothing malformed: the reader rejects a row whose field count, date or
+  // state names it cannot make sense of, so an empty unparseable list is the
+  // real assertion that the two formats agree.
+  assert.deepEqual(parsed.unparseable, []);
+  assert.equal(parsed.observations.length, 2);
+
+  const [first, second] = parsed.observations;
+  assert.equal(first.num, 7);
+  assert.equal(first.date, "2026-06-01");
+  assert.equal(first.from, "Evaluated");
+  assert.equal(first.to, "Applied");
+  assert.equal(second.to, "Responded");
+
+  // Deliberately NOT asserted here: that these observations are trusted for
+  // day-math (`dayMath === true`, and absent from `dataQuality.unknownSources`).
+  // That is true of the format but not yet of the reader — `web` is in neither
+  // of its source allow-lists, so both rows come back flagged and reach no hop
+  // figure. Asserting it now would fail for a reason this PR cannot fix from
+  // inside `web/`. Fixed separately in #2897 / #2898; this assertion tightens to
+  // include it once that lands.
+});


### PR DESCRIPTION
Closes #2714

## What changed

The web status route now appends to `data/status-log.tsv`, the transition ledger `set-status.mjs` already writes and `funnel-velocity.mjs` and `company-history.mjs` already read. Before this, only CLI transitions were recorded, so an installation driven from the web app produced no ledger at all.

The route had no reason to hold the previous status, so the value the ledger needs was not available in the handler. It now captures the status cell before overwriting it and canonicalizes that value, so an aliased cell such as "aplicado" is not read as a fresh transition into Applied.

The append lives in a new `web/src/lib/core/status-log.mjs` rather than inline in the route. That matches how the other testable web logic is arranged and lets it be covered from `web/tests/lib/` without standing up a route harness. It writes the same format `set-status.mjs` writes, places the ledger beside the tracker file so a `CAREER_OPS_TRACKER` redirect keeps the two together, and records `web` in the source column so the two producers stay distinguishable.

## Why the failure handling looks the way it does

By the time the append runs, the tracker write has already committed. A ledger failure is therefore reported back to the caller and never thrown, on the same reasoning `set-status.mjs` uses when it warns instead of failing: losing one history row is better than turning a successful status change into a failed one. The response gains a `statusLogged` flag so a caller can tell the difference.

Re-selecting the status a row already has writes nothing. Self-transitions would inflate every hop count derived from the ledger.

## Deliberately out of scope

The route does not take a tracker lock, and this change does not add one. That is a real concern but a separate one, and it applies to the tracker write rather than to the ledger. Likewise, backfilling history for rows that moved before this existed is left alone.

## Verification

`web/tests/lib/status-log.test.mjs` covers the format byte for byte against what `set-status.mjs` writes, the sibling-of-tracker path, the no-op case, append rather than overwrite, the source column, the date default, an unwritable ledger returning instead of throwing, and rejection of values containing a tab or newline before anything is written.

```
node --test "tests/**/*.test.mjs"    # 137 pass, 0 fail
npx tsc --noEmit                     # clean
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Status updates now record each transition, including previous and new statuses.
  * Transition records include the update source and date.
  * Responses indicate whether the transition was successfully recorded.

* **Bug Fixes**
  * Status updates remain successful if transition recording fails.
  * Unchanged statuses are no longer recorded as new transitions.
  * Invalid transition data is safely rejected without interrupting status updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->