### PR TITLE
test(scan): pin the company canonicalizer argument through loadDedupSnapshot

### DIFF
--- a/tests/scan-dedup-snapshot.test.mjs
+++ b/tests/scan-dedup-snapshot.test.mjs
@@ -21,7 +21,7 @@ import { pass, fail } from './helpers.mjs';
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { loadDedupSnapshot } from '../scan.mjs';
+import { loadDedupSnapshot, buildCompanyCanonicalizer } from '../scan.mjs';
 
 console.log('\nscan.mjs — dedup snapshot: one read per source, golden outputs (#2382)');
 
@@ -164,7 +164,31 @@ function sameArray(actual, expected) {
   }
 }
 
-// ── 3. Fresh install: absent files degrade to empty, never throw ────────────
+// ── 3. Company canonicalizer must actually reach the role-key collector ─────
+// main() builds this from config.company_aliases and passes it as
+// loadDedupSnapshot's second argument. Every fixture company canonicalizes to
+// itself under the default normalizer, so checks 1–2 cannot see that argument:
+// dropping `canonicalize` from the collectSeenCompanyRoles call inside
+// loadDedupSnapshot leaves them all green. An alias map that rewrites one
+// fixture company makes the wiring observable — if it breaks, company_aliases
+// silently stops applying to company+role dedup and the same role is listed
+// twice under two spellings.
+{
+  const files = { 'scan-history.tsv': HISTORY, 'pipeline.md': PIPELINE, 'applications.md': APPLICATIONS };
+  const canonicalize = buildCompanyCanonicalizer({ 'Zeta Industries': ['Zeta'] });
+  const snapshot = inSandbox(files, () => loadDedupSnapshot(POLICY, canonicalize));
+  if (
+    snapshot.seenCompanyRoles.has('zeta industries::sre') &&
+    !snapshot.seenCompanyRoles.has('zeta::sre') &&
+    snapshot.seenCompanyRoles.has('acme::platform engineer')
+  ) {
+    pass('aliased company lands under its canonical role key (canonicalize argument is live, not defaulted)');
+  } else {
+    fail(`aliased snapshot wrong: hasCanonical=${snapshot.seenCompanyRoles.has('zeta industries::sre')} hasRaw=${snapshot.seenCompanyRoles.has('zeta::sre')} hasAcme=${snapshot.seenCompanyRoles.has('acme::platform engineer')} (want true/false/true)`);
+  }
+}
+
+// ── 4. Fresh install: absent files degrade to empty, never throw ────────────
 {
   try {
     const snapshot = inSandbox({}, () => loadDedupSnapshot(POLICY));
@@ -183,7 +207,7 @@ function sameArray(actual, expected) {
   }
 }
 
-// ── 4. Empty file ≡ absent file ─────────────────────────────────────────────
+// ── 5. Empty file ≡ absent file ─────────────────────────────────────────────
 // readIfExists hands '' to the collectors for an absent file; a zero-byte file
 // must land in the same place.
 {


### PR DESCRIPTION
Closes the gap you flagged when merging #2601: the snapshot test pinned the recheck `policy` argument as live but not `buildCompanyCanonicalizer(config.company_aliases)`, so dropping the third argument from the `collectSeenCompanyRoles` call inside `loadDedupSnapshot` left the suite green while `company_aliases` silently stopped applying to company+role dedup.

The reason checks 1 and 2 could not see it: every fixture company canonicalizes to itself under `defaultCompanyNormalizer`, so the argument was invisible on that fixture no matter what it did. The new check passes an alias map that rewrites one fixture company (`Zeta` → `Zeta Industries`) and asserts the role key lands under the canonical spelling, with the raw key absent and an unaliased company untouched.

I re-ran your mutation before committing: with the third argument dropped at the `collectSeenCompanyRoles` call, the new check fails with `hasCanonical=false hasRaw=true`; restored, it passes. Full suite 3431/0, the one warning being the pre-existing Polish CV reorder fixture asserting its own warning.

Thanks for the differential probe on the goldens, and for catching that this refactor is what made the argument losable in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded scan deduplication coverage for company aliases.
  * Verified that alternate company names are consistently mapped to their canonical names when generating role keys.
  * Preserved coverage for fresh-install and empty-file scenarios while updating test organization to include the new validation case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->