### PR TITLE
test(skills): create .git/info before emptying the fixture exclude file

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5301,7 +5301,16 @@ console.log('\n12c. Materialized skill index mode');
     // core.excludesFile is only the GLOBAL layer. `git init` also seeds
     // .git/info/exclude from a template, which GIT_TEMPLATE_DIR can still point
     // at an ambient one, so empty that layer too rather than assume it is inert.
-    writeFileSync(join(fixtureRoot, '.git', 'info', 'exclude'), '');
+    //
+    // mkdirSync first, because the same GIT_TEMPLATE_DIR that makes this write
+    // necessary is what can make its parent absent: pointed at an empty or a
+    // non-existent directory, `git init` still succeeds but seeds no .git/info,
+    // and the bare write threw ENOENT before the fixture ran a single assertion
+    // (santifer, reviewing #2567). Assuming the default template here would be
+    // the same ambient-environment dependency this block exists to remove.
+    const excludePath = join(fixtureRoot, '.git', 'info', 'exclude');
+    mkdirSync(dirname(excludePath), { recursive: true });
+    writeFileSync(excludePath, '');
     gitRun(['config', 'core.symlinks', 'false']);
     gitRun(['config', 'core.excludesFile', emptyExcludes]);
     gitRun(['config', 'user.email', 'test@example.com']);


### PR DESCRIPTION
You flagged this reviewing #2567 and merged the rest without it, so here it is on its own.

`test-all.mjs` section 12c empties `.git/info/exclude` so an ambient template cannot leak ignore rules into the fixture. The write assumed `.git/info/` exists, which holds only for the default git template.

Both shapes you named reproduce. `GIT_TEMPLATE_DIR` pointing at an empty directory, and pointing at a path that does not exist (git init warns and continues), each produce a repository with no `.git/info` at all. The bare write then threw ENOENT before the fixture ran a single assertion, so a block added to remove an environment dependency introduced a new one of the same family.

`mkdirSync(dirname(...), { recursive: true })` before the write.

## Verification

Replicated the fixture's init-and-write, once as merged and once with the fix, across all three template shapes:

```
case                                       as merged    with fix
default template (no GIT_TEMPLATE_DIR)     ok           ok
GIT_TEMPLATE_DIR -> empty dir              ENOENT       ok
GIT_TEMPLATE_DIR -> missing path           ENOENT       ok
```

Full suite on a clean worktree at `main` plus this change: 3430 passed, 0 failed, 1 warning (`cv-sync-check.mjs exited with error (expected without user data)`, a fresh-clone artifact).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup reliability when the configured Git template directory is empty or does not yet exist.
  * Ensured required Git metadata directories are created automatically before setup files are written.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->