### PR TITLE
fix(verify-cv-facts): fold allow_metrics through the same noun synonyms

### DIFF
--- a/verify-cv-facts.mjs
+++ b/verify-cv-facts.mjs
@@ -266,16 +266,41 @@ export function metricClaims(text) {
   return claims;
 }
 
+/**
+ * Build the allow-list a metric claim is checked against.
+ *
+ * Claims extracted from text are folded through NOUN_SYNONYMS; allow_metrics
+ * entries used to be normalized only, so an exception written in the spelling
+ * a human reaches for - `77 repos` - never matched the canonical `77
+ * repositories` the extractor produces. The entry then did nothing at all and
+ * the CV still failed the gate, with no diagnostic pointing at the allow-list
+ * (CodeRabbit, reviewing #2175). A silently inert exception is the same failure
+ * class this script exists to catch.
+ *
+ * Both spellings are added rather than the canonical one alone: metricClaims()
+ * yields nothing for an entry no pattern recognizes (a bare `$900k`, a
+ * percentage), so replacing normalizeClaim outright would drop those exceptions
+ * instead of widening them. The union can only ever allow more, never less.
+ */
+function allowedMetricSet(sourceText, allowMetrics) {
+  const allowed = new Set(metricClaims(sourceText));
+  for (const entry of allowMetrics || []) {
+    allowed.add(normalizeClaim(entry));
+    for (const canonical of metricClaims(String(entry))) allowed.add(canonical);
+  }
+  return allowed;
+}
+
 /** Compare generated metric claims against source text without reading files. */
 export function auditClaims(targetText, sourceText, config = {}) {
-  const allowed = new Set([
-    ...metricClaims(sourceText),
-    ...(config.allow_metrics || []).map(normalizeClaim),
-  ]);
+  const allowed = allowedMetricSet(sourceText, config.allow_metrics);
   const invented = [...metricClaims(targetText)].filter(claim => !allowed.has(claim));
+  // Hoisted: stripMarkup re-ran the whole markup pass once per configured
+  // phrase (CodeRabbit, reviewing #2175). Same result, one pass.
+  const targetPlain = stripMarkup(targetText).toLowerCase();
   const forbidden = (config.forbidden_phrases || [])
     .filter(Boolean)
-    .filter(phrase => stripMarkup(targetText).toLowerCase().includes(String(phrase).toLowerCase()));
+    .filter(phrase => targetPlain.includes(String(phrase).toLowerCase()));
   return { invented, forbidden };
 }
 
@@ -316,10 +341,7 @@ export function verifyFacts(targetText, {
 } = {}) {
   const sourceText = sourcePaths.map(path => readIfExists(resolveInputPath(path, cwd))).join('\n');
   const config = loadConfig(resolveInputPath(configPath, cwd));
-  const allowed = new Set([
-    ...metricClaims(sourceText),
-    ...config.allow_metrics.map(normalizeClaim),
-  ]);
+  const allowed = allowedMetricSet(sourceText, config.allow_metrics);
   const targetClaims = metricClaims(targetText);
   const invented = [...targetClaims].filter(claim => !allowed.has(claim));
   const sourceNormalized = normalizeFact(stripMarkup(sourceText));
@@ -428,6 +450,19 @@ function runSelfTest() {
     auditClaims('Reached 94,772 users', source, { allow_metrics: ['94,772 users'] }).invented,
     []
   );
+  // An exception is written in the spelling a human reaches for, which is not
+  // always the canonical noun the extractor emits. Before the allow-list was
+  // folded too, this entry matched nothing and the CV stayed red.
+  equal('a synonym-spelled exception is honoured',
+    auditClaims('Maintained 77 repositories', source, { allow_metrics: ['77 repos'] }).invented, []);
+  equal('the canonical spelling still works',
+    auditClaims('Maintained 77 repositories', source, { allow_metrics: ['77 repositories'] }).invented, []);
+  // and folding the allow-list must not swallow an entry no claim pattern
+  // recognizes, which is what routing it through metricClaims alone would do.
+  equal('a currency exception survives the folding',
+    auditClaims('Managed a $900K budget', source, { allow_metrics: ['$900K'] }).invented, []);
+  equal('an unrelated exception still leaves the claim invented',
+    auditClaims('Maintained 77 repositories', source, { allow_metrics: ['12 repos'] }).invented, ['77 repositories']);
   equal(
     'forbidden phrase',
     auditClaims('A proven track record', source, { forbidden_phrases: ['proven track record'] }).forbidden,


### PR DESCRIPTION
Closing out a review comment on #2175 that I left unanswered at the time.

Claims extracted from text are canonicalized through `NOUN_SYNONYMS`, so `77 repos` on a CV becomes `77 repositories`. `allow_metrics` entries went through `normalizeClaim` only. An exception written in the spelling a human actually reaches for therefore matched nothing: the entry did nothing at all, the CV still failed the gate, and nothing in the output pointed at the allow-list as the reason.

That is the same failure class this script exists to catch, one layer up. The user sees the exact claim they just allowed still reported as invented, with no signal that their exception was inert.

## The shape of the fix

Both call sites (`auditClaims` and `verifyFacts`) built the allow-list independently, so this extracts `allowedMetricSet()` and routes both through it.

Allow-list entries now contribute **both** spellings rather than the canonical one alone. `metricClaims()` yields nothing for an entry no claim pattern recognizes, such as a bare currency figure or a percentage, so replacing `normalizeClaim` outright would silently drop those exceptions instead of widening them, trading one silent no-op for another. The union can only ever allow more, never less.

Also hoists `stripMarkup(targetText)` out of the forbidden-phrase filter, where it re-ran the whole markup pass once per configured phrase. Same result, one pass.

## Verification

Four new self-test assertions:

- a synonym-spelled exception is honoured
- the canonical spelling still works
- a currency exception survives the folding
- an unrelated exception still leaves the claim invented

Seen failing first: removing the synonym folding turns the first one red (`expected [] / actual ["77 repositories"]`), and the other three stay green, which is what pins the "widen, never narrow" property.

`verify-cv-facts.mjs --self-test`: 43 passed, 0 failed. Full suite on a clean worktree: 3430 passed, 0 failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved verification of factual claims against configured metric exceptions.
  * Added support for synonym-spelled and currency-based metric exceptions.
  * Prevented unrelated exceptions from being incorrectly treated as valid matches.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->