### PR TITLE
fix(jd-skill-gap): recognize all six markdown heading levels

### DIFF
--- a/jd-skill-gap.mjs
+++ b/jd-skill-gap.mjs
@@ -433,6 +433,24 @@ Python, Docker, Zookeeper
     true
   );
 
+  // The cv.md side of the six-level widening: SKILLS_HEADING_RE and
+  // ANY_HEADING_RE also stopped at four. An h5 "Skills" heading meant no
+  // named section was found at all (everything downgraded to
+  // supportedByResume), and once it IS found, the h6 heading after it must
+  // still close the section - otherwise Experience prose leaks into the
+  // named skills and upgrades to existing. One assert per regex: reverting
+  // SKILLS_HEADING_RE to #{1,4} turns the first red, reverting
+  // ANY_HEADING_RE alone turns the second red.
+  const deepHeadingCv = [
+    '# Resume', '',
+    '##### Skills', 'Python, Docker, PostgreSQL', '',
+    '###### Experience', 'Deployed Kubernetes clusters for internal tools.',
+  ].join('\n');
+  const deepCvResult = classifySkillGaps(['Python', 'Docker', 'PostgreSQL', 'Kubernetes'], deepHeadingCv);
+  eq('an h5 Skills heading is recognized as the named section', deepCvResult.existing.includes('Python'), true);
+  eq('the named section stops at the h6 heading (Kubernetes stays prose)', deepCvResult.existing.includes('Kubernetes'), false);
+  eq('prose under the h6 still classifies as supportedByResume', deepCvResult.supportedByResume.includes('Kubernetes'), true);
+
   // Regression: requirement headings that are full sentences or bare
   // uppercase rather than the noun forms ("Requirements", "Qualifications").
   // Each of these silently yielded ZERO skills, which is indistinguishable

--- a/jd-skill-gap.mjs
+++ b/jd-skill-gap.mjs
@@ -48,7 +48,7 @@ const CV_PATH = 'cv.md';
 // JD could yield zero skills - which reads identically to "no gaps found" and
 // is the more dangerous of the two failure modes this file warns about.
 const REQUIREMENT_HEADER_RE = new RegExp(
-  '^#{0,4}\\s*(?:' + [
+  '^#{0,6}\\s*(?:' + [
     'required', 'requirements', 'qualifications', 'must[- ]have', 'preferred', 'nice[- ]to[- ]have',
     "what\\s+we(?:'|’)?\\s*re\\s+looking\\s+for",
     "what\\s+you(?:(?:'|’)ll|\\s+will)?\\s+bring",
@@ -57,7 +57,7 @@ const REQUIREMENT_HEADER_RE = new RegExp(
     'your\\s+(?:background|experience|profile)',
     'you\\s+(?:may|might|could)\\s+be\\s+a\\s+good\\s+fit',
     // Ashby's default template ships a bare "YOU HAVE:" heading (no markdown
-    // hashes - already allowed by the ^#{0,4} prefix). Without this the whole
+    // hashes - already allowed by the ^#{0,6} prefix). Without this the whole
     // requirements block is invisible even though the bullets under it are
     // perfectly well formed.
     "you(?:(?:'|’)ll|\\s+will)?\\s+have",
@@ -76,12 +76,12 @@ const REQUIREMENT_HEADER_RE = new RegExp(
 // the benefits list into "required skills" - turning perks like "401k",
 // "Equity" and "Carrot" into reported skill gaps.
 const NON_REQUIREMENT_HEADER_RE = new RegExp(
-  '^#{0,4}\\s*(?:' + [
+  '^#{0,6}\\s*(?:' + [
     // Responsibilities. The negative lookahead keeps "You will have" on the
     // requirements side — this list is tested BEFORE REQUIREMENT_HEADER_RE in
     // scanJd(), so without it a "You will have:" heading would close a block
     // instead of opening one. Bare "YOU WILL" must close: the fallback that
-    // ends a block on a new heading only fires for markdown headings (#{1,4}),
+    // ends a block on a new heading only fires for markdown headings (#{1,6}),
     // so an unhashed responsibilities heading left the block open and scored
     // its duties as required skills.
     'you\\s+will(?!\\s+have)',
@@ -172,7 +172,7 @@ function scanJd(jdText) {
       continue;
     }
     if (inRequirementsBlock && line.trim() === '') continue;
-    if (inRequirementsBlock && /^#{1,4}\s/.test(line) && !REQUIREMENT_HEADER_RE.test(line)) {
+    if (inRequirementsBlock && /^#{1,6}\s/.test(line) && !REQUIREMENT_HEADER_RE.test(line)) {
       inRequirementsBlock = false;
     }
 
@@ -278,8 +278,8 @@ function skillMentionedInText(skill, text) {
 // section at all or matches a literal "Z" character later in the text.
 // Scanning line-by-line for the next heading avoids the anchor entirely.
 
-const SKILLS_HEADING_RE = /^#{1,4}\s*Skills\s*$/i;
-const ANY_HEADING_RE = /^#{1,4}\s/;
+const SKILLS_HEADING_RE = /^#{1,6}\s*Skills\s*$/i;
+const ANY_HEADING_RE = /^#{1,6}\s/;
 
 /**
  * Split cv.md into its named "Skills" section (if any) and the remaining
@@ -466,7 +466,7 @@ Python, Docker, Zookeeper
   // The assertion above only proves YOU WILL cannot OPEN a block. Closing is
   // the case that actually bites: postings routinely list requirements first
   // and duties second, and the block-ending fallback in scanJd() fires only on
-  // markdown headings (#{1,4}) — so a bare responsibilities heading left the
+  // markdown headings (#{1,6}) — so a bare responsibilities heading left the
   // block open and reported every duty as a missing skill.
   const dutiesAfterRequirementsJd = [
     '# Role', '', 'YOU HAVE:', '- Experience with Python', '',
@@ -484,6 +484,21 @@ Python, Docker, Zookeeper
     extractJdSkills('# Role\n\nYou Will Have:\n- Experience with Kubernetes\n').includes('Kubernetes'),
     true
   );
+
+  // Markdown defines six heading levels, and the block-ending fallback only
+  // recognized four (CodeRabbit, reviewing #2176). A posting pasted out of a
+  // deeply nested doc - or converted from HTML, where an ATS wraps sections in
+  // h5/h6 - kept the requirements block open across its own next heading, so
+  // everything below it scored as a required skill.
+  const deepHeadingJd = [
+    '##### Requirements', '- Experience with Python', '',
+    '##### Benefits', '- Equity and a Carrot subscription', '',
+    '###### About Us', '- We use Kubernetes internally for our own platform',
+  ].join('\n');
+  const deepSkills = extractJdSkills(deepHeadingJd);
+  eq('an h5 requirements heading is recognized', deepSkills.includes('Python'), true);
+  eq('an h5 heading closes the block (Equity)', deepSkills.includes('Equity'), false);
+  eq('an h6 heading stays closed (Kubernetes)', deepSkills.includes('Kubernetes'), false);
 
   // Regression: generic JD boilerplate must not be misreported as a skill gap.
   const boilerplateJd = `


### PR DESCRIPTION
Closing out a review comment on #2176 that I left unanswered at the time.

Markdown defines six heading levels. The requirement-header prefix, the non-requirement prefix, the block-ending fallback in `scanJd()`, and the `cv.md` Skills scanner all stopped at four.

Two ways that bites a real posting:

1. **No block opens at all.** A JD pasted out of a deeply nested doc, or converted from HTML by an ATS that wraps its sections in h5/h6, produces an empty skill list. That reads exactly like "no gaps found", which is the silent failure mode this file already warns about in its own header comment.
2. **An open block never closes.** Where a requirements block does open, its own next heading no longer ends it, so the benefits and about-us sections below score as required skills. The same "Carrot as a missing skill" outcome, reached by a different route.

Widened all four sites to `#{1,6}` / `#{0,6}`.

## Verification

Three new self-test assertions, on a fixture using h5 and h6 headings:

- an h5 requirements heading is recognized
- an h5 heading closes the block
- an h6 heading stays closed

Seen failing first, and isolated per mechanism rather than as one lump: reverting the heading levels turns the first red. The two closing assertions are covered redundantly, by the non-requirement prefix and by the block-ending fallback independently, so reverting either alone leaves them green and reverting both turns them red. Noting that explicitly because a reviewer checking one mutation would reasonably read them as vacuous.

`jd-skill-gap.mjs --self-test`: 63 passed, 0 failed. Full suite on a clean worktree: 3430 passed, 0 failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved job description and CV heading detection across all Markdown heading levels.
  - Fixed requirement sections ending correctly around deeper headings and responsibility headings.
  - Preserved recognition of “You Will Have” as a requirements header.
  - Improved handling of benefits, “About” sections, and other content following requirements.

- **Tests**
  - Added coverage for deep headings and requirement-section boundary cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->