### PR TITLE
test(scan): stop the suite inheriting a user's own lane overrides

### DIFF
--- a/tests/scan-output-paths.test.mjs
+++ b/tests/scan-output-paths.test.mjs
@@ -47,12 +47,35 @@ function makeLane() {
   return { dir, portals };
 }
 
-const runScan = (dir, env) => execFileSync(NODE, [join(ROOT, 'scan.mjs')], {
-  cwd: dir,
-  env: { ...process.env, ...env },
-  encoding: 'utf-8',
-  stdio: ['ignore', 'pipe', 'pipe'],
-});
+// Every variable scan.mjs resolves a path from. Cleared before each spawn so a
+// test's environment is only what that test asked for.
+//
+// This matters more here than in a typical suite, because the audience for
+// these variables is precisely the person running the suite with them set: the
+// docs added alongside this feature tell a second-lane user to export
+// CAREER_OPS_PIPELINE and CAREER_OPS_SCAN_HISTORY. With the parent environment
+// inherited wholesale, check 1 below - the one asserting DEFAULT behavior -
+// would follow that user's override and append fixture postings to their real
+// inbox, and the corresponding scan-history write would poison their dedup
+// source. A test suite must not be able to write into the data it is testing
+// the handling of (CodeRabbit, reviewing #2568).
+const SCANNER_PATH_VARS = [
+  'CAREER_OPS_PORTALS',
+  'CAREER_OPS_PROFILE',
+  'CAREER_OPS_PIPELINE',
+  'CAREER_OPS_SCAN_HISTORY',
+];
+
+const runScan = (dir, env) => {
+  const childEnv = { ...process.env };
+  for (const name of SCANNER_PATH_VARS) delete childEnv[name];
+  return execFileSync(NODE, [join(ROOT, 'scan.mjs')], {
+    cwd: dir,
+    env: { ...childEnv, ...env },
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+};
 
 /** Pending rows in a pipeline file; [] when the file was never created. */
 function entries(pipelinePath) {
@@ -171,5 +194,45 @@ function entries(pipelinePath) {
     fail(`scan into a new directory failed: ${err.message}`);
   } finally {
     rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// 5. The suite's own isolation, asserted rather than assumed. Check 1 claims to
+//    exercise DEFAULT paths, but it can only do that if nothing ambient reaches
+//    the child - and the user most likely to run this suite with these variables
+//    exported is the second-lane user this feature was built for. Simulate that
+//    environment and confirm the fixture's writes land in the lane's own
+//    directory and nowhere else.
+//
+//    Goes through the same runScan() the checks above use, deliberately. A case
+//    that spawned scan.mjs with its own hand-built environment would keep
+//    passing if the clearing were dropped, which is the whole failure mode: on a
+//    machine with these variables unset, removing it changes nothing observable.
+{
+  const { dir, portals } = makeLane();
+  const ambientRoot = mkdtempSync(join(tmpdir(), 'scan-outpaths-ambient-'));
+  const ambientPipeline = join(ambientRoot, 'pipeline.md');
+  const ambientHistory = join(ambientRoot, 'scan-history.tsv');
+  const saved = SCANNER_PATH_VARS.map((name) => [name, process.env[name]]);
+  try {
+    process.env.CAREER_OPS_PIPELINE = ambientPipeline;
+    process.env.CAREER_OPS_SCAN_HISTORY = ambientHistory;
+    runScan(dir, { CAREER_OPS_PORTALS: portals });
+    const laneEntries = entries(join(dir, 'data', 'pipeline.md')).length;
+    const leaked = existsSync(ambientPipeline) || existsSync(ambientHistory);
+    if (laneEntries > 0 && !leaked) {
+      pass('an ambient CAREER_OPS_PIPELINE / CAREER_OPS_SCAN_HISTORY cannot redirect this suite (#2568)');
+    } else {
+      fail(`suite is not isolated from the ambient environment: ${laneEntries} lane entr(y/ies), ambient files ${leaked ? 'WRITTEN' : 'untouched'} (#2568)`);
+    }
+  } catch (err) {
+    fail(`ambient-environment isolation check failed: ${err.message}`);
+  } finally {
+    for (const [name, value] of saved) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(ambientRoot, { recursive: true, force: true });
   }
 }


### PR DESCRIPTION
Found while going back through the review comments on #2568. CodeRabbit raised it there and I never answered; it is still live, and it is worse on a customized install than the original note suggested.

`runScan` spread `process.env` into every child, so the suite's behavior depended on the environment it was run in. Check 1 asserts DEFAULT output paths, and an inherited `CAREER_OPS_PIPELINE` redirects precisely that check.

The audience is what makes it concrete. The docs added with this feature tell a second-lane user to export `CAREER_OPS_PIPELINE` and `CAREER_OPS_SCAN_HISTORY`, so the person most likely to run this suite with them set is the person the feature was written for. What they get is fixture postings appended to their real inbox, and the matching rows written into `scan-history.tsv`. The second half is the quiet one: that file is the dedup source, so a real posting colliding with a fixture row is skipped silently on a later scan, which is the same failure this feature exists to prevent.

Clears the four scanner path variables before applying each check's explicit overrides.

## Why there is a check 5

Asserting the isolation rather than assuming it, for the same reason as the clearing itself: on a machine with these variables unset, removing the clearing changes nothing observable, so nothing would catch its removal.

Check 5 sets the variables in the parent, runs through the same `runScan()` the other checks use, and requires both that the lane's own file received the postings and that the ambient paths were never created. A case that spawned `scan.mjs` with its own hand-built environment would have stayed green.

## Verification

`tests/scan-output-paths.test.mjs`: 5 passed, 0 failed. Full suite: 3431 passed, 0 failed, 1 warning (`cv-sync-check.mjs exited with error (expected without user data)`, a fresh-clone artifact).

Mutation: removing the clearing turns check 5 red with

```
suite is not isolated from the ambient environment: 0 lane entr(y/ies), ambient files WRITTEN (#2568)
```

which is the reported bug verbatim: zero postings in the lane's own file, and both ambient paths written instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved scan path test isolation by clearing environment-based overrides between tests.
  * Added coverage confirming ambient configuration cannot redirect default scan paths.
  * Added cleanup for restored environment settings and temporary test directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->