### PR TITLE
feat(verify-portals): --unmined finds companies stuck in search_queries

### DIFF
--- a/tests/verify-portals-unmined.test.mjs
+++ b/tests/verify-portals-unmined.test.mjs
@@ -1,0 +1,197 @@
+// tests/verify-portals-unmined.test.mjs — the search_queries coverage hole.
+//
+// A search_queries entry only yields links for a human to open; it never feeds
+// the scanner. Groq and Cerebras lived in one for months with live ATS boards,
+// and nothing reported it because both the entry and the scan looked fine.
+//
+// Network-free: findUnmined takes an injected fetchJson, so the probe matrix is
+// exercised without touching the rate-limited ATS directories.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildHintStopwords,
+  companyFromHost,
+  companyHintsFromQuery,
+  unminedHints,
+  findUnmined,
+} from '../verify-portals.mjs';
+
+const CFG = {
+  title_filter: {
+    positive: ['AI Engineer', 'Machine Learning', 'Design Verification', 'RTL', 'Inference', 'Physical Design'],
+    negative: ['Sales'],
+  },
+  location_filter: { allow: ['San Jose', 'Sunnyvale'] },
+  tracked_companies: [{ name: 'Cadence' }, { name: 'd-Matrix' }],
+  search_queries: [],
+};
+const SW = buildHintStopwords(CFG);
+
+// ── host → company ───────────────────────────────────────────────────────────
+
+test('a careers subdomain is stripped to the company', () => {
+  assert.equal(companyFromHost('careers.amd.com'), 'amd');
+  assert.equal(companyFromHost('jobs.apple.com'), 'apple');
+  assert.equal(companyFromHost('www.tesla.com'), 'tesla');
+});
+
+test('a path after the host is ignored', () => {
+  assert.equal(companyFromHost('google.com/about/careers'), 'google');
+  assert.equal(companyFromHost('tesla.com/careers'), 'tesla');
+});
+
+test('a non-.com TLD is still a TLD', () => {
+  assert.equal(companyFromHost('cerebras.ai'), 'cerebras');
+  assert.equal(companyFromHost('together.ai'), 'together');
+  assert.equal(companyFromHost('breezy.hr'), null, 'known aggregator');
+});
+
+test('multi-label public suffixes drop both labels', () => {
+  assert.equal(companyFromHost('www.example.co.uk'), 'example');
+});
+
+test('aggregator hosts name no company', () => {
+  // site:jobs.ashbyhq.com is a cross-company search — promoting "ashbyhq" to
+  // tracked_companies would be nonsense.
+  assert.equal(companyFromHost('job-boards.greenhouse.io'), null);
+  assert.equal(companyFromHost('jobs.ashbyhq.com'), null);
+  assert.equal(companyFromHost('jobs.lever.co'), null);
+});
+
+test('a bare word is not a host', () => {
+  assert.equal(companyFromHost('groq'), null);
+  assert.equal(companyFromHost(''), null);
+});
+
+// ── query → company hints ────────────────────────────────────────────────────
+
+test('site: hosts become hints', () => {
+  const q = 'site:careers.amd.com ("RTL" OR "Machine Learning") "San Jose"';
+  assert.deepEqual(companyHintsFromQuery(q, SW), ['amd']);
+});
+
+test('quoted proper nouns become hints', () => {
+  const q = '("ChipAgents" OR "Silimate" OR "Astrus") careers ("engineer" OR "research")';
+  assert.deepEqual(companyHintsFromQuery(q, SW), ['chipagents', 'silimate', 'astrus']);
+});
+
+test('a quoted fragment of a filter keyword is vocabulary, not a company', () => {
+  // The bug this rule exists for: "Verification" and "AI" are quoted in real
+  // queries but appear only INSIDE keywords ("Design Verification", "AI
+  // Engineer"), so whole-phrase matching let both through as company names.
+  const q = 'site:tesla.com/careers ("RTL" OR "Verification" OR "AI")';
+  assert.deepEqual(companyHintsFromQuery(q, SW), ['tesla']);
+});
+
+test('a partial overlap with filter vocabulary survives', () => {
+  // "Physical Intelligence" is a real lab. "physical" is in the filter via
+  // "Physical Design"; "intelligence" is the company's own word, so it stays.
+  assert.deepEqual(companyHintsFromQuery('("Physical Intelligence") careers', SW), ['physical intelligence']);
+});
+
+test('lowercase and sentence-length quotes are search language', () => {
+  const q = '("will sponsor" OR "we are hiring engineers across the stack")';
+  assert.deepEqual(companyHintsFromQuery(q, SW), []);
+});
+
+test('locations from the user config are not companies', () => {
+  assert.deepEqual(companyHintsFromQuery('("San Jose" OR "Sunnyvale")', SW), []);
+});
+
+// ── config → unmined set ─────────────────────────────────────────────────────
+
+test('already-tracked companies are not findings', () => {
+  const cfg = {
+    ...CFG,
+    search_queries: [{ name: 'EDA', query: '("Synopsys" OR "Cadence") jobs', enabled: true }],
+  };
+  assert.deepEqual(unminedHints(cfg).map((h) => h.hint), ['synopsys'], 'Cadence is tracked');
+});
+
+test('tracked matching tolerates punctuation differences', () => {
+  const cfg = { ...CFG, search_queries: [{ name: 'x', query: '("d-Matrix" OR "Etched")' }] };
+  assert.deepEqual(unminedHints(cfg).map((h) => h.hint), ['etched'], 'd-Matrix already tracked');
+});
+
+test('a disabled search entry is not mined', () => {
+  const cfg = { ...CFG, search_queries: [{ name: 'off', query: '("Silimate")', enabled: false }] };
+  assert.deepEqual(unminedHints(cfg), []);
+});
+
+test('one company named by two entries reports both sources', () => {
+  const cfg = {
+    ...CFG,
+    search_queries: [
+      { name: 'B entry', query: 'site:groq.com/careers "RTL"' },
+      { name: 'A entry', query: '("Groq")' },
+    ],
+  };
+  const [only] = unminedHints(cfg);
+  assert.equal(only.hint, 'groq');
+  assert.deepEqual(only.sources, ['A entry', 'B entry'], 'sorted, deduped');
+});
+
+test('missing sections are not a crash', () => {
+  assert.deepEqual(unminedHints({}), []);
+  assert.deepEqual(unminedHints(null), []);
+});
+
+// ── probing ──────────────────────────────────────────────────────────────────
+
+/** Resolve only the exact urls given; everything else 404s like a bad slug. */
+function fakeFetch(liveUrlSubstrings) {
+  return async (url) => {
+    const hit = liveUrlSubstrings.find((s) => url.includes(s));
+    if (!hit) { const e = new Error('404'); e.status = 404; throw e; }
+    if (url.includes('ashby')) return { jobs: [{ title: 'x' }, { title: 'y' }] };
+    return { jobs: [{ title: 'x' }, { title: 'y' }] };
+  };
+}
+
+test('a company with a live board is reported with its slug', async () => {
+  const cfg = { ...CFG, search_queries: [{ name: 'silicon', query: 'site:cerebras.ai "RTL"' }] };
+  const [r] = await findUnmined(cfg, { fetchJson: fakeFetch(['/cerebras']) });
+  assert.equal(r.hint, 'cerebras');
+  assert.equal(r.hit.slug, 'cerebras');
+  assert.equal(r.hit.status, 'live');
+});
+
+test('a derived slug variant is found when the bare name is not', async () => {
+  // together.ai's board is 'togetherai', not 'together' — the miss that makes
+  // probing the bare host label alone insufficient.
+  const cfg = { ...CFG, search_queries: [{ name: 'infra', query: 'site:together.ai "Inference"' }] };
+  const [r] = await findUnmined(cfg, { fetchJson: fakeFetch(['/togetherai']) });
+  assert.equal(r.hit.slug, 'togetherai');
+});
+
+test('a live-but-empty board still counts as mineable', async () => {
+  // Groq's real state: board reachable, zero openings. Tracking it now means
+  // the first posting is caught automatically instead of by someone noticing.
+  const cfg = { ...CFG, search_queries: [{ name: 'silicon', query: 'site:groq.com/careers "RTL"' }] };
+  const fetchJson = async (url) => {
+    if (!url.includes('/groq')) { const e = new Error('404'); e.status = 404; throw e; }
+    return { jobs: [] };
+  };
+  const [r] = await findUnmined(cfg, { fetchJson });
+  assert.equal(r.hit.status, 'empty');
+});
+
+test('a name with no board anywhere reports no hit', async () => {
+  const cfg = { ...CFG, search_queries: [{ name: 'big', query: 'site:google.com/about/careers "ASIC"' }] };
+  const [r] = await findUnmined(cfg, { fetchJson: fakeFetch([]) });
+  assert.equal(r.hit, null, 'websearch really is the right tool for this one');
+});
+
+test('probing stops at the first hit for a company', async () => {
+  // The ATS directories rate-limit hard; exhausting every variant of every hint
+  // would poison the run for the companies probed after it.
+  let calls = 0;
+  const cfg = { ...CFG, search_queries: [{ name: 'x', query: 'site:cerebras.ai "RTL"' }] };
+  const fetchJson = async (url) => {
+    calls++;
+    if (!url.includes('/cerebras')) { const e = new Error('404'); e.status = 404; throw e; }
+    return { jobs: [{ title: 'x' }] };
+  };
+  await findUnmined(cfg, { fetchJson });
+  assert.ok(calls <= 3, `stopped early, took ${calls} probes for a first-candidate hit`);
+});

--- a/verify-portals.mjs
+++ b/verify-portals.mjs
@@ -17,7 +17,10 @@
  * Usage:
  *   node verify-portals.mjs                 # sweep tracked_companies in portals.yml
  *   node verify-portals.mjs --add cursor    # probe slug variants for one name
+ *   node verify-portals.mjs --unmined       # companies stuck in search_queries
+ *                                           #   that actually have a scannable board
  *   node verify-portals.mjs --strict        # exit non-zero if any slug is unresolved
+ *                                           #   (with --unmined: if any board is unmined)
  *   node verify-portals.mjs --file <path>   # use a specific portals file
  *
  * Network: only the sweep / --add paths hit the network. Importing the module
@@ -150,6 +153,200 @@ export function deriveSlugCandidates(name) {
     candidates.push(`${base}.tech`, `${base}.io`);
   }
   return [...new Set(candidates)].filter(Boolean);
+}
+
+// ── Unmined search_queries ───────────────────────────────────────────────────
+//
+// A `search_queries` entry only produces links for a human to open; it never
+// feeds the zero-LLM scanner. So a company that exists ONLY inside a query
+// string is invisible to every scan, and until now nothing said so. Groq and
+// Cerebras sat in one such entry with live ATS boards the scanner would have
+// read for free — the miss was silent because both the entry and the scan
+// looked healthy.
+//
+// The check below extracts the companies a query names, discards the ones that
+// are really role/skill/location vocabulary, and probes what survives. The
+// probe is the final arbiter: a bogus hint just resolves to no board, so the
+// extraction is allowed to be generous.
+//
+// Scope: only the three slug-addressable ATSs (Greenhouse/Ashby/Lever) are
+// probed, because a slug is the whole address there. Workday needs a tenant AND
+// a site, Gem a board id — not guessable from a company name, so this reports
+// "no Greenhouse/Ashby/Lever board" rather than "no board". Concretely, it
+// would have caught Cerebras from that Tesla/Groq/Cerebras query but NOT Groq,
+// whose board is on Gem. A silent partial answer would be worse than a stated
+// one, hence the wording in the output.
+
+/** Hosts that aggregate many employers. `site:jobs.ashbyhq.com` is a
+ *  cross-company search — its host names no company worth promoting. */
+const AGGREGATOR_HOSTS = [
+  'greenhouse.io', 'ashbyhq.com', 'lever.co', 'myworkdayjobs.com', 'workday.com',
+  'smartrecruiters.com', 'jobvite.com', 'icims.com', 'bamboohr.com', 'gem.com',
+  'recruitee.com', 'teamtailor.com', 'personio.com', 'workable.com', 'breezy.hr',
+  'linkedin.com', 'indeed.com', 'glassdoor.com', 'ycombinator.com', 'wellfound.com',
+];
+
+/** Subdomain labels that describe a careers site rather than the company. */
+const CAREERS_SUBDOMAINS = new Set([
+  'careers', 'career', 'jobs', 'job', 'job-boards', 'boards', 'apply', 'hire',
+  'hiring', 'talent', 'work', 'working', 'recruiting', 'join', 'www',
+]);
+
+/** Two-label public suffixes we care about; anything else drops one label. */
+const MULTI_LABEL_SUFFIXES = new Set([
+  'co.uk', 'com.au', 'co.jp', 'com.br', 'co.in', 'com.cn', 'co.nz', 'com.mx',
+]);
+
+/** Recruiting boilerplate that is never a company. Role, skill and city
+ *  vocabulary is deliberately NOT hardcoded here — buildHintStopwords pulls it
+ *  from the user's own title_filter / location_filter, so this list stays small
+ *  and does not rot as they retune their search. */
+const GENERIC_QUERY_TERMS = [
+  'visa sponsorship', 'will sponsor', 'sponsorship', 'h-1b', 'h1b', 'green card',
+  'careers', 'career', 'jobs', 'job', 'hiring', 'apply', 'openings', 'engineer',
+  'engineering', 'research', 'remote', 'onsite', 'on-site', 'hybrid', 'senior',
+  'staff', 'principal', 'lead', 'intern', 'internship', 'new grad', 'usa',
+  'united states', 'california', 'us', 'full-time', 'contract',
+];
+
+/**
+ * Search vocabulary a query may quote, which is never a company name.
+ *
+ * Sourced from the user's own config rather than a fixed list: whatever they
+ * put in title_filter is by definition role/skill language, and whatever is in
+ * location_filter is by definition a place. Retuning the search therefore
+ * retunes this automatically.
+ *
+ * Returns phrases AND their individual words, because queries quote fragments
+ * of a keyword rather than the keyword itself — `"Verification"` against a
+ * `Design Verification` filter, `"AI"` against `AI Engineer`. Matching only
+ * whole phrases let both through as company names.
+ *
+ * @param {Record<string, any>|null|undefined} cfg - Parsed portals.yml.
+ * @returns {{phrases: Set<string>, words: Set<string>}} Lowercased.
+ */
+export function buildHintStopwords(cfg) {
+  const phrases = new Set(GENERIC_QUERY_TERMS);
+  const words = new Set();
+  const tf = cfg?.title_filter ?? {};
+  const lf = cfg?.location_filter ?? {};
+  for (const list of [tf.positive, tf.negative, lf.allow, lf.block, lf.always_allow]) {
+    if (!Array.isArray(list)) continue;
+    for (const item of list) {
+      if (typeof item !== 'string' || !item.trim()) continue;
+      phrases.add(item.trim().toLowerCase());
+    }
+  }
+  for (const phrase of phrases) {
+    for (const w of phrase.split(/[^a-z0-9+#]+/i)) if (w) words.add(w);
+  }
+  return { phrases, words };
+}
+
+/**
+ * The company name behind a `site:` host, or null for aggregators.
+ *
+ * careers.amd.com → amd · google.com/about/careers → google · cerebras.ai →
+ * cerebras · job-boards.greenhouse.io → null (aggregator).
+ *
+ * @param {string} host - Host, optionally with a trailing path.
+ * @returns {string|null}
+ */
+export function companyFromHost(host) {
+  const bare = String(host || '').toLowerCase().split('/')[0].replace(/^www\./, '').trim();
+  if (!bare || !bare.includes('.')) return null;
+  if (AGGREGATOR_HOSTS.some((h) => bare === h || bare.endsWith(`.${h}`))) return null;
+
+  const labels = bare.split('.').filter(Boolean);
+  const lastTwo = labels.slice(-2).join('.');
+  const withoutSuffix = MULTI_LABEL_SUFFIXES.has(lastTwo) ? labels.slice(0, -2) : labels.slice(0, -1);
+  // Walk in from the right: the registrable label sits just left of the suffix,
+  // and anything further left is a subdomain like "careers".
+  const meaningful = withoutSuffix.filter((l) => !CAREERS_SUBDOMAINS.has(l));
+  const name = meaningful.length ? meaningful[meaningful.length - 1] : '';
+  return name || null;
+}
+
+/**
+ * Company names a websearch query mentions.
+ *
+ * Two sources: `site:` hosts (deterministic) and quoted proper nouns (fuzzy,
+ * filtered by `stopwords`). Both are candidates only — probeSlug decides.
+ *
+ * @param {string} query
+ * @param {{phrases: Set<string>, words: Set<string>}} [stopwords] - From buildHintStopwords().
+ * @returns {string[]} Distinct hints, lowercased.
+ */
+export function companyHintsFromQuery(query, stopwords) {
+  const phrases = stopwords?.phrases ?? new Set();
+  const words = stopwords?.words ?? new Set();
+  const q = String(query || '');
+  const hints = [];
+
+  /** Search vocabulary if every word of it is search vocabulary. A partial
+   *  overlap is kept: "Physical Intelligence" survives a `Physical Design`
+   *  filter because "intelligence" is the company's own word. The cost is that
+   *  a company named exactly after a keyword it hires for ("Triton") is missed
+   *  — a quiet miss, versus flooding the report with every role word quoted. */
+  const isVocabulary = (text) => {
+    if (phrases.has(text)) return true;
+    const parts = text.split(/[^a-z0-9+#]+/i).filter(Boolean);
+    return parts.length > 0 && parts.every((p) => words.has(p));
+  };
+
+  for (const m of q.matchAll(/site:([^\s)"']+)/gi)) {
+    const name = companyFromHost(m[1]);
+    if (name && !isVocabulary(name)) hints.push(name);
+  }
+
+  for (const m of q.matchAll(/"([^"]+)"/g)) {
+    const raw = m[1].trim();
+    const lower = raw.toLowerCase();
+    if (!raw || isVocabulary(lower)) continue;
+    // A company name in a query is a proper noun: it starts with a capital and
+    // is not a sentence. Lowercase fragments ("will sponsor") and long phrases
+    // are search language, not employers.
+    if (!/^[A-Z0-9]/.test(raw)) continue;
+    if (raw.split(/\s+/).length > 3) continue;
+    hints.push(lower);
+  }
+
+  return [...new Set(hints)];
+}
+
+/**
+ * Companies named in search_queries that are not tracked as scannable boards.
+ *
+ * @param {Record<string, any>|null|undefined} cfg - Parsed portals.yml.
+ * @returns {{hint: string, sources: string[]}[]} Sorted by hint.
+ */
+export function unminedHints(cfg) {
+  const stopwords = buildHintStopwords(cfg);
+
+  // Already-tracked companies are the point of the exercise, not a finding.
+  // Match on the derived slug shapes too, so "Cerebras" in a query is
+  // recognised as the tracked "Cerebras" entry regardless of punctuation.
+  const tracked = new Set();
+  for (const c of cfg?.tracked_companies ?? []) {
+    if (typeof c?.name !== 'string') continue;
+    tracked.add(c.name.toLowerCase());
+    for (const s of deriveSlugCandidates(c.name)) tracked.add(s);
+  }
+
+  /** @type {Map<string, Set<string>>} */
+  const byHint = new Map();
+  for (const entry of cfg?.search_queries ?? []) {
+    if (entry?.enabled === false || typeof entry?.query !== 'string') continue;
+    for (const hint of companyHintsFromQuery(entry.query, stopwords)) {
+      if (tracked.has(hint)) continue;
+      if (!byHint.has(hint)) byHint.set(hint, new Set());
+      byHint.get(hint).add(String(entry.name ?? '(unnamed)'));
+    }
+  }
+
+  return [...byHint.entries()]
+    .map(([hint, sources]) => ({ hint, sources: [...sources].sort() }))
+    .sort((a, b) => a.hint.localeCompare(b.hint));
 }
 
 /**
@@ -502,6 +699,74 @@ async function runAdd(name, { fetchJson }) {
   }
 }
 
+/**
+ * Probe every company named in search_queries but not tracked.
+ *
+ * Stops at the first resolving slug per company: the goal is a yes/no on "is
+ * there a board here", and the ATS directories rate-limit hard enough that
+ * exhaustively probing every variant of every hint would poison the run.
+ *
+ * @returns {Promise<{hint: string, sources: string[], hit: object|null}[]>}
+ */
+export async function findUnmined(cfg, { fetchJson = defaultFetchJson, onProgress } = {}) {
+  const results = [];
+  for (const { hint, sources } of unminedHints(cfg)) {
+    let hit = null;
+    outer: for (const slug of deriveSlugCandidates(hint)) {
+      for (const ats of Object.keys(ATS)) {
+        const r = await probeSlug(ats, slug, { fetchJson });
+        if (r.status === 'live' || r.status === 'empty') { hit = r; break outer; }
+      }
+    }
+    results.push({ hint, sources, hit });
+    onProgress?.({ hint, hit });
+  }
+  return results;
+}
+
+async function runUnmined(filePath, { fetchJson }) {
+  if (!existsSync(filePath)) {
+    console.log(`verify-portals: no portals file at ${filePath} — nothing to check.`);
+    return 0;
+  }
+  const cfg = yaml.load(readFileSync(filePath, 'utf8')) || {};
+  const hints = unminedHints(cfg);
+  if (hints.length === 0) {
+    console.log('No untracked companies named in search_queries. Nothing to mine.');
+    return 0;
+  }
+
+  console.log(
+    `Probing ${hints.length} company name(s) found only in search_queries, across ${Object.keys(ATS).join('/')}...\n`,
+  );
+  const results = await findUnmined(cfg, { fetchJson });
+  const found = results.filter((r) => r.hit);
+
+  const probed = Object.keys(ATS).join('/');
+  for (const { hint, sources, hit } of results) {
+    if (!hit) {
+      // Deliberately not "no board": only the three slug-addressable ATSs are
+      // probed. AMD and Apple genuinely do have boards — on Workday and their
+      // own stack — which need tenant/site identifiers this can't guess.
+      console.log(`  ·  ${hint} — no ${probed} board (may still be on Workday, Gem, or a custom site)`);
+      continue;
+    }
+    const detail = hit.status === 'live' ? `${hit.jobCount} jobs` : 'live but empty';
+    console.log(`  ${ICON[hit.status]} ${hint} — ${hit.ats}/${hit.slug} (${detail})`);
+    console.log(`       named in: ${sources.join(', ')}`);
+  }
+
+  if (found.length) {
+    console.log(
+      `\n${found.length} of ${results.length} have a real board. A search_queries entry only ` +
+        'produces links for a human;\nmove these to tracked_companies so the scanner actually reads them.',
+    );
+  } else {
+    console.log('\nNo scannable boards behind these names — the search entries are earning their keep.');
+  }
+  return found.length;
+}
+
 async function main() {
   const args = process.argv.slice(2);
   const strict = args.includes('--strict');
@@ -510,6 +775,15 @@ async function main() {
   const addFlag = args.indexOf('--add');
   if (addFlag !== -1) {
     await runAdd(args[addFlag + 1] || '', { fetchJson });
+    return;
+  }
+
+  if (args.includes('--unmined')) {
+    const f = args.indexOf('--file');
+    const p = resolve(f === -1 ? DEFAULT_PORTALS_PATH : args[f + 1] || '');
+    const n = await runUnmined(p, { fetchJson });
+    // --strict makes this a CI gate: an unmined board is a silent coverage hole.
+    if (strict && n > 0) process.exit(1);
     return;
   }
 


### PR DESCRIPTION
Closes #2693.

## The blind spot

A `search_queries` entry only produces links for a human to open. It never feeds
the zero-LLM scanner. So a company named **only** inside a query string is
invisible to every scan — and nothing reports it: the entry validates,
`verify-portals` passes, the scan succeeds, and the company simply never appears.

Found in my own `portals.yml`:

```yaml
- name: Tesla / Groq / Cerebras — silicon
  query: '(site:tesla.com/careers OR site:groq.com/careers OR site:cerebras.ai/careers) ("RTL" OR ...)'
```

Cerebras has a live Ashby board with **123 postings**. Together AI (Greenhouse,
59) and Baseten (Ashby, 66) were the same story from other entries. ~250
postings never scanned, with no signal anywhere.

## `node verify-portals.mjs --unmined`

Extracts the companies a query names, drops the ones that are really search
vocabulary, probes what survives, reports which have a real board.

**Stopwords come from the user's own `title_filter` / `location_filter`**, not a
hardcoded list — retuning the search retunes the filter. Including individual
*words*, because queries quote fragments (`"Verification"`, `"AI"`) of keywords
(`Design Verification`, `AI Engineer`); whole-phrase matching alone reported
both as company names. A partial overlap survives: "Physical Intelligence" is
kept against a `Physical Design` filter because "intelligence" is the company's
own word.

**Probing stops at the first resolving slug per company.** The ATS directories
rate-limit hard enough that exhausting every variant would poison the run for
whatever is probed after it. Derived variants are still needed —
`together.ai`'s board is `togetherai`, so the bare host label misses it.

**Scope is stated, not implied.** Only Greenhouse/Ashby/Lever are probed, since
a slug is the whole address there. The output says *"no Greenhouse/Ashby/Lever
board"*, not *"no board"* — AMD and Apple do have boards, just not guessable
ones. This would have caught Cerebras but **not** Groq, who moved to Gem. That
limitation is in the module header, the `--help`, and the output itself.

`--strict` turns it into a CI gate.

## Testing

Rebased onto today's `main`; `node test-all.mjs` → **3432 passed, 0 failed**.

22 tests, network-free via injected `fetchJson`. Live run against a real
49-keyword config: 10 company names extracted with zero noise, one new finding
(`astrus` → lever, live but empty).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `--unmined` option to discover company names found in enabled search queries but not yet tracked.
  * Checks likely Greenhouse, Ashby, and Lever board addresses and reports reachable results.
  * Added `--strict` mode to fail verification when unmined boards are detected.

* **Documentation**
  * Updated command usage guidance for the new portal discovery and strict verification options.

* **Tests**
  * Added network-free coverage for discovery, filtering, aggregation, probing, and early-stop scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->