### PR TITLE
feat(scan): record the titles the filter rejects

### DIFF
--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -43,7 +43,7 @@ import lever from './providers/lever.mjs';
 import ashby from './providers/ashby.mjs';
 import workday from './providers/workday.mjs';
 import icims from './providers/icims.mjs';
-import { buildTitleFilter, buildLocationFilter, buildContentFilter, matchedTitleKeywords, loadSeenUrls, normalizeUrlForDedup, appendToPipeline, appendToScanHistory, loadBlacklist, parseSinceDays } from './scan.mjs';
+import { buildTitleFilter, buildLocationFilter, buildContentFilter, matchedTitleKeywords, recordTitleReject, flushTitleRejects, loadSeenUrls, normalizeUrlForDedup, appendToPipeline, appendToScanHistory, loadBlacklist, parseSinceDays } from './scan.mjs';
 import { SEED_SOURCES, toPortalEntry } from './seeds/vc-portfolios.mjs';
 import { normalizeCompany } from './tracker-utils.mjs';
 
@@ -397,7 +397,14 @@ export function filterBlacklistedOffers(offers, blacklist, { includeBlacklisted 
 // (#1846) unit-testable without mocking providers or duplicating the rule
 // order in two places for the caller that doesn't need per-stage counts.
 export function passesFilters(job, { titleFilter, locationFilter, contentFilter, titleFilterConfig }) {
-  if (!titleFilter(job.title)) return false;
+  if (!titleFilter(job.title)) {
+    // Both title-reject sites record: this pure helper serves the legacy path
+    // while the loop below has its own inline check for the per-stage counters.
+    // Patching only one left the log empty on the path the scanner actually
+    // takes, which is exactly the kind of silence this log exists to end.
+    recordTitleReject(job.title, job.company, job.source);
+    return false;
+  }
   // job.url is passed so the location filter can fall back to the URL's own
   // location segment when the provider reports a rolled-up "N Locations" string;
   // job.title so a title-stated remote role survives a city-only location.
@@ -717,7 +724,7 @@ async function main() {
       }
       if (dateClass === 'stale') continue;
       if (dateClass === 'undated' && !opts.includeUndated) { droppedNoDate++; continue; }
-      if (!titleFilter(job.title)) continue;
+      if (!titleFilter(job.title)) { recordTitleReject(job.title, job.company, job.source || ats); continue; }
       // job.url is passed so the location filter can fall back to the URL's own
       // location segment when the provider reports a rolled-up "N Locations" string;
       // job.title so a title-stated remote role survives a city-only location.
@@ -1057,8 +1064,21 @@ async function main() {
 
 // Only run main() when invoked directly, not when imported by tests.
 if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
-  main().catch(err => {
-    console.error('Fatal:', err.message);
-    process.exit(1);
-  });
+  main()
+    .catch(err => {
+      console.error('Fatal:', err.message);
+      process.exitCode = 1;
+    })
+    // Covers every exit path — main() has several early returns, and a crash
+    // partway through a sweep still leaves rejects worth keeping.
+    //
+    // Deliberately NOT guarded by --dry-run, unlike the pipeline and
+    // scan-history writes. That guard exists so a rehearsal never adds work to
+    // the user's queue or claims results it did not save; a bounded diagnostic
+    // file under data/ does neither. Guarding it would also leave the log empty
+    // on the surface most scans come from — the web Explorer always passes
+    // --dry-run.
+    .finally(() => {
+      try { flushTitleRejects(); } catch { /* never fail a scan over its own telemetry */ }
+    });
 }

--- a/scan.mjs
+++ b/scan.mjs
@@ -1870,6 +1870,106 @@ export function loadBlacklist(filePath = BLACKLIST_PATH) {
   return parseBlacklist(readFileSync(filePath, 'utf-8'));
 }
 
+// ── Title-reject log ────────────────────────────────────────────────
+//
+// Every scan throws away far more than it keeps — on one measured run, 6,499
+// of 8,289 postings were rejected on title alone. Only the count survived, in
+// scan-runs.tsv's filtered_title, which means the question that actually
+// matters ("is my keyword list missing something?") has no evidence behind it
+// and has to be answered by guessing synonyms.
+//
+// Recording the titles makes it derivable instead: the near-miss set is
+// (rejected titles) ∩ (vocabulary in cv.md) − (current positives). That
+// updates itself when the CV changes, with no keyword curation by hand.
+//
+// Deliberately records the FACT, not the reason. Which negative keyword
+// rejected a title is recomputable offline from portals.yml by whatever reads
+// this — paying for it inside the hot loop, 6,499 times a scan, buys nothing.
+
+const SCAN_REJECTS_PATH = process.env.CAREER_OPS_SCAN_REJECTS || 'data/scan-rejects.tsv';
+export const SCAN_REJECTS_HEADER = 'title\tcompany\tsource\tlast_seen\ttimes_seen\n';
+
+// Distinct titles worth keeping. The near-miss analysis cares about the variety
+// of language the market uses, not how often one posting reappears — so the log
+// is deduped by title and capped rather than being an append-only stream that
+// grows by thousands per scan.
+const SCAN_REJECTS_CAP = 5000;
+
+const rejectBuffer = new Map(); // normalized title → row
+
+/** Buffer one rejected title. Cheap by design: called in the scan's hot loop. */
+export function recordTitleReject(title, company = '', source = '') {
+  const t = (title || '').trim();
+  if (!t) return;
+  const key = t.toLowerCase().replace(/\s+/g, ' ');
+  const prev = rejectBuffer.get(key);
+  if (prev) { prev.times += 1; return; }
+  rejectBuffer.set(key, { title: t, company: company || '', source: source || '', times: 1 });
+}
+
+export function rejectBufferSize() { return rejectBuffer.size; }
+
+/**
+ * Merge the buffer into the log and write once, at the end of a scan.
+ *
+ * Merged rather than overwritten so vocabulary seen in earlier scans is not
+ * lost when a later scan happens to use narrower sources. Newest-first on
+ * last_seen, then truncated — an old title that stopped appearing is the first
+ * thing to drop.
+ */
+export function flushTitleRejects(filePath = SCAN_REJECTS_PATH, now = new Date()) {
+  if (rejectBuffer.size === 0) return 0;
+  const stamp = now.toISOString().slice(0, 10);
+  const rows = new Map();
+
+  try {
+    if (existsSync(filePath)) {
+      const lines = readFileSync(filePath, 'utf-8').split('\n').filter((l) => l.trim());
+      for (const line of lines.slice(1)) {
+        const [title, company, source, lastSeen, times] = line.split('\t');
+        if (!title) continue;
+        rows.set(title.toLowerCase().replace(/\s+/g, ' '), {
+          title, company: company || '', source: source || '',
+          lastSeen: lastSeen || '', times: Number(times) || 1,
+        });
+      }
+    }
+  } catch {
+    // Unreadable log → start fresh rather than losing this scan's evidence too.
+  }
+
+  for (const [key, r] of rejectBuffer) {
+    const prev = rows.get(key);
+    rows.set(key, {
+      title: r.title,
+      company: r.company || prev?.company || '',
+      source: r.source || prev?.source || '',
+      lastSeen: stamp,
+      times: (prev?.times || 0) + r.times,
+    });
+  }
+  rejectBuffer.clear();
+
+  const sorted = [...rows.values()]
+    .sort((a, b) => (b.lastSeen || '').localeCompare(a.lastSeen || '') || b.times - a.times)
+    .slice(0, SCAN_REJECTS_CAP);
+
+  try {
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    // Tabs and newlines in a scraped title would shear the columns.
+    const clean = (s) => String(s).replace(/[\t\r\n]+/g, ' ').trim();
+    writeFileSync(
+      filePath,
+      SCAN_REJECTS_HEADER + sorted.map((r) => [clean(r.title), clean(r.company), clean(r.source), r.lastSeen, r.times].join('\t')).join('\n') + '\n',
+      'utf-8',
+    );
+  } catch {
+    // Best-effort: failing to log rejects must never fail the scan itself.
+    return 0;
+  }
+  return sorted.length;
+}
+
 // ── Scan-run persistence (#1604) ────────────────────────────────────
 
 const SCAN_RUNS_PATH = 'data/scan-runs.tsv';
@@ -2391,6 +2491,7 @@ async function main() {
 
         if (!titleFilter(job.title)) {
           totalFilteredTitle++;
+          recordTitleReject(job.title, company.name, sourceName);
           continue;
         }
         if (classifyTier && skipTiers.includes(classifyTier(job.title))) {
@@ -2758,6 +2859,10 @@ async function main() {
       filteredPostedDate: totalFilteredPostedDate,
       filteredCountryEligibility: totalFilteredCountryEligibility,
     });
+    // Written once, at the end — the recorder buffers in memory so the hot loop
+    // never touches disk. Guarded with the other writes: a --dry-run must leave
+    // no trace.
+    flushTitleRejects();
   }
 
   console.log(`\n→ Run /career-ops pipeline to evaluate new offers.`);

--- a/tests/scan-reject-log.test.mjs
+++ b/tests/scan-reject-log.test.mjs
@@ -1,0 +1,103 @@
+// tests/scan-reject-log.test.mjs — the title-reject log.
+//
+// Network-free by construction. The live scanners were useless for verifying
+// this: the ATS directories rate-limit hard after a few sweeps (190 of 240
+// boards unreachable in one attempt), so a run can retrieve nothing at all and
+// an empty log is indistinguishable from a broken recorder. These call the
+// filter path directly.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { recordTitleReject, flushTitleRejects, rejectBufferSize, buildTitleFilter, buildLocationFilter } from '../scan.mjs';
+import { passesFilters } from '../scan-ats-full.mjs';
+
+const tmp = () => join(mkdtempSync(join(tmpdir(), 'co-rej-')), 'scan-rejects.tsv');
+const rows = (f) => readFileSync(f, 'utf-8').split('\n').filter((l) => l.trim()).slice(1).map((l) => l.split('\t'));
+
+test('dedupes by title and counts repeats', () => {
+  const f = tmp();
+  recordTitleReject('Staff Product Designer', 'Airwallex', 'ashby');
+  recordTitleReject('Staff Product Designer', 'Airwallex', 'ashby');
+  recordTitleReject('Strategic Account Director', 'Cadence', 'workday');
+  assert.equal(rejectBufferSize(), 2, 'buffer holds distinct titles, not occurrences');
+  assert.equal(flushTitleRejects(f), 2);
+  const r = rows(f);
+  assert.equal(r.length, 2);
+  assert.equal(r.find((x) => x[0] === 'Staff Product Designer')[4], '2', 'repeat counted');
+  rmSync(f, { force: true });
+});
+
+test('the buffer is drained by a flush', () => {
+  const f = tmp();
+  recordTitleReject('A Title', 'Co', 'greenhouse');
+  flushTitleRejects(f);
+  assert.equal(rejectBufferSize(), 0, 'a second flush must not rewrite the same rejects');
+  assert.equal(flushTitleRejects(f), 0, 'nothing buffered → no write, no empty file churn');
+  rmSync(f, { force: true });
+});
+
+test('merges with an existing log instead of replacing it', () => {
+  // A later scan over narrower sources must not erase vocabulary an earlier one
+  // saw — the near-miss analysis reads the accumulated set.
+  const f = tmp();
+  recordTitleReject('Older Title', 'Co1', 'lever');
+  flushTitleRejects(f);
+  recordTitleReject('Newer Title', 'Co2', 'ashby');
+  flushTitleRejects(f);
+  const titles = rows(f).map((r) => r[0]);
+  assert.ok(titles.includes('Older Title') && titles.includes('Newer Title'));
+  rmSync(f, { force: true });
+});
+
+test('times_seen accumulates across separate scans', () => {
+  const f = tmp();
+  recordTitleReject('Recurring Title', 'Co', 'lever');
+  flushTitleRejects(f);
+  recordTitleReject('Recurring Title', 'Co', 'lever');
+  flushTitleRejects(f);
+  assert.equal(rows(f)[0][4], '2');
+  rmSync(f, { force: true });
+});
+
+test('tabs and newlines in a scraped title cannot shear the columns', () => {
+  const f = tmp();
+  recordTitleReject('Bad\tTitle\nWith Breaks', 'Co', 'greenhouse');
+  flushTitleRejects(f);
+  const raw = readFileSync(f, 'utf-8').split('\n').filter((l) => l.trim());
+  assert.equal(raw.length, 2, 'one header plus exactly one data row');
+  assert.equal(raw[1].split('\t').length, 5);
+  rmSync(f, { force: true });
+});
+
+test('an unwritable path fails silently — a scan is never lost over its telemetry', () => {
+  recordTitleReject('Some Title', 'Co', 'lever');
+  assert.equal(flushTitleRejects('/proc/definitely/not/writable/x.tsv'), 0);
+  assert.equal(rejectBufferSize(), 0, 'buffer still drained, so the next flush is clean');
+});
+
+test('passesFilters records the titles it rejects', () => {
+  // The path the reverse scanner actually takes. Patching only the inline check
+  // left this one silent, and rate limiting hid it.
+  const f = tmp();
+  const titleFilter = buildTitleFilter({ positive: ['Inference'], negative: ['Sales'] });
+  const locationFilter = buildLocationFilter(null);
+  const job = (title) => ({ title, company: 'Co', source: 'greenhouse', location: '', url: '' });
+
+  assert.equal(passesFilters(job('Senior Inference Engineer'), { titleFilter, locationFilter, contentFilter: null }), true);
+  assert.equal(passesFilters(job('Strategic Account Director'), { titleFilter, locationFilter, contentFilter: null }), false);
+  assert.equal(passesFilters(job('Staff Product Designer'), { titleFilter, locationFilter, contentFilter: null }), false);
+
+  assert.equal(rejectBufferSize(), 2, 'only the rejected titles are recorded');
+  flushTitleRejects(f);
+  const titles = rows(f).map((r) => r[0]);
+  assert.ok(!titles.includes('Senior Inference Engineer'), 'an accepted title is not logged');
+  rmSync(f, { force: true });
+});
+
+test('empty and whitespace titles are ignored', () => {
+  recordTitleReject('', 'Co', 'lever');
+  recordTitleReject('   ', 'Co', 'lever');
+  assert.equal(rejectBufferSize(), 0);
+});

--- a/tests/scan-reject-log.test.mjs
+++ b/tests/scan-reject-log.test.mjs
@@ -7,7 +7,7 @@
 // filter path directly.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { recordTitleReject, flushTitleRejects, rejectBufferSize, buildTitleFilter, buildLocationFilter } from '../scan.mjs';
@@ -72,9 +72,24 @@ test('tabs and newlines in a scraped title cannot shear the columns', () => {
 });
 
 test('an unwritable path fails silently — a scan is never lost over its telemetry', () => {
+  // The unwritable path has to be unwritable on every runner, and the obvious
+  // spellings are not. `/proc/...` is only special on Linux: on Windows it
+  // resolves to C:\proc\... and flush's `mkdirSync(recursive)` CREATES it under
+  // the runner's admin token, so the write succeeds and this assertion fails on
+  // exactly the platform that never sees a /proc. chmod is no better — it is a
+  // no-op for the owner on Windows.
+  //
+  // A regular FILE standing where a directory must be is refused identically
+  // everywhere (ENOTDIR on POSIX, ENOENT/ENOTDIR on Windows), by the filesystem
+  // rather than by permissions, so it needs no privileges to set up and cannot
+  // be defeated by having too many.
+  const blocked = join(mkdtempSync(join(tmpdir(), 'co-rej-')), 'not-a-directory');
+  writeFileSync(blocked, 'this is a file, not a directory');
+
   recordTitleReject('Some Title', 'Co', 'lever');
-  assert.equal(flushTitleRejects('/proc/definitely/not/writable/x.tsv'), 0);
+  assert.equal(flushTitleRejects(join(blocked, 'scan-rejects.tsv')), 0);
   assert.equal(rejectBufferSize(), 0, 'buffer still drained, so the next flush is clean');
+  rmSync(blocked, { force: true });
 });
 
 test('passesFilters records the titles it rejects', () => {


### PR DESCRIPTION
Closes #2695.

## The gap

Every scan discards far more than it keeps — **6,499 of 8,289 postings on title
alone** in one measured run — and only the *count* survives, in `scan-runs.tsv`'s
`filtered_title`.

So "is my keyword list missing something?" has no evidence behind it and can only
be answered by guessing synonyms. Guessing demonstrably does not work: auditing
one 49-keyword filter (#2694) found 8 keywords that had never matched anything.

## What it does

Records the rejected titles to `data/scan-rejects.tsv`, so the near-miss set
becomes **derivable** rather than guessed:

```
(rejected titles) ∩ (cv.md vocabulary) − (current positives)
```

That updates itself when the CV changes and needs no keyword curation by hand.

- **Deduped by title, capped at 5,000.** The analysis cares about the variety of
  language the market uses, not how often one posting reappears.
- **Merged with the existing log on write**, so a later narrow scan cannot erase
  vocabulary an earlier broad one saw.
- **Buffered in memory, flushed once at the end** — the hot loop never touches
  disk. A write failure is swallowed: a scan is never lost over its telemetry.
- **Records the fact, not the reason.** Which negative keyword rejected a title
  is recomputable offline from `portals.yml`; paying for it inside the loop,
  thousands of times per scan, buys nothing.

## Two calls I'd rather agree on than defend in review

**1. The reverse scanner filters titles in two places** — the pure
`passesFilters()` helper and an inline check that keeps per-stage counters.
Patching only the inline one left the log empty on the path the scanner actually
takes, and rate limiting hid it. Both are patched here. Whether that duplication
should be collapsed is a separate change; happy to do it if you want it.

**2. Not guarded by `--dry-run`,** unlike the pipeline and scan-history writes.
My reasoning: that rule exists so a dry run cannot add to your queue or claim it
saved results, and a bounded diagnostic file under `data/` does neither — while
the web Explorer *always* passes `--dry-run`, so guarding it would leave the log
permanently empty on the main usage path. I can see the argument the other way
and will change it on request.

## Testing

Rebased onto today's `main`; `node test-all.mjs` → **3432 passed, 0 failed**.

8 tests, network-free by construction. The live scanners were useless for
verifying this — the ATS directories rate-limit hard enough that a run retrieves
nothing at all, and an empty log is indistinguishable from a broken recorder, so
the tests call the filter path directly. Column shearing from tabs/newlines in a
scraped title is covered, as is the two-call-site trap above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent tracking for titles rejected by scan filters, including title, company, source, and repeat counts.
  * Rejection records are deduplicated, sorted, limited in size, and retained across scans.

* **Bug Fixes**
  * Rejection data is saved even when a scan encounters an error.
  * Scan failures now preserve their original error message while completing cleanup reliably.

* **Tests**
  * Added coverage for rejection tracking, persistence, formatting, failure handling, and filter integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->