### PR TITLE
fix(set-status): the --role guard dropped every non-Latin letter, so it wrote to unmatched rows (#2670)

### DIFF
--- a/set-status-tests.mjs
+++ b/set-status-tests.mjs
@@ -233,6 +233,91 @@ const TRACKER_REPORT_MISMATCH = `# Applications Tracker
   rmSync(sb.dir, { recursive: true, force: true });
 }
 
+// ── 1f. Non-Latin titles must not all collapse to the same role (#2670) ─
+// The equality normalizer stripped `[^a-z0-9]`, which deletes every non-Latin
+// LETTER, not just punctuation. Any title written entirely in Japanese, Arabic
+// or Cyrillic keyed to "", two different titles compared equal ("" === ""), and
+// the guard that exists to stop a status reaching the wrong row accepted the
+// mismatch and wrote. The repo ships modes/ja/, modes/ar/ and modes/ru/, so
+// these are shipped-market titles, not exotica. Company matching already used
+// the Unicode-aware normalizeTextKey; only the role guard was left ASCII-only.
+{
+  const TRACKER_CJK = `# Applications Tracker
+
+| # | Date | Company | Role | Score | Status | PDF | Report | Notes |
+|---|------|---------|------|-------|--------|-----|--------|-------|
+| 1 | 2026-06-01 | リクルート | バックエンドエンジニア | 4.0/5 | Evaluated | ✅ | [1](../reports/001-recruit-2026-06-01.md) | — |
+`;
+  const sb = makeSandbox(TRACKER_CJK);
+  const before = readTracker(sb);
+  const r = runSetStatus(['リクルート', 'Rejected', '--role', 'フロントエンドエンジニア', '--json'], sb);
+  let parsed = null;
+  try { parsed = JSON.parse(r.stdout); } catch {}
+  if (r.code === 3 && parsed?.code === 'role-mismatch' && readTracker(sb) === before) {
+    pass('role-mismatch: a different Japanese title does not match (#2670)');
+  } else {
+    fail(`role-mismatch cjk: code=${r.code} json=${JSON.stringify(parsed)}\n${r.stdout}${r.stderr}`);
+  }
+
+  // Two titles differing ONLY by a parenthesised city — the fullwidth
+  // parentheses are punctuation and must still collapse, so what has to
+  // distinguish them is the city itself.
+  const sb2 = makeSandbox(`# Applications Tracker
+
+| # | Date | Company | Role | Score | Status | PDF | Report | Notes |
+|---|------|---------|------|-------|--------|-----|--------|-------|
+| 1 | 2026-06-01 | リクルート | エンジニア（東京） | 4.0/5 | Evaluated | ✅ | [1](../reports/001-recruit-2026-06-01.md) | — |
+`);
+  const before2 = readTracker(sb2);
+  const r2 = runSetStatus(['リクルート', 'Rejected', '--role', 'エンジニア（大阪）', '--json'], sb2);
+  if (r2.code === 3 && readTracker(sb2) === before2) {
+    pass('role-mismatch: same Japanese title, different city does not match (#2670)');
+  } else {
+    fail(`role-mismatch cjk-city: code=${r2.code}\n${r2.stdout}${r2.stderr}`);
+  }
+
+  // The guard must not over-fire: the SAME non-Latin title still proceeds,
+  // including across a Unicode normalization form (NFD input vs NFC row).
+  const r3 = runSetStatus(['リクルート', 'Applied', '--role', 'バックエンドエンジニア'], sb);
+  if (r3.code === 0 && /\| 1 \|[^\n]*\| Applied \|/.test(readTracker(sb))) {
+    pass('role-mismatch: the same Japanese title still proceeds (#2670)');
+  } else {
+    fail(`role-mismatch cjk-equal: code=${r3.code}\n${r3.stdout}${r3.stderr}`);
+  }
+  const nfdRole = "バックエンドエンジニア".normalize('NFD');
+  if (nfdRole === "バックエンドエンジニア") {
+    fail("role-mismatch cjk-nfd: fixture is not actually decomposed — the case would prove nothing");
+  }
+  const r4 = runSetStatus(["リクルート", 'Responded', '--role', nfdRole], sb);
+  if (r4.code === 0 && /\| 1 \|[^\n]*\| Responded \|/.test(readTracker(sb))) {
+    pass('role-mismatch: a decomposed (NFD) Japanese title still matches (#2670)');
+  } else {
+    fail(`role-mismatch cjk-nfd: code=${r4.code}\n${r4.stdout}${r4.stderr}`);
+  }
+  rmSync(sb.dir, { recursive: true, force: true });
+  rmSync(sb2.dir, { recursive: true, force: true });
+}
+
+// ── 1g. The same collapse hits Arabic and Cyrillic (#2670) ─
+// Not a CJK quirk: `[^a-z0-9]` deletes every letter outside the Latin range,
+// so modes/ar/ and modes/ru/ titles were equally unprotected.
+{
+  const sb = makeSandbox(`# Applications Tracker
+
+| # | Date | Company | Role | Score | Status | PDF | Report | Notes |
+|---|------|---------|------|-------|--------|-----|--------|-------|
+| 1 | 2026-06-01 | Яндекс | Разработчик | 4.0/5 | Evaluated | ✅ | [1](../reports/001-yandex-2026-06-01.md) | — |
+`);
+  const before = readTracker(sb);
+  const r = runSetStatus(['Яндекс', 'Rejected', '--role', 'Тестировщик', '--json'], sb);
+  if (r.code === 3 && readTracker(sb) === before) {
+    pass('role-mismatch: a different Cyrillic title does not match (#2670)');
+  } else {
+    fail(`role-mismatch cyrillic: code=${r.code}\n${r.stdout}${r.stderr}`);
+  }
+  rmSync(sb.dir, { recursive: true, force: true });
+}
+
 // ── 2. Update by company name (single match) ────────────────────
 {
   const sb = makeSandbox(TRACKER_9);

--- a/set-status-tests.mjs
+++ b/set-status-tests.mjs
@@ -318,6 +318,41 @@ const TRACKER_REPORT_MISMATCH = `# Applications Tracker
   rmSync(sb.dir, { recursive: true, force: true });
 }
 
+// ── 1h. Fullwidth C＃ / C＋＋ must not collapse together (#2670) ─
+// The symbol pre-map matches ASCII "#" and "++", but normalizeTextKey folds
+// NFKC AFTER it, so a fullwidth ＃/＋＋ reached the collapse still fullwidth, was
+// stripped as punctuation, and both titles keyed to "c engineer". Fullwidth
+// forms are ordinary Japanese typography, so this is the same shipped-market
+// surface as §1f. Pre-normalizing NFKC lets the ASCII pre-map see them.
+// The collision predates the #2670 fix — "[^a-z0-9]" dropped them too.
+{
+  const sb = makeSandbox(`# Applications Tracker
+
+| # | Date | Company | Role | Score | Status | PDF | Report | Notes |
+|---|------|---------|------|-------|--------|-----|--------|-------|
+| 1 | 2026-06-01 | Contoso | C＋＋ Engineer | 4.0/5 | Evaluated | ✅ | [1](../reports/001-contoso-2026-06-01.md) | — |
+`);
+  const before = readTracker(sb);
+  const r = runSetStatus(['contoso', 'SKIP', '--role', 'C＃ Engineer', '--json'], sb);
+  let parsed = null;
+  try { parsed = JSON.parse(r.stdout); } catch {}
+  if (r.code === 3 && parsed?.code === 'role-mismatch' && readTracker(sb) === before) {
+    pass('role-mismatch: fullwidth C＃ does not match a fullwidth C＋＋ row (#2670)');
+  } else {
+    fail(`role-mismatch fullwidth: code=${r.code} json=${JSON.stringify(parsed)}\n${r.stdout}${r.stderr}`);
+  }
+
+  // Not over-firing: the ASCII spelling of the SAME title still matches, which
+  // is exactly what the NFKC folding buys.
+  const r2 = runSetStatus(['contoso', 'Applied', '--role', 'C++ Engineer'], sb);
+  if (r2.code === 0 && /\| 1 \|[^\n]*\| Applied \|/.test(readTracker(sb))) {
+    pass('role-mismatch: ASCII "C++ Engineer" matches the fullwidth row (#2670)');
+  } else {
+    fail(`role-mismatch fullwidth-equal: code=${r2.code}\n${r2.stdout}${r2.stderr}`);
+  }
+  rmSync(sb.dir, { recursive: true, force: true });
+}
+
 // ── 2. Update by company name (single match) ────────────────────
 {
   const sb = makeSandbox(TRACKER_9);

--- a/set-status.mjs
+++ b/set-status.mjs
@@ -70,7 +70,7 @@
 import { readFileSync, existsSync, appendFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { extractTrackerReportNumbers, resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
+import { extractTrackerReportNumbers, resolveColumns, parseTrackerRow, normalizeTextKey } from './tracker-parse.mjs';
 import { roleFuzzyMatch } from './role-matcher.mjs';
 import {
   rebuildRow, resolveTrackerPath, writeFileAtomic, loadCanonicalStates, resolveCanonicalState,
@@ -408,15 +408,22 @@ if (isBareNumericSelector && !flags.force) {
 // entirely baseline vocabulary (["platform","engineer"]) so that same-titled
 // sibling reqs never auto-merge. That makes it unusable on its own here — it
 // would reject --role "Platform Engineer" against a row that IS exactly that.
-const normalizeRoleText = s => String(s ?? '')
-  .toLowerCase()
-  // Preserve symbols that distinguish real titles before collapsing generic
-  // punctuation — otherwise "C# Engineer" and "C++ Engineer" both fold to
-  // "c engineer" and the exact-equality path treats them as the same row.
-  .replace(/\+\+/g, ' plusplus ')
-  .replace(/#/g, ' sharp ')
-  .replace(/[^a-z0-9]+/g, ' ')
-  .trim();
+// The collapse must drop PUNCTUATION, never letters. `[^a-z0-9]` dropped every
+// letter outside the Latin range, so any title written entirely in Japanese,
+// Arabic or Cyrillic keyed to '' — two different titles then compared equal
+// ('' === '') and the guard wrote the status to a row it had never actually
+// matched (#2670). normalizeTextKey is the Unicode-aware normalizer company
+// matching already used; it also folds NFKC, so a decomposed title still
+// matches its composed row.
+const normalizeRoleText = s => normalizeTextKey(
+  String(s ?? '')
+    // Preserve symbols that distinguish real titles before collapsing generic
+    // punctuation — otherwise "C# Engineer" and "C++ Engineer" both fold to
+    // "c engineer" and the exact-equality path treats them as the same row.
+    .replace(/\+\+/g, ' plusplus ')
+    .replace(/#/g, ' sharp '),
+  ' ',
+);
 const roleMatchesTarget = normalizeRoleText(target.role) === normalizeRoleText(flags.role)
   || roleFuzzyMatch(target.role, flags.role);
 

--- a/set-status.mjs
+++ b/set-status.mjs
@@ -417,6 +417,13 @@ if (isBareNumericSelector && !flags.force) {
 // matches its composed row.
 const normalizeRoleText = s => normalizeTextKey(
   String(s ?? '')
+    // NFKC first: normalizeTextKey folds it too, but only AFTER this pre-map, so
+    // a fullwidth ＃/＋＋ would reach the collapse unrecognized and be stripped as
+    // punctuation — "C＃ Engineer" and "C＋＋ Engineer" both keying to
+    // "c engineer". Fullwidth forms are ordinary Japanese typography, so this is
+    // the same shipped-market surface as the rest of #2670. Folding here also
+    // makes the ASCII and fullwidth spellings of one title match each other.
+    .normalize('NFKC')
     // Preserve symbols that distinguish real titles before collapsing generic
     // punctuation — otherwise "C# Engineer" and "C++ Engineer" both fold to
     // "c engineer" and the exact-equality path treats them as the same row.


### PR DESCRIPTION
Closes #2670.

The `--role` guard exists to stop a status reaching the wrong tracker row (#2009). Its equality normalizer collapsed with `[^a-z0-9]+`, which drops every **letter** outside the Latin range, not just punctuation. Any title written entirely in a non-Latin script keys to `""`, two different titles compare equal, and the guard accepts the mismatch and writes.

## Reproduced before touching the code

```
"バックエンドエンジニア"  → ""
"フロントエンドエンジニア" → ""
"エンジニア（東京）"      → ""
"مهندس برمجيات"          → ""
"Разработчик"            → ""
"Platform Engineer"      → "platform engineer"
```

Driven through the real CLI on a sandbox tracker, asking to update a `バックエンドエンジニア` row while passing `--role フロントエンドエンジニア`:

```json
{"changed":true,"num":1,"company":"リクルート","role":"バックエンドエンジニア",
 "oldStatus":"Evaluated","newStatus":"Rejected","statusLogged":true}
```

Exit `0`. The guard did not merely fail to reject — it wrote the status, and logged the transition, against a row whose role it had never matched.

## Wider than the issue states

#2670 frames this as CJK. It is not: `[^a-z0-9]` deletes Arabic and Cyrillic letters just as completely, and the repo ships `modes/ar/` and `modes/ru/` alongside `modes/ja/`. These are shipped-market titles. The PR covers all three.

## The fix

`normalizeRoleText` now folds through `normalizeTextKey` from `tracker-parse.mjs` — the Unicode-aware normalizer **company** matching has used all along, so this removes an inconsistency rather than inventing a rule. The C#/C++ symbol pre-map is kept ahead of it and unchanged.

`normalizeTextKey` also applies NFKC, so a decomposed title still matches its composed row — a property the tests pin explicitly.

| Input | Before | After |
|---|---|---|
| `バックエンドエンジニア` | `""` | `バックエンドエンジニア` |
| `フロントエンドエンジニア` | `""` | `フロントエンドエンジニア` |
| `C++ Engineer` | `c plusplus engineer` | `c plusplus engineer` |
| `C# Engineer` | `c sharp engineer` | `c sharp engineer` |

## Test plan

`set-status-tests.mjs` §1c–1e covered Latin and C#/C++ only. New §1f and §1g, mirroring §1c's shape and driving the real CLI against a sandbox tracker:

- a different Japanese title is rejected, tracker byte-identical afterwards;
- two Japanese titles differing only by a parenthesised city are rejected — the fullwidth parens still collapse as punctuation, so the city is what separates them;
- the guard does not over-fire: the same Japanese title still proceeds;
- an **NFD-decomposed** Japanese title still matches its NFC row. The fixture asserts it is genuinely decomposed first, so the case cannot pass vacuously if the folding is removed;
- a different Cyrillic title is rejected.

- [x] The three rejection cases verified red before the fix (they exited `0` with `changed:true`); the two "still proceeds" cases pass before and after, which is what makes them guards.
- [x] `node set-status-tests.mjs` — 80 passed, 0 failed.
- [x] `node test-all.mjs` — 3430 passed, 0 failed (the single warning is the pre-existing `Dashboard build skipped — go compiler not in env`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved role matching for Japanese, Arabic, Cyrillic, and other Unicode titles.
  * Correctly handles equivalent Unicode text, including decomposed Japanese input.
  * Preserves distinctions between roles that differ by city or punctuation.
  * Keeps `C#` and `C++` titles distinct during matching.
  * Prevents mismatched titles from modifying tracker status.
* **Tests**
  * Added regression coverage for Unicode matching and safe failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->