### PR TITLE
fix(classify-tier): an incidental senior word outranked an explicit intern marker, so scan silently dropped internships

### DIFF
--- a/classify-tier.mjs
+++ b/classify-tier.mjs
@@ -79,20 +79,45 @@ export function classifyTier(title) {
     { pattern: /\bco-op\b/i, tier: 'intern', weight: 1 },
     {
       pattern: {
-        test: (t) => /\bgraduate\b/i.test(t) && /\b(program|scheme)\b/i.test(t)
+        test: (t) => /\bgraduate\b/i.test(t) && /\b(program|scheme)\b/i.test(t),
+        // Position of the level word itself, not of the "program" qualifier.
+        search: (t) => t.search(/\bgraduate\b/i)
       },
       tier: 'intern',
       weight: 1
     }
   ];
 
+  // POSITION decides, not seniority rank. Ranking by weight meant any senior
+  // word anywhere outranked an explicit programme marker, and in real titles
+  // that word is usually naming the team, office or person the role sits beside
+  // — "Summer Intern, Director of Product" is an internship. English job titles
+  // put the level first, so the LEFTMOST marker is the role's own level. That
+  // still reads "Senior Intern Coordinator" as senior: there the senior word
+  // genuinely leads the title.
+  //
+  // This is not cosmetic: scan.mjs drops a posting whose tier is in
+  // `skip_tiers` without naming it, so a junior candidate skipping `senior`
+  // silently lost the internships they were scanning for.
+  //
+  // Weight survives only as the tie-break for two markers at the same offset,
+  // which keeps the longer, more specific pattern of an overlapping pair
+  // (`mid-level` over `mid`, `entry-level` over `entry`).
   let bestMatch = null;
+  let bestIndex = Infinity;
 
   for (const matcher of matchers) {
-    if (matcher.pattern.test(cleanTitle)) {
-      if (!bestMatch || matcher.weight > bestMatch.weight) {
-        bestMatch = matcher;
-      }
+    // Match first: the graduate matcher is a COMPOUND condition (graduate AND
+    // program/scheme), so its position alone would fire on a bare "Graduate
+    // Engineer" that the condition itself rejects.
+    if (!matcher.pattern.test(cleanTitle)) continue;
+    const index = typeof matcher.pattern.search === 'function'
+      ? matcher.pattern.search(cleanTitle)
+      : cleanTitle.search(matcher.pattern);
+    if (index < 0) continue;
+    if (index < bestIndex || (index === bestIndex && matcher.weight > bestMatch.weight)) {
+      bestMatch = matcher;
+      bestIndex = index;
     }
   }
 

--- a/classify-tier.mjs
+++ b/classify-tier.mjs
@@ -81,7 +81,13 @@ export function classifyTier(title) {
       pattern: {
         test: (t) => /\bgraduate\b/i.test(t) && /\b(program|scheme)\b/i.test(t),
         // Position of the level word itself, not of the "program" qualifier.
-        search: (t) => t.search(/\bgraduate\b/i)
+        // Deliberately NOT named `search`: overloading a String.prototype method
+        // name on a matcher object makes `pattern.search(title)` read as the
+        // built-in, which coerces its argument to a RegExp — CodeQL flagged it
+        // as regex injection on the CLI's argv-derived title. The regex here is
+        // a literal and nothing is compiled from input, but the name was the
+        // problem, for a reader as much as for the analyzer.
+        levelWordIndex: (t) => t.search(/\bgraduate\b/i)
       },
       tier: 'intern',
       weight: 1
@@ -111,8 +117,8 @@ export function classifyTier(title) {
     // program/scheme), so its position alone would fire on a bare "Graduate
     // Engineer" that the condition itself rejects.
     if (!matcher.pattern.test(cleanTitle)) continue;
-    const index = typeof matcher.pattern.search === 'function'
-      ? matcher.pattern.search(cleanTitle)
+    const index = typeof matcher.pattern.levelWordIndex === 'function'
+      ? matcher.pattern.levelWordIndex(cleanTitle)
       : cleanTitle.search(matcher.pattern);
     if (index < 0) continue;
     if (index < bestIndex || (index === bestIndex && matcher.weight > bestMatch.weight)) {

--- a/classify-tier.mjs
+++ b/classify-tier.mjs
@@ -94,6 +94,33 @@ export function classifyTier(title) {
     }
   ];
 
+  // Guard (a): "Associate [*] Director/VP/Chief/Principal/Partner/Head-of" resolves
+  // to senior. The `associate` prefix qualifies the seniority band of a senior role;
+  // it does not demote it to entry-level. Works for both a direct compound
+  // ("Associate Director") and a broad one ("Associate Creative Director"). Checked
+  // before the position loop because `associate` always precedes the senior noun,
+  // so the leftmost-marker rule would fire on `associate` at index 0 and return entry.
+  const associateAt = cleanTitle.search(/\bassociate\b/i);
+  if (associateAt >= 0) {
+    const afterAssociate = cleanTitle.slice(associateAt + 'associate'.length);
+    if (/\b(director|vice\s+president|vp|principal|partner|chief|head\s+of)\b/i.test(afterAssociate)) {
+      return 'senior';
+    }
+  }
+
+  // Guard (b): [intern/entry marker] + [programme bridge noun] + [senior role noun]
+  // resolves to senior. "Intern Program Director" manages an intern programme; it is
+  // not itself an internship. The bridge-noun set is a closed list — a generic
+  // adjacency rule breaks "Junior Staff Accountant" (staff is a senior matcher but
+  // not a bridge word for this construction).
+  const programBridge = /\b(?:intern(?:ship)?|trainee|co-op|graduate|junior|entry(?:-level)?)\s+(?:program|scheme|talent|cohort)\b/i;
+  if (programBridge.test(cleanTitle)) {
+    const afterBridge = cleanTitle.replace(programBridge, ' ').trim();
+    if (/\b(chief|vp|vice\s+president|director|principal|staff|lead|senior|sr\.?|head\s+of|partner)\b/i.test(afterBridge)) {
+      return 'senior';
+    }
+  }
+
   // POSITION decides, not seniority rank. Ranking by weight meant any senior
   // word anywhere outranked an explicit programme marker, and in real titles
   // that word is usually naming the team, office or person the role sits beside

--- a/tests/classify-tier-position.test.mjs
+++ b/tests/classify-tier-position.test.mjs
@@ -71,6 +71,35 @@ try {
 
   // Non-string input keeps its documented fallback.
   check(null, 'mid');
+
+  // ── Guard (a): associate + senior-role noun → senior ──
+  // The `associate` prefix qualifies the seniority band; it does not make the
+  // role entry-level. Direct compound and broad compound (adjective between
+  // associate and the noun) must both resolve to senior.
+  check('Associate Director, Data Science', 'senior');
+  check('Associate Creative Director', 'senior');
+  check('Associate Vice President, Technology', 'senior');
+  check('Associate Principal Scientist', 'senior');
+  check('Associate Chief Nursing Officer', 'senior');
+  check('Associate Head of Product', 'senior');
+  check('Associate Director', 'senior');
+  // Guard: associate without a senior-role noun keeps its entry classification.
+  check('Associate Software Engineer', 'entry');
+  check('Associate Developer', 'entry');
+
+  // ── Guard (b): [level marker] + [programme bridge] + [senior noun] → senior ──
+  // "Intern Program Director" manages an intern programme; it is not an
+  // internship. Guard is scoped to a closed bridge-noun set so that
+  // "Junior Staff Accountant" (staff is a senior matcher, not a bridge) is
+  // unaffected — already pinned above.
+  check('Intern Program Director', 'senior');
+  check('Internship Program Director', 'senior');
+  check('Graduate Program Director', 'senior');
+  check('Graduate Scheme Lead', 'senior');
+  check('Trainee Program Director', 'senior');
+  check('Junior Talent Director', 'senior');
+  check('Junior Talent Lead', 'senior');
+  check('Entry-Level Program Director', 'senior');
 } catch (error) {
   fail(`classify-tier.mjs tests could not run: ${error.message}`);
 }

--- a/tests/classify-tier-position.test.mjs
+++ b/tests/classify-tier-position.test.mjs
@@ -1,0 +1,76 @@
+// tests/classify-tier-position.test.mjs — which level marker wins when a title
+// carries more than one.
+//
+// classifyTier resolved conflicts by SENIORITY RANK: senior(4) > mid(3) >
+// entry(2) > intern(1), highest wins. Real titles break that, because the
+// senior-sounding word is usually naming the team, office or person the role
+// sits next to, not the role's own level — "Summer Intern, Director of
+// Product" is an internship, not a directorship. Every such title classified
+// `senior`.
+//
+// It matters because scan.mjs:2396 drops a posting outright when its tier is in
+// `skip_tiers`, with no log line naming it. A junior candidate skipping
+// `senior` therefore lost exactly the internships they were scanning for.
+//
+// The rule under test is POSITION: English job titles put the level first, so
+// the LEFTMOST marker is the role's own. That also keeps "Senior Intern
+// Coordinator" senior — a role that manages interns, where `senior` genuinely
+// leads the title.
+import { pass, fail, ROOT } from './helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nclassify-tier.mjs — the leftmost level marker is the role\'s own');
+
+try {
+  const { classifyTier } = await import(pathToFileURL(join(ROOT, 'classify-tier.mjs')).href);
+
+  const check = (title, expected) => {
+    const got = classifyTier(title);
+    if (got === expected) pass(`"${title}" → ${expected}`);
+    else fail(`"${title}" → ${got}, expected ${expected}`);
+  };
+
+  // ── An incidental senior word must not outrank an explicit programme marker ──
+  check('Intern - Office of the Chief Technology Officer', 'intern');
+  check('Software Engineering Intern, Lead Generation Platform', 'intern');
+  check('Marketing Intern - Senior Living Community', 'intern');
+  check('Summer Intern, Director of Product', 'intern');
+  check('Graduate Trainee - Head of Retail Division', 'intern');
+
+  // ── Same for an explicit junior marker ──
+  check('Junior Developer - Team Lead Support', 'entry');
+  // Adjacent, no separator: "Staff Accountant" is the role, "Junior" the level.
+  check('Junior Staff Accountant', 'entry');
+
+  // ── The guard: a senior word that genuinely LEADS the title still wins ──
+  // A role that manages interns. This is the case seniority-rank ordering got
+  // right, and the position rule must not lose it.
+  check('Senior Intern Coordinator', 'senior');
+  check('Lead Software Engineer', 'senior');
+  check('VP of Engineering', 'senior');
+  check('Director of Engineering, Junior Talent', 'senior');
+
+  // ── Unambiguous titles are untouched ──
+  check('Software Engineer Intern', 'intern');
+  check('Junior Software Engineer', 'entry');
+  check('Senior Software Engineer', 'senior');
+  check('Software Engineer I', 'entry');
+  check('Software Engineer II', 'mid');
+  check('Software Engineer', 'mid');
+  // A numbered level still loses to a level word that leads the title.
+  check('Senior Software Engineer III', 'senior');
+  // ...and wins over one that trails it.
+  check('Engineer II - Senior Platform Group', 'mid');
+
+  // ── The acronym preprocessing must survive the change ──
+  check('A.I. Researcher', 'mid');
+  check('I.T. Specialist II', 'mid');
+  check('Graduate Engineer', 'mid');
+  check('Graduate Engineer Program', 'intern');
+
+  // Non-string input keeps its documented fallback.
+  check(null, 'mid');
+} catch (error) {
+  fail(`classify-tier.mjs tests could not run: ${error.message}`);
+}


### PR DESCRIPTION
No issue — found while auditing `classify-tier.mjs`, one of the core scripts with no test file. `CONTRIBUTING.md:22` welcomes a direct PR for a bug fix.

## The defect

`classifyTier` resolved conflicts by **seniority rank**: `senior(4) > mid(3) > entry(2) > intern(1)`, highest wins. So a single senior-sounding word anywhere in a title outranked an explicit programme marker.

Real titles break that, because that word is usually naming the team, office or person the role sits beside — not the role's own level. Measured on `main`:

| Title | `main` | Should be |
|---|---|---|
| `Intern - Office of the Chief Technology Officer` | **senior** | intern |
| `Summer Intern, Director of Product` | **senior** | intern |
| `Software Engineering Intern, Lead Generation Platform` | **senior** | intern |
| `Marketing Intern - Senior Living Community` | **senior** | intern |
| `Graduate Trainee - Head of Retail Division` | **senior** | intern |
| `Junior Developer - Team Lead Support` | **senior** | entry |
| `Junior Staff Accountant` | **senior** | entry |
| `Engineer II - Senior Platform Group` | **senior** | mid |

Every title carrying both an explicit junior/intern marker and any incidental senior word came out `senior`.

## Why it costs something

`scan.mjs:2396` drops a posting outright when its tier is in `skip_tiers`:

```js
if (classifyTier && skipTiers.includes(classifyTier(job.title))) {
  totalFilteredTier++;
  continue;
}
```

The counter is aggregate — no log line names the dropped posting. So the failure is silent, and it lands on the wrong side: a **junior candidate** setting `skip_tiers: [senior]` loses exactly the internships they are scanning for, and never learns they existed.

The reverse direction is only noise: `templates/portals.example.yml:266` suggests `skip_tiers: [intern, entry]` for senior candidates, who then keep seeing internships they asked to hide.

## The fix

**Position decides, not seniority rank.** English job titles put the level first, so the leftmost marker is the role's own.

That single rule also preserves the case rank ordering got right: `Senior Intern Coordinator` — a role that manages interns — stays `senior`, because there the senior word genuinely leads the title. Same for `Director of Engineering, Junior Talent`.

Weight survives only as the tie-break for two markers at the same offset, which keeps the longer pattern of an overlapping pair (`mid-level` over `mid`).

One subtlety: the graduate matcher is a compound condition (`graduate` AND `program|scheme`), so it needs its own position accessor and must still be `test`ed before its index is taken — otherwise a bare `Graduate Engineer` would match on the position of `graduate` alone. It carries a `search` returning the offset of the level word rather than of the qualifier.

## Test plan

`classify-tier.mjs` ships 15 inline cases behind `--test` but has no file under `tests/`. This adds `tests/classify-tier-position.test.mjs` (24 cases), picked up by `test-all.mjs` auto-discovery.

Every relaxation is paired with a case asserting the senior classification still fires when it should, and the unambiguous titles (`Software Engineer I/II`, `Senior Software Engineer`, `A.I. Researcher`, `I.T. Specialist II`) are pinned so the acronym preprocessing and the roman-numeral matchers are proven untouched.

- [x] 8 of the 24 verified red on `main`; the 4 guard cases pass before and after, which is what makes them guards.
- [x] `node classify-tier.mjs --test` — all 15 inline cases still pass, unchanged.
- [x] `node test-all.mjs` — 3454 passed, 0 failed (the single warning is the pre-existing `Dashboard build skipped — go compiler not in env`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved role tier classification by prioritizing the earliest matching title marker.
  * Refined seniority handling for associate-qualified senior roles and program-bridge titles.
  * Improved recognition of numbered levels, acronyms, graduate programs, and programme-director roles.
  * Preserved accurate handling of compound graduate-program and scheme titles.

* **Tests**
  * Added coverage for title ordering, seniority terms, numbered levels, acronym processing, graduate-program distinctions, and non-text fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->