### PR TITLE
fix(agent-inbox): stamp queued items in local time, not UTC

### DIFF
--- a/agent-inbox-tests.mjs
+++ b/agent-inbox-tests.mjs
@@ -123,5 +123,36 @@ console.log('6. first add on the default path self-heals .gitignore (idempotent)
   check('.gitignore gains exactly one data/agent-inbox.md rule', ruleCount === 1, `count=${ruleCount}`);
 }
 
+// ---------------------------------------------------------------------------
+console.log('7. items are stamped in LOCAL time, not UTC');
+{
+  // Two zones 26 hours apart, so their wall clocks NEVER agree — not on the
+  // hour, and on most instants not even on the date. A UTC stamp is identical
+  // in both, so "the two differ" is a complete test that cannot go green by
+  // accident of when it runs (a naive assertion against the host's own zone
+  // passes trivially in CI, where TZ is usually UTC).
+  const ZONES = ['Etc/GMT-14', 'Etc/GMT+12']; // POSIX sign: UTC+14 and UTC-12.
+  const stamps = ZONES.map((TZ) => {
+    const inbox = join(tmp('inbox-'), 'agent-inbox.md');
+    run(inbox, ['add', `tz probe ${TZ}`], { env: { ...process.env, CAREER_OPS_INBOX: inbox, TZ } });
+    const m = /^- \[ \] (\d{4}-\d{2}-\d{2} \d{2}:\d{2}) —/m.exec(readFileSync(inbox, 'utf8'));
+    return m && m[1];
+  });
+
+  check('both runs produced a well-formed stamp', stamps.every(Boolean), JSON.stringify(stamps));
+  check('stamps differ between UTC+14 and UTC-12 (i.e. they are local, not UTC)',
+    stamps[0] !== stamps[1], `${stamps[0]} vs ${stamps[1]}`);
+
+  // And each stamp is actually that zone's wall clock, not merely "different".
+  ZONES.forEach((TZ, i) => {
+    if (!stamps[i]) return;
+    // sv-SE renders as YYYY-MM-DD HH:MM:SS, so slicing to 16 matches stamp().
+    const expected = new Date().toLocaleString('sv-SE', { timeZone: TZ }).slice(0, 16);
+    // One minute of slack: the child may have run either side of a rollover.
+    const near = Math.abs(new Date(`${stamps[i]}Z`) - new Date(`${expected}Z`)) <= 60_000;
+    check(`stamp matches ${TZ} wall clock`, near, `got ${stamps[i]}, expected ~${expected}`);
+  });
+}
+
 console.log(`\nResults: ${passed} passed, ${failed} failed`);
 process.exit(failed ? 1 : 0);

--- a/agent-inbox.mjs
+++ b/agent-inbox.mjs
@@ -45,7 +45,17 @@ const HEADER = [
 ].join('\n');
 
 function stamp() {
-  return new Date().toISOString().slice(0, 16).replace('T', ' ');
+  // LOCAL time, never UTC. `new Date().toISOString()` stamps the UTC date, so
+  // anywhere west of Greenwich an evening `add` is filed under tomorrow: after
+  // 20:00 US Eastern, an item queued Tuesday night reads "Wednesday". The queue
+  // is a provenance log — when something was asked for is part of the record,
+  // and every artifact derived from it inherits the wrong day.
+  // Built from the local getters rather than a locale trick so the format is
+  // fixed regardless of the host's ICU data. Same reasoning as the local dates
+  // in work-search-log.mjs.
+  const d = new Date();
+  const p = (n) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ${p(d.getHours())}:${p(d.getMinutes())}`;
 }
 
 function ensureGitignored() {


### PR DESCRIPTION
### The bug

`stamp()` builds every queue entry's timestamp from `new Date().toISOString()`:

```js
function stamp() {
  return new Date().toISOString().slice(0, 16).replace('T', ' ');
}
```

That is the UTC clock. Anywhere west of Greenwich an evening `add` is filed under
tomorrow's date — after 20:00 US Eastern, an item queued Tuesday night reads Wednesday.

Observed in ordinary use rather than constructed. An item queued at **22:26 EDT** was written
to the queue as:

```
 6. [ ] 2026-08-12 02:26 — Fractional/advisory sweep …
```

### Why it matters beyond cosmetics

`data/agent-inbox.md` is a provenance log — `modes/agent-inbox.md` has the draining agent
append `→ result:` lines to it, so *when something was asked for* is part of the record, and
anything derived from the queue inherits the wrong day. The failure is also silent and
self-consistent: every stamp is wrong the same way, so nothing looks anomalous inside the file.


### The fix

Build the stamp from the local getters. Deliberately not `toLocaleString` with a locale that
happens to render ISO — the output format shouldn't depend on the host's ICU data.

### Test

Two zones **26 hours apart** — `Etc/GMT-14` (UTC+14) and `Etc/GMT+12` (UTC-12). Their wall
clocks never agree at any instant, so:

- the two stamps must differ, and
- each must match that zone's wall clock (one minute of slack for a rollover between the two
  child processes).

A UTC stamp is identical in both zones, so this cannot go green by accident of when it runs.
That mattered: the obvious version of this test — assert the stamp matches the host's local
time — passes trivially on CI, where `TZ` is usually UTC and local *is* UTC. It would have
proved nothing.

Verified failing against the unfixed code:

```
❌ stamps differ between UTC+14 and UTC-12 — 2026-08-12 02:33 vs 2026-08-12 02:33
❌ stamp matches Etc/GMT-14 wall clock — got 2026-08-12 02:33, expected ~2026-08-12 16:33
❌ stamp matches Etc/GMT+12 wall clock — got 2026-08-12 02:33, expected ~2026-08-11 14:33
Results: 17 passed, 3 failed
```

With the fix: `node agent-inbox-tests.mjs` → **20 passed, 0 failed**.
`node test-all.mjs` on a clean checkout of this branch → **3429 passed, 0 failed**, 2 warnings
(environmental: no user `cv.md`, no Go compiler for the dashboard build).

### Scope, and one sibling worth a follow-up

Deliberately limited to `agent-inbox.mjs`. The `new Date().toISOString()` idiom appears in a
dozen other files, and most are correct as-is — vCard `REV:` in `contacts.mjs` is specified as
UTC, lock and sentinel timestamps have no local meaning.

But **`followup-seed.mjs:94`** looks like the same defect with the same shape:

```js
return new Date().toISOString().slice(0, 10);
```

That value seeds the pinned first follow-up date, so an application marked Applied on a US
evening would get a follow-up date a day early. I haven't touched it here — separate concern,
separate review. Happy to send a follow-up PR if you'd like it fixed, or to leave it to you.

### Relationship to #2739

Independent. #2739 (open) changes `resolve` numbering in the same file; this touches only
`stamp()`. Branched from `main`, not from that PR. A textual conflict in the test file is
possible if both land — happy to rebase, in either order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Queue item timestamps now reflect the local date and time instead of UTC.
  * Timestamp formatting remains consistent as `YYYY-MM-DD HH:mm`.

* **Tests**
  * Added regression coverage for timestamp accuracy across different time zones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
