### PR TITLE
fix(reply-watch): reject unrecognized CLI flags instead of treating them as a candidates path

### DIFF
--- a/reply-watch.mjs
+++ b/reply-watch.mjs
@@ -214,16 +214,16 @@ const USAGE = 'Usage: node reply-watch.mjs [path/to/candidates.json]';
 async function main() {
   const args = process.argv.slice(2);
 
-  if (args.includes('--help') || args.includes('-h')) {
-    console.log(USAGE);
-    process.exit(0);
-  }
-
   const positional = args.filter(a => !a.startsWith('-'));
   const unknownFlags = args.filter(a => a.startsWith('-') && !KNOWN_FLAGS.includes(a));
   if (unknownFlags.length > 0) {
     console.error(`Error: unrecognized flag(s): ${unknownFlags.join(', ')}. Valid flags: ${KNOWN_FLAGS.join(', ')}`);
     process.exit(1);
+  }
+
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(USAGE);
+    process.exit(0);
   }
 
   const candidatesPath = positional[0] || DEFAULT_CANDIDATES_PATH;

--- a/reply-watch.mjs
+++ b/reply-watch.mjs
@@ -208,8 +208,25 @@ async function updateTrackerStatuses(updates) {
   }
 }
 
+const KNOWN_FLAGS = ['--help', '-h'];
+const USAGE = 'Usage: node reply-watch.mjs [path/to/candidates.json]';
+
 async function main() {
-  const candidatesPath = process.argv[2] || DEFAULT_CANDIDATES_PATH;
+  const args = process.argv.slice(2);
+
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(USAGE);
+    process.exit(0);
+  }
+
+  const positional = args.filter(a => !a.startsWith('-'));
+  const unknownFlags = args.filter(a => a.startsWith('-') && !KNOWN_FLAGS.includes(a));
+  if (unknownFlags.length > 0) {
+    console.error(`Error: unrecognized flag(s): ${unknownFlags.join(', ')}. Valid flags: ${KNOWN_FLAGS.join(', ')}`);
+    process.exit(1);
+  }
+
+  const candidatesPath = positional[0] || DEFAULT_CANDIDATES_PATH;
   ensureCandidatesFile(candidatesPath);
 
   if (!fs.existsSync(candidatesPath)) {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -376,6 +376,61 @@ try {
       fail(`${name} crashed${formatRunFailure()}`);
     }
   }
+
+  // reply-watch.mjs CLI flag validation (#2743). main() used to read
+  // process.argv[2] purely positionally with no flag checking: `--help` or
+  // any typo'd flag silently became the "candidates path" argument, and
+  // since that "path" doesn't exist, ensureCandidatesFile() created a real
+  // file named e.g. `--help` on disk. Mirrors the scan-ats-full.mjs
+  // KNOWN_FLAGS precedent (#1633/#1635): --help/-h print usage and exit 0,
+  // any other flag-looking arg is rejected with exit 1 — neither path
+  // should ever touch the filesystem.
+  {
+    const replyWatchCli = (...argv) => spawnSync(NODE, [join(scriptTmp, 'reply-watch.mjs'), ...argv], {
+      cwd: scriptTmp,
+      encoding: 'utf-8',
+      timeout: 30000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    const helpR = replyWatchCli('--help');
+    const hR = replyWatchCli('-h');
+    const bogusR = replyWatchCli('--bogus');
+
+    const helpOk = helpR.status === 0 && /Usage:/.test(helpR.stdout)
+      && !existsSync(join(scriptTmp, '--help'));
+    const hOk = hR.status === 0 && /Usage:/.test(hR.stdout)
+      && !existsSync(join(scriptTmp, '-h'));
+    const bogusOk = bogusR.status === 1 && /unrecognized flag/.test(bogusR.stderr)
+      && bogusR.stderr.includes('--bogus') && !existsSync(join(scriptTmp, '--bogus'));
+
+    if (helpOk && hOk && bogusOk) {
+      pass('reply-watch.mjs rejects --help/-h/unrecognized flags without creating a stray candidates file (#2743)');
+    } else {
+      fail(`reply-watch.mjs flag validation broken: help=${JSON.stringify({ status: helpR.status, stdout: helpR.stdout, exists: existsSync(join(scriptTmp, '--help')) })} h=${JSON.stringify({ status: hR.status, stdout: hR.stdout, exists: existsSync(join(scriptTmp, '-h')) })} bogus=${JSON.stringify({ status: bogusR.status, stderr: bogusR.stderr, exists: existsSync(join(scriptTmp, '--bogus')) })}`);
+    }
+
+    // Regression: the existing no-args-uses-default and explicit-path
+    // behaviors must be unchanged by the new flag-parsing gate. Both run to
+    // completion here — the copied scriptTmp tracker has zero rows, so no
+    // candidates ever match an application, no update-recommendation prompt
+    // fires, and the process exits on its own without touching stdin.
+    const defaultCandidatesFile = join(scriptTmp, 'data', 'reply-candidates.json');
+    const noArgsR = replyWatchCli();
+    const noArgsOk = noArgsR.status === 0 && existsSync(defaultCandidatesFile)
+      && /application updates need review/.test(noArgsR.stdout);
+
+    const explicitPath = join(scriptTmp, 'my-candidates.json');
+    const explicitR = replyWatchCli(explicitPath);
+    const explicitOk = explicitR.status === 0 && existsSync(explicitPath)
+      && /application updates need review/.test(explicitR.stdout);
+
+    if (noArgsOk && explicitOk) {
+      pass('reply-watch.mjs no-args-uses-default and explicit-path behaviors unchanged (#2743 regression)');
+    } else {
+      fail(`reply-watch.mjs regression broken: noArgs=${JSON.stringify({ status: noArgsR.status, exists: existsSync(defaultCandidatesFile) })} explicit=${JSON.stringify({ status: explicitR.status, exists: existsSync(explicitPath) })}`);
+    }
+  }
 } finally {
   rmSync(scriptTmp, { recursive: true, force: true });
 }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -410,6 +410,19 @@ try {
       fail(`reply-watch.mjs flag validation broken: help=${JSON.stringify({ status: helpR.status, stdout: helpR.stdout, exists: existsSync(join(scriptTmp, '--help')) })} h=${JSON.stringify({ status: hR.status, stdout: hR.stdout, exists: existsSync(join(scriptTmp, '-h')) })} bogus=${JSON.stringify({ status: bogusR.status, stderr: bogusR.stderr, exists: existsSync(join(scriptTmp, '--bogus')) })}`);
     }
 
+    // CodeRabbit (#2745): --help paired with an unrecognized flag must still
+    // reject — unknown-flag validation has to run before --help short-circuits,
+    // otherwise `reply-watch.mjs --help --bogus` would exit 0 instead of erroring.
+    const mixedR = replyWatchCli('--help', '--bogus');
+    const mixedOk = mixedR.status === 1 && /unrecognized flag/.test(mixedR.stderr)
+      && mixedR.stderr.includes('--bogus') && !/Usage:/.test(mixedR.stdout)
+      && !existsSync(join(scriptTmp, '--help')) && !existsSync(join(scriptTmp, '--bogus'));
+    if (mixedOk) {
+      pass('reply-watch.mjs rejects an unrecognized flag even when --help is also present (#2745)');
+    } else {
+      fail(`reply-watch.mjs --help+--bogus should still error, not exit clean: ${JSON.stringify({ status: mixedR.status, stdout: mixedR.stdout, stderr: mixedR.stderr })}`);
+    }
+
     // Regression: the existing no-args-uses-default and explicit-path
     // behaviors must be unchanged by the new flag-parsing gate. Both run to
     // completion here — the copied scriptTmp tracker has zero rows, so no


### PR DESCRIPTION
## Summary
- `reply-watch.mjs`'s `main()` read `process.argv[2]` purely positionally with no flag validation, so `node reply-watch.mjs --help` (or any typo'd/unrecognized flag) was silently treated as the candidates.json path.
- Since that "path" didn't exist, `ensureCandidatesFile()` created a real file named e.g. `--help` on disk and ran a full classification pass against the mock fixture instead of printing usage or failing fast.
- Adds a `KNOWN_FLAGS` allowlist (`--help`, `-h`): `--help`/`-h` now print a short usage line and exit 0; any other flag-looking arg errors (`Error: unrecognized flag(s): ...`) and exits 1. Neither path touches the filesystem. The existing no-args-uses-default and explicit-path behaviors are unchanged.
- Mirrors the precedent already established in `scan-ats-full.mjs` for this exact failure class (#1633 / PR #1635).

Closes #2743

## Test plan
- [x] Added CLI-level tests to `test-all.mjs` (reusing the existing `scriptTmp` throwaway-copy smoke-test fixture, since `reply-watch.mjs` has no `--self-test` mode and its existing coverage lives in `test-all.mjs`, not a sibling `.test.mjs`):
  - `--help` / `-h` print usage, exit 0, and do not create any file.
  - `--bogus` errors, exits 1, and does not create any file.
  - Regression: no-args-uses-default and explicit-valid-path-argument behaviors run to completion unchanged.
- [x] `node test-all.mjs --quick` — 3431 passed, 0 failed, 1 pre-existing warning (unrelated to this change).
- [x] Manually verified pre-fix repro (`node reply-watch.mjs --help` created a stray `--help` file containing the mock fixture and ran a full classification pass) and post-fix behavior (`node reply-watch.mjs --help` now only prints usage and exits 0, no file created).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--help` and `-h` options with usage information.
  * Added support for specifying a candidates file path from the command line.
* **Bug Fixes**
  * Unrecognized command-line options now produce an error instead of being ignored.
  * Preserved default-path behavior when no file path is provided.
* **Tests**
  * Added regression coverage for help, invalid options, default paths, and explicit file paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->