### PR TITLE
fix(dedup-tracker): reject unrecognized flags instead of silently live-running

### DIFF
--- a/dedup-tracker.mjs
+++ b/dedup-tracker.mjs
@@ -33,15 +33,15 @@ const USAGE = `Usage: node dedup-tracker.mjs [--dry-run]`;
 
 const cliArgs = process.argv.slice(2);
 
-if (cliArgs.includes('--help') || cliArgs.includes('-h')) {
-  console.log(USAGE);
-  process.exit(0);
-}
-
 const unknownFlags = cliArgs.filter(a => a.startsWith('-') && !KNOWN_FLAGS.includes(a));
 if (unknownFlags.length) {
   console.error(`Error: unrecognized flag(s): ${unknownFlags.join(', ')}. Valid flags: ${KNOWN_FLAGS.join(', ')}`);
   process.exit(1);
+}
+
+if (cliArgs.includes('--help') || cliArgs.includes('-h')) {
+  console.log(USAGE);
+  process.exit(0);
 }
 
 const DRY_RUN = process.argv.includes('--dry-run');

--- a/dedup-tracker.mjs
+++ b/dedup-tracker.mjs
@@ -23,6 +23,27 @@ const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 // (original). CAREER_OPS_TRACKER lets tests point the script at an isolated
 // fixture so the real user tracker is never touched.
 const APPS_FILE = resolveTrackerPath(CAREER_OPS);
+
+// ── CLI args ────────────────────────────────────────────────────────
+// Same shape as scan-ats-full.mjs (#1633/PR #1635) and reply-watch.mjs
+// (#2743): an unrecognized flag must fail fast, never silently fall through
+// to the live-run default and write to the real tracker (#2744).
+const KNOWN_FLAGS = ['--dry-run', '--help', '-h'];
+const USAGE = `Usage: node dedup-tracker.mjs [--dry-run]`;
+
+const cliArgs = process.argv.slice(2);
+
+if (cliArgs.includes('--help') || cliArgs.includes('-h')) {
+  console.log(USAGE);
+  process.exit(0);
+}
+
+const unknownFlags = cliArgs.filter(a => a.startsWith('-') && !KNOWN_FLAGS.includes(a));
+if (unknownFlags.length) {
+  console.error(`Error: unrecognized flag(s): ${unknownFlags.join(', ')}. Valid flags: ${KNOWN_FLAGS.join(', ')}`);
+  process.exit(1);
+}
+
 const DRY_RUN = process.argv.includes('--dry-run');
 
 // Ensure the target tracker directory exists in both normal and fixture mode.

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -8589,6 +8589,95 @@ try {
   fail(`shared role matcher / dedup safety tests crashed: ${e.message}`);
 }
 
+// ── DEDUP FLAG VALIDATION (#2744) ─────────────────────────────────────────
+// Any argv token dedup-tracker.mjs didn't recognize used to fall straight
+// through: DRY_RUN stayed false and the script ran its real, destructive
+// merge-and-write pass. `--check` (a plausible-sounding typo for --dry-run)
+// happened for real. Same shape as scan-ats-full.mjs (#1633/#1635).
+console.log('\n🧪 Testing dedup-tracker flag validation (#2744)...');
+try {
+  const flagTmp = mkdtempSync(join(tmpdir(), 'career-ops-dedup-flags-'));
+  try {
+    mkdirSync(join(flagTmp, 'data'));
+    const tracker = join(flagTmp, 'data', 'applications.md');
+    const seedTracker =
+      '# Applications Tracker\n\n' +
+      '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+      '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
+      '| 1 | 2026-01-08 | FlagCo | Engineer | 3.9/5 | Evaluated | ❌ | [1](../reports/001-flagco.md) | first row |\n' +
+      '| 1 | 2026-01-09 | FlagCo | Engineer | 4.2/5 | Evaluated | ❌ | [2](../reports/002-flagco.md) | exact duplicate |\n';
+    const env = { ...process.env, CAREER_OPS_TRACKER: tracker };
+
+    // --help / -h: print usage, exit 0, do not touch the tracker.
+    writeFileSync(tracker, seedTracker);
+    const helpResult = run(NODE, ['dedup-tracker.mjs', '--help'], { env });
+    if (helpResult !== null && /Usage:.*dedup-tracker\.mjs/.test(helpResult)) {
+      pass('dedup-tracker --help prints usage and exits 0');
+    } else {
+      fail(`dedup-tracker --help should print usage and exit 0, got: ${JSON.stringify(helpResult)}`);
+    }
+    if (readFileSync(tracker, 'utf-8') === seedTracker) {
+      pass('dedup-tracker --help does not run the dedup/write pass');
+    } else {
+      fail('dedup-tracker --help mutated the tracker — it must exit before any write path');
+    }
+
+    const hResult = run(NODE, ['dedup-tracker.mjs', '-h'], { env });
+    if (hResult !== null && /Usage:.*dedup-tracker\.mjs/.test(hResult)) {
+      pass('dedup-tracker -h prints usage and exits 0');
+    } else {
+      fail(`dedup-tracker -h should print usage and exit 0, got: ${JSON.stringify(hResult)}`);
+    }
+
+    // Unrecognized flag (the #2744 repro: --check, a plausible typo for
+    // --dry-run): must error, exit 1, and — critically — never reach the
+    // write path.
+    writeFileSync(tracker, seedTracker);
+    const checkResult = run(NODE, ['dedup-tracker.mjs', '--check'], { env });
+    const checkFailure = lastRunFailure();
+    if (checkResult === null && checkFailure?.status === 1 && /unrecognized flag/i.test(checkFailure.stderr)) {
+      pass('dedup-tracker --check (unrecognized flag) errors and exits 1 (#2744 repro)');
+    } else {
+      fail(`dedup-tracker --check should error and exit 1 with an "unrecognized flag" message: ${formatRunFailure()}`);
+    }
+    if (readFileSync(tracker, 'utf-8') === seedTracker) {
+      pass('dedup-tracker --check does NOT run the live write path — tracker untouched (#2744)');
+    } else {
+      fail('dedup-tracker --check mutated the tracker — the #2744 bug is still live');
+    }
+
+    // Regression: --dry-run must still work exactly as before (previews,
+    // does not write).
+    writeFileSync(tracker, seedTracker);
+    const dryRunResult = run(NODE, ['dedup-tracker.mjs', '--dry-run'], { env });
+    if (dryRunResult === null) {
+      fail('dedup-tracker.mjs --dry-run crashed after the flag-validation fix');
+    } else if (readFileSync(tracker, 'utf-8') === seedTracker) {
+      pass('dedup-tracker --dry-run still previews without writing (regression)');
+    } else {
+      fail('dedup-tracker --dry-run wrote to the tracker — regression');
+    }
+
+    // Regression: no-flags (real run) must still merge the exact duplicate.
+    writeFileSync(tracker, seedTracker);
+    const liveResult = run(NODE, ['dedup-tracker.mjs'], { env });
+    if (liveResult === null) {
+      fail('dedup-tracker.mjs (no flags) crashed after the flag-validation fix');
+    } else {
+      const engineerRows = readFileSync(tracker, 'utf-8').split('\n').filter(l => l.includes('| Engineer |'));
+      if (engineerRows.length === 1 && engineerRows[0].includes('4.2/5')) {
+        pass('dedup-tracker (no flags) still merges an exact duplicate live (regression)');
+      } else {
+        fail(`dedup-tracker (no flags) live-run regression: ${engineerRows.length} Engineer rows`);
+      }
+    }
+  } finally {
+    rmSync(flagTmp, { recursive: true, force: true });
+  }
+} catch (e) {
+  fail(`dedup-tracker flag validation tests crashed: ${e.message}`);
+}
+
 // ── DEDUP BLIND-VIA CHANNEL KEY: NON-LATIN AGENCIES (#2393) ──────────────
 // Unknown-employer rows (Company `?`) group by their Via channel. dedup-tracker
 // keyed that group with the file-local normalizeCompany(), which strips

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -8646,6 +8646,25 @@ try {
       fail('dedup-tracker --check mutated the tracker — the #2744 bug is still live');
     }
 
+    // CodeRabbit (#2746): --help combined with an unrecognized flag must
+    // still reject — unknown-flag validation has to run before --help
+    // short-circuits, otherwise `dedup-tracker.mjs --help --check` would
+    // exit 0 instead of erroring.
+    writeFileSync(tracker, seedTracker);
+    const mixedResult = run(NODE, ['dedup-tracker.mjs', '--help', '--check'], { env });
+    const mixedFailure = lastRunFailure();
+    if (mixedResult === null && mixedFailure?.status === 1 && /unrecognized flag/i.test(mixedFailure.stderr)
+        && !/Usage:/.test(mixedFailure.stdout || '')) {
+      pass('dedup-tracker --help --check still rejects the unrecognized flag (#2746)');
+    } else {
+      fail(`dedup-tracker --help+--check should still error, not exit clean: ${formatRunFailure()}`);
+    }
+    if (readFileSync(tracker, 'utf-8') === seedTracker) {
+      pass('dedup-tracker --help --check does NOT run the live write path — tracker untouched (#2746)');
+    } else {
+      fail('dedup-tracker --help --check mutated the tracker — the #2746 ordering bug is still live');
+    }
+
     // Regression: --dry-run must still work exactly as before (previews,
     // does not write).
     writeFileSync(tracker, seedTracker);


### PR DESCRIPTION
## Summary

Closes #2744.

`dedup-tracker.mjs` only checked for `--dry-run` via `process.argv.includes('--dry-run')`. Any other flag — including a plausible typo like `--check` — was silently ignored, `DRY_RUN` stayed `false`, and the script ran its real, destructive merge-and-write pass against the live tracker (`data/applications.md`) with no warning. This happened for real: someone typed `--check` expecting a dry-run/preview and instead got a live write, with a `.bak` backup file as the only safety net.

This is the same failure shape already fixed twice in this repo:
- `scan-ats-full.mjs` — #1633 / PR #1635
- `reply-watch.mjs` — #2743 (PR in flight)

This PR applies the identical pattern to `dedup-tracker.mjs`, scoped to just that file:
- `KNOWN_FLAGS = ['--dry-run', '--help', '-h']`
- `--help` / `-h` prints usage and exits 0, before any dedup logic runs
- Any `-`-prefixed arg not in `KNOWN_FLAGS` prints `Error: unrecognized flag(s): ...` and exits 1, before any dedup/write logic runs
- `--dry-run` and the no-flags (live-run) behaviors are unchanged

A maintainer comment was already posted on #2744 asking santifer's opinion on extracting a shared flag-validation helper now that this is a third instance of the same class — that's an open follow-up question, not something this PR builds.

## Test plan

- [x] Added coverage in `test-all.mjs` (same `run()` + `CAREER_OPS_TRACKER` fixture convention as the existing dedup-tracker tests): `--help`/`-h` print usage, exit 0, and do not touch the tracker; `--check` (the #2744 repro) errors, exits 1, and — critically — does NOT reach the write path (tracker file byte-identical before/after); `--dry-run` and no-flags (real run, exact-duplicate merge) regression-tested unchanged.
- [x] `node test-all.mjs --quick` — 3436 passed, 0 failed, 1 pre-existing/unrelated warning (`cv-sync-check.mjs exited with error (expected without user data)`)
- [x] Manually verified the exact issue repro: `node dedup-tracker.mjs --check` now prints `Error: unrecognized flag(s): --check. Valid flags: --dry-run, --help, -h` and exits 1, without touching `data/applications.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added command-line help via `--help` and `-h`, including usage information.
  * Documented supported options: `--dry-run`, `--help`, and `-h`.
  * Added clear errors for unsupported command-line flags.

* **Bug Fixes**
  * Invalid flags now exit safely without modifying tracker data.
  * Confirmed dry-run and duplicate-merging behavior remain non-destructive and functional.

* **Tests**
  * Added end-to-end coverage for help, invalid flags, dry-run, and duplicate merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->