### PR TITLE
security(archive-posting): add SSRF / private-IP egress safeguards

### DIFF
--- a/archive-posting.mjs
+++ b/archive-posting.mjs
@@ -26,8 +26,9 @@ import { chromium } from 'playwright';
 import { writeFile, readFile } from 'fs/promises';
 import { existsSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import { reportPrefix } from './jd-capture.mjs';
+import { rejectPrivateOrInvalid, validateUrlSecurity } from './liveness-browser.mjs';
 
 const ROOT = dirname(fileURLToPath(import.meta.url));
 const JDS_DIR = join(ROOT, 'jds');
@@ -35,10 +36,7 @@ const PIPELINE_PATH = join(ROOT, 'data', 'pipeline.md');
 
 // ── CLI parsing ──────────────────────────────────────────────────────────────
 
-const args = process.argv.slice(2);
-
-if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
-  console.log(`
+const HELP_TEXT = `
 ╔══════════════════════════════════════════════════════════════════╗
 ║           career-ops — Job Posting Archiver                     ║
 ╚══════════════════════════════════════════════════════════════════╝
@@ -77,9 +75,7 @@ if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
     node archive-posting.mjs "https://jobs.lever.co/acme/xyz" --report=42
     node archive-posting.mjs --pipeline
     npm run archive -- "https://jobs.lever.co/elevenlabs/abc"
-`);
-  process.exit(0);
-}
+`;
 
 let targetUrl = null;
 let overrideCompany = null;
@@ -88,49 +84,59 @@ let pipelineMode = false;
 let dryRun = false;
 let reportNum = null;
 
-for (let i = 0; i < args.length; i++) {
-  const arg = args[i];
-  if (arg === '--pipeline') {
-    pipelineMode = true;
-  } else if (arg === '--dry-run') {
-    dryRun = true;
-  } else if (arg.startsWith('--company=')) {
-    overrideCompany = arg.slice('--company='.length).trim();
-  } else if (arg === '--company' && args[i + 1]) {
-    overrideCompany = args[++i].trim();
-  } else if (arg.startsWith('--role=')) {
-    overrideRole = arg.slice('--role='.length).trim();
-  } else if (arg === '--role' && args[i + 1]) {
-    overrideRole = args[++i].trim();
-  } else if (arg.startsWith('--report=')) {
-    reportNum = arg.slice('--report='.length).trim();
-  } else if (arg === '--report') {
-    // Consume the value explicitly. Left unconsumed it would fall through to the
-    // bare-argument branch below and be mistaken for the URL. Consume it even
-    // when absent: a trailing `--report` used to be dropped silently, archiving
-    // the posting with no report prefix — unfindable, which is the failure this
-    // flag exists to prevent. The empty string reaches the validator below and
-    // exits non-zero instead.
-    reportNum = args[++i]?.trim() ?? '';
-  } else if (!arg.startsWith('--') && !targetUrl) {
-    targetUrl = arg;
+// Parsing lives in a function, not at module scope, so importing this file for
+// its exports doesn't read process.argv or call process.exit — the repo's
+// standard direct-run guard at the bottom is what invokes it.
+function parseCliArgs(args) {
+  if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
+    console.log(HELP_TEXT);
+    process.exit(0);
   }
-}
 
-if (reportNum !== null) {
-  if (!/^\d+$/.test(reportNum) || Number(reportNum) <= 0) {
-    console.error(`Invalid --report value: "${reportNum}". Expected a positive report number.`);
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--pipeline') {
+      pipelineMode = true;
+    } else if (arg === '--dry-run') {
+      dryRun = true;
+    } else if (arg.startsWith('--company=')) {
+      overrideCompany = arg.slice('--company='.length).trim();
+    } else if (arg === '--company' && args[i + 1]) {
+      overrideCompany = args[++i].trim();
+    } else if (arg.startsWith('--role=')) {
+      overrideRole = arg.slice('--role='.length).trim();
+    } else if (arg === '--role' && args[i + 1]) {
+      overrideRole = args[++i].trim();
+    } else if (arg.startsWith('--report=')) {
+      reportNum = arg.slice('--report='.length).trim();
+    } else if (arg === '--report') {
+      // Consume the value explicitly. Left unconsumed it would fall through to the
+      // bare-argument branch below and be mistaken for the URL. Consume it even
+      // when absent: a trailing `--report` used to be dropped silently, archiving
+      // the posting with no report prefix — unfindable, which is the failure this
+      // flag exists to prevent. The empty string reaches the validator below and
+      // exits non-zero instead.
+      reportNum = args[++i]?.trim() ?? '';
+    } else if (!arg.startsWith('--') && !targetUrl) {
+      targetUrl = arg;
+    }
+  }
+
+  if (reportNum !== null) {
+    if (!/^\d+$/.test(reportNum) || Number(reportNum) <= 0) {
+      console.error(`Invalid --report value: "${reportNum}". Expected a positive report number.`);
+      process.exit(1);
+    }
+    if (pipelineMode) {
+      console.error('--report applies to a single posting; it cannot be combined with --pipeline.');
+      process.exit(1);
+    }
+  }
+
+  if (!pipelineMode && !targetUrl) {
+    console.error('No URL provided. Run with --help for usage.');
     process.exit(1);
   }
-  if (pipelineMode) {
-    console.error('--report applies to a single posting; it cannot be combined with --pipeline.');
-    process.exit(1);
-  }
-}
-
-if (!pipelineMode && !targetUrl) {
-  console.error('No URL provided. Run with --help for usage.');
-  process.exit(1);
 }
 
 // ── Utilities ────────────────────────────────────────────────────────────────
@@ -249,14 +255,63 @@ async function extractPipelineEntries() {
 
 // ── Core archive function ────────────────────────────────────────────────────
 
-async function archiveUrl(browser, url, { company: companyHint, role: roleHint } = {}) {
+/**
+ * Register the egress guard on a Playwright context.
+ *
+ * Registered on the *context* rather than the page: a route bound to a single
+ * page doesn't cover requests the flow makes outside it, and the context is
+ * what owns the whole navigation. Both layers of the shared guard run here —
+ * the literal-host check first (cheap, no network), then the DNS re-check that
+ * catches a public hostname resolving into private space.
+ *
+ * @param {import('playwright').BrowserContext} context - Context to guard.
+ */
+export async function installEgressGuard(context) {
+  await context.route('**/*', async (route) => {
+    const requestUrl = route.request().url();
+
+    const verdict = rejectPrivateOrInvalid(requestUrl);
+    if (verdict) {
+      console.warn(`   Blocked request to restricted destination: ${requestUrl} (${verdict.reason})`);
+      return route.abort('blockedbyclient');
+    }
+
+    try {
+      await validateUrlSecurity(requestUrl);
+      return route.continue();
+    } catch (err) {
+      console.warn(`   Blocked request to restricted destination (DNS): ${requestUrl} - ${err.message}`);
+      return route.abort('blockedbyclient');
+    }
+  });
+}
+
+export async function archiveUrl(browser, url, { company: companyHint, role: roleHint } = {}) {
   console.log(`\n🔗  ${url}`);
 
-  const page = await browser.newPage();
+  // Refuse before launching any navigation, so an obviously-internal target
+  // never reaches Playwright at all.
+  const preGuard = rejectPrivateOrInvalid(url);
+  if (preGuard) {
+    throw new Error(`refusing to archive restricted destination: ${preGuard.reason}`);
+  }
+
+  const context = await browser.newContext();
+  await installEgressGuard(context);
+  const page = await context.newPage();
 
   try {
     const response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 });
     const httpStatus = response?.status() ?? 0;
+
+    // Re-check where we actually landed. The route guard already inspects every
+    // redirect hop, so this is defence-in-depth: a first-hop-only check is the
+    // classic miss here, and asserting on the settled URL costs nothing.
+    const landedUrl = page.url();
+    const postGuard = rejectPrivateOrInvalid(landedUrl);
+    if (postGuard) {
+      throw new Error(`refusing to archive restricted destination after redirect: ${postGuard.reason}`);
+    }
 
     // Give SPAs (Ashby, Lever, Workday) time to hydrate
     await page.waitForTimeout(2000);
@@ -305,7 +360,7 @@ async function archiveUrl(browser, url, { company: companyHint, role: roleHint }
     return { filename, reference, url, size: pdfBuffer.length };
 
   } finally {
-    await page.close();
+    await context.close();
   }
 }
 
@@ -389,7 +444,10 @@ async function main() {
   if (failed > 0) process.exit(1);
 }
 
-main().catch(err => {
-  console.error('❌  Fatal:', err.message);
-  process.exit(1);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  parseCliArgs(process.argv.slice(2));
+  main().catch(err => {
+    console.error('❌  Fatal:', err.message);
+    process.exit(1);
+  });
+}

--- a/liveness-browser.mjs
+++ b/liveness-browser.mjs
@@ -190,7 +190,12 @@ async function resolveDnsCached(hostname) {
   }
 }
 
-async function validateUrlSecurity(urlString) {
+// Second layer of the egress guard: `rejectPrivateOrInvalid` only sees the
+// literal host, so a public hostname that *resolves* to private space still
+// gets through it. Resolve and re-check every address before the request is
+// allowed out. Exported so other Playwright callers (archive-posting.mjs) wire
+// up the same two-layer guard instead of growing a second implementation.
+export async function validateUrlSecurity(urlString) {
   const url = new URL(urlString.endsWith('.') ? urlString.slice(0, -1) : urlString);
   const hostname = url.hostname;
   const host = normalizeHost(hostname);

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1058,6 +1058,146 @@ try {
   fail(`Liveness classification tests crashed: ${e.message}`);
 }
 
+// ── 3b. ARCHIVE-POSTING EGRESS GUARD (#1956) ────────────────────
+//
+// archive-posting.mjs drives Playwright at a URL the user pastes in (or that
+// arrives via data/pipeline.md), and used to navigate with zero egress
+// safeguards — so a hostile posting link could render an internal service or a
+// cloud metadata endpoint straight into a PDF. It now wires up the *same*
+// two-layer guard liveness-browser.mjs exports rather than carrying a second
+// implementation, so these tests pin the wiring, not a copy of the guard logic.
+try {
+  const { archiveUrl, installEgressGuard } = await import(
+    pathToFileURL(join(ROOT, 'archive-posting.mjs')).href
+  );
+  const { setHostResolver } = await import(
+    pathToFileURL(join(ROOT, 'liveness-browser.mjs')).href
+  );
+
+  // Stop each run the moment navigation starts: everything after goto() is PDF
+  // rendering and a writeFile into jds/, which these assertions don't need and
+  // must not perform.
+  const STOP = 'archive-guard-test-stop';
+
+  // Records what the guard did, and never lets the flow reach page.pdf().
+  function makeMockBrowser({ landedUrl = 'https://example.com/job/1' } = {}) {
+    const state = { routeCallback: null, contextCreated: false, closed: false };
+    const context = {
+      async route(pattern, callback) {
+        state.pattern = pattern;
+        state.routeCallback = callback;
+      },
+      async newPage() {
+        return {
+          async goto() {
+            if (state.stopAtGoto) throw new Error(STOP);
+            return { status: () => 200 };
+          },
+          url: () => landedUrl,
+          async waitForTimeout() { throw new Error(STOP); },
+          async title() { return ''; },
+          async $eval() { return ''; },
+        };
+      },
+      async close() { state.closed = true; },
+    };
+    const browser = {
+      async newContext() {
+        state.contextCreated = true;
+        return context;
+      },
+    };
+    return { browser, state };
+  }
+
+  // Drives a registered route handler and reports the verdict it reached.
+  async function runGuard(requestUrl) {
+    const { browser, state } = makeMockBrowser();
+    state.stopAtGoto = true;
+    await archiveUrl(browser, 'https://example.com/job/1').catch(() => {});
+    if (!state.routeCallback) return { registered: false };
+    let verdict = null;
+    await state.routeCallback({
+      request: () => ({ url: () => requestUrl }),
+      abort: async (code) => { verdict = { action: 'abort', code }; },
+      continue: async () => { verdict = { action: 'continue' }; },
+    });
+    return { registered: true, verdict, pattern: state.pattern };
+  }
+
+  // 1. Pre-navigation refusal — an obviously-internal target must not reach
+  //    Playwright at all, so no context is ever created.
+  const { browser: preBrowser, state: preState } = makeMockBrowser();
+  let preError = null;
+  await archiveUrl(preBrowser, 'http://169.254.169.254/latest/meta-data/')
+    .catch((err) => { preError = err; });
+  if (preError && /restricted destination/.test(preError.message) && !preState.contextCreated) {
+    pass('archive-posting refuses a private-IP target before opening a browser context');
+  } else {
+    fail(`archive-posting pre-navigation guard failed: error=${preError?.message ?? 'none'}, contextCreated=${preState.contextCreated}`);
+  }
+
+  // 2. The guard is registered on the context for every request, not just the
+  //    page's first hop — a page-scoped route wouldn't cover the whole flow.
+  const registration = await runGuard('https://example.com/assets/logo.png');
+  if (registration.registered && registration.pattern === '**/*') {
+    pass('archive-posting registers the egress guard on the context for all requests');
+  } else {
+    fail(`archive-posting did not register a context-wide route: ${JSON.stringify(registration)}`);
+  }
+
+  // 3. Legitimate subresources still go through — a guard that blocks
+  //    everything would pass a naive block-only test while breaking archiving.
+  if (registration.verdict?.action === 'continue') {
+    pass('archive-posting egress guard allows legitimate public requests');
+  } else {
+    fail(`archive-posting egress guard blocked a legitimate request: ${JSON.stringify(registration.verdict)}`);
+  }
+
+  // 4. Redirect hop straight to a literal private address.
+  const literalHop = await runGuard('http://10.0.0.5/internal');
+  if (literalHop.verdict?.action === 'abort' && literalHop.verdict.code === 'blockedbyclient') {
+    pass('archive-posting egress guard blocks a redirect hop to a literal private IP');
+  } else {
+    fail(`archive-posting egress guard let a private-IP hop through: ${JSON.stringify(literalHop.verdict)}`);
+  }
+
+  // 5. The case the literal-host check cannot see: a public-looking hostname
+  //    that resolves into loopback. Without the DNS layer this hop is allowed,
+  //    which is the whole reason validateUrlSecurity is reused here.
+  const restoreArchiveResolver = setHostResolver(async (hostname) => (
+    hostname === 'ssrf-blocked-host.local' ? ['127.0.0.1'] : ['93.184.216.34']
+  ));
+  try {
+    const dnsHop = await runGuard('http://ssrf-blocked-host.local/sensitive-internal');
+    if (dnsHop.verdict?.action === 'abort' && dnsHop.verdict.code === 'blockedbyclient') {
+      pass('archive-posting egress guard blocks a hostname that resolves to loopback');
+    } else {
+      fail(`archive-posting egress guard missed a DNS-resolved private target: ${JSON.stringify(dnsHop.verdict)}`);
+    }
+  } finally {
+    restoreArchiveResolver();
+  }
+
+  // 6. Landed-URL re-check after navigation. A first-hop-only check is the
+  //    classic miss, so the settled URL is asserted too.
+  const { browser: landedBrowser } = makeMockBrowser({ landedUrl: 'http://169.254.169.254/latest/meta-data/' });
+  let landedError = null;
+  await archiveUrl(landedBrowser, 'https://example.com/job/1')
+    .catch((err) => { landedError = err; });
+  if (landedError && /after redirect/.test(landedError.message)) {
+    pass('archive-posting refuses to render a page that landed on a private address');
+  } else {
+    fail(`archive-posting landed-URL guard failed: ${landedError?.message ?? 'no error'}`);
+  }
+
+  if (typeof installEgressGuard !== 'function') {
+    fail('archive-posting does not export installEgressGuard');
+  }
+} catch (e) {
+  fail(`archive-posting egress guard tests crashed: ${e.message}`);
+}
+
 // ── 4. DASHBOARD BUILD ──────────────────────────────────────────
 
 if (!QUICK) {


### PR DESCRIPTION
## What does this PR do?

`archive-posting.mjs` drives Playwright at a URL the user pastes in (or that arrives via `data/pipeline.md`) and navigated with no egress safeguards at all, so a hostile posting link could render an internal service or a cloud metadata endpoint straight into a PDF on disk. This wires up the guard `liveness-browser.mjs` already exports — rather than adding a second one, per your note on the issue.

## Related issue

Fixes #1956

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---

## The gap, demonstrated

A local service on `127.0.0.1:8931` standing in for something on the user's network, serving `INTERNAL-SECRET-TOKEN-9f3a` and a fake `db-password`. Same command against both trees.

**On `main` (`92dea48`) — archived it:**

```
🔗  http://127.0.0.1:8931/
   Company: unknown
   Role:    Internal Admin Console
   Output:  jds/2026-08-11_unknown_internal-admin-console.pdf
Saved (19.8 KB)
  Archived: 1 saved  0 failed
```

The PDF is not a blank page — it captured the content:

```
$ pdftotext jds/2026-08-11_unknown_internal-admin-console.pdf -
INTERNAL-SECRET-TOKEN-9f3a
metadata: db-password=hunter2
```

**On this branch — refused, nothing written:**

```
🔗  http://127.0.0.1:8931/
   ❌  Failed: refusing to archive restricted destination: blocked host 127.0.0.1
  Archived: 0 saved  1 failed
```

Exit code is 1, and `jds/` stays empty.

## What changed

Three wiring points, all reusing the shared guard:

1. **Pre-navigation check on the input URL**, so an obviously-internal target never reaches Playwright at all.
2. **`launch → newContext() + context.route('**/*') → newPage()`** instead of `browser.newPage()`. The route is registered on the *context* rather than the page, so it covers every request in the flow rather than one page's first hop.
3. **Re-check of the settled URL after navigation** — a first-hop-only check is the classic miss on a 302 into link-local space, so the landed URL is asserted too.

## Two calls that go beyond the sketch I posted on the issue

Flagging both explicitly so they're easy to veto:

**I exported `validateUrlSecurity` from `liveness-browser.mjs`.** I had said I'd import `rejectPrivateOrInvalid`, but that one only inspects the literal host — a public-looking hostname that *resolves* to `127.0.0.1` walks straight past it. `checkUrlLiveness` runs both layers in its route handler, so moving only one would have shipped half a guard. Exporting the DNS layer keeps this a single shared implementation instead of a second one. Happy to drop it to one layer if you'd rather keep that function private.

**`archive-posting.mjs` gains the repo's standard direct-run guard** (`process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href`) and exports `archiveUrl`. This isn't a new pattern — `add-entry.mjs`, `detect-reposts.mjs`, `check-table-freshness.mjs` and a dozen others already have it; `archive-posting.mjs` was one of the stragglers. Without it, importing the module for a test runs the CLI parser and calls `process.exit`, which kills the test process. CLI behaviour is unchanged: `--help` and the no-argument path both still exit 0, and the existing `archive-posting.mjs --help` assertion in `test-all.mjs` still passes.

## A correction to something I said on the issue

I listed `generate-pdf.mjs` as having "the same" zero-SSRF-guard problem. Having read it properly, that was overstated: it only navigates to a local `file://` temp document and runs with `javaScriptEnabled: false`, so there's no attacker-controlled URL reaching `page.goto`. Not an equivalent gap, and I've kept it out of this PR rather than bundling a change that isn't warranted.

## Tests

Six cases in `test-all.mjs`, pinning the wiring rather than re-testing the guard logic that `liveness-browser`'s own section already covers — and deliberately covering both arms, so a guard that simply blocked everything would fail:

- private-IP target is refused **before a browser context is even created**
- the guard is registered on the context for `**/*`, not on a single page
- a legitimate public subresource still `continue()`s
- a redirect hop to a literal private IP is aborted
- a hostname that *resolves* to loopback is aborted (the case the literal-host check can't see)
- a page that lands on a link-local address is refused after navigation

## Verification

```
node test-all.mjs
📊 Results: 3282 passed, 0 failed, 1 warnings
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Added protection against navigation to private or invalid network destinations.
  * Validates DNS resolution and redirect targets before and during web archiving.
  * Prevents unsafe requests throughout the browser session.

* **Reliability**
  * Improved command-line handling for safer archiving.
  * Ensures browser resources are closed after archiving.

* **Tests**
  * Added coverage for blocked private destinations, redirects, DNS validation, and permitted public requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->