### PR TITLE
fix(reserve-report-num): do not read a bare date file as a report number

### DIFF
--- a/reserve-report-num.mjs
+++ b/reserve-report-num.mjs
@@ -56,10 +56,22 @@ function trackerPathFor(options = {}) {
     : resolveTrackerPath(options.rootDir || ROOT);
 }
 
+// A bare date file is not a report. `scan-ats-full.mjs --md-out reports/` writes
+// its digest as `reports/YYYY-MM-DD.md`, which matches `/^(\d+)-/` and is read
+// as report #2026 — pushing every later reservation to 2027+, silently and
+// permanently.
+//
+// Deliberately narrow: report filenames in the wild are not all
+// `NNN-slug-DATE.md` (`1001-taken.md` and `NNN-RESERVED.md` are both real), so
+// requiring a trailing date would drop legitimate occupancy. Exclude only names
+// that are *entirely* a date. See tests/reserve-report-num.test.mjs.
+const BARE_DATE_FILE_RE = /^\d{4}-\d{2}-\d{2}\.md$/;
+
 function occupiedFromReports(reportsDir) {
   const occupied = new Set();
   if (!existsSync(reportsDir)) return occupied;
   for (const name of readdirSync(reportsDir)) {
+    if (BARE_DATE_FILE_RE.test(name)) continue;
     const match = name.match(/^(\d+)-/);
     if (!match) continue;
     const num = parseInt(match[1], 10);

--- a/tests/reserve-report-num.test.mjs
+++ b/tests/reserve-report-num.test.mjs
@@ -1,0 +1,73 @@
+// Regression: a dated file in reports/ must not be read as a report number.
+//
+// `scan-ats-full.mjs --md-out reports/` writes `reports/YYYY-MM-DD.md`. The old
+// occupancy scan matched `/^(\d+)-/`, so `2026-08-12.md` was read as report
+// #2026 and the next reservation jumped to 2027 — silently, and permanently.
+
+import { strict as assert } from 'assert';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { reserveReportNumbers, releaseReportNumbers } from '../reserve-report-num.mjs';
+import { pass, fail } from './helpers.mjs';
+
+// Reserve one slot in a scratch root and report which number it got. Released
+// afterwards so the assertion reflects the occupancy scan, not leftover state.
+async function peekIn(files) {
+  const dir = mkdtempSync(join(tmpdir(), 'rrn-'));
+  mkdirSync(join(dir, 'reports'), { recursive: true });
+  mkdirSync(join(dir, 'data'), { recursive: true });
+  writeFileSync(
+    join(dir, 'data/applications.md'),
+    '# Applications Tracker\n\n'
+    + '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n'
+    + '|---|---|---|---|---|---|---|---|---|\n'
+  );
+  for (const f of files) writeFileSync(join(dir, 'reports', f), '# x\n');
+  try {
+    const nums = await reserveReportNumbers(1, { rootDir: dir });
+    await releaseReportNumbers(nums, { rootDir: dir });
+    return String(nums[0]).padStart(3, '0');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const cases = [
+  {
+    name: 'scan digest is ignored',
+    files: ['009-acme-2026-08-12.md', '2026-08-12.md'],
+    expect: '010',
+  },
+  {
+    name: 'real reports still counted',
+    files: ['009-acme-2026-08-12.md', '010-globex-2026-08-12.md'],
+    expect: '011',
+  },
+  {
+    name: 'RESERVED sentinels still counted',
+    files: ['009-acme-2026-08-12.md', '010-RESERVED.md'],
+    expect: '011',
+  },
+  {
+    name: 'digest alone leaves numbering at the start',
+    files: ['2026-08-12.md'],
+    expect: '001',
+  },
+];
+
+for (const c of cases) {
+  let got;
+  try {
+    got = await peekIn(c.files);
+  } catch (err) {
+    fail(`${c.name}: threw ${err.message.split('\n')[0]}`);
+    continue;
+  }
+  try {
+    assert.equal(got, c.expect);
+    pass(`${c.name} → ${got}`);
+  } catch {
+    fail(`${c.name}: expected ${c.expect}, got ${got}`);
+  }
+}


### PR DESCRIPTION
Fixes #2757

## Problem

`scan-ats-full.mjs --md-out reports/` writes its digest as `reports/YYYY-MM-DD.md`. `occupiedFromReports()` matches every filename against `/^(\d+)-/`, so `2026-08-12.md` captures `2026` and is recorded as an occupied report number.

```
$ node reserve-report-num.mjs --peek
010
$ touch reports/2026-08-12.md
$ node reserve-report-num.mjs --peek
2027
```

Silent and permanent — the sentinel written at 2027 keeps the number occupied even after the digest is deleted. Report numbers reach tracker rows, tracker report links, PDF filenames and `merge-tracker.mjs`, so it spreads before anyone notices.

## Fix

Skip filenames that are *entirely* a date.

Deliberately narrow. My first attempt required the full report shape (`NNN-slug-YYYY-MM-DD.md` or `NNN-RESERVED.md`) and **broke two existing tests** — `four-digit report files advance a contiguous range` uses a bare `1001-taken.md`, and `unsafe report-number ranges fail before creating a partial sentinel` uses `<MAX_SAFE_INTEGER-1>-existing.md`. Neither carries a trailing date, and both are legitimately occupied. Excluding only the digest shape leaves all existing occupancy behaviour untouched.

## Tests

New `tests/reserve-report-num.test.mjs` (auto-discovered), 4 cases:

- a digest alongside a real report is ignored → `010`, not `2027`
- real reports still counted
- `NNN-RESERVED.md` sentinels still counted
- a digest alone leaves numbering at `001`

Full suite on this branch: **3434 passed, 0 failed**. The 1 warning is pre-existing and unrelated (Go absent → dashboard build skipped) — it is also present on unmodified `main` in my environment.

## Note

`AGENTS.md` documents `--md-out <dir>` without restriction, and `reports/` is the natural target for a markdown digest, so this is reachable from documented usage. Worth considering a follow-up that warns when `--md-out` points at `reports/`; I have left that out to keep this change minimal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented date-named Markdown files, such as `YYYY-MM-DD.md`, from affecting report and reservation number availability.
  * Numbered reports and reservation markers continue to be counted correctly.

* **Tests**
  * Added regression coverage for reserving, releasing, and scanning report numbers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->