### PR TITLE
fix(workday): key the cap-hit warning on entry provenance, not on --since

### DIFF
--- a/providers/workday.mjs
+++ b/providers/workday.mjs
@@ -168,7 +168,7 @@ export default {
    * as providers/glints.mjs's firewall).
    *
    * @param {{ name?: string, api?: string, careers_url?: string, max_pages?: number }} entry
-   * @param {{ fetchJson: (url: string, opts?: object) => Promise<any>, sinceMs?: number, maxPages?: number }} ctx
+   * @param {{ fetchJson: (url: string, opts?: object) => Promise<any>, sinceMs?: number, maxPages?: number, syntheticEntries?: boolean }} ctx
    * @returns {Promise<Array<{title: string, url: string, company: string, location: string, postedAt?: number}>>}
    */
   async fetch(entry, ctx) {
@@ -283,15 +283,22 @@ export default {
     // portal entry to point at, and no fixed cap can guarantee full coverage of
     // an unbounded company directory anyway; nothing else to suggest there.
     //
-    // The branch below keys on `sinceMs === null` as a proxy for that
-    // distinction. Since #2418 the proxy is no longer exact: `scan.mjs --since`
-    // also sets ctx.sinceMs, so those runs take the else branch and get the
-    // terser message even though they DO have a portals.yml entry to raise.
-    // Harmless (the cap is still surfaced, just without the suggestion) but
-    // worth knowing before trusting the proxy — see #2495.
+    // The branch below used to key on `sinceMs === null` as a proxy for that
+    // distinction, which held only because scan-ats-full.mjs was the sole
+    // caller setting it. #2418 broke the proxy — `scan.mjs --since` sets
+    // ctx.sinceMs too, so a tracked entry lost the actionable half of the
+    // message on every --since run (#2495). Provenance is now stated by the
+    // caller instead of inferred from an unrelated flag, so a future caller
+    // that starts setting sinceMs cannot re-couple the two concerns.
+    //
+    // Absence means "tracked": scan-ats-full.mjs is the only caller that
+    // synthesizes entries AND can reach the cap (discover-ats.mjs and
+    // verify-portals.mjs both probe with ctx.maxPages: 1, which never sets
+    // stopReason to 'cap'), so it is the one place that opts out.
+    const syntheticEntries = ctx?.syntheticEntries === true;
     if (stopReason === 'cap') {
       const jobsSummary = `${jobs.length}${total !== null ? ` of ${total}` : ''} jobs`;
-      if (sinceMs === null) {
+      if (!syntheticEntries) {
         console.error(`⚠️  workday: ${entry.name} truncated at max_pages=${maxPages} (${jobsSummary}) — raise max_pages on this entry for more`);
       } else {
         // Workday's CXS backend can report `total` as exactly

--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -641,7 +641,14 @@ async function main() {
   // sinceMs once postings are confidently past the --since window, and
   // includeUndated (when false) for a tenant that exposes no postedOn at
   // all, since its postings would all be dropped as undated below anyway.
-  const ctx = { ...makeHttpCtx(), sinceMs: cutoff, includeUndated: opts.includeUndated };
+  //
+  // syntheticEntries states what this scanner's entries ARE: built from the
+  // external ATS dataset, not read from portals.yml tracked_companies.
+  // workday.mjs picks its cap-hit warning from it — there is no portal entry
+  // here for the user to edit, so "raise max_pages on this entry" would be
+  // inactionable. It used to infer that from sinceMs being set, which stopped
+  // being true once #2418 taught scan.mjs --since to set it too (#2495).
+  const ctx = { ...makeHttpCtx(), sinceMs: cutoff, includeUndated: opts.includeUndated, syntheticEntries: true };
   const date = new Date().toISOString().slice(0, 10);
 
   // Same defensive default as completedSources/counters below: a version-1

--- a/tests/providers/workday.test.mjs
+++ b/tests/providers/workday.test.mjs
@@ -224,6 +224,70 @@ try {
     fail(`workday fetch cap: expected a truncation warning, got ${JSON.stringify(capturedWarnings)}`);
   }
 
+  // Which cap warning fires is keyed on ENTRY PROVENANCE, not on the date
+  // bound (#2495). "raise max_pages on this entry for more" is only actionable
+  // when the caller has a real portals.yml tracked_companies entry to edit;
+  // scan-ats-full.mjs synthesizes its entries from an external dataset and has
+  // nothing to point at, so it gets the terser line.
+  //
+  // `sinceMs === null` used to stand in for that distinction because
+  // scan-ats-full.mjs was the only caller setting it. Since #2418 `scan.mjs
+  // --since` sets ctx.sinceMs too, so the proxy silently mislabels a tracked
+  // entry as synthesized. These three cases pin the two messages to provenance
+  // so the next caller to start setting sinceMs cannot re-couple them.
+  const capEntry = { name: 'CappedCo', careers_url: 'https://cappedco.wd5.myworkdayjobs.com/careers', max_pages: 3 };
+  // total=200 → 10 pages available, capped at 3. Every posting is "Posted
+  // Today" so the --since early-stop never pre-empts the cap.
+  const capPage = () => ({
+    total: 200,
+    jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `Job ${i}`, externalPath: `/job/board/${i}`, postedOn: 'Posted Today' })),
+  });
+  const runCapCase = async (ctxExtra) => {
+    const { errors } = await captureConsoleErrors(() =>
+      workday.fetch(capEntry, mkWorkdayCtx(async () => capPage(), ctxExtra)));
+    return errors.map(String);
+  };
+  const ADVICE = /raise max_pages on this entry for more/;
+  const sevenDaysAgo = Date.now() - 7 * 86_400_000;
+
+  // scan.mjs without --since — the case that always worked.
+  const capFullRun = await runCapCase({});
+  if (capFullRun.some(w => ADVICE.test(w))) {
+    pass('workday.fetch() cap warning: a full scan.mjs run gets the "raise max_pages" advice');
+  } else {
+    fail(`workday cap warning (full run): expected the raise-max_pages advice, got ${JSON.stringify(capFullRun)}`);
+  }
+
+  // scan.mjs --since — same tracked entry, same cap; only the date bound differs.
+  const capSinceRun = await runCapCase({ sinceMs: sevenDaysAgo, includeUndated: true });
+  if (capSinceRun.some(w => ADVICE.test(w))) {
+    pass('workday.fetch() cap warning: a scan.mjs --since run keeps the "raise max_pages" advice');
+  } else {
+    fail(`workday cap warning (--since run): expected the raise-max_pages advice, got ${JSON.stringify(capSinceRun)}`);
+  }
+
+  // scan-ats-full.mjs — synthesized entries, nothing for the user to edit.
+  const capReverseScan = await runCapCase({ sinceMs: sevenDaysAgo, syntheticEntries: true });
+  if (capReverseScan.some(w => /truncated at 3 pages/.test(w)) && !capReverseScan.some(w => ADVICE.test(w))) {
+    pass('workday.fetch() cap warning: a reverse scan (synthesized entries) stays terse, no advice');
+  } else {
+    fail(`workday cap warning (reverse scan): expected the terse line without advice, got ${JSON.stringify(capReverseScan)}`);
+  }
+
+  // The "total may be Workday-capped" tag rides on the terse line and is about
+  // the tenant's total, not about provenance — it must survive the rekey.
+  const suspectEntry = { name: 'SuspectCo', careers_url: 'https://suspectco.wd5.myworkdayjobs.com/careers', max_pages: 3 };
+  const { errors: suspectWarnings } = await captureConsoleErrors(() =>
+    workday.fetch(suspectEntry, mkWorkdayCtx(async () => ({
+      total: 60, // exactly max_pages * PAGE_SIZE → the suspicious shape
+      jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `Job ${i}`, externalPath: `/job/board/${i}`, postedOn: 'Posted Today' })),
+    }), { sinceMs: sevenDaysAgo, syntheticEntries: true })));
+  if (suspectWarnings.some(w => /total may be Workday-capped, not real/.test(String(w)))) {
+    pass('workday.fetch() cap warning: the Workday-capped-total tag survives on the reverse-scan line');
+  } else {
+    fail(`workday cap warning (suspect total): expected the capped-total tag, got ${JSON.stringify(suspectWarnings)}`);
+  }
+
   // fetch() pagination cap — entry.max_pages raises the cap for a genuinely
   // large tenant (e.g. Deutsche Bank-scale postings)
   let overriddenWorkdayRequests = 0;
@@ -470,8 +534,8 @@ try {
     fail(`workday wide-since: requests=${wideRequests}, jobs=${wideJobs.length} (expected 2/40)`);
   }
 
-  // fetch() cap-hit warning — reverse-scan context (ctx.sinceMs set, as
-  // scan-ats-full.mjs always does) where entries are synthesized from an
+  // fetch() cap-hit warning — reverse-scan context (ctx.syntheticEntries set,
+  // as scan-ats-full.mjs does) where entries are synthesized from an
   // external dataset, not portals.yml: there's no portal entry to edit, and
   // — per the "no fixed cap can guarantee full coverage" conclusion — no
   // fix to advise at all, so the message is just the short fact, with
@@ -483,7 +547,7 @@ try {
     workday.fetch(entry, mkWorkdayCtx(async () => ({
       total: 1_000_000,
       jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `NoDate ${i}`, externalPath: `/job/board/nodate-${i}` })), // no postedOn
-    }), { sinceMs: noDateSinceMs, includeUndated: true })));
+    }), { sinceMs: noDateSinceMs, includeUndated: true, syntheticEntries: true })));
   if (noDateWarnings.some(w => /truncated at \d+ pages/.test(w))) {
     pass('workday.fetch() cap-hit warning fires in reverse-scan context (tenant has no dates, includeUndated on)');
   } else {
@@ -554,7 +618,7 @@ try {
     workday.fetch(entry, mkWorkdayCtx(async () => ({
       total: 1_000_000,
       jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `Fresh ${i}`, externalPath: `/job/board/fresh-${i}`, postedOn: 'Posted Today' })),
-    }), { sinceMs: datedCapSinceMs })));
+    }), { sinceMs: datedCapSinceMs, syntheticEntries: true })));
   if (datedCapWarnings.some(w => /truncated at \d+ pages \(2000 of 1000000 jobs\)/.test(w))) {
     pass('workday.fetch() cap-hit warning reports the short "truncated at N pages" form');
   } else {
@@ -577,7 +641,7 @@ try {
     workday.fetch(entry, mkWorkdayCtx(async () => ({
       total: 2000, // === DEFAULT_MAX_PAGES (100) * PAGE_SIZE (20)
       jobPostings: Array.from({ length: 20 }, (_, i) => ({ title: `Suspect ${i}`, externalPath: `/job/board/suspect-${i}`, postedOn: 'Posted Today' })),
-    }), { sinceMs: suspectCapSinceMs })));
+    }), { sinceMs: suspectCapSinceMs, syntheticEntries: true })));
   if (suspectCapWarnings.some(w => /\(total may be Workday-capped, not real\)/.test(w))) {
     pass('workday.fetch() cap-hit warning flags a suspected Workday-side total cap when total === maxPages*PAGE_SIZE');
   } else {


### PR DESCRIPTION
## What does this PR do?

`providers/workday.mjs` picked between its two cap-hit warnings by testing `sinceMs === null`. That was a proxy for the real question — *"does this caller have a `portals.yml` `tracked_companies` entry the user could edit?"* — and since #2418 the proxy no longer holds, so a `scan.mjs --since` run loses the `raise max_pages on this entry for more` advice on a tracked company. This states provenance explicitly instead of inferring it: `scan-ats-full.mjs` sets `ctx.syntheticEntries`, and the message is keyed on that.

## Related issue

Fixes #2495

## Reproducing it

Driving `workday.fetch()` directly with a mock transport, one `tracked_companies` entry with `max_pages: 3`, `total: 200`, every posting `Posted Today` (so the `--since` early-stop never pre-empts the cap). The **only** difference between the two runs is `ctx.sinceMs`:

| run | warning | actionable? |
|---|---|---|
| `node scan.mjs` (`sinceMs = null`) | `⚠️  workday: AcmeCorp truncated at max_pages=3 (60 of 200 jobs) — raise max_pages on this entry for more` | ✅ |
| `node scan.mjs --since 7d` (`sinceMs = now-7d`) | `⚠️  workday: AcmeCorp truncated at 3 pages (60 of 200 jobs)` | ❌ |

After this change both runs emit the first line, and a reverse scan still gets the second.

You mentioned on the issue that you don't mark anything `confirmed` until you've reproduced the exact branch — this is a provider-level reproduction against a mock transport, not a live tenant, so it pins the branch rather than the field report. Happy to adjust if you'd rather see it framed differently.

## Why the change touches a second file

`workday.mjs` on its own can only *infer* provenance, which is the bug. The one caller that both synthesizes entries and can reach the cap has to say so — `scan-ats-full.mjs` is a one-line `ctx` addition. `discover-ats.mjs` and `verify-portals.mjs` also call `workday.fetch()` with synthesized/tracked entries, but both probe with `ctx.maxPages: 1`, which never sets `stopReason` to `'cap'`, so neither needs to opt in. Absence of the flag therefore means "tracked", which keeps the next caller that starts setting `sinceMs` from re-coupling the two concerns — the shape you and @LayerC0de both landed on in the issue.

## Before / after

```diff
-    if (sinceMs === null) {
+    const syntheticEntries = ctx?.syntheticEntries === true;
+    if (!syntheticEntries) {
```

Both message strings are unchanged; only the condition selecting between them moved. The `(total may be Workday-capped, not real)` tag is about the tenant's `total`, not about provenance, so it stays on the terse line — pinned by a test so the rekey can't quietly drop it.

## Tests

Four assertions in `tests/providers/workday.test.mjs`, pinning which warning fires for which caller:

- a full `scan.mjs` run gets the advice
- a `scan.mjs --since` run **keeps** the advice ← fails on `main`, passes here
- a reverse scan (synthesized entries) stays terse, no advice
- the Workday-capped-total tag survives on the reverse-scan line

Three existing tests encoded the old proxy (they simulated "reverse-scan context" with `sinceMs` alone); they now declare `syntheticEntries: true`, which is what they were always describing in their comments.

`node test-all.mjs`: **3434 passed, 0 failed** (3430 on `main` — the +4 are the new assertions). The single warning is the pre-existing `cv-sync-check.mjs exited with error (expected without user data)`, present on `main` too.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination-limit warnings for tracked job listings, including clearer guidance to increase the maximum page limit when results may be incomplete.
  * Refined warnings for externally sourced listings to provide more relevant messaging without suggesting portal-specific changes.
  * Preserved existing indicators when Workday reports a capped total of available results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->