### PR TITLE
fix(deps): raise the js-yaml floor to ^4.3.1 and guard it

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
     "dotenv": "^17.0.0",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.3.1",
     "playwright": "1.62.1"
   }
 }

--- a/tests/js-yaml-version-floor.test.mjs
+++ b/tests/js-yaml-version-floor.test.mjs
@@ -40,18 +40,31 @@ console.log('\njs-yaml must never be declared with a range admitting a known-vul
 const JS_YAML_FLOOR = [4, 3, 1];
 const FLOOR_TEXT = JS_YAML_FLOOR.join('.');
 
-/** @returns {string[]} every tracked package.json in the repo. */
+/**
+ * @returns {{files: string[], error: string|null}} every tracked package.json.
+ * The error is returned rather than thrown: an uncaught throw here kills the
+ * process before the reporting below runs, so a missing git or a ROOT that is
+ * not a work tree would surface as a crash instead of a counted failure. Every
+ * other way this sweep can cover nothing is reported through fail(); this one
+ * has to be too, or the fail-closed guarantee has a hole exactly where the
+ * discovery step is.
+ */
 function manifests() {
-  // -z: NUL-separated, so a path containing a newline or quote cannot split a
-  // record and silently drop a manifest from the sweep.
-  const out = execFileSync('git', ['-C', ROOT, 'ls-files', '-z', '--', '*package.json'], {
-    encoding: 'utf-8',
-    maxBuffer: 16 * 1024 * 1024,
-  });
-  return out
-    .split('\0')
-    .filter((p) => p && basename(p) === 'package.json')
-    .map((p) => join(ROOT, p));
+  try {
+    // -z: NUL-separated, so a path containing a newline or quote cannot split a
+    // record and silently drop a manifest from the sweep.
+    const out = execFileSync('git', ['-C', ROOT, 'ls-files', '-z', '--', '*package.json'], {
+      encoding: 'utf-8',
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    const files = out
+      .split('\0')
+      .filter((p) => p && basename(p) === 'package.json')
+      .map((p) => join(ROOT, p));
+    return { files, error: null };
+  } catch (err) {
+    return { files: [], error: err.message.split('\n')[0] };
+  }
 }
 
 // Lowest version a range can resolve to, for the range shapes this repo uses.
@@ -99,7 +112,7 @@ const unparseable = [];
 const unreadable = [];
 let declaring = 0;
 
-const found = manifests();
+const { files: found, error: discoveryError } = manifests();
 for (const file of found) {
   let pkg;
   try {
@@ -123,7 +136,9 @@ for (const file of found) {
 
 // Zero manifests, or manifests but none declaring js-yaml, both mean the sweep
 // proved nothing — the exact shape of silent pass this test exists to prevent.
-if (found.length === 0) {
+if (discoveryError !== null) {
+  fail(`could not list tracked manifests, so the js-yaml floor sweep ran against nothing: ${discoveryError}`);
+} else if (found.length === 0) {
   fail('git ls-files produced no package.json — the js-yaml floor sweep scanned nothing');
 } else if (unreadable.length > 0) {
   fail(`could not parse ${unreadable.length} manifest(s), so the js-yaml floor sweep is incomplete: ${unreadable.join(', ')}`);

--- a/tests/js-yaml-version-floor.test.mjs
+++ b/tests/js-yaml-version-floor.test.mjs
@@ -1,0 +1,138 @@
+// tests/js-yaml-version-floor.test.mjs — no manifest may declare a js-yaml range
+// that admits a version with a known advisory.
+//
+// js-yaml has had two HIGH advisories fixed inside the 4.x line:
+//   GHSA-52cp-r559-cp3m  fixed in 4.3.0
+//   CVE-2026-59870 / GHSA-5p4m-2wfm-xmqj (quadratic CPU in !!omap resolution)
+//                        fixed in 4.3.1
+// So 4.3.1 is the lowest version carrying both fixes, and any range whose lowest
+// satisfying version is below it is a declaration that a vulnerable version is
+// acceptable.
+//
+// The lower bound of the range IS the guarantee, and it is easy to believe
+// otherwise. `^4.3.0` reads as "4.3.0 and its security patches" but it literally
+// permits 4.3.0, the version the second advisory was filed against. The root
+// package-lock.json is gitignored, so nothing else holds the line: a fresh
+// install (CI) resolves the newest 4.x and looks fine, while a developer checkout
+// whose lockfile already pins the vulnerable version stays there — `npm install`
+// reports success and changes nothing, because the pinned version satisfies the
+// declared range. That is not hypothetical; it is how this was found.
+//
+// Manifests are DISCOVERED, not listed. A hardcoded pair holds only until the
+// next workspace is added, and the failure is silent: the new manifest simply is
+// not checked. `git ls-files` is the set that ships, needs no skip-list, and
+// cannot wander into untracked scratch (a killed test-all.mjs run leaves a
+// `.tmp-script-test-*` copy of the whole repo behind).
+//
+// KNOWN LIMIT — this checks the declared range, not what a lockfile resolved to.
+// The two answer different questions: the range is the project's standing claim
+// about what is acceptable, a lockfile is one snapshot of one resolution. A range
+// that excludes the vulnerable versions makes every future resolution safe, which
+// is the durable half.
+
+import { pass, fail, ROOT } from './helpers.mjs';
+import { readFileSync } from 'fs';
+import { execFileSync } from 'child_process';
+import { join, relative, basename } from 'path';
+
+console.log('\njs-yaml must never be declared with a range admitting a known-vulnerable version');
+
+const JS_YAML_FLOOR = [4, 3, 1];
+const FLOOR_TEXT = JS_YAML_FLOOR.join('.');
+
+/** @returns {string[]} every tracked package.json in the repo. */
+function manifests() {
+  // -z: NUL-separated, so a path containing a newline or quote cannot split a
+  // record and silently drop a manifest from the sweep.
+  const out = execFileSync('git', ['-C', ROOT, 'ls-files', '-z', '--', '*package.json'], {
+    encoding: 'utf-8',
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  return out
+    .split('\0')
+    .filter((p) => p && basename(p) === 'package.json')
+    .map((p) => join(ROOT, p));
+}
+
+// Lowest version a range can resolve to, for the range shapes this repo uses.
+// Returns null for anything else — a range we cannot read is reported, never
+// assumed safe, because "unrecognized" and "fine" must not look the same.
+function rangeMinimum(range) {
+  const m = /^(?:\^|~|>=)?\s*(\d+)\.(\d+)\.(\d+)$/.exec(String(range ?? '').trim());
+  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+}
+
+function atLeastFloor(v) {
+  for (let i = 0; i < JS_YAML_FLOOR.length; i++) {
+    if (v[i] > JS_YAML_FLOOR[i]) return true;
+    if (v[i] < JS_YAML_FLOOR[i]) return false;
+  }
+  return true;
+}
+
+// Guard the guard: a parser that returned null for everything, or a comparator
+// that returned true for everything, would report a clean sweep forever. Prove
+// both directions fire before trusting the verdict on the real manifests.
+const REJECT = ['^4.1.1', '^4.2.0', '^4.3.0', '~4.3.0', '>=4.0.0', '3.15.0'];
+const ACCEPT = ['^4.3.1', '~4.3.2', '4.3.1', '>=4.4.0', '^5.2.3'];
+const UNREADABLE = ['4.x', 'latest', '^4.2 || ^5', 'github:nodeca/js-yaml', ''];
+const rejectsLow = REJECT.every((r) => {
+  const min = rangeMinimum(r);
+  return min !== null && !atLeastFloor(min);
+});
+const acceptsOk = ACCEPT.every((r) => {
+  const min = rangeMinimum(r);
+  return min !== null && atLeastFloor(min);
+});
+const flagsUnknown = UNREADABLE.every((r) => rangeMinimum(r) === null);
+if (rejectsLow && acceptsOk && flagsUnknown) {
+  pass(`floor check rejects ${REJECT.length} low ranges, accepts ${ACCEPT.length} safe ones, and flags ${UNREADABLE.length} it cannot read`);
+} else {
+  fail(`floor check broken: rejectsLow=${rejectsLow} acceptsOk=${acceptsOk} flagsUnknown=${flagsUnknown} — it would report a clean sweep regardless of the manifests`);
+}
+
+const offenders = [];
+const unparseable = [];
+// A manifest that cannot be read is not a manifest that passes. Anything
+// unreadable is its own failure rather than a skip, so the sweep cannot go green
+// while covering less of the tree than it claims.
+const unreadable = [];
+let declaring = 0;
+
+const found = manifests();
+for (const file of found) {
+  let pkg;
+  try {
+    pkg = JSON.parse(readFileSync(file, 'utf-8'));
+  } catch (err) {
+    unreadable.push(`${relative(ROOT, file)} (${err.code || err.message})`);
+    continue;
+  }
+  // `@types/js-yaml` is types-only and ships no parser, so it is deliberately
+  // not covered by the floor.
+  const range = pkg.dependencies?.['js-yaml'] ?? pkg.devDependencies?.['js-yaml'];
+  if (range === undefined) continue; // a manifest that does not use js-yaml is fine
+  declaring++;
+  const min = rangeMinimum(range);
+  if (min === null) {
+    unparseable.push(`${relative(ROOT, file)} declares "${range}"`);
+  } else if (!atLeastFloor(min)) {
+    offenders.push(`${relative(ROOT, file)} declares "${range}" (admits ${min.join('.')})`);
+  }
+}
+
+// Zero manifests, or manifests but none declaring js-yaml, both mean the sweep
+// proved nothing — the exact shape of silent pass this test exists to prevent.
+if (found.length === 0) {
+  fail('git ls-files produced no package.json — the js-yaml floor sweep scanned nothing');
+} else if (unreadable.length > 0) {
+  fail(`could not parse ${unreadable.length} manifest(s), so the js-yaml floor sweep is incomplete: ${unreadable.join(', ')}`);
+} else if (declaring === 0) {
+  fail(`none of the ${found.length} tracked manifests declares js-yaml — either the dependency was dropped (delete this test) or the sweep is looking in the wrong place`);
+} else if (unparseable.length > 0) {
+  fail(`js-yaml range(s) this check cannot read as a lower bound, verify against the ${FLOOR_TEXT} floor by hand: ${unparseable.join(', ')}`);
+} else if (offenders.length === 0) {
+  pass(`all ${declaring} manifest(s) declaring js-yaml are at or above the ${FLOOR_TEXT} floor (GHSA-52cp-r559-cp3m, CVE-2026-59870)`);
+} else {
+  fail(`js-yaml range(s) below the ${FLOOR_TEXT} security floor — raise them: ${offenders.join(', ')}`);
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,7 +11,7 @@
         "@paper-design/shaders-react": "^0.0.78",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "js-yaml": "^4.2.0",
+        "js-yaml": "^4.3.1",
         "lucide-react": "^1.8.0",
         "next": "16.3.0",
         "playwright-core": "^1.61.0",

--- a/web/package.json
+++ b/web/package.json
@@ -17,7 +17,7 @@
     "@paper-design/shaders-react": "^0.0.78",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.1",
     "lucide-react": "^1.8.0",
     "next": "16.3.0",
     "playwright-core": "^1.61.0",


### PR DESCRIPTION
## What does this PR do?

Raises the declared `js-yaml` range to `^4.3.1` in both manifests, so neither permits a version carrying a published HIGH advisory, and adds an auto-discovered test that asserts the floor so it cannot quietly go stale again.

## Related issue

Fixes #2766

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---

## The declaration, not the resolution

Two HIGH advisories were fixed inside the 4.x line: GHSA-52cp-r559-cp3m in 4.3.0, and CVE-2026-59870 (quadratic CPU in `!!omap` resolution) in 4.3.1. Both declared ranges sit below them.

| Manifest | Before | After | Resolved (unchanged) |
|---|---|---|---|
| `package.json` | `^4.1.1` | `^4.3.1` | 4.3.1 |
| `web/package.json` | `^4.2.0` | `^4.3.1` | 4.3.1 |

#2698 moved `web/package-lock.json` onto 4.3.1, which fixed the resolution but not the declaration. At the root there is no lockfile to fall back on, since `package-lock.json` is gitignored, so the range is the whole guarantee there.

Only the ranges moved. Neither lockfile was regenerated, and `web/package-lock.json` changed by exactly one line, the recorded range for the direct dependency, so the manifest and the lock do not disagree on disk. The resolved version is 4.3.1 on both sides before and after, so nothing about the installed tree changes.

The reason this is worth fixing rather than leaving to the lockfile: a fresh install with no lockfile present resolves the newest 4.x and looks fine, which is what CI does every run. The case that bites is a checkout whose lockfile already pins an older version. That version satisfies the declared range, so `npm install` exits clean and changes nothing. Raising the range fixes that case too, because once the vulnerable versions no longer satisfy it, a plain `npm install` moves the tree on its own.

## The guard

`tests/js-yaml-version-floor.test.mjs` reads the declared minimum of every manifest that depends on `js-yaml` and compares it to one `JS_YAML_FLOOR` constant. Same auto-discovered layout as `tests/js-yaml-import-form.test.mjs` from #2656, so there is nothing to register in `test-all.mjs`.

It **discovers** manifests with `git ls-files` rather than carrying a hardcoded list. A list holds only until the next workspace, and the failure is the silent kind: the new manifest simply is not checked. There is already a third tracked manifest, `scaffolder/package.json`, which happens not to declare `js-yaml` today.

It fails closed on every degenerate case, so a sweep that covered nothing cannot report success: no manifests found, manifests found but none declaring `js-yaml`, an unreadable manifest, or a range it cannot read as a lower bound (`4.x`, `latest`, a union range) is reported for a human to check rather than assumed safe.

It proves its own parser and comparator against sixteen probe ranges before trusting either on the real files, in the same spirit as the detector self-check in #2656. A comparator that returned true for everything, or a parser that returned null for everything, would otherwise report a clean sweep forever.

One deliberate limit, noted in the file: this checks the declared range, not what a lockfile resolved to. They answer different questions, and the range is the durable half, since it makes every future resolution safe rather than one snapshot of one.

If you would rather take the two-line range bump on its own and skip the guard, say so and I will drop the test file. It is separable.

## Verification

Confirmed failing against the current ranges before the change:

```
✅ floor check rejects 6 low ranges, accepts 5 safe ones, and flags 5 it cannot read
❌ js-yaml range(s) below the 4.3.1 security floor — raise them: package.json declares "^4.1.1" (admits 4.1.1), web/package.json declares "^4.2.0" (admits 4.2.0)
```

and after:

| Gate | Result |
|---|---|
| `node test-all.mjs` | 3579 passed, 0 failed, 1 warning (3577 on `main`, so the difference is exactly the two new assertions) |
| `npm audit` (root) | 0 vulnerabilities, `js-yaml` 4.3.1 |
| `npm ci` (in `web/`) | clean |
| `npm audit` (in `web/`) | 0 vulnerabilities, `js-yaml` 4.3.1 |
| `npm test` (in `web/`) | 133 passed, 0 failed |
| `npx tsc --noEmit` (in `web/`) | clean |
| `npm run build` (in `web/`) | clean |
| `go test ./...` (in `dashboard/`) | all packages ok |

Built on `main` at `03fc92b`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the YAML parsing dependency to version 4.3.1 or newer across the project.
  - Improved security by ensuring all application manifests meet the minimum supported dependency version.

- **Tests**
  - Added validation to detect missing, unreadable, invalid, or outdated dependency declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->