### PR TITLE
fix(csod): send bootstrap session cookies; repair fetchResponse()

### DIFF
--- a/providers/_http.mjs
+++ b/providers/_http.mjs
@@ -58,12 +58,26 @@ export async function fetchText(url, opts = {}) {
   return fetchWithTimeout(url, opts, (res) => res.text());
 }
 
-// Returns the raw Response (after the timeout + non-2xx guard) so providers that
-// need response headers — e.g. startup.ch reads Set-Cookie to prime a session —
-// can route through ctx instead of re-implementing fetch. Pass redirect:'error'
-// like every other provider call so a 3xx can't be followed to a private IP.
+// Returns a Response (after the timeout + non-2xx guard) so providers that need
+// response headers — csod.mjs reads Set-Cookie to prime the session its search
+// API requires — can route through ctx instead of re-implementing fetch. Pass
+// redirect:'error' like every other provider call so a 3xx can't be followed to
+// a private IP.
+//
+// The body is read here, inside the timer window, and handed back as an
+// equivalent Response. Two reasons: returning the live Response would let a
+// server that stalls its body hang the caller forever with the abort timer
+// already cleared (the failure fetchWithTimeout documents above), and this
+// function previously omitted the `consume` argument entirely, so it threw
+// "consume is not a function" on every call — it had no working callers to
+// preserve bug-compatibility with. Header identity, including repeated
+// Set-Cookie (getSetCookie()), survives the reconstruction.
+const NULL_BODY_STATUSES = new Set([204, 205, 304]);
 export async function fetchResponse(url, opts = {}) {
-  return await fetchWithTimeout(url, opts);
+  return await fetchWithTimeout(url, opts, async (res) => {
+    const body = NULL_BODY_STATUSES.has(res.status) ? null : await res.text();
+    return new Response(body, { status: res.status, statusText: res.statusText, headers: res.headers });
+  });
 }
 
 /** Jitter added to a backoff so concurrent retries don't re-collide in lockstep. */

--- a/providers/csod.mjs
+++ b/providers/csod.mjs
@@ -7,9 +7,13 @@
 //
 // The search API is public but wants a bearer token. The career-site home page
 // is a small (~5 KB) bootstrap document that embeds an ANONYMOUS JWT as
-// `"token":"eyJ…"` — no login, no session cookies needed. Flow per fetch:
+// `"token":"eyJ…"` — no login needed. It ALSO sets session cookies, and some
+// tenants (verified live on careers-kln) reject the search call with
+// "HTTP 401 CSOD Unauthorized" unless those cookies come back alongside the
+// token, so both halves of the bootstrap response matter. Flow per fetch:
 //
-//   1. GET  {origin}/ux/ats/careersite/{siteId}/home?c={corpName}   → extract token
+//   1. GET  {origin}/ux/ats/careersite/{siteId}/home?c={corpName}
+//                                          → extract token AND session cookies
 //   2. POST {origin}/services/x/career-site/v1/search               → page through
 //      body: {careerSiteId, careerSitePageId, pageNumber (1-based), pageSize,
 //             cultureId, cultureName, searchText:"", …empty facet arrays}
@@ -55,6 +59,27 @@ export function resolveConfig(entry) {
     homeUrl: `${u.origin}/ux/ats/careersite/${siteId}/home?c=${encodeURIComponent(corpName)}`,
     searchApi: `${u.origin}/services/x/career-site/v1/search`,
   };
+}
+
+/**
+ * Build a `Cookie` request header from the bootstrap response's Set-Cookie
+ * headers. Only the leading name=value pair is meaningful on a request;
+ * attributes (path/HttpOnly/Secure/SameSite/Expires) describe storage rules for
+ * a browser jar and are dropped. A repeated name takes its last definition,
+ * mirroring jar semantics. Returns '' when nothing usable was set, which the
+ * caller treats as "send no cookie header at all".
+ * @param {string[]} setCookies @returns {string}
+ */
+export function cookieHeaderFrom(setCookies) {
+  const jar = new Map();
+  for (const raw of Array.isArray(setCookies) ? setCookies : []) {
+    if (typeof raw !== 'string') continue;
+    const pair = raw.split(';', 1)[0].trim();
+    const eq = pair.indexOf('=');
+    if (eq <= 0) continue; // no '=', or an empty name — not a cookie
+    jar.set(pair.slice(0, eq).trim(), pair.slice(eq + 1).trim());
+  }
+  return [...jar].map(([name, value]) => `${name}=${value}`).join('; ');
 }
 
 /**
@@ -146,7 +171,27 @@ export default {
     const cfg = resolveConfig(entry);
     if (!cfg) throw new Error(`csod: cannot resolve careersite URL for ${entry.name}`);
 
-    const html = await ctx.fetchText(cfg.homeUrl, { headers: { accept: 'text/html' } });
+    // The bootstrap page yields two things, not one: the anonymous bearer
+    // token, and — on some tenants — the session cookies the search API
+    // insists on. careers-kln rejects an otherwise valid token+body with
+    // "HTTP 401 CSOD Unauthorized" until those cookies come back with it, so
+    // the token alone is not a sufficient credential. Prefer ctx.fetchResponse
+    // to see Set-Cookie; fall back to fetchText when the caller's ctx predates
+    // it (older embedders and test mocks), which keeps the pre-cookie
+    // behaviour intact for tenants that never needed it.
+    //
+    // cfg.homeUrl and cfg.searchApi are both built from the same parsed
+    // origin, so replaying these cookies cannot reach a third-party host.
+    let html;
+    let cookie = '';
+    if (typeof ctx.fetchResponse === 'function') {
+      const res = await ctx.fetchResponse(cfg.homeUrl, { headers: { accept: 'text/html' } });
+      const setCookies = typeof res?.headers?.getSetCookie === 'function' ? res.headers.getSetCookie() : [];
+      cookie = cookieHeaderFrom(setCookies);
+      html = await res.text();
+    } else {
+      html = await ctx.fetchText(cfg.homeUrl, { headers: { accept: 'text/html' } });
+    }
     const token = extractToken(html);
     if (!token) throw new Error(`csod: no anonymous token on ${cfg.homeUrl}`);
 
@@ -165,6 +210,7 @@ export default {
           'content-type': 'application/json',
           accept: 'application/json',
           authorization: `Bearer ${token}`,
+          ...(cookie ? { cookie } : {}),
         },
         body: JSON.stringify({
           careerSiteId: cfg.siteId,

--- a/providers/csod.mjs
+++ b/providers/csod.mjs
@@ -45,7 +45,9 @@ export function resolveConfig(entry) {
   } catch {
     return null;
   }
-  if (u.protocol !== 'https:' && u.protocol !== 'http:') return null;
+  // HTTPS only: the bootstrap Set-Cookie values are replayed on the search
+  // request, so an http: entry would put session cookies on the wire in clear.
+  if (u.protocol !== 'https:') return null;
   const host = u.host.toLowerCase();
   if (host !== 'csod.com' && !host.endsWith('.csod.com')) return null;
   const m = u.pathname.match(/\/ux\/ats\/careersite\/(\d+)\//i) || u.pathname.match(/\/ux\/ats\/careersite\/(\d+)$/i);
@@ -182,15 +184,17 @@ export default {
     //
     // cfg.homeUrl and cfg.searchApi are both built from the same parsed
     // origin, so replaying these cookies cannot reach a third-party host.
+    // redirect:'error' on the bootstrap keeps that true: origin validation
+    // covers the URL we ask for, not wherever a 3xx would send us.
     let html;
     let cookie = '';
     if (typeof ctx.fetchResponse === 'function') {
-      const res = await ctx.fetchResponse(cfg.homeUrl, { headers: { accept: 'text/html' } });
+      const res = await ctx.fetchResponse(cfg.homeUrl, { redirect: 'error', headers: { accept: 'text/html' } });
       const setCookies = typeof res?.headers?.getSetCookie === 'function' ? res.headers.getSetCookie() : [];
       cookie = cookieHeaderFrom(setCookies);
       html = await res.text();
     } else {
-      html = await ctx.fetchText(cfg.homeUrl, { headers: { accept: 'text/html' } });
+      html = await ctx.fetchText(cfg.homeUrl, { redirect: 'error', headers: { accept: 'text/html' } });
     }
     const token = extractToken(html);
     if (!token) throw new Error(`csod: no anonymous token on ${cfg.homeUrl}`);

--- a/tests/providers/_http.test.mjs
+++ b/tests/providers/_http.test.mjs
@@ -12,7 +12,7 @@ import { pathToFileURL } from 'url';
 
 console.log('\nProvider — _http retry helpers');
 
-const { isRetryableError, fetchJsonWithRetry } =
+const { isRetryableError, fetchJsonWithRetry, fetchResponse } =
   await import(pathToFileURL(join(ROOT, 'providers/_http.mjs')).href);
 
 // isRetryableError() — status-based classification.
@@ -90,5 +90,43 @@ if (isRetryableError(nonTypeErrorLookalike) === true) {
     } else {
       fail(`fetchJsonWithRetry redirect refusal: calls=${calls}, error=${e?.message}`);
     }
+  }
+}
+
+// ── fetchResponse() ─────────────────────────────────────────────────────────
+// Regression: fetchResponse() previously called the internal fetchWithTimeout
+// WITHOUT its required `consume` callback, so every call threw
+// "consume is not a function". It had no callers, so nothing caught it until
+// csod.mjs needed Set-Cookie off the bootstrap response. These tests pin the
+// contract it is meant to provide.
+{
+  const realFetch = globalThis.fetch;
+  const stub = (body, init) => { globalThis.fetch = async () => new Response(body, init); };
+  try {
+    // Repeated Set-Cookie must survive — this is the whole reason the helper
+    // exists, and a naive header copy collapses them into one comma-joined value.
+    const headers = new Headers();
+    headers.append('set-cookie', 'ASP.NET_SessionId=abc; path=/; HttpOnly');
+    headers.append('set-cookie', 'tenant=kln; Secure');
+    stub('{"token":"tok"}', { status: 200, headers });
+    const res = await fetchResponse('https://example.com/home');
+    const cookies = res.headers.getSetCookie();
+    if (cookies.length === 2 && cookies[0].startsWith('ASP.NET_SessionId=abc')) {
+      pass('fetchResponse() preserves repeated Set-Cookie headers');
+    } else {
+      fail(`fetchResponse() set-cookie wrong: ${JSON.stringify(cookies)}`);
+    }
+    if (await res.text() === '{"token":"tok"}') pass('fetchResponse() body is still readable by the caller');
+    else fail('fetchResponse() body should be readable');
+
+    // A null-body status must not blow up the Response reconstruction.
+    stub(null, { status: 204 });
+    const empty = await fetchResponse('https://example.com/empty');
+    if (empty.status === 204) pass('fetchResponse() handles null-body statuses (204) without throwing');
+    else fail(`fetchResponse() 204 wrong: status=${empty.status}`);
+  } catch (e) {
+    fail(`fetchResponse() threw: ${e.message}`);
+  } finally {
+    globalThis.fetch = realFetch;
   }
 }

--- a/tests/providers/csod.test.mjs
+++ b/tests/providers/csod.test.mjs
@@ -108,6 +108,63 @@ try {
   await csod.fetch({ name: 'X', api: 'https://x.csod.com/ux/ats/careersite/1/home?c=x' }, { ...mockCtx, fetchText: async () => '<html/>' }).catch((e) => { tokenErr = e.message; });
   if (/no anonymous token/.test(tokenErr)) pass('csod.fetch() throws when the home page carries no token');
   else fail(`csod.fetch() should throw on missing token, got: ${JSON.stringify(tokenErr)}`);
+
+  // ── Session cookie priming ────────────────────────────────────────────────
+  // Some tenants (verified live on careers-kln.csod.com) reject the search API
+  // with "HTTP 401 CSOD Unauthorized" unless the request carries the session
+  // cookies the bootstrap home page set — the anonymous bearer token alone is
+  // not enough. The provider must therefore read Set-Cookie off the bootstrap
+  // RESPONSE and replay it on every search call.
+  const mkCookieCtx = (setCookies) => {
+    const calls = { search: 0, cookieHeaders: [], homeUrls: [] };
+    return {
+      calls,
+      sleep: async () => {},
+      fetchText: async () => { throw new Error('fetchText must not be used when fetchResponse exists'); },
+      fetchResponse: async (url) => {
+        calls.homeUrls.push(url);
+        const headers = new Headers();
+        for (const c of setCookies) headers.append('set-cookie', c);
+        return new Response('{"token":"tok.abc"}', { status: 200, headers });
+      },
+      fetchJson: async (_url, opts) => {
+        // Record the raw value — an absent header must stay `undefined` here,
+        // so don't normalise it to null or the omission assertion can't tell
+        // "no header" from "header set to null".
+        calls.cookieHeaders.push(opts?.headers?.cookie);
+        calls.search++;
+        return { data: { totalCount: 1, requisitions: [mkReq(1, 'Job 1')] } };
+      },
+    };
+  };
+
+  const cookieCtx = mkCookieCtx(['ASP.NET_SessionId=abc123; path=/; HttpOnly', 'csod_tenant=kln; Secure; SameSite=None']);
+  const cookieJobs = await csod.fetch({ name: 'KLN', api: 'https://careers-kln.csod.com/ux/ats/careersite/14/home?c=careers-kln' }, cookieCtx);
+  if (cookieJobs.length === 1) pass('csod.fetch() still returns jobs when priming cookies');
+  else fail(`csod.fetch() cookie path returned ${cookieJobs.length} jobs`);
+  const sentCookie = cookieCtx.calls.cookieHeaders[0];
+  if (sentCookie === 'ASP.NET_SessionId=abc123; csod_tenant=kln') pass('csod.fetch() replays bootstrap Set-Cookie as a cookie header (attributes stripped)');
+  else fail(`csod.fetch() cookie header wrong: ${JSON.stringify(sentCookie)}`);
+
+  // No Set-Cookie → no cookie header at all (never send an empty one).
+  const bareCtx = mkCookieCtx([]);
+  await csod.fetch({ name: 'X', api: 'https://x.csod.com/ux/ats/careersite/1/home?c=x' }, bareCtx);
+  if (bareCtx.calls.cookieHeaders[0] === undefined) pass('csod.fetch() omits the cookie header when the tenant sets none');
+  else fail(`csod.fetch() should omit cookie header, got ${JSON.stringify(bareCtx.calls.cookieHeaders[0])}`);
+
+  // Backward compatibility: a ctx without fetchResponse (older callers, test
+  // mocks) must keep working via fetchText rather than crashing.
+  const legacyCtx = {
+    sleep: async () => {},
+    fetchText: async () => '{"token":"tok.legacy"}',
+    fetchJson: async (_url, opts) => {
+      if (opts?.headers?.cookie !== undefined) throw new Error('legacy path must not send a cookie header');
+      return { data: { totalCount: 1, requisitions: [mkReq(1, 'Job 1')] } };
+    },
+  };
+  const legacyJobs = await csod.fetch({ name: 'L', api: 'https://l.csod.com/ux/ats/careersite/2/home?c=l' }, legacyCtx);
+  if (legacyJobs.length === 1) pass('csod.fetch() falls back to fetchText when ctx has no fetchResponse');
+  else fail(`csod.fetch() legacy path returned ${legacyJobs.length} jobs`);
 } catch (e) {
   fail(`csod provider tests crashed: ${e.message}`);
 }

--- a/tests/providers/csod.test.mjs
+++ b/tests/providers/csod.test.mjs
@@ -25,6 +25,10 @@ try {
   }
   if (resolveConfig({ api: 'https://career-x.csod.com/other/path' }) === null) pass('csod.resolveConfig() rejects non-careersite paths');
   else fail('csod.resolveConfig() should reject non-careersite paths');
+  // HTTPS-only: the bootstrap session cookies are replayed on the search
+  // request, so an http: tenant would put them on the wire in clear.
+  if (resolveConfig({ api: 'http://career-ohb.csod.com/ux/ats/careersite/4/home?c=career-ohb' }) === null) pass('csod.resolveConfig() rejects http:// (cookies must never go out in clear)');
+  else fail('csod.resolveConfig() should reject http:// careersite URLs');
 
   // detect — host-anchored, path-shape required; spoofs return null.
   if (csod.detect({ careers_url: 'https://career-ohb.csod.com/ux/ats/careersite/4/home?c=career-ohb' })) pass('csod.detect() matches *.csod.com careersite URLs');
@@ -116,13 +120,14 @@ try {
   // not enough. The provider must therefore read Set-Cookie off the bootstrap
   // RESPONSE and replay it on every search call.
   const mkCookieCtx = (setCookies) => {
-    const calls = { search: 0, cookieHeaders: [], homeUrls: [] };
+    const calls = { search: 0, cookieHeaders: [], homeUrls: [], bootstrapOpts: [] };
     return {
       calls,
       sleep: async () => {},
       fetchText: async () => { throw new Error('fetchText must not be used when fetchResponse exists'); },
-      fetchResponse: async (url) => {
+      fetchResponse: async (url, opts) => {
         calls.homeUrls.push(url);
+        calls.bootstrapOpts.push(opts);
         const headers = new Headers();
         for (const c of setCookies) headers.append('set-cookie', c);
         return new Response('{"token":"tok.abc"}', { status: 200, headers });
@@ -146,6 +151,12 @@ try {
   if (sentCookie === 'ASP.NET_SessionId=abc123; csod_tenant=kln') pass('csod.fetch() replays bootstrap Set-Cookie as a cookie header (attributes stripped)');
   else fail(`csod.fetch() cookie header wrong: ${JSON.stringify(sentCookie)}`);
 
+  // Origin validation only covers the URL we ask for. Without redirect:'error'
+  // the bootstrap would follow a 3xx off the validated csod.com host — and the
+  // cookies it collected there would then be replayed by the search call.
+  if (cookieCtx.calls.bootstrapOpts[0]?.redirect === 'error') pass('csod.fetch() refuses redirects on the bootstrap request');
+  else fail(`csod.fetch() bootstrap must pass redirect:'error', got ${JSON.stringify(cookieCtx.calls.bootstrapOpts[0]?.redirect)}`);
+
   // No Set-Cookie → no cookie header at all (never send an empty one).
   const bareCtx = mkCookieCtx([]);
   await csod.fetch({ name: 'X', api: 'https://x.csod.com/ux/ats/careersite/1/home?c=x' }, bareCtx);
@@ -156,7 +167,10 @@ try {
   // mocks) must keep working via fetchText rather than crashing.
   const legacyCtx = {
     sleep: async () => {},
-    fetchText: async () => '{"token":"tok.legacy"}',
+    fetchText: async (_url, opts) => {
+      if (opts?.redirect !== 'error') throw new Error(`legacy bootstrap must pass redirect:'error', got ${JSON.stringify(opts?.redirect)}`);
+      return '{"token":"tok.legacy"}';
+    },
     fetchJson: async (_url, opts) => {
       if (opts?.headers?.cookie !== undefined) throw new Error('legacy path must not send a cookie header');
       return { data: { totalCount: 1, requisitions: [mkReq(1, 'Job 1')] } };


### PR DESCRIPTION
Closes #2768

Two coupled bugs: CSOD tenants that enforce session cookies scan as `401` / zero jobs, and the helper that would fix it — `fetchResponse()` — has never worked.

## 1. `csod.mjs` — replay the bootstrap session cookies

CSOD's `/services/x/career-site/v1/search` needs the cookies the bootstrap home page sets **alongside** the anonymous JWT. The provider read that page with `ctx.fetchText()`, which discards response headers, so `Set-Cookie` was dropped and every search arrived unauthenticated.

The bootstrap now goes through `ctx.fetchResponse` so `Set-Cookie` is visible, and the cookies are replayed as a `cookie` header on each search POST.

- New exported helper `cookieHeaderFrom()` — keeps the leading `name=value`, strips attributes (`path`/`HttpOnly`/`Secure`/`SameSite`/`Expires`) since those describe browser-jar storage rules and mean nothing on a request, last-wins per name.
- Tenants that set **no** cookies get **no** `cookie` header, not an empty one. This matters: `career-ohb` works today without cookies and must keep working.
- Falls back to `ctx.fetchText` when a ctx has no `fetchResponse`, so older embedders and existing test mocks are unaffected.
- `cfg.homeUrl` and `cfg.searchApi` are built from the same parsed origin, so the replayed cookies cannot reach a third-party host.

The header comment claiming "no login, no session cookies needed" is corrected — that assumption is what the bug was made of.

## 2. `_http.mjs` — make `fetchResponse()` actually run

```js
export async function fetchResponse(url, opts = {}) {
  return await fetchWithTimeout(url, opts);   // `consume` never passed
}
```

`fetchWithTimeout` ends in `return await consume(res)`, so this threw `TypeError: consume is not a function` on **every** call. It went unnoticed because it has no callers — `git grep` matches only `_http.mjs` and `_types.js`. (Its comment cites a `startup.ch` provider as precedent; that provider isn't in this repo.)

**Why not just `(res) => res`:** returning the live `Response` would reintroduce the failure documented directly above it in the same file — a server that sends headers then stalls its body hangs the caller with the abort timer already cleared, which that comment records as having "froze full-directory sweeps silently". So the body is read **inside** the timer window and returned as an equivalent `Response`. Callers keep the standard `{ headers, status, text() }` shape without inheriting the stall.

Null-body statuses (204/205/304) are guarded — the `Response` constructor throws on those with a body. Repeated `Set-Cookie` survives the reconstruction, which is the entire point of the helper and is now pinned by a test.

Since the function never successfully executed, there's no prior behaviour to preserve.

## Verification

Live, against the public `careers-kln.csod.com` tenant (siteId 14):

```
before:  Total jobs found: 0   ✗ HTTP 401 CSOD Unauthorized Exception:Check your credentials.
after:   Total jobs found: 34
```

34 matches the `totalCount` returned by a hand-issued request with a cookie jar, so the board is fully enumerated, not partially.

Tests added:
- `tests/providers/csod.test.mjs` — cookie replay with attributes stripped; header omitted when the tenant sets none; `fetchText` fallback when `ctx` has no `fetchResponse`.
- `tests/providers/_http.test.mjs` — `fetchResponse()` preserves repeated `Set-Cookie`, body stays readable, 204 doesn't throw. These fail on `main` with `consume is not a function`.

Suite status on this branch: **provider suite 1,410 passed / 0 failed** across 79 files; `tests/providers/_http.test.mjs` and `tests/providers/csod.test.mjs` green. (`test-all.mjs` OOMs on my ARM64 box, so files were run individually.)

Both tests were confirmed red before the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed handling for empty-body responses, including successful no-content requests.
  - Preserved response headers, status details, and readable response bodies.
  - Improved CSOD search authentication by retaining session cookies from the initial connection.
  - Restricted CSOD careersite connections to HTTPS for secure cookie handling.
  - Maintained compatibility with previous text-based response handling.
- **Tests**
  - Added coverage for repeated cookies, empty responses, cookie reuse, redirects, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->