### PR TITLE
feat(cli): shared flag-validation helper, migrate 3 fixed scripts, fix scan.mjs (#2270)

### DIFF
--- a/dedup-tracker.mjs
+++ b/dedup-tracker.mjs
@@ -17,6 +17,7 @@ import {
   openTrackerTransaction, rebuildRow, resolveTrackerPath, normalizeCompany,
 } from './tracker-utils.mjs';
 import { resolveColumns, parseTrackerRow, normalizeVia } from './tracker-parse.mjs';
+import { validateFlags } from './lib/cli-flags.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 // Support both layouts: data/applications.md (boilerplate) and applications.md
@@ -27,22 +28,14 @@ const APPS_FILE = resolveTrackerPath(CAREER_OPS);
 // ── CLI args ────────────────────────────────────────────────────────
 // Same shape as scan-ats-full.mjs (#1633/PR #1635) and reply-watch.mjs
 // (#2743): an unrecognized flag must fail fast, never silently fall through
-// to the live-run default and write to the real tracker (#2744).
+// to the live-run default and write to the real tracker (#2744). Shared via
+// lib/cli-flags.mjs's validateFlags() (#2775).
 const KNOWN_FLAGS = ['--dry-run', '--help', '-h'];
 const USAGE = `Usage: node dedup-tracker.mjs [--dry-run]`;
 
 const cliArgs = process.argv.slice(2);
 
-const unknownFlags = cliArgs.filter(a => a.startsWith('-') && !KNOWN_FLAGS.includes(a));
-if (unknownFlags.length) {
-  console.error(`Error: unrecognized flag(s): ${unknownFlags.join(', ')}. Valid flags: ${KNOWN_FLAGS.join(', ')}`);
-  process.exit(1);
-}
-
-if (cliArgs.includes('--help') || cliArgs.includes('-h')) {
-  console.log(USAGE);
-  process.exit(0);
-}
+validateFlags(cliArgs, KNOWN_FLAGS, USAGE);
 
 const DRY_RUN = process.argv.includes('--dry-run');
 

--- a/lib/cli-flags.mjs
+++ b/lib/cli-flags.mjs
@@ -1,13 +1,21 @@
 /**
- * cli-flags.mjs — reading a value-taking CLI flag in BOTH accepted forms.
+ * cli-flags.mjs — shared CLI argv helpers.
+ *
+ * Two related but distinct defects, both born from scripts hand-rolling their
+ * own argv parsing and independently getting it wrong the same way:
  *
  * `args.indexOf('--flag')` returns -1 for `--flag=value`, so a lookup written
  * that way silently DISCARDS the value the caller supplied and the script runs
  * with its default instead — reporting a result for inputs nobody asked for,
  * with no warning. That is the defect #2401 described for weekly-digest
  * (`--from=…` digesting the wrong week) and #2402 fixed there and in
- * company-history.mjs; this module is the same semantics in one place, so the
- * next script does not have to rediscover it.
+ * company-history.mjs. `flagValue`/`hasFlag` are the shared fix.
+ *
+ * An unrecognized or mistyped flag (`--dryrun` instead of `--dry-run`)
+ * silently falls through to default/live behavior instead of failing fast —
+ * fixed independently, in the identical shape, in scan-ats-full.mjs
+ * (#1633/#1635), reply-watch.mjs (#2743/#2745) and dedup-tracker.mjs
+ * (#2744/#2746). `validateFlags` is that shape in one place (#2775).
  */
 
 /**
@@ -45,4 +53,65 @@ export function flagValue(args, flag) {
 export function hasFlag(args, flag) {
   if (!Array.isArray(args)) return false;
   return args.some((a) => typeof a === 'string' && (a === flag || a.startsWith(`${flag}=`)));
+}
+
+/**
+ * Reject an unrecognized CLI flag before it can fall through to default/live
+ * behavior, then handle --help/-h.
+ *
+ * Three scripts hand-rolled this exact shape independently — scan-ats-full.mjs
+ * (#1633/#1635), reply-watch.mjs (#2743/#2745), dedup-tracker.mjs
+ * (#2744/#2746) — because an unrecognized or mistyped flag (e.g. `--dryrun`
+ * for `--dry-run`) was silently ignored and the script ran with its default,
+ * live behavior instead of failing fast. #2775 collects the pattern here so
+ * the next script does not have to rediscover it; scan.mjs's own instance
+ * (#2270 — `--help` triggered a full live scan) is fixed by calling this
+ * directly rather than adding a fourth hand-rolled copy.
+ *
+ * Order matters: the unrecognized-flag check runs BEFORE the --help check.
+ * CodeRabbit caught the reverse ordering as a bug on both #2745 and #2746 —
+ * `--help --bogus` must still error, not exit 0 having never looked at
+ * `--bogus` at all.
+ *
+ * @param {string[]} args - argv slice.
+ * @param {string[]} knownFlags - Every flag name this script accepts,
+ *   leading dashes included (e.g. `['--dry-run', '--help', '-h']`).
+ * @param {string} usage - Usage text printed for `--help`/`-h`.
+ * @param {{valueFlags?: string[]}} [options] - `valueFlags` lists flags whose
+ *   space-separated value is the NEXT argv token (e.g. `--since 7`). Without
+ *   this, a value that itself starts with `-` (e.g. `--since -5`, a negative
+ *   day count) would be misread as an unrecognized flag rather than left for
+ *   the caller's own value validation to reject with a clearer message.
+ *   `--flag=value` is self-contained and never needs to be listed.
+ * @returns {void} Returns normally when every flag is recognized and --help
+ *   was not requested; otherwise prints and calls `process.exit()`.
+ */
+export function validateFlags(args, knownFlags, usage, { valueFlags = [] } = {}) {
+  if (!Array.isArray(args)) return;
+
+  // A value-taking flag's space-separated value (e.g. the `-5` in
+  // `--since -5`) must not be mistaken for an unrecognized flag just because
+  // it happens to start with `-`. Mirrors scan-ats-full.mjs's own adjacency
+  // rule: only a token that does NOT start with `--` is treated as a value,
+  // so a genuinely missing operand (next token is itself a flag) still falls
+  // through to the caller's own "requires a value" check.
+  const consumedValueIndices = new Set();
+  args.forEach((a, idx) => {
+    if (valueFlags.includes(a) && args[idx + 1] !== undefined && !args[idx + 1].startsWith('--')) {
+      consumedValueIndices.add(idx + 1);
+    }
+  });
+
+  const unknownFlags = args.filter((a, idx) =>
+    typeof a === 'string' && a.startsWith('-') && !consumedValueIndices.has(idx)
+    && !knownFlags.includes(a.split('=')[0]));
+  if (unknownFlags.length > 0) {
+    console.error(`Error: unrecognized flag(s): ${unknownFlags.join(', ')}. Valid flags: ${knownFlags.join(', ')}`);
+    process.exit(1);
+  }
+
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(usage);
+    process.exit(0);
+  }
 }

--- a/lib/cli-flags.mjs
+++ b/lib/cli-flags.mjs
@@ -102,9 +102,11 @@ export function validateFlags(args, knownFlags, usage, { valueFlags = [] } = {})
     }
   });
 
-  const unknownFlags = args.filter((a, idx) =>
-    typeof a === 'string' && a.startsWith('-') && !consumedValueIndices.has(idx)
-    && !knownFlags.includes(a.split('=')[0]));
+  const unknownFlags = args.filter((a, idx) => {
+    if (typeof a !== 'string' || !a.startsWith('-') || consumedValueIndices.has(idx)) return false;
+    const flag = a.split('=')[0];
+    return !knownFlags.includes(flag) || (a.includes('=') && !valueFlags.includes(flag));
+  });
   if (unknownFlags.length > 0) {
     console.error(`Error: unrecognized flag(s): ${unknownFlags.join(', ')}. Valid flags: ${knownFlags.join(', ')}`);
     process.exit(1);

--- a/reply-watch.mjs
+++ b/reply-watch.mjs
@@ -20,6 +20,7 @@ import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 import {
   openTrackerTransaction, rebuildRow, resolveTrackerPath,
 } from './tracker-utils.mjs';
+import { validateFlags } from './lib/cli-flags.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DEFAULT_CANDIDATES_PATH = path.join(__dirname, 'data', 'reply-candidates.json');
@@ -215,16 +216,7 @@ async function main() {
   const args = process.argv.slice(2);
 
   const positional = args.filter(a => !a.startsWith('-'));
-  const unknownFlags = args.filter(a => a.startsWith('-') && !KNOWN_FLAGS.includes(a));
-  if (unknownFlags.length > 0) {
-    console.error(`Error: unrecognized flag(s): ${unknownFlags.join(', ')}. Valid flags: ${KNOWN_FLAGS.join(', ')}`);
-    process.exit(1);
-  }
-
-  if (args.includes('--help') || args.includes('-h')) {
-    console.log(USAGE);
-    process.exit(0);
-  }
+  validateFlags(args, KNOWN_FLAGS, USAGE);
 
   const candidatesPath = positional[0] || DEFAULT_CANDIDATES_PATH;
   ensureCandidatesFile(candidatesPath);

--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -46,6 +46,7 @@ import icims from './providers/icims.mjs';
 import { buildTitleFilter, buildLocationFilter, buildContentFilter, matchedTitleKeywords, loadSeenUrls, normalizeUrlForDedup, appendToPipeline, appendToScanHistory, loadBlacklist, parseSinceDays } from './scan.mjs';
 import { SEED_SOURCES, toPortalEntry } from './seeds/vc-portfolios.mjs';
 import { normalizeCompany } from './tracker-utils.mjs';
+import { validateFlags } from './lib/cli-flags.mjs';
 
 // ── Config ──────────────────────────────────────────────────────────
 
@@ -226,28 +227,13 @@ const USAGE = `Usage:
 function parseArgs(argv) {
   const args = argv.slice(2);
 
-  if (args.includes('--help') || args.includes('-h')) {
-    console.log(USAGE);
-    process.exit(0);
-  }
-
-  // A value-taking flag's space-separated value (e.g. the `-tmp` in
-  // `--md-out -tmp`) must not be mistaken for an unrecognized flag just
-  // because it happens to start with `-`. Mirrors valueOf()'s own adjacency
-  // rule below so `--flag value` and `--flag=value` are validated consistently.
-  const consumedValueIndices = new Set();
-  args.forEach((a, idx) => {
-    if (VALUE_FLAGS.includes(a) && args[idx + 1] !== undefined && !args[idx + 1].startsWith('--')) {
-      consumedValueIndices.add(idx + 1);
-    }
-  });
-
-  const unknownFlags = args.filter((a, idx) =>
-    a.startsWith('-') && !consumedValueIndices.has(idx) && !KNOWN_FLAGS.includes(a.split('=')[0]));
-  if (unknownFlags.length) {
-    console.error(`Error: unrecognized flag(s): ${unknownFlags.join(', ')}. Valid flags: ${KNOWN_FLAGS.join(', ')}`);
-    process.exit(1);
-  }
+  // Shared with reply-watch.mjs/dedup-tracker.mjs/scan.mjs via
+  // lib/cli-flags.mjs (#2775). This also fixes a latent ordering bug this
+  // script had before the pattern was consolidated: the unrecognized-flag
+  // check now runs BEFORE --help, so `--help --bogus` still errors instead
+  // of exiting 0 having never looked at `--bogus` (the same ordering
+  // CodeRabbit flagged on #2745/#2746).
+  validateFlags(args, KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS });
 
   const valueOf = (flag) => {
     const idx = args.indexOf(flag);

--- a/scan.mjs
+++ b/scan.mjs
@@ -29,6 +29,12 @@
  *   node scan.mjs --verify --throttle          # jittered ~5-10s gap between checks (stay under rate limits)
  *   node scan.mjs --verify --throttle=8000     # custom base gap in ms (waits base..2*base)
  *   node scan.mjs --include-blacklisted        # let data/blacklist.md matches through (annotated)
+ *   node scan.mjs --since 7                    # postings from the last 7 days
+ *   node scan.mjs --posted-after 2026-07-01    # absolute lower bound on posting date
+ *   node scan.mjs --posted-before 2026-08-01   # absolute upper bound on posting date
+ *   node scan.mjs --rediscover-404             # re-verify tracked URLs that 404/410 (rides on --verify)
+ *   node scan.mjs --quiet                      # suppress the manifesto footer
+ *   node scan.mjs --help                       # print this usage block and exit
  */
 
 import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync } from 'fs';
@@ -46,7 +52,7 @@ import { resolveColumns, parseTrackerRow, normalizeTextKey } from './tracker-par
 import { normalizeCompany } from './tracker-utils.mjs';
 import { normalizeCompanyName } from './invite-match.mjs';
 import { withPipelineLock } from './pipeline-lock.mjs';
-import { flagValue, hasFlag } from './lib/cli-flags.mjs';
+import { flagValue, hasFlag, validateFlags } from './lib/cli-flags.mjs';
 import { withPortalHealthLock } from './portal-health-lock.mjs';
 
 try {
@@ -2105,8 +2111,43 @@ function guardStatusFor(code) {
   return 'skipped_invalid_url';
 }
 
+// ── CLI args ────────────────────────────────────────────────────────
+// #2270: `node scan.mjs --help` used to run a full live scan and write to
+// pipeline.md/scan-history.tsv instead of printing usage — the flag was
+// never checked at all. Same shape as scan-ats-full.mjs (#1633/#1635),
+// reply-watch.mjs (#2743/#2745) and dedup-tracker.mjs (#2744/#2746), shared
+// via lib/cli-flags.mjs's validateFlags() (#2775).
+const KNOWN_FLAGS = [
+  '--dry-run', '--verify', '--headed-fallback', '--throttle', '--rediscover-404',
+  '--include-blacklisted', '--company', '--posted-after', '--posted-before',
+  '--since', '--quiet', '--help', '-h',
+];
+
+// Flags whose space-separated value is the NEXT argv token (the `--flag=value`
+// form is self-contained and never needs this). --throttle is deliberately
+// excluded: only its bare and `--throttle=<ms>` forms are read below, so a
+// following token is never its value.
+const VALUE_FLAGS = ['--company', '--posted-after', '--posted-before', '--since'];
+
+const USAGE = `Usage:
+  node scan.mjs                              # scan all enabled companies
+  node scan.mjs --dry-run                    # preview without writing files
+  node scan.mjs --company Cohere             # scan a single company
+  node scan.mjs --verify                     # Playwright-check each new URL; drop expired postings
+  node scan.mjs --verify --headed-fallback   # retry anti-bot-blocked URLs in a headed browser (needs a display)
+  node scan.mjs --verify --throttle          # jittered ~5-10s gap between checks (stay under rate limits)
+  node scan.mjs --verify --throttle=8000     # custom base gap in ms (waits base..2*base)
+  node scan.mjs --rediscover-404             # re-verify tracked URLs that 404/410 (rides on --verify)
+  node scan.mjs --include-blacklisted        # let data/blacklist.md matches through (annotated)
+  node scan.mjs --since 7                    # postings from the last 7 days
+  node scan.mjs --posted-after 2026-07-01    # absolute lower bound on posting date
+  node scan.mjs --posted-before 2026-08-01   # absolute upper bound on posting date
+  node scan.mjs --quiet                      # suppress the manifesto footer
+  node scan.mjs --help                       # print this usage block and exit`;
+
 async function main() {
   const args = process.argv.slice(2);
+  validateFlags(args, KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS });
   const dryRun = args.includes('--dry-run');
   const verify = args.includes('--verify');
   // Opt-in: on an anti-bot challenge (e.g. pracuj.pl Cloudflare wall), retry the

--- a/tests/cli-flags.test.mjs
+++ b/tests/cli-flags.test.mjs
@@ -5,7 +5,8 @@
 // result for inputs nobody asked for. Verified on main before the fix:
 // `process-quality --file=X` read the default tracker, `validate-portals
 // --file=X` validated portals.yml, `detect-reposts --window=5` used 90 days.
-import { pass, fail, ROOT } from './helpers.mjs';
+import { pass, fail, NODE, ROOT } from './helpers.mjs';
+import { spawnSync } from 'child_process';
 import { join } from 'path';
 import { pathToFileURL } from 'url';
 
@@ -59,6 +60,89 @@ try {
   check('hasFlag is false when absent', hasFlag(['--summary'], '--only'), false);
   check('hasFlag respects the prefix boundary', hasFlag(['--only-me'], '--only'), false);
   check('hasFlag on a non-array is false', hasFlag(null, '--only'), false);
+
+  // validateFlags — the unrecognized-flag / --help shape hand-rolled
+  // identically by scan-ats-full.mjs (#1633/#1635), reply-watch.mjs
+  // (#2743/#2745) and dedup-tracker.mjs (#2744/#2746), consolidated here for
+  // #2775 and reused as-is by scan.mjs's own fix (#2270).
+  const { validateFlags } = await import(pathToFileURL(join(ROOT, 'lib/cli-flags.mjs')).href);
+
+  // The all-valid path never calls process.exit, so it is safe to call
+  // in-process and assert it simply returns.
+  try {
+    validateFlags(['--dry-run'], ['--dry-run', '--help', '-h'], 'usage');
+    pass('a fully-valid args array returns normally, without exiting');
+  } catch (e) {
+    fail(`validateFlags threw on valid args: ${e.message}`);
+  }
+  try {
+    validateFlags([], ['--dry-run', '--help', '-h'], 'usage');
+    pass('an empty args array returns normally');
+  } catch (e) {
+    fail(`validateFlags threw on empty args: ${e.message}`);
+  }
+
+  // Everything that exits the process is spawned in a child process — a
+  // direct in-process exit would kill this test runner too.
+  const cliFlagsUrl = JSON.stringify(pathToFileURL(join(ROOT, 'lib/cli-flags.mjs')).href);
+  const runValidate = (args, knownFlags, usage, options) => {
+    const script = `
+      const { validateFlags } = await import(${cliFlagsUrl});
+      validateFlags(${JSON.stringify(args)}, ${JSON.stringify(knownFlags)}, ${JSON.stringify(usage)}${options ? `, ${JSON.stringify(options)}` : ''});
+      console.log('REACHED-END');
+    `;
+    return spawnSync(NODE, ['--input-type=module', '-e', script], { encoding: 'utf-8', timeout: 15000 });
+  };
+
+  {
+    const r = runValidate(['--bogus'], ['--help', '-h'], 'USAGE-TEXT');
+    if (r.status === 1 && /unrecognized flag\(s\): --bogus\. Valid flags: --help, -h/.test(r.stderr || '') && !/REACHED-END/.test(r.stdout || '')) {
+      pass('an unrecognized flag exits 1 with the expected error');
+    } else {
+      fail(`unrecognized-flag case => status=${r.status} stdout=${r.stdout} stderr=${r.stderr}`);
+    }
+  }
+
+  {
+    const r = runValidate(['--help'], ['--help', '-h'], 'USAGE-TEXT');
+    if (r.status === 0 && /USAGE-TEXT/.test(r.stdout || '')) {
+      pass('--help prints usage and exits 0');
+    } else {
+      fail(`--help case => status=${r.status} stdout=${r.stdout} stderr=${r.stderr}`);
+    }
+  }
+
+  {
+    const r = runValidate(['-h'], ['--help', '-h'], 'USAGE-TEXT');
+    if (r.status === 0 && /USAGE-TEXT/.test(r.stdout || '')) {
+      pass('-h prints usage and exits 0');
+    } else {
+      fail(`-h case => status=${r.status} stdout=${r.stdout} stderr=${r.stderr}`);
+    }
+  }
+
+  {
+    // Ordering: --help plus an unrecognized flag must still error, not exit 0
+    // having never looked at the unrecognized flag (the CodeRabbit finding on
+    // #2745/#2746).
+    const r = runValidate(['--help', '--bogus'], ['--help', '-h'], 'USAGE-TEXT');
+    if (r.status === 1 && /unrecognized flag\(s\): --bogus/.test(r.stderr || '') && !/USAGE-TEXT/.test(r.stdout || '')) {
+      pass('--help plus an unrecognized flag still errors (unrecognized check runs before --help)');
+    } else {
+      fail(`--help + unrecognized order case => status=${r.status} stdout=${r.stdout} stderr=${r.stderr}`);
+    }
+  }
+
+  {
+    // valueFlags: a value that itself looks like a flag (a negative number)
+    // must not be misread as an unrecognized flag.
+    const r = runValidate(['--since', '-5'], ['--since', '--help', '-h'], 'USAGE-TEXT', { valueFlags: ['--since'] });
+    if (r.status === 0 && /REACHED-END/.test(r.stdout || '')) {
+      pass('a valueFlags-listed flag\'s negative-number-shaped value is not misread as unrecognized');
+    } else {
+      fail(`valueFlags negative-value case => status=${r.status} stdout=${r.stdout} stderr=${r.stderr}`);
+    }
+  }
 } catch (e) {
   fail(`cli-flags tests crashed: ${e.message}`);
 }

--- a/tests/cli-flags.test.mjs
+++ b/tests/cli-flags.test.mjs
@@ -143,6 +143,31 @@ try {
       fail(`valueFlags negative-value case => status=${r.status} stdout=${r.stdout} stderr=${r.stderr}`);
     }
   }
+
+  {
+    // CodeRabbit (#2778): --dry-run=1 must NOT be accepted just because its
+    // base flag --dry-run is known — --dry-run isn't in valueFlags, so the
+    // `=value` form is meaningless to it, and every caller of validateFlags
+    // checks `args.includes('--dry-run')`, which is false for the string
+    // '--dry-run=1' — a silent way to run with zero dry-run protection.
+    const r = runValidate(['--dry-run=1'], ['--dry-run', '--help', '-h'], 'USAGE-TEXT');
+    if (r.status === 1 && /unrecognized flag\(s\): --dry-run=1/.test(r.stderr || '')) {
+      pass('--dry-run=1 is rejected — a boolean flag not in valueFlags may not take =value (#2778)');
+    } else {
+      fail(`--dry-run=1 case => status=${r.status} stdout=${r.stdout} stderr=${r.stderr}`);
+    }
+  }
+
+  {
+    // CodeRabbit (#2778): the equals form of a genuine value-taking flag must
+    // still be accepted, including a negative-number-shaped value.
+    const r = runValidate(['--since=-5'], ['--since', '--help', '-h'], 'USAGE-TEXT', { valueFlags: ['--since'] });
+    if (r.status === 0 && /REACHED-END/.test(r.stdout || '')) {
+      pass('--since=-5 is accepted — the equals form of a valueFlags-listed flag (#2778)');
+    } else {
+      fail(`--since=-5 case => status=${r.status} stdout=${r.stdout} stderr=${r.stderr}`);
+    }
+  }
 } catch (e) {
   fail(`cli-flags tests crashed: ${e.message}`);
 }

--- a/tests/scan-help-flag.test.mjs
+++ b/tests/scan-help-flag.test.mjs
@@ -1,0 +1,95 @@
+// tests/scan-help-flag.test.mjs — scan.mjs must not run a live scan on
+// --help or on an unrecognized flag (#2270).
+//
+// Before this fix, `node scan.mjs --help` never looked at --help at all: it
+// fell straight through argument parsing into a full live scan, reading
+// portals.yml, hitting every configured ATS, and appending to
+// pipeline.md/scan-history.tsv — the exact "unrecognized/mistyped flag
+// silently falls through to live behavior" failure class already fixed
+// (identically) in scan-ats-full.mjs (#1633/#1635), reply-watch.mjs
+// (#2743/#2745) and dedup-tracker.mjs (#2744/#2746), now shared via
+// lib/cli-flags.mjs's validateFlags() (#2775).
+//
+// HERMETIC: every run pins CAREER_OPS_PORTALS at a path that does not exist.
+// If --help or an unrecognized flag were NOT handled before the portals
+// check, the run would reach "portals.yml not found" instead of exiting on
+// the flag itself — so that message doubles as proof a live scan was
+// attempted. Each assertion also checks the subprocess actually ran (no
+// spawn error, no signal), so a timeout cannot pass silently.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const NO_PORTALS = join(tmpdir(), 'career-ops-no-such-portals.yml');
+const PORTALS_NOT_FOUND = /portals\.yml not found/i;
+
+function runScan(...args) {
+  const r = spawnSync(process.execPath, [join(ROOT, 'scan.mjs'), ...args], {
+    cwd: ROOT,
+    encoding: 'utf-8',
+    timeout: 30_000,
+    env: { ...process.env, CAREER_OPS_PORTALS: NO_PORTALS },
+  });
+  assert.equal(r.error, undefined, `scan.mjs failed to spawn: ${r.error?.message}`);
+  assert.equal(r.signal, null, `scan.mjs was killed by ${r.signal} (timeout?)`);
+  return { ...r, all: `${r.stdout ?? ''}${r.stderr ?? ''}` };
+}
+
+test('--help prints usage and exits 0, without reaching the portals check', () => {
+  const r = runScan('--help');
+  assert.equal(r.status, 0, `expected exit 0, got ${r.status}: ${r.all}`);
+  assert.match(r.stdout, /Usage:/);
+  assert.match(r.stdout, /node scan\.mjs/);
+  assert.doesNotMatch(r.all, PORTALS_NOT_FOUND, '--help must exit before any scan logic runs');
+});
+
+test('-h prints usage and exits 0, without reaching the portals check', () => {
+  const r = runScan('-h');
+  assert.equal(r.status, 0, `expected exit 0, got ${r.status}: ${r.all}`);
+  assert.match(r.stdout, /Usage:/);
+  assert.doesNotMatch(r.all, PORTALS_NOT_FOUND);
+});
+
+test('an unrecognized flag errors and exits 1, without reaching the portals check', () => {
+  const r = runScan('--bogus-flag');
+  assert.notEqual(r.status, 0, `expected non-zero exit, got 0: ${r.all}`);
+  assert.match(r.stderr, /unrecognized flag\(s\): --bogus-flag/);
+  assert.match(r.stderr, /Valid flags:/);
+  assert.doesNotMatch(r.all, PORTALS_NOT_FOUND, 'an unrecognized flag must not fall through to a live scan');
+});
+
+test('--help plus an unrecognized flag still errors (unrecognized check runs before --help)', () => {
+  const r = runScan('--help', '--bogus-flag');
+  assert.notEqual(r.status, 0, `expected non-zero exit, got 0: ${r.all}`);
+  assert.match(r.stderr, /unrecognized flag\(s\): --bogus-flag/);
+  assert.doesNotMatch(r.stdout, /Usage:/, '--help must not print/exit 0 while an unrecognized flag is present');
+});
+
+test('a mistyped known flag (--dryrun for --dry-run) is rejected, not silently ignored', () => {
+  const r = runScan('--dryrun');
+  assert.notEqual(r.status, 0, `expected non-zero exit, got 0: ${r.all}`);
+  assert.match(r.stderr, /unrecognized flag\(s\): --dryrun/);
+  assert.doesNotMatch(r.all, PORTALS_NOT_FOUND, 'a mistyped flag must not fall through to a live scan');
+});
+
+test('a genuinely empty argv still reaches normal scan logic (regression: recognized flags are unaffected)', () => {
+  const r = runScan();
+  assert.match(r.all, PORTALS_NOT_FOUND, 'no flags at all must proceed past flag validation into the real run');
+});
+
+test('--since 7 (a recognized value-taking flag) still reaches normal scan logic', () => {
+  const r = runScan('--since', '7');
+  assert.match(r.all, PORTALS_NOT_FOUND, '--since 7 must be accepted and proceed into the real run');
+});
+
+test('--since -5 (negative value) is not misread as an unrecognized flag', () => {
+  // The value itself is rejected by scan.mjs's own --since validator further
+  // down the pipeline, not by the flag allowlist — so this must NOT print
+  // "unrecognized flag(s): -5".
+  const r = runScan('--since', '-5');
+  assert.doesNotMatch(r.stderr, /unrecognized flag\(s\)/, '-5 must not be misread as an unrecognized flag');
+});


### PR DESCRIPTION
Closes #2775. Closes #2270.

## What this is

Three scripts (`scan-ats-full.mjs` #1633/#1635, `reply-watch.mjs` #2743/#2745, `dedup-tracker.mjs` #2744/#2746) independently hand-rolled the identical fix for the identical bug: an unrecognized/mistyped CLI flag silently falling through to default/live behavior instead of failing fast. `lib/cli-flags.mjs` gains `validateFlags(args, knownFlags, usage, { valueFlags })` — the shape all three converged on, in one place:

- Any `-`-prefixed arg not in `knownFlags` errors and exits 1 — checked **before** `--help`/`-h` is honored (the ordering CodeRabbit flagged as a bug on both #2745 and #2746: `--help --bogus` must still error, not exit 0 having never looked at `--bogus`).
- `--help`/`-h` prints the caller-supplied usage and exits 0.
- An optional `valueFlags` list (mirroring `scan-ats-full.mjs`'s existing adjacency rule) keeps a value-taking flag's own value — e.g. the `-5` in `--since -5` — from being misread as an unrecognized flag.

## Migration (behavior-preserving)

`scan-ats-full.mjs`, `reply-watch.mjs`, and `dedup-tracker.mjs` now call the shared helper instead of their own copies. Same error messages, same exit codes, same usage text — this is de-duplication, not a behavior change. (`scan-ats-full.mjs` picks up one small fix as a side effect: its own `--help`-before-unknown-flag ordering had the same latent bug the other two were caught on, just never exercised by a test that combined both.)

## The one genuinely new fix: `scan.mjs` (#2270)

`node scan.mjs --help` never checked `--help` at all — it fell straight through into a full live scan, hitting every configured ATS and writing to `pipeline.md`/`scan-history.tsv`. Same failure class as the other three, fixed the same way. `KNOWN_FLAGS` was built from the script's own existing docblock usage examples; `--company`/`--posted-after`/`--posted-before`/`--since` are registered as `valueFlags` (`--throttle` deliberately isn't — it's only ever read in its bare or `--throttle=<ms>` forms).

## Tests

- `tests/cli-flags.test.mjs` extended with direct unit coverage of `validateFlags` (unrecognized-flag rejection, `--help`/`-h`, the ordering case, `valueFlags` negative-number handling) plus subprocess-level coverage for cases that need a real exit code.
- New `tests/scan-help-flag.test.mjs`: hermetic (`CAREER_OPS_PORTALS` pointed at a nonexistent path) coverage proving `--help`, `-h`, and an unrecognized flag on `scan.mjs` never reach the portals-loading step — i.e. never attempt a live scan.
- `node test-all.mjs --quick`: 3647 passed, 0 failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent command-line flag validation across scanning and monitoring commands.
  * Added support for value-based flags, including negative values.
  * Expanded scan help documentation with available options.

* **Bug Fixes**
  * Unrecognized or mistyped flags now fail clearly before command execution.
  * Help options consistently display usage information and exit successfully.

* **Tests**
  * Added coverage for valid flags, invalid flags, help aliases, value handling, and validation order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->