### PR TITLE
find.mjs: reject mistyped flags instead of silently searching for them

### DIFF
--- a/find.mjs
+++ b/find.mjs
@@ -126,10 +126,34 @@ export function findMatches(rows, query, pdfIndex = new Map()) {
 
 // ── CLI ─────────────────────────────────────────────────────────────
 
-function main() {
-  const args = process.argv.slice(2);
+const KNOWN_FLAGS = ['--json', '--help', '-h'];
+
+const USAGE = `Usage:
+  node find.mjs <report# | tracker# | company/role fragment> [--json]
+  node find.mjs --help                            # print this usage block and exit`;
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(USAGE);
+    process.exit(0);
+  }
+
+  const unknownFlags = args.filter(a => a.startsWith('-') && !KNOWN_FLAGS.includes(a));
+  if (unknownFlags.length) {
+    console.error(`Error: unrecognized flag(s): ${unknownFlags.join(', ')}. Valid flags: ${KNOWN_FLAGS.join(', ')}`);
+    console.error(USAGE);
+    process.exit(1);
+  }
+
   const json = args.includes('--json');
   const query = args.filter(a => a !== '--json').join(' ').trim();
+  return { json, query };
+}
+
+function main() {
+  const { json, query } = parseArgs(process.argv);
   if (!query) {
     console.log('Usage: node find.mjs <report# | tracker# | company/role fragment> [--json]');
     process.exitCode = 1;


### PR DESCRIPTION
## What does this PR do?

Adds argument validation to find.mjs so unknown flags are rejected with a helpful usage message instead of being treated as search terms. It also adds --help/-h support while keeping existing searches --json working as before.
<!-- Describe the change in 1-3 sentences -->

## Related issue

Fixes #2773 
<!-- Link the issue this PR addresses, if it has one. Format: Fixes #123 / Closes #123 -->
<!-- Issue-first is asked for NEW FEATURES, new modes/commands, and architecture changes — it saves you from building something we'd have to redirect. -->
<!-- No issue needed, send the PR straight in: bug fixes, new zero-auth scanner providers, docs, and translations. We don't want to slow these down. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--help` and `-h` options with usage information.
  * Improved command-line argument handling for JSON flags and queries.

* **Bug Fixes**
  * Unrecognized command-line options now produce a clear error message and usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->