### PR TITLE
fix(web): fold Turkish dotted capitals in status keys, and stop hand-copying the state list

### DIFF
--- a/web/src/lib/core/states.ts
+++ b/web/src/lib/core/states.ts
@@ -2,13 +2,23 @@ import fs from "node:fs";
 import path from "node:path";
 import * as yaml from "js-yaml";
 import { careerOpsRoot } from "@/lib/career-ops";
+import { CANONICAL_STATES } from "@/lib/format";
 
 /**
  * ACL for templates/states.yml — the SINGLE SOURCE OF TRUTH for canonical
  * application states (career-ops writer + dashboard reader both read it). Per the
- * web↔core contract we READ it live and never hardcode the list (the maintainer
- * once mis-listed it from memory — the file had one more). The FALLBACK below is
- * only a last resort if the file is unreadable, and is kept identical to the file.
+ * web↔core contract we READ it live and never hardcode the list.
+ *
+ * The hand-maintained FALLBACK that used to live here is gone. It promised to be
+ * "kept identical to the file" and was not: it shipped without `hired` (#2282)
+ * and later drifted 31 aliases behind. The core states the rule outright in
+ * followup-cadence.mjs — "a fallback copy is the same copy in disguise and drifts
+ * the same way" — and two incidents in this file proved it.
+ *
+ * The degraded path now derives from CANONICAL_STATES, the list CI already
+ * freezes against states.yml (test-all §55.3b). So when states.yml is unreadable
+ * we accept exactly what the UI is able to offer — labels only, no aliases —
+ * and there is no second list that can drift on its own.
  */
 export type CanonicalState = {
   id: string;
@@ -18,17 +28,13 @@ export type CanonicalState = {
   group: string;
 };
 
-const FALLBACK: CanonicalState[] = [
-  { id: "evaluated", label: "Evaluated", aliases: ["evaluada"], description: "Offer evaluated with report, pending decision", group: "evaluated" },
-  { id: "applied", label: "Applied", aliases: ["aplicado", "enviada", "aplicada", "sent"], description: "Application submitted", group: "applied" },
-  { id: "responded", label: "Responded", aliases: ["respondido"], description: "Company has responded (not yet interview)", group: "responded" },
-  { id: "interview", label: "Interview", aliases: ["entrevista"], description: "Active interview process", group: "interview" },
-  { id: "offer", label: "Offer", aliases: ["oferta"], description: "Offer received", group: "offer" },
-  { id: "rejected", label: "Rejected", aliases: ["rechazado", "rechazada"], description: "Rejected by company", group: "rejected" },
-  { id: "discarded", label: "Discarded", aliases: ["descartado", "descartada", "cerrada", "cancelada"], description: "Discarded by candidate or offer closed", group: "discarded" },
-  { id: "skip", label: "SKIP", aliases: ["no_aplicar", "no aplicar", "skip", "monitor"], description: "Doesn't fit, don't apply", group: "skip" },
-  { id: "hired", label: "Hired", aliases: ["contratado", "contratada", "hired", "accepted", "accept"], description: "Offer accepted, job landed!", group: "hired" },
-];
+const FALLBACK: CanonicalState[] = CANONICAL_STATES.map((label) => ({
+  id: label.toLowerCase(),
+  label,
+  aliases: [],
+  description: "",
+  group: label.toLowerCase(),
+}));
 
 /**
  * Cached per resolved states.yml path and keyed on the file's mtime+size (one
@@ -87,13 +93,35 @@ export function canonicalLabels(): string[] {
   return readCanonicalStates().map((s) => s.label);
 }
 
+/**
+ * Fold a raw status the SAME way the core's foldStatusInput does
+ * (tracker-utils.mjs). A bare toLowerCase() is not enough: JS lowercases the
+ * Turkish dotted capital `İ` to `i` + U+0307 and the mark survives, so every
+ * all-caps Turkish status ("TEKLİF", "KABUL EDİLDİ") missed every alias here
+ * while the CLI resolved it — the web answered HTTP 400 for rows the core
+ * considered perfectly canonical.
+ *
+ * NO `NFD`, and that is the whole safety property (5df43e7): NFKC leaves ż, ė
+ * and ġ as single precomposed code points this strip cannot reach, while
+ * `i` + U+0307 has no precomposed form and stays exposed. Decomposing first
+ * looks equivalent and collapses Żubr/Zubr.
+ */
+function foldStatusInput(input: string): string {
+  return String(input ?? "")
+    .replace(/\*\*/g, "")
+    .trim()
+    .normalize("NFKC")
+    .toLowerCase()
+    .replace(/̇/gu, "");
+}
+
 /** Map any raw status (label/id/alias, case-insensitive) to its canonical label,
  *  or null if unrecognized. */
 export function canonicalizeStatus(raw: string): string | null {
-  const q = raw.trim().toLowerCase().replace(/\*\*/g, "");
+  const q = foldStatusInput(raw);
   if (!q) return null;
   for (const s of readCanonicalStates()) {
-    if (s.label.toLowerCase() === q || s.id.toLowerCase() === q || s.aliases.some((a) => a.toLowerCase() === q)) {
+    if (foldStatusInput(s.label) === q || foldStatusInput(s.id) === q || s.aliases.some((a) => foldStatusInput(a) === q)) {
       return s.label;
     }
   }


### PR DESCRIPTION
Completes the web arm of the Turkish `İ` fold (#2705 shipped the core and the TUI), plus removes the second drifting copy in the same file.

## 1. The web disagreed with the core it derives from

`canonicalizeStatus` used a bare `toLowerCase()`. JS lowercases `İ` to `i` + U+0307 and the mark survives, so **every all-caps Turkish status missed every alias**:

| input | core (in main) | web (before) |
|---|---|---|
| `TEKLİF` | Offer | **HTTP 400** |
| `KABUL EDİLDİ` | Hired | **HTTP 400** |
| `DEĞERLENDİRİLDİ` | Evaluated | **HTTP 400** |
| `REDDEDİLDİ` | Rejected | **HTTP 400** |

Not dead code: `api/status/route.ts:27` gates the writeback on this, so a Turkish user could not set a status from the dashboard at all.

Now folded exactly like the core's `foldStatusInput`, **with no `NFD`** — that omission is the whole safety property: NFKC leaves `ż`/`ė`/`ġ` as single precomposed code points the strip can't reach, while `i` + U+0307 has no precomposed form and stays exposed. Decomposing first collapses `Żubr`/`Zubr` (the regression 5df43e7 had to undo).

## 2. The hand-maintained FALLBACK is gone

Its own doc comment promised it was *"kept identical to the file"*. It wasn't: it shipped without `hired` (#2282) and had drifted **31 aliases** behind. The core already writes the rule down — *"a fallback copy is the same copy in disguise and drifts the same way"* (`followup-cadence.mjs`) — and this file proved it twice.

The degraded path now derives from `CANONICAL_STATES`, the list CI **already freezes** against `states.yml` (§55.3b). An unreadable `states.yml` therefore accepts exactly what the UI is able to offer, and **no second list is left that can drift on its own**.

## Verification

Against `main`'s `states.yml`: the six Turkish inputs resolve to Offer / Hired / Evaluated / Rejected / Interview / Applied; `**Hired**` still strips its bold; unknown input still returns `null`. typecheck + `next build` green, web suite **133/133**.

Refs #2369.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved status recognition across capitalization, spacing, formatting markers, and Unicode variations.
  * Fallback status labels are now generated consistently from canonical terminology.
  * Fallback statuses use standardized lowercase identifiers and groups, with clear empty alias and description fields.

* **Documentation**
  * Clarified how fallback statuses are generated and used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->