### PR TITLE
Closes #2787: emit no-response-friction signal per RFC #1506 schema v1

### DIFF
--- a/company-history.mjs
+++ b/company-history.mjs
@@ -781,7 +781,14 @@ export function buildNoResponseFrictionSignals(result, opts = {}) {
     // would report severity 'pattern' even though only one fact actually
     // contributed to the 'silent-on-you' label.
     const activeFacts = includeStale ? card.responsiveness.facts : card.responsiveness.facts.filter(f => !f.stale);
-    const silentFacts = activeFacts.filter(f => 'silentDays' in f);
+    // A fact with an unusable appliedDate must be excluded before anchor
+    // selection and severity counting, not just skipped later when computing
+    // observedAt from the already-chosen anchor: left in, a malformed date
+    // could win the lexicographic reduce below (producing no usable
+    // observedAt at all) or, even when a valid fact wins the anchor, still
+    // inflate severity to 'pattern' despite not actually contributing a
+    // usable silent-application fact (CodeRabbit, PR #2788).
+    const silentFacts = activeFacts.filter(f => 'silentDays' in f && silentFactObservedAt(f) !== null);
     if (silentFacts.length === 0) continue; // defensive; label implies >=1
 
     // Most-recent APPLICATION anchors observedAt — compare appliedDate, not
@@ -1243,6 +1250,27 @@ async function runSelfTest() {
     );
     check(singleSignalsAgain[0]?.sourceHash === singleSignals[0]?.sourceHash, 'sourceHash is deterministic across repeated runs against the same fact (dedup-safe)');
 
+    // sourceHash must actually be sensitive to companyKey and observedAt —
+    // determinism alone doesn't prove the hash isn't a constant or doesn't
+    // silently drop one of its inputs (CodeRabbit, PR #2788).
+    const { records: differentCompanySignals } = buildNoResponseFrictionSignals(
+      buildCompanyCards(
+        { trackerRows: [row(203, 'DifferentCompanyCo', 'Applied', '2026-05-01')], followupRows: [], repostClusters: [], sourcesLoaded: { tracker: true, followups: false, scanHistory: false, statusLog: false } },
+        { now: NOW, silenceWindowDays: 28 },
+      ),
+      fixedOpts,
+    );
+    check(differentCompanySignals[0]?.sourceHash !== singleSignals[0]?.sourceHash, 'sourceHash differs when companyKey differs (same observedAt month) — companyKey is a real hash input, not dropped');
+
+    const { records: differentMonthSignals } = buildNoResponseFrictionSignals(
+      buildCompanyCards(
+        { trackerRows: [row(204, 'SingleSilentCo', 'Applied', '2026-06-01')], followupRows: [], repostClusters: [], sourcesLoaded: { tracker: true, followups: false, scanHistory: false, statusLog: false } },
+        { now: NOW, silenceWindowDays: 28 },
+      ),
+      fixedOpts,
+    );
+    check(differentMonthSignals[0]?.sourceHash !== singleSignals[0]?.sourceHash, 'sourceHash differs when observedAt differs (same companyKey) — observedAt is a real hash input, not dropped');
+
     // severity excludes stale facts from the count unless --include-stale is
     // passed — a card with one active + one stale silent fact must report
     // 'single', matching what the 'silent-on-you' label itself was computed
@@ -1262,6 +1290,19 @@ async function runSelfTest() {
     check(activePlusStaleSignals.length === 1, 'active+stale fixture: still exactly one record for the card');
     check(activePlusStaleSignals[0]?.severity === 'single', 'active+stale fixture: severity is single — the stale fact does not inflate it to pattern, matching the label');
 
+    // The includeStale:true emission path must actually be exercised
+    // end-to-end (not just the default-exclusion path above), so a
+    // regression in the opt-in branch would be caught (CodeRabbit, PR #2788).
+    const activePlusStaleIncludeStaleResult = buildCompanyCards(
+      { trackerRows: staleRows, followupRows: [], repostClusters: [], sourcesLoaded: { tracker: true, followups: false, scanHistory: false, statusLog: false } },
+      { now: NOW, silenceWindowDays: 28, includeStale: true },
+    );
+    const { records: activePlusStaleIncludeStaleSignals } = buildNoResponseFrictionSignals(
+      activePlusStaleIncludeStaleResult,
+      { ...fixedOpts, includeStale: true },
+    );
+    check(activePlusStaleIncludeStaleSignals[0]?.severity === 'pattern', 'active+stale fixture with includeStale:true: severity is pattern — the stale fact now counts');
+
     // silentFactObservedAt returning null (unusable appliedDate) must skip the
     // card entirely — no record, no crash. Constructed directly rather than
     // through buildCompanyCards, since computeResponsiveness() never produces
@@ -1277,6 +1318,29 @@ async function runSelfTest() {
     };
     const { records: unusableDateSignals } = buildNoResponseFrictionSignals(unusableDateResult, fixedOpts);
     check(unusableDateSignals.length === 0, 'a card whose anchor fact has an unusable appliedDate is skipped entirely — no record emitted');
+
+    // Mixed valid/invalid facts: the unusable-date fact must be filtered out
+    // BEFORE anchor selection and severity counting, not merely tolerated by
+    // whichever fact happens to win the reduce — otherwise it could win the
+    // anchor outright, or (even when the valid fact wins) still inflate
+    // severity to 'pattern' despite contributing no usable observation
+    // (CodeRabbit, PR #2788).
+    const mixedValidityResult = {
+      companies: [{
+        key: 'mixed-validity-co',
+        responsiveness: {
+          label: 'silent-on-you',
+          facts: [
+            { num: 1, appliedDate: '2026-06-01', silentDays: 40, stale: false },
+            { num: 2, appliedDate: 'not-a-real-date', silentDays: 40, stale: false },
+          ],
+        },
+      }],
+    };
+    const { records: mixedValiditySignals } = buildNoResponseFrictionSignals(mixedValidityResult, fixedOpts);
+    check(mixedValiditySignals.length === 1, 'mixed valid/invalid facts: still exactly one record — the invalid fact does not block emission');
+    check(mixedValiditySignals[0]?.observedAt === '2026-06', 'mixed valid/invalid facts: observedAt anchors on the valid fact');
+    check(mixedValiditySignals[0]?.severity === 'single', 'mixed valid/invalid facts: severity is single — the invalid fact does not count toward pattern');
 
     // silentFactObservedAt must trim appliedDate before slicing, not just
     // before validating: parseDate() tolerates surrounding whitespace, but a

--- a/company-history.mjs
+++ b/company-history.mjs
@@ -169,6 +169,21 @@ function parseArgs(argv) {
     process.exit(1);
   }
 
+  // --emit-signal is a bare boolean flag, not a value flag: the unknown-flag
+  // check above strips a `--flag=value` suffix before matching against
+  // KNOWN_FLAGS, so `--emit-signal=true` passes that check silently. But the
+  // boolean read below is an exact-token `args.includes('--emit-signal')`,
+  // which is false for `--emit-signal=true` — so the flag would be accepted
+  // as "known" yet never actually turn signal emission on. Reject any `=`
+  // form explicitly so a typo fails loudly instead of silently emitting
+  // nothing.
+  const emitSignalValue = args.find(a => a.startsWith('--emit-signal='));
+  if (emitSignalValue) {
+    console.error('Error: --emit-signal does not accept a value.');
+    console.error(USAGE);
+    process.exit(1);
+  }
+
   const summaryMode = args.includes('--summary');
   const company = valueOf('--company');
   const emitSignal = args.includes('--emit-signal');
@@ -671,7 +686,13 @@ export function computeSourceHash({ companyKey, observedAt, severity }) {
 // changes for a given fact, so anchoring on it keeps the hash stable.
 function silentFactObservedAt(fact) {
   const appliedDate = parseDate(fact.appliedDate);
-  const source = appliedDate ? fact.appliedDate : null;
+  // parseDate() tolerates surrounding whitespace when validating, but the
+  // schema's observedAt (and sourceHash, which is computed over it) must be
+  // a clean YYYY-MM slice — so trim before slicing, not just before
+  // validating, or a whitespace-padded appliedDate (e.g. ' 2026-06-01 ')
+  // would slice out the leading space plus wrong characters instead of the
+  // real year-month.
+  const source = appliedDate ? fact.appliedDate.trim() : null;
   return typeof source === 'string' && source.length >= 7 ? source.slice(0, 7) : null;
 }
 
@@ -1158,6 +1179,23 @@ async function runSelfTest() {
     };
     const unusableDateSignals = buildNoResponseFrictionSignals(unusableDateResult, fixedOpts);
     check(unusableDateSignals.length === 0, 'a card whose anchor fact has an unusable appliedDate is skipped entirely — no record emitted');
+
+    // silentFactObservedAt must trim appliedDate before slicing, not just
+    // before validating: parseDate() tolerates surrounding whitespace, but a
+    // whitespace-padded appliedDate sliced without trimming would produce a
+    // malformed observedAt (leading space, wrong characters) instead of the
+    // clean YYYY-MM the schema requires.
+    const paddedDateResult = {
+      companies: [{
+        key: 'padded-date-co',
+        responsiveness: {
+          label: 'silent-on-you',
+          facts: [{ num: 1, appliedDate: ' 2026-06-01 ', silentDays: 40, stale: false }],
+        },
+      }],
+    };
+    const paddedDateSignals = buildNoResponseFrictionSignals(paddedDateResult, fixedOpts);
+    check(paddedDateSignals[0]?.observedAt === '2026-06', 'a whitespace-padded appliedDate still produces a clean YYYY-MM observedAt');
 
     // anchor selection compares appliedDate, not tracker row num: a lower-num
     // row with a MORE RECENT appliedDate (a backfilled/out-of-order entry)

--- a/company-history.mjs
+++ b/company-history.mjs
@@ -41,10 +41,11 @@
  *      node company-history.mjs --self-test
  */
 
-import { readFileSync, existsSync } from 'fs';
+import { readFileSync, existsSync, writeFileSync, mkdtempSync, rmSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { createHash } from 'crypto';
+import { tmpdir } from 'os';
 import * as yaml from 'js-yaml';
 
 import { parseScanHistory, detectReposts } from './detect-reposts.mjs';
@@ -94,7 +95,13 @@ const USAGE = `Usage:
   node company-history.mjs --silence-window 21    # override the default silence window (days)
   node company-history.mjs --include-stale        # include facts older than 365d in label computation
   node company-history.mjs --self-test            # run the in-memory test suite
-  node company-history.mjs --emit-signal          # also print RFC #1506 schema-v1 no-response-friction records (JSON Lines, opt-in only)
+  node company-history.mjs --summary --emit-signal  # human-readable cards, then RFC #1506 schema-v1 no-response-friction
+                                                   # records as JSON Lines (one record per line) on stdout. --emit-signal
+                                                   # REQUIRES --summary: without it, default/--company mode already prints
+                                                   # a single parsable JSON document, and appending JSON Lines after it
+                                                   # would make stdout un-parsable as one JSON value. --summary's output is
+                                                   # not JSON to begin with, so appending JSON Lines after it stays clean —
+                                                   # bare --emit-signal (no --summary) exits 1 with this same explanation.
   node company-history.mjs --help                 # print this usage block and exit`;
 
 function parseArgs(argv) {
@@ -162,15 +169,35 @@ function parseArgs(argv) {
     process.exit(1);
   }
 
+  const summaryMode = args.includes('--summary');
+  const company = valueOf('--company');
+  const emitSignal = args.includes('--emit-signal');
+
+  // --emit-signal REQUIRES --summary (and is incompatible with --company).
+  // Default mode and --company mode both print a single parsable JSON
+  // document on stdout; appending JSON Lines signal records after that
+  // document would make stdout un-parsable as one JSON value. --summary's
+  // output is human-readable text, not JSON, so appending JSON Lines after it
+  // is the one combination that stays clean — fail fast here rather than
+  // silently corrupting a piped consumer's parse. `--company` wins over
+  // `--summary` in the output-selection branch below (see the CLI run body),
+  // so `--company --summary --emit-signal` would otherwise still print a bare
+  // JSON object followed by JSON Lines; reject that combination too.
+  if (emitSignal && (!summaryMode || company)) {
+    console.error('Error: --emit-signal requires --summary and cannot be combined with --company (default and --company mode already print a single JSON document; appending JSON Lines after it would break JSON parsing of stdout). Use: node company-history.mjs --summary --emit-signal');
+    console.error(USAGE);
+    process.exit(1);
+  }
+
   return {
-    summaryMode: args.includes('--summary'),
+    summaryMode,
     selfTestMode: args.includes('--self-test'),
-    company: valueOf('--company'),
+    company,
     silenceWindowArg,
     includeStale: args.includes('--include-stale'),
     scanHistoryOverride: valueOf('--scan-history'),
     followupsOverride: valueOf('--followups'),
-    emitSignal: args.includes('--emit-signal'),
+    emitSignal,
   };
 }
 
@@ -634,16 +661,17 @@ export function computeSourceHash({ companyKey, observedAt, severity }) {
   return `sha256:${createHash('sha256').update(raw).digest('hex')}`;
 }
 
-// One silent fact -> its observedAt month. Uses the date the application
-// actually CROSSED the silence window (appliedDate + silenceWindowDays), not
-// the date the script happened to run — so the same underlying fact emits the
-// same observedAt (and therefore the same sourceHash) on every run, which
-// dedup depends on. Falls back to the appliedDate itself if the arithmetic
-// ever fails to produce a parsable date.
-function silentFactObservedAt(fact, silenceWindowDays) {
+// One silent fact -> its observedAt month. Anchored on fact.appliedDate's own
+// month directly — deliberately NOT on appliedDate + silenceWindowDays. The
+// window is configurable (--silence-window, or resolveDefaultSilenceWindow())
+// so a window-derived observedAt would shift month (and therefore shift
+// sourceHash, see computeSourceHash above) for the SAME underlying silent
+// fact depending on what window happened to be in effect on a given run —
+// which breaks the dedup that sourceHash exists to support. appliedDate never
+// changes for a given fact, so anchoring on it keeps the hash stable.
+function silentFactObservedAt(fact) {
   const appliedDate = parseDate(fact.appliedDate);
-  const crossedAt = appliedDate ? addDays(appliedDate, silenceWindowDays) : null;
-  const source = crossedAt || fact.appliedDate;
+  const source = appliedDate ? fact.appliedDate : null;
   return typeof source === 'string' && source.length >= 7 ? source.slice(0, 7) : null;
 }
 
@@ -656,23 +684,39 @@ function silentFactObservedAt(fact, silenceWindowDays) {
 // severity: 'single' for exactly one silent fact on the card, 'pattern' for
 // 2+ (the candidate applied more than once and went unanswered more than
 // once at the same company).
+//
+// opts.includeStale mirrors the CLI's --include-stale flag: pass true to
+// count stale (>365d, or --staleAfterDays override) silent facts towards
+// severity, matching whatever includeStale value the caller used to compute
+// `result`'s labels. Left false (the default), a stale silent fact never
+// contributes to severity, keeping severity consistent with the label it
+// rode in on.
 export function buildNoResponseFrictionSignals(result, opts = {}) {
   const region = opts.region ?? resolveRegion(opts.profilePath);
   const emittedBy = opts.emittedBy ?? resolveEmittedBy(opts.packagePath);
-  const silenceWindowDays = Number.isFinite(result?.metadata?.silenceWindowDays)
-    ? result.metadata.silenceWindowDays
-    : DEFAULT_SILENCE_WINDOW_DAYS;
+  const includeStale = !!opts.includeStale;
 
   const records = [];
   for (const card of Array.isArray(result?.companies) ? result.companies : []) {
     if (card?.responsiveness?.label !== 'silent-on-you') continue;
 
-    const silentFacts = card.responsiveness.facts.filter(f => 'silentDays' in f);
+    // Mirror computeResponsiveness()'s own stale filter: the label was
+    // computed from activeFacts (stale facts excluded unless --include-stale),
+    // but card.responsiveness.facts still carries every fact, stale or not.
+    // Without this filter a card with one active + one stale silent fact
+    // would report severity 'pattern' even though only one fact actually
+    // contributed to the 'silent-on-you' label.
+    const activeFacts = includeStale ? card.responsiveness.facts : card.responsiveness.facts.filter(f => !f.stale);
+    const silentFacts = activeFacts.filter(f => 'silentDays' in f);
     if (silentFacts.length === 0) continue; // defensive; label implies >=1
 
-    // Most-recent silent fact anchors observedAt (largest applied num).
-    const anchorFact = silentFacts.reduce((a, b) => (b.num > a.num ? b : a));
-    const observedAt = silentFactObservedAt(anchorFact, silenceWindowDays);
+    // Most-recent APPLICATION anchors observedAt — compare appliedDate, not
+    // tracker row num. num is just row-insertion order; a backfilled or
+    // out-of-order row can carry a larger num with an OLDER appliedDate, which
+    // would silently anchor on a stale application despite the "most-recent"
+    // intent. ISO date strings sort correctly with plain string comparison.
+    const anchorFact = silentFacts.reduce((a, b) => (String(b.appliedDate) > String(a.appliedDate) ? b : a));
+    const observedAt = silentFactObservedAt(anchorFact);
     if (!observedAt) continue; // unusable date — no record, no crash
 
     const severity = silentFacts.length >= 2 ? 'pattern' : 'single';
@@ -1080,9 +1124,75 @@ async function runSelfTest() {
     );
     check(singleSignalsAgain[0]?.sourceHash === singleSignals[0]?.sourceHash, 'sourceHash is deterministic across repeated runs against the same fact (dedup-safe)');
 
+    // severity excludes stale facts from the count unless --include-stale is
+    // passed — a card with one active + one stale silent fact must report
+    // 'single', matching what the 'silent-on-you' label itself was computed
+    // from (computeResponsiveness excludes stale facts from the label too).
+    const staleRows = [
+      row(220, 'ActivePlusStaleCo', 'Applied', '2026-06-01'), // active: well within 365d
+      row(221, 'ActivePlusStaleCo', 'Applied', '2024-01-01'), // stale: >365d before NOW
+    ];
+    const activePlusStaleResult = buildCompanyCards(
+      { trackerRows: staleRows, followupRows: [], repostClusters: [], sourcesLoaded: { tracker: true, followups: false, scanHistory: false, statusLog: false } },
+      { now: NOW, silenceWindowDays: 28 },
+    );
+    check(activePlusStaleResult.companies[0].responsiveness.label === 'silent-on-you', 'active+stale fixture: label is silent-on-you (only the active fact drives it)');
+    const activePlusStaleFacts = activePlusStaleResult.companies[0].responsiveness.facts;
+    check(activePlusStaleFacts.some(f => f.stale) && activePlusStaleFacts.some(f => !f.stale), 'active+stale fixture: card carries both a stale and an active silent fact');
+    const activePlusStaleSignals = buildNoResponseFrictionSignals(activePlusStaleResult, fixedOpts);
+    check(activePlusStaleSignals.length === 1, 'active+stale fixture: still exactly one record for the card');
+    check(activePlusStaleSignals[0]?.severity === 'single', 'active+stale fixture: severity is single — the stale fact does not inflate it to pattern, matching the label');
+
+    // silentFactObservedAt returning null (unusable appliedDate) must skip the
+    // card entirely — no record, no crash. Constructed directly rather than
+    // through buildCompanyCards, since computeResponsiveness() never produces
+    // a fact with an unparsable appliedDate in the first place.
+    const unusableDateResult = {
+      companies: [{
+        key: 'unusable-date-co',
+        responsiveness: {
+          label: 'silent-on-you',
+          facts: [{ num: 1, appliedDate: 'not-a-real-date', silentDays: 40, stale: false }],
+        },
+      }],
+    };
+    const unusableDateSignals = buildNoResponseFrictionSignals(unusableDateResult, fixedOpts);
+    check(unusableDateSignals.length === 0, 'a card whose anchor fact has an unusable appliedDate is skipped entirely — no record emitted');
+
+    // anchor selection compares appliedDate, not tracker row num: a lower-num
+    // row with a MORE RECENT appliedDate (a backfilled/out-of-order entry)
+    // must still win the anchor, keeping observedAt tied to the true
+    // most-recent application.
+    const outOfOrderRows = [
+      row(230, 'OutOfOrderCo', 'Applied', '2026-06-01'), // lower num, more recent applied date
+      row(231, 'OutOfOrderCo', 'Applied', '2026-01-01'), // higher num, older applied date
+    ];
+    const outOfOrderResult = buildCompanyCards(
+      { trackerRows: outOfOrderRows, followupRows: [], repostClusters: [], sourcesLoaded: { tracker: true, followups: false, scanHistory: false, statusLog: false } },
+      { now: NOW, silenceWindowDays: 28 },
+    );
+    const outOfOrderSignals = buildNoResponseFrictionSignals(outOfOrderResult, fixedOpts);
+    check(outOfOrderSignals[0]?.observedAt === '2026-06', 'anchor fact is chosen by appliedDate (2026-06-01), not by the larger tracker row num (231, dated 2026-01-01)');
+
     // resolveRegion / resolveEmittedBy degrade gracefully against a missing file.
     check(resolveRegion(join(CAREER_OPS, '__does-not-exist__.yml')) === 'unknown', 'resolveRegion degrades to "unknown" when profile.yml is absent');
     check(resolveEmittedBy(join(CAREER_OPS, '__does-not-exist__.json')) === 'career-ops', 'resolveEmittedBy degrades to a version-less string when package.json is unreadable');
+
+    // resolveRegion: a mapped country goes through COUNTRY_REGION_MAP, and an
+    // unmapped country degrades to a slugified `unmapped/<slug>` rather than
+    // crashing or falling all the way back to 'unknown'.
+    const regionTmpDir = mkdtempSync(join(tmpdir(), 'company-history-region-test-'));
+    try {
+      const mappedProfilePath = join(regionTmpDir, 'mapped-profile.yml');
+      writeFileSync(mappedProfilePath, 'location:\n  country: Canada\n');
+      check(resolveRegion(mappedProfilePath) === 'north-america/canada', 'resolveRegion maps a known country via COUNTRY_REGION_MAP');
+
+      const unmappedProfilePath = join(regionTmpDir, 'unmapped-profile.yml');
+      writeFileSync(unmappedProfilePath, 'location:\n  country: Narnia\n');
+      check(resolveRegion(unmappedProfilePath) === 'unmapped/narnia', 'resolveRegion degrades an unmapped country to unmapped/<slug>, not "unknown"');
+    } finally {
+      rmSync(regionTmpDir, { recursive: true, force: true });
+    }
   }
 
   console.log(`\n  company-history self-test: ${pass} passed, ${fail} failed\n`);
@@ -1137,12 +1247,17 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
       }
 
       // --emit-signal is additive and opt-in only: without the flag, output
-      // above is byte-for-byte identical to pre-#2787 behavior. When passed,
+      // above is byte-for-byte identical to pre-#2787 behavior. parseArgs()
+      // already rejects --emit-signal unless it's paired with --summary (and
+      // without --company), so by the time we get here `summaryMode` is true
+      // and the human-readable renderSummary() text — not a JSON document —
+      // is what the signal records get appended after; stdout stays a single
+      // parsable unit for whichever format was actually printed. When passed,
       // RFC #1506 schema-v1 no-response-friction records print as JSON Lines
       // (one record per line) after the normal output — nothing is written to
       // disk and nothing is published anywhere.
       if (emitSignal) {
-        const signals = buildNoResponseFrictionSignals(result);
+        const signals = buildNoResponseFrictionSignals(result, { includeStale });
         for (const record of signals) {
           console.log(JSON.stringify(record));
         }

--- a/company-history.mjs
+++ b/company-history.mjs
@@ -583,14 +583,27 @@ export function getCompanyCard(result, companyName) {
 // shape, per @Schlaflied's converged-schema comment that @santifer ratified):
 //   { schemaVersion: 1, companyKey, region, signalType: 'no-response-friction',
 //     detail: null, severity: 'single'|'pattern'|null,
-//     sourceDetector: 'no-response-friction', sourceHash: 'sha256:...',
+//     sourceDetector: 'company-history', sourceHash: 'sha256:...',
 //     observedAt: 'YYYY-MM', emittedBy: 'career-ops vX.Y.Z' }
 //
 // `sourceDetector` enum so far: 'interview-redflag' | 'process-friction'
-// (named in the RFC thread) | 'no-response-friction' (this detector — the
-// third, established here per artemtrofymenko's PR #2788 review since the
-// RFC thread didn't pre-name it; matches the existing naming convention of
-// "sourceDetector value == signalType value" used by this signal already).
+// (named in the RFC thread) | 'company-history' (this script — the third,
+// established here per artemtrofymenko's PR #2788 review). Originally set to
+// 'no-response-friction' (the signal name); renamed to 'company-history' per
+// a follow-up (weak-preference, non-blocking) suggestion from the same
+// reviewer: the existing precedent is interview-redflag.mjs, which emits 4
+// different signal types under the RFC's enum but always tags
+// `sourceDetector: 'interview-redflag'` — the TOOL name, not any one signal
+// name. sourceDetector identifies the producing script, not the specific
+// signal type it happened to emit. This also future-proofs the value:
+// company-history.mjs already computes two independent axes
+// (responsiveness and postingChurn); only responsiveness feeds a signal
+// today (no-response-friction), but if postingChurn ever feeds a second
+// signal type later, a value scoped to this one signal would be wrong for
+// that record — 'company-history' stays correct regardless of how many
+// signal types this script eventually produces. Renaming an enum value
+// already present in emitted records is expensive, so this was worth fixing
+// before anything shipped with the old value.
 // `detail` is null here — this signal is derived purely from tracker dates,
 // with no free text to carry (unlike e.g. process-friction's
 // "interviewer no-show, no reschedule notice" example in the RFC).
@@ -815,7 +828,7 @@ export function buildNoResponseFrictionSignals(result, opts = {}) {
       signalType: 'no-response-friction',
       detail: null,
       severity,
-      sourceDetector: 'no-response-friction',
+      sourceDetector: 'company-history',
       sourceHash: computeSourceHash({ companyKey: card.key, observedAt }),
       observedAt,
       emittedBy,
@@ -1154,7 +1167,7 @@ async function runSelfTest() {
     check(typeof singleSignals[0]?.sourceHash === 'string' && singleSignals[0].sourceHash.startsWith('sha256:'), 'sourceHash is present and sha256-prefixed');
     check(singleSignals[0]?.schemaVersion === 1, 'emitted record carries schemaVersion 1 (ratified RFC #1506 shape)');
     check(singleSignals[0]?.detail === null, 'emitted record carries detail: null — this signal is derived purely from dates, no free text');
-    check(singleSignals[0]?.sourceDetector === 'no-response-friction', 'emitted record carries sourceDetector: no-response-friction');
+    check(singleSignals[0]?.sourceDetector === 'company-history', 'emitted record carries sourceDetector: company-history (the producing tool, not the signal name — matches interview-redflag.mjs precedent)');
 
     // pattern: two SEPARATE applications to the same company, both silent.
     const patternResult = buildCompanyCards(

--- a/company-history.mjs
+++ b/company-history.mjs
@@ -788,8 +788,14 @@ export function buildNoResponseFrictionSignals(result, opts = {}) {
     // tracker row num. num is just row-insertion order; a backfilled or
     // out-of-order row can carry a larger num with an OLDER appliedDate, which
     // would silently anchor on a stale application despite the "most-recent"
-    // intent. ISO date strings sort correctly with plain string comparison.
-    const anchorFact = silentFacts.reduce((a, b) => (String(b.appliedDate) > String(a.appliedDate) ? b : a));
+    // intent. ISO date strings sort correctly with plain string comparison —
+    // but only once trimmed: a whitespace-padded value (e.g. ' 2026-06-01 ')
+    // compares incorrectly against an untrimmed neighbor, which would select
+    // the wrong anchor and emit a wrong observedAt/sourceHash (CodeRabbit,
+    // PR #2788).
+    const anchorFact = silentFacts.reduce((a, b) => (
+      String(b.appliedDate).trim() > String(a.appliedDate).trim() ? b : a
+    ));
     const observedAt = silentFactObservedAt(anchorFact);
     if (!observedAt) continue; // unusable date — no record, no crash
 
@@ -1303,6 +1309,20 @@ async function runSelfTest() {
     );
     const { records: outOfOrderSignals } = buildNoResponseFrictionSignals(outOfOrderResult, fixedOpts);
     check(outOfOrderSignals[0]?.observedAt === '2026-06', 'anchor fact is chosen by appliedDate (2026-06-01), not by the larger tracker row num (231, dated 2026-01-01)');
+
+    // anchor selection must trim before comparing: an untrimmed whitespace-
+    // padded date can sort incorrectly against a clean neighbor and select
+    // the wrong (older) anchor (CodeRabbit, PR #2788).
+    const paddedAnchorRows = [
+      row(240, 'PaddedAnchorCo', 'Applied', ' 2026-06-01 '), // padded, actually most recent
+      row(241, 'PaddedAnchorCo', 'Applied', '2026-05-01'),   // clean, actually older
+    ];
+    const paddedAnchorResult = buildCompanyCards(
+      { trackerRows: paddedAnchorRows, followupRows: [], repostClusters: [], sourcesLoaded: { tracker: true, followups: false, scanHistory: false, statusLog: false } },
+      { now: NOW, silenceWindowDays: 28 },
+    );
+    const { records: paddedAnchorSignals } = buildNoResponseFrictionSignals(paddedAnchorResult, fixedOpts);
+    check(paddedAnchorSignals[0]?.observedAt === '2026-06', 'anchor selection trims before comparing, so a whitespace-padded but more-recent appliedDate still wins over a clean but older one');
 
     // resolveRegion / resolveEmittedBy degrade gracefully against a missing file.
     // Per artemtrofymenko's PR #2788 review, an unresolvable region no longer

--- a/company-history.mjs
+++ b/company-history.mjs
@@ -392,6 +392,14 @@ export function computeResponsiveness(rows, followupCountsByAppNum, opts = {}) {
         followupsSent,
         confidence: followupsSent >= 1 ? 'confirmed-by-followups' : 'unconfirmed',
         stale: silentDays > staleAfterDays,
+        // Carried through so buildNoResponseFrictionSignals() can derive
+        // postingChannel (#3010) from the anchor fact without a second join
+        // back to the tracker row — row.via is the tracker's own tagged
+        // via={Agency} field (AGENTS.md's "Optional Via field", #1596), or
+        // its em-dash "confirmed direct" convention. Never fabricated here:
+        // absent/undefined stays null, exactly like resolveRegion()'s null
+        // for "no data", not a guessed value.
+        via: row.via ?? null,
         dateBasis,
         // Real set-status.mjs syntax (it rejects unknown flags, so the
         // instruction must only use flags that exist): --on records the real
@@ -611,6 +619,19 @@ export function getCompanyCard(result, companyName) {
 // Privacy: enum/hash/date fields only — no candidate name, no free-text notes,
 // no verbatim quotes anywhere in an emitted record (same discipline as
 // interview-redflag / process-friction).
+//
+// ADDITIVE field, not part of the ratified v1 shape above: `postingChannel`
+// ('direct-employer' | 'staffing-agency' | 'unknown'), proposed in #3010 and
+// pending its own review — kept separate from the RFC-ratified 10 fields
+// because it has not itself been ratified. Per @strelov1's (freehire.me)
+// production measurement cited in #3010, a single-criterion structural
+// signal like this one systematically misfires on staffing/recruiting
+// agencies, which legitimately post client roles that never appear on their
+// own careers page — conflating "agency-mediated posting" with "shady
+// posting". No new detection: it wires in the tracker's own existing tagged
+// `via={Agency}` field (#1596) via resolvePostingChannel() below, the same
+// "never fabricate, degrade to unknown" discipline resolveRegion() already
+// uses for the `region` field above.
 
 // Best-effort country -> region-slug mapping for the RFC's `region` field
 // (e.g. "north-america/canada"). Deliberately small: covers the markets this
@@ -678,6 +699,26 @@ export function resolveRegion(profilePath = PROFILE_FILE) {
   if (mapped) return mapped;
   const slug = slugify(country);
   return slug ? `unmapped/${slug}` : null;
+}
+
+// Distinguishes who actually posted the role — the direct employer, or a
+// third-party staffing/recruiting agency filling a client req — for the
+// additive `postingChannel` field (#3010; see the schema comment block
+// above). Reuses the tracker's own existing `via` convention (AGENTS.md's
+// "Optional Via field", #1596) rather than adding new detection: a non-empty
+// tagged value that isn't the em-dash sentinel means agency-mediated; the
+// tracker's own em-dash convention means confirmed-direct; and — matching
+// resolveRegion()'s "never fabricate, degrade to a real absence" discipline
+// — an undefined, null, or blank/whitespace-only `via` means no data was
+// ever recorded either way, so this returns 'unknown' rather than guessing
+// 'direct-employer'. `unknown` here is a real, RFC-sanctioned enum value
+// (unlike resolveRegion()'s rejected 'unknown' literal), so no null-vs-string
+// caller-side handling is needed the way region emission requires.
+export function resolvePostingChannel(via) {
+  if (typeof via !== 'string') return 'unknown';
+  const trimmed = via.trim();
+  if (!trimmed) return 'unknown';
+  return trimmed === '—' ? 'direct-employer' : 'staffing-agency';
 }
 
 // package.json version -> "career-ops vX.Y.Z". Missing/unparsable package.json
@@ -820,6 +861,11 @@ export function buildNoResponseFrictionSignals(result, opts = {}) {
     if (!observedAt) continue; // unusable date — no record, no crash
 
     const severity = silentFacts.length >= 2 ? 'pattern' : 'single';
+    // postingChannel rides on the same anchor fact as observedAt — it is a
+    // property of that specific application (the tracker row's own `via`),
+    // not of the company card as a whole, so it must not be recomputed from
+    // a different fact than the one that decided observedAt/sourceHash.
+    const postingChannel = resolvePostingChannel(anchorFact.via);
 
     records.push({
       schemaVersion: 1,
@@ -832,6 +878,7 @@ export function buildNoResponseFrictionSignals(result, opts = {}) {
       sourceHash: computeSourceHash({ companyKey: card.key, observedAt }),
       observedAt,
       emittedBy,
+      postingChannel,
     });
   }
 
@@ -1245,10 +1292,10 @@ async function runSelfTest() {
       const keys = Object.keys(record).sort();
       check(
         JSON.stringify(keys) === JSON.stringify([
-          'companyKey', 'detail', 'emittedBy', 'observedAt', 'region', 'schemaVersion',
-          'severity', 'signalType', 'sourceDetector', 'sourceHash',
+          'companyKey', 'detail', 'emittedBy', 'observedAt', 'postingChannel', 'region',
+          'schemaVersion', 'severity', 'signalType', 'sourceDetector', 'sourceHash',
         ]),
-        'emitted record carries exactly the ratified schema-v1 10 fields, nothing extra (no notes/name leakage), nothing missing',
+        'emitted record carries the ratified schema-v1 10 fields plus the additive postingChannel field (#3010), nothing extra (no notes/name leakage), nothing missing',
       );
     }
 
@@ -1445,6 +1492,40 @@ async function runSelfTest() {
     } finally {
       rmSync(regionTmpDir, { recursive: true, force: true });
     }
+  }
+
+  // --- postingChannel field (#3010): derived from the tracker's own `via` ---
+  {
+    // agency-tagged via -> staffing-agency.
+    const agencyResult = buildCompanyCards(
+      { trackerRows: [{ ...row(260, 'AgencyPostedCo', 'Applied', '2026-05-01'), via: 'Hays' }], followupRows: [], repostClusters: [], sourcesLoaded: { tracker: true, followups: false, scanHistory: false, statusLog: false } },
+      { now: NOW, silenceWindowDays: 28 },
+    );
+    check(agencyResult.companies[0].responsiveness.facts[0].via === 'Hays', 'row.via survives onto the silent fact');
+    const { records: agencySignals } = buildNoResponseFrictionSignals(agencyResult, { region: 'north-america/canada', emittedBy: 'career-ops vTEST' });
+    check(agencySignals[0]?.postingChannel === 'staffing-agency', 'a tagged agency via value emits postingChannel: staffing-agency');
+
+    // em-dash via (tracker's own "confirmed direct" convention) -> direct-employer.
+    const directResult = buildCompanyCards(
+      { trackerRows: [{ ...row(261, 'DirectConfirmedCo', 'Applied', '2026-05-01'), via: '—' }], followupRows: [], repostClusters: [], sourcesLoaded: { tracker: true, followups: false, scanHistory: false, statusLog: false } },
+      { now: NOW, silenceWindowDays: 28 },
+    );
+    const { records: directSignals } = buildNoResponseFrictionSignals(directResult, { region: 'north-america/canada', emittedBy: 'career-ops vTEST' });
+    check(directSignals[0]?.postingChannel === 'direct-employer', 'an em-dash via value (confirmed direct, no agency) emits postingChannel: direct-employer');
+
+    // absent/blank via -> unknown (never guessed as direct-employer).
+    const noDataResult = buildCompanyCards(
+      { trackerRows: [row(262, 'NoViaDataCo', 'Applied', '2026-05-01')], followupRows: [], repostClusters: [], sourcesLoaded: { tracker: true, followups: false, scanHistory: false, statusLog: false } },
+      { now: NOW, silenceWindowDays: 28 },
+    );
+    const { records: noDataSignals } = buildNoResponseFrictionSignals(noDataResult, { region: 'north-america/canada', emittedBy: 'career-ops vTEST' });
+    check(noDataSignals[0]?.postingChannel === 'unknown', 'a row with no recorded via emits postingChannel: unknown, never a guessed direct-employer');
+
+    check(resolvePostingChannel('  ') === 'unknown', 'resolvePostingChannel: whitespace-only via is unknown, not staffing-agency');
+    check(resolvePostingChannel(null) === 'unknown', 'resolvePostingChannel: null via is unknown');
+    check(resolvePostingChannel(undefined) === 'unknown', 'resolvePostingChannel: undefined via is unknown');
+    check(resolvePostingChannel('Acme Staffing') === 'staffing-agency', 'resolvePostingChannel: any non-em-dash tagged agency name is staffing-agency');
+    check(resolvePostingChannel('—') === 'direct-employer', 'resolvePostingChannel: exact em-dash is direct-employer');
   }
 
   console.log(`\n  company-history self-test: ${pass} passed, ${fail} failed\n`);

--- a/company-history.mjs
+++ b/company-history.mjs
@@ -579,10 +579,21 @@ export function getCompanyCard(result, companyName) {
 // window shipped in #1712; per #2787 we standardize on the one window this
 // script already has tested rather than adding a second, undocumented cutoff.
 //
-// Schema v1 (verbatim from RFC #1506, ratified 2026-07-16):
-//   { companyKey, region, signalType: 'no-response-friction',
-//     severity: 'single'|'pattern'|null, sourceHash: 'sha256:...',
+// Schema v1 (verbatim from RFC #1506, ratified 2026-07-16 — full 10-field
+// shape, per @Schlaflied's converged-schema comment that @santifer ratified):
+//   { schemaVersion: 1, companyKey, region, signalType: 'no-response-friction',
+//     detail: null, severity: 'single'|'pattern'|null,
+//     sourceDetector: 'no-response-friction', sourceHash: 'sha256:...',
 //     observedAt: 'YYYY-MM', emittedBy: 'career-ops vX.Y.Z' }
+//
+// `sourceDetector` enum so far: 'interview-redflag' | 'process-friction'
+// (named in the RFC thread) | 'no-response-friction' (this detector — the
+// third, established here per artemtrofymenko's PR #2788 review since the
+// RFC thread didn't pre-name it; matches the existing naming convention of
+// "sourceDetector value == signalType value" used by this signal already).
+// `detail` is null here — this signal is derived purely from tracker dates,
+// with no free text to carry (unlike e.g. process-friction's
+// "interviewer no-show, no reschedule notice" example in the RFC).
 //
 // Privacy: enum/hash/date fields only — no candidate name, no free-text notes,
 // no verbatim quotes anywhere in an emitted record (same discipline as
@@ -632,21 +643,28 @@ function slugify(value) {
 // Reads config/profile.yml -> location.country the same way followup-cadence.mjs
 // reads config/profile.yml (existsSync guard, try/catch parse, silent
 // degradation — a missing or unparsable profile must never crash signal
-// emission, it just means region is 'unknown').
+// emission). Returns null when a region genuinely cannot be resolved (no
+// profile, unparsable profile, no country field) — per artemtrofymenko's
+// review on PR #2788, a literal 'unknown' string would imply a real
+// `unknown/` shared-layer directory if this schema were ever published, so
+// callers must treat null as "skip emission, don't fabricate a region"
+// rather than emitting a misleading placeholder value. A country that IS
+// present but unmapped in COUNTRY_REGION_MAP still resolves (to
+// `unmapped/<slug>`) — that is real information, not a placeholder.
 export function resolveRegion(profilePath = PROFILE_FILE) {
-  if (!profilePath || !existsSync(profilePath)) return 'unknown';
+  if (!profilePath || !existsSync(profilePath)) return null;
   let raw;
   try {
     raw = yaml.load(readFileSync(profilePath, 'utf-8')) || {};
   } catch {
-    return 'unknown';
+    return null;
   }
   const country = raw?.location?.country;
-  if (!country || typeof country !== 'string') return 'unknown';
+  if (!country || typeof country !== 'string') return null;
   const mapped = COUNTRY_REGION_MAP[country.trim().toLowerCase()];
   if (mapped) return mapped;
   const slug = slugify(country);
-  return slug ? `unmapped/${slug}` : 'unknown';
+  return slug ? `unmapped/${slug}` : null;
 }
 
 // package.json version -> "career-ops vX.Y.Z". Missing/unparsable package.json
@@ -666,13 +684,26 @@ export function resolveEmittedBy(packagePath = PACKAGE_JSON) {
 // Deterministic (not random) so repeated runs against the same underlying
 // fact produce the same sourceHash — required for downstream dedup. The
 // hashed input is already fully reconstructable from the record's own
-// plaintext fields (companyKey/observedAt/severity/signalType), so the hash
-// adds no additional linkable information beyond what those fields already
-// expose; it is opaque only in the sense that it cannot be reversed back into
+// plaintext fields (companyKey/observedAt/signalType), so the hash adds no
+// additional linkable information beyond what those fields already expose;
+// it is opaque only in the sense that it cannot be reversed back into
 // anything MORE sensitive (raw applicant identity, notes text, etc.) than is
 // already in plaintext.
-export function computeSourceHash({ companyKey, observedAt, severity }) {
-  const raw = `no-response-friction|${companyKey}|${observedAt}|${severity ?? 'null'}`;
+//
+// `severity` is deliberately EXCLUDED from the hash (fixed per
+// artemtrofymenko's PR #2788 review, which caught this against a real
+// tracker): severity can legitimately change over time for the SAME
+// underlying company-month fact (e.g. a candidate applies once and goes
+// silent -> 'single'; applies again later and also goes silent -> 'pattern').
+// Hashing severity in would make the same companyKey+observedAt fact produce
+// a different sourceHash depending on when the record was emitted, so a
+// downstream dedup pool couldn't tell two emissions describe the same
+// evolving fact — both would coexist with contradictory severity instead of
+// the later one superseding the earlier. Keying the hash on
+// signalType|companyKey|observedAt only (what is being described, not values
+// that can accumulate) makes companyKey|observedAt the stable identity.
+export function computeSourceHash({ companyKey, observedAt }) {
+  const raw = `no-response-friction|${companyKey}|${observedAt}`;
   return `sha256:${createHash('sha256').update(raw).digest('hex')}`;
 }
 
@@ -712,14 +743,36 @@ function silentFactObservedAt(fact) {
 // `result`'s labels. Left false (the default), a stale silent fact never
 // contributes to severity, keeping severity consistent with the label it
 // rode in on.
+//
+// Returns { records, warnings } (matching this repo's established
+// discover-ats.mjs / check-table-freshness.mjs shape), not a bare array.
+// region is resolved once per run (it is a property of the candidate's own
+// profile, not of any individual company) — when it cannot be resolved,
+// per artemtrofymenko's PR #2788 review, this "says nothing" rather than
+// emitting a misleading 'unknown' literal: no records are emitted for this
+// run and a warning explains why, instead of hard-erroring the whole
+// command over one unresolvable field.
 export function buildNoResponseFrictionSignals(result, opts = {}) {
   const region = opts.region ?? resolveRegion(opts.profilePath);
   const emittedBy = opts.emittedBy ?? resolveEmittedBy(opts.packagePath);
   const includeStale = !!opts.includeStale;
 
   const records = [];
+  const warnings = [];
+
   for (const card of Array.isArray(result?.companies) ? result.companies : []) {
     if (card?.responsiveness?.label !== 'silent-on-you') continue;
+
+    // region is a property of the candidate's own profile, so it is the
+    // same (or the same absence) for every company in a given run — but the
+    // skip is expressed per-company (rather than as one early return for the
+    // whole call) so the warning names exactly which company's signal was
+    // dropped, matching the shape a future per-company region override could
+    // reuse without a rewrite here.
+    if (!region) {
+      warnings.push(`region could not be resolved from config/profile.yml — signal not emitted for ${card.key}.`);
+      continue;
+    }
 
     // Mirror computeResponsiveness()'s own stale filter: the label was
     // computed from activeFacts (stale facts excluded unless --include-stale),
@@ -743,18 +796,21 @@ export function buildNoResponseFrictionSignals(result, opts = {}) {
     const severity = silentFacts.length >= 2 ? 'pattern' : 'single';
 
     records.push({
+      schemaVersion: 1,
       companyKey: card.key,
       region,
       signalType: 'no-response-friction',
+      detail: null,
       severity,
-      sourceHash: computeSourceHash({ companyKey: card.key, observedAt, severity }),
+      sourceDetector: 'no-response-friction',
+      sourceHash: computeSourceHash({ companyKey: card.key, observedAt }),
       observedAt,
       emittedBy,
     });
   }
 
   records.sort((a, b) => compareCompany(a.companyKey, b.companyKey));
-  return records;
+  return { records, warnings };
 }
 
 // --- Summary rendering (pure) ---
@@ -1073,7 +1129,8 @@ async function runSelfTest() {
       { trackerRows: [row(200, 'SingleSilentCo', 'Applied', '2026-05-01')], followupRows: [], repostClusters: [], sourcesLoaded: { tracker: true, followups: false, scanHistory: false, statusLog: false } },
       { now: NOW, silenceWindowDays: 28 },
     );
-    const singleSignals = buildNoResponseFrictionSignals(singleResult, fixedOpts);
+    const { records: singleSignals, warnings: singleWarnings } = buildNoResponseFrictionSignals(singleResult, fixedOpts);
+    check(singleWarnings.length === 0, 'resolvable region: no warnings emitted');
     check(singleSignals.length === 1, 'exactly one no-response-friction record emitted for a single silent-on-you card');
     check(singleSignals[0]?.severity === 'single', 'one silent fact on the card -> severity single');
     check(singleSignals[0]?.signalType === 'no-response-friction', 'emitted record carries signalType no-response-friction');
@@ -1082,6 +1139,9 @@ async function runSelfTest() {
     check(singleSignals[0]?.emittedBy === 'career-ops vTEST', 'emitted emittedBy matches the resolved version string');
     check(/^\d{4}-\d{2}$/.test(singleSignals[0]?.observedAt || ''), 'observedAt is strictly month-only (YYYY-MM, no day)');
     check(typeof singleSignals[0]?.sourceHash === 'string' && singleSignals[0].sourceHash.startsWith('sha256:'), 'sourceHash is present and sha256-prefixed');
+    check(singleSignals[0]?.schemaVersion === 1, 'emitted record carries schemaVersion 1 (ratified RFC #1506 shape)');
+    check(singleSignals[0]?.detail === null, 'emitted record carries detail: null — this signal is derived purely from dates, no free text');
+    check(singleSignals[0]?.sourceDetector === 'no-response-friction', 'emitted record carries sourceDetector: no-response-friction');
 
     // pattern: two SEPARATE applications to the same company, both silent.
     const patternResult = buildCompanyCards(
@@ -1096,9 +1156,37 @@ async function runSelfTest() {
       { now: NOW, silenceWindowDays: 28 },
     );
     check(patternResult.companies[0].responsiveness.label === 'silent-on-you', 'two-application silent fixture still labels silent-on-you (precondition for the pattern check below)');
-    const patternSignals = buildNoResponseFrictionSignals(patternResult, fixedOpts);
+    const { records: patternSignals } = buildNoResponseFrictionSignals(patternResult, fixedOpts);
     check(patternSignals.length === 1, 'still exactly one record per company card, even with 2 silent facts');
     check(patternSignals[0]?.severity === 'pattern', 'two silent facts on the same card -> severity pattern');
+
+    // artemtrofymenko's PR #2788 review scenario, verbatim: the SAME
+    // companyKey + observedAt (same company, same month) must produce the
+    // SAME sourceHash whether the card carries 1 silent fact (severity
+    // 'single') or 2 (severity 'pattern') — severity is explicitly excluded
+    // from the hash so a later emission with updated severity supersedes
+    // the earlier one in a dedup pool instead of coexisting as a phantom
+    // duplicate.
+    const sameMonthSingleResult = buildCompanyCards(
+      { trackerRows: [row(240, 'SeverityHashCo', 'Applied', '2026-05-03')], followupRows: [], repostClusters: [], sourcesLoaded: { tracker: true, followups: false, scanHistory: false, statusLog: false } },
+      { now: NOW, silenceWindowDays: 28 },
+    );
+    const sameMonthPatternResult = buildCompanyCards(
+      {
+        trackerRows: [
+          row(241, 'SeverityHashCo', 'Applied', '2026-05-03'),
+          row(242, 'SeverityHashCo', 'Applied', '2026-05-10'),
+        ],
+        followupRows: [], repostClusters: [],
+        sourcesLoaded: { tracker: true, followups: false, scanHistory: false, statusLog: false },
+      },
+      { now: NOW, silenceWindowDays: 28 },
+    );
+    const { records: sameMonthSingleSignals } = buildNoResponseFrictionSignals(sameMonthSingleResult, fixedOpts);
+    const { records: sameMonthPatternSignals } = buildNoResponseFrictionSignals(sameMonthPatternResult, fixedOpts);
+    check(sameMonthSingleSignals[0]?.severity === 'single' && sameMonthPatternSignals[0]?.severity === 'pattern', 'severity/hash fixture: single vs pattern severity actually differs (precondition)');
+    check(sameMonthSingleSignals[0]?.observedAt === sameMonthPatternSignals[0]?.observedAt, 'severity/hash fixture: both anchor to the same observedAt month (precondition)');
+    check(sameMonthSingleSignals[0]?.sourceHash === sameMonthPatternSignals[0]?.sourceHash, 'sourceHash is identical for the same companyKey+observedAt despite different severity (single vs pattern) — fixes the dedup-breaking bug from PR #2788 review');
 
     // no record for responded-before / mixed / no-history cards — only
     // silent-on-you triggers this signal.
@@ -1117,26 +1205,30 @@ async function runSelfTest() {
     );
     const labelsPresent = noSignalResult.companies.map(c => c.responsiveness.label);
     check(labelsPresent.includes('responded-before') && labelsPresent.includes('mixed') && labelsPresent.includes('no-history'), 'no-signal fixture actually exercises responded-before, mixed, and no-history cards');
-    const noSignals = buildNoResponseFrictionSignals(noSignalResult, fixedOpts);
+    const { records: noSignals } = buildNoResponseFrictionSignals(noSignalResult, fixedOpts);
     check(noSignals.length === 0, 'responded-before, mixed, and no-history cards emit zero no-response-friction records');
 
     // running WITHOUT --emit-signal semantics: buildNoResponseFrictionSignals
     // is only ever invoked by the CLI when the flag is passed (verified by
     // reading the CLI wiring above); at the pure-function level, confirm the
-    // emitted records never carry free text (notes) or a candidate name —
-    // only the enum/hash/date fields in the schema.
+    // emitted records carry exactly the ratified 10-field schema-v1 shape —
+    // no free text (notes), no candidate name, nothing extra, nothing
+    // missing.
     const allEmitted = [...singleSignals, ...patternSignals];
     for (const record of allEmitted) {
       const keys = Object.keys(record).sort();
       check(
-        JSON.stringify(keys) === JSON.stringify(['companyKey', 'emittedBy', 'observedAt', 'region', 'severity', 'signalType', 'sourceHash']),
-        'emitted record carries exactly the schema-v1 fields, nothing extra (no notes/name leakage)',
+        JSON.stringify(keys) === JSON.stringify([
+          'companyKey', 'detail', 'emittedBy', 'observedAt', 'region', 'schemaVersion',
+          'severity', 'signalType', 'sourceDetector', 'sourceHash',
+        ]),
+        'emitted record carries exactly the ratified schema-v1 10 fields, nothing extra (no notes/name leakage), nothing missing',
       );
     }
 
     // sourceHash is deterministic (dedup-safe): rebuilding the same fixture
     // twice must produce the same hash for the same underlying fact.
-    const singleSignalsAgain = buildNoResponseFrictionSignals(
+    const { records: singleSignalsAgain } = buildNoResponseFrictionSignals(
       buildCompanyCards(
         { trackerRows: [row(200, 'SingleSilentCo', 'Applied', '2026-05-01')], followupRows: [], repostClusters: [], sourcesLoaded: { tracker: true, followups: false, scanHistory: false, statusLog: false } },
         { now: NOW, silenceWindowDays: 28 },
@@ -1160,7 +1252,7 @@ async function runSelfTest() {
     check(activePlusStaleResult.companies[0].responsiveness.label === 'silent-on-you', 'active+stale fixture: label is silent-on-you (only the active fact drives it)');
     const activePlusStaleFacts = activePlusStaleResult.companies[0].responsiveness.facts;
     check(activePlusStaleFacts.some(f => f.stale) && activePlusStaleFacts.some(f => !f.stale), 'active+stale fixture: card carries both a stale and an active silent fact');
-    const activePlusStaleSignals = buildNoResponseFrictionSignals(activePlusStaleResult, fixedOpts);
+    const { records: activePlusStaleSignals } = buildNoResponseFrictionSignals(activePlusStaleResult, fixedOpts);
     check(activePlusStaleSignals.length === 1, 'active+stale fixture: still exactly one record for the card');
     check(activePlusStaleSignals[0]?.severity === 'single', 'active+stale fixture: severity is single — the stale fact does not inflate it to pattern, matching the label');
 
@@ -1177,7 +1269,7 @@ async function runSelfTest() {
         },
       }],
     };
-    const unusableDateSignals = buildNoResponseFrictionSignals(unusableDateResult, fixedOpts);
+    const { records: unusableDateSignals } = buildNoResponseFrictionSignals(unusableDateResult, fixedOpts);
     check(unusableDateSignals.length === 0, 'a card whose anchor fact has an unusable appliedDate is skipped entirely — no record emitted');
 
     // silentFactObservedAt must trim appliedDate before slicing, not just
@@ -1194,7 +1286,7 @@ async function runSelfTest() {
         },
       }],
     };
-    const paddedDateSignals = buildNoResponseFrictionSignals(paddedDateResult, fixedOpts);
+    const { records: paddedDateSignals } = buildNoResponseFrictionSignals(paddedDateResult, fixedOpts);
     check(paddedDateSignals[0]?.observedAt === '2026-06', 'a whitespace-padded appliedDate still produces a clean YYYY-MM observedAt');
 
     // anchor selection compares appliedDate, not tracker row num: a lower-num
@@ -1209,16 +1301,21 @@ async function runSelfTest() {
       { trackerRows: outOfOrderRows, followupRows: [], repostClusters: [], sourcesLoaded: { tracker: true, followups: false, scanHistory: false, statusLog: false } },
       { now: NOW, silenceWindowDays: 28 },
     );
-    const outOfOrderSignals = buildNoResponseFrictionSignals(outOfOrderResult, fixedOpts);
+    const { records: outOfOrderSignals } = buildNoResponseFrictionSignals(outOfOrderResult, fixedOpts);
     check(outOfOrderSignals[0]?.observedAt === '2026-06', 'anchor fact is chosen by appliedDate (2026-06-01), not by the larger tracker row num (231, dated 2026-01-01)');
 
     // resolveRegion / resolveEmittedBy degrade gracefully against a missing file.
-    check(resolveRegion(join(CAREER_OPS, '__does-not-exist__.yml')) === 'unknown', 'resolveRegion degrades to "unknown" when profile.yml is absent');
+    // Per artemtrofymenko's PR #2788 review, an unresolvable region no longer
+    // returns the literal string 'unknown' (which would imply a real
+    // `unknown/` shared-layer directory) — it returns null instead, and the
+    // caller (buildNoResponseFrictionSignals, tested below) is responsible
+    // for turning that into "skip emission + warn", not a placeholder value.
+    check(resolveRegion(join(CAREER_OPS, '__does-not-exist__.yml')) === null, 'resolveRegion degrades to null (not the string "unknown") when profile.yml is absent');
     check(resolveEmittedBy(join(CAREER_OPS, '__does-not-exist__.json')) === 'career-ops', 'resolveEmittedBy degrades to a version-less string when package.json is unreadable');
 
     // resolveRegion: a mapped country goes through COUNTRY_REGION_MAP, and an
     // unmapped country degrades to a slugified `unmapped/<slug>` rather than
-    // crashing or falling all the way back to 'unknown'.
+    // crashing or falling all the way back to null.
     const regionTmpDir = mkdtempSync(join(tmpdir(), 'company-history-region-test-'));
     try {
       const mappedProfilePath = join(regionTmpDir, 'mapped-profile.yml');
@@ -1227,7 +1324,27 @@ async function runSelfTest() {
 
       const unmappedProfilePath = join(regionTmpDir, 'unmapped-profile.yml');
       writeFileSync(unmappedProfilePath, 'location:\n  country: Narnia\n');
-      check(resolveRegion(unmappedProfilePath) === 'unmapped/narnia', 'resolveRegion degrades an unmapped country to unmapped/<slug>, not "unknown"');
+      check(resolveRegion(unmappedProfilePath) === 'unmapped/narnia', 'resolveRegion degrades an unmapped country to unmapped/<slug>, not null');
+
+      // Region-resolution-failure -> skip-emission-with-warning (Finding 3,
+      // PR #2788 review): a profile with no resolvable region must not crash
+      // the tool and must not emit a misleading 'unknown' record — it emits
+      // zero records for that run plus a warning naming the skipped company.
+      // A second company/report with a resolvable region (fixedOpts, used
+      // throughout this test block) still gets its record — proven by every
+      // other assertion in this section, which all pass a resolvable region.
+      const noRegionProfilePath = join(regionTmpDir, 'no-region-profile.yml');
+      writeFileSync(noRegionProfilePath, 'someOtherKey: true\n');
+      const noRegionResult = buildCompanyCards(
+        { trackerRows: [row(250, 'NoRegionCo', 'Applied', '2026-05-01')], followupRows: [], repostClusters: [], sourcesLoaded: { tracker: true, followups: false, scanHistory: false, statusLog: false } },
+        { now: NOW, silenceWindowDays: 28 },
+      );
+      const { records: noRegionSignals, warnings: noRegionWarnings } = buildNoResponseFrictionSignals(
+        noRegionResult,
+        { profilePath: noRegionProfilePath, emittedBy: 'career-ops vTEST' },
+      );
+      check(noRegionSignals.length === 0, 'unresolvable region: no no-response-friction record emitted, no crash');
+      check(noRegionWarnings.length === 1 && noRegionWarnings[0].includes(noRegionResult.companies[0].key), 'unresolvable region: exactly one warning naming the skipped companyKey');
     } finally {
       rmSync(regionTmpDir, { recursive: true, force: true });
     }
@@ -1295,7 +1412,10 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
       // (one record per line) after the normal output — nothing is written to
       // disk and nothing is published anywhere.
       if (emitSignal) {
-        const signals = buildNoResponseFrictionSignals(result, { includeStale });
+        const { records: signals, warnings } = buildNoResponseFrictionSignals(result, { includeStale });
+        for (const warning of warnings) {
+          console.error(`company-history.mjs: ${warning}`);
+        }
         for (const record of signals) {
           console.log(JSON.stringify(record));
         }

--- a/company-history.mjs
+++ b/company-history.mjs
@@ -44,6 +44,7 @@
 import { readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
+import { createHash } from 'crypto';
 import * as yaml from 'js-yaml';
 
 import { parseScanHistory, detectReposts } from './detect-reposts.mjs';
@@ -54,10 +55,13 @@ import {
   parseAppliedDate,
   parseDate,
   daysBetween,
+  addDays,
   normalizeStatus,
 } from './followup-cadence.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
+const PROFILE_FILE = process.env.CAREER_OPS_PROFILE || join(CAREER_OPS, 'config/profile.yml');
+const PACKAGE_JSON = join(CAREER_OPS, 'package.json');
 
 const DEFAULT_STALE_AFTER_DAYS = 365;
 const DEFAULT_SILENCE_WINDOW_DAYS = 28;
@@ -80,7 +84,7 @@ const companyCollator = new Intl.Collator('en');
 const compareCompany = (a, b) => companyCollator.compare(String(a), String(b));
 
 // --- CLI args ---
-const KNOWN_FLAGS = ['--summary', '--self-test', '--company', '--silence-window', '--include-stale', '--scan-history', '--followups', '--help', '-h'];
+const KNOWN_FLAGS = ['--summary', '--self-test', '--company', '--silence-window', '--include-stale', '--scan-history', '--followups', '--emit-signal', '--help', '-h'];
 const VALUE_FLAGS = ['--company', '--silence-window', '--scan-history', '--followups'];
 
 const USAGE = `Usage:
@@ -90,6 +94,7 @@ const USAGE = `Usage:
   node company-history.mjs --silence-window 21    # override the default silence window (days)
   node company-history.mjs --include-stale        # include facts older than 365d in label computation
   node company-history.mjs --self-test            # run the in-memory test suite
+  node company-history.mjs --emit-signal          # also print RFC #1506 schema-v1 no-response-friction records (JSON Lines, opt-in only)
   node company-history.mjs --help                 # print this usage block and exit`;
 
 function parseArgs(argv) {
@@ -165,6 +170,7 @@ function parseArgs(argv) {
     includeStale: args.includes('--include-stale'),
     scanHistoryOverride: valueOf('--scan-history'),
     followupsOverride: valueOf('--followups'),
+    emitSignal: args.includes('--emit-signal'),
   };
 }
 
@@ -521,6 +527,171 @@ export function getCompanyCard(result, companyName) {
   };
 }
 
+// --- no-response-friction signal emission (RFC #1506 schema v1, --emit-signal only) ---
+//
+// Opt-in, local-only. Reuses the `silent-on-you` responsiveness fact
+// company-history.mjs already computes above (computeResponsiveness()) rather
+// than deriving a second silence detector: the 28-day DEFAULT_SILENCE_WINDOW_DAYS
+// (or its --silence-window override) IS this signal's threshold. RFC #1506's
+// original discussion floated a 14-day baseline before this script's 28-day
+// window shipped in #1712; per #2787 we standardize on the one window this
+// script already has tested rather than adding a second, undocumented cutoff.
+//
+// Schema v1 (verbatim from RFC #1506, ratified 2026-07-16):
+//   { companyKey, region, signalType: 'no-response-friction',
+//     severity: 'single'|'pattern'|null, sourceHash: 'sha256:...',
+//     observedAt: 'YYYY-MM', emittedBy: 'career-ops vX.Y.Z' }
+//
+// Privacy: enum/hash/date fields only — no candidate name, no free-text notes,
+// no verbatim quotes anywhere in an emitted record (same discipline as
+// interview-redflag / process-friction).
+
+// Best-effort country -> region-slug mapping for the RFC's `region` field
+// (e.g. "north-america/canada"). Deliberately small: covers the markets this
+// repo already has explicit support for (see modes/<lang>/ market sets) plus
+// a few common others. An unmapped or missing country degrades to a slug of
+// the raw country string (still useful for grouping) rather than crashing or
+// guessing a continent — 'unknown' when there is no country at all.
+const COUNTRY_REGION_MAP = {
+  canada: 'north-america/canada',
+  'united states': 'north-america/united-states',
+  'united states of america': 'north-america/united-states',
+  usa: 'north-america/united-states',
+  us: 'north-america/united-states',
+  mexico: 'north-america/mexico',
+  'united kingdom': 'europe/united-kingdom',
+  uk: 'europe/united-kingdom',
+  germany: 'europe/germany',
+  austria: 'europe/austria',
+  switzerland: 'europe/switzerland',
+  france: 'europe/france',
+  belgium: 'europe/belgium',
+  luxembourg: 'europe/luxembourg',
+  japan: 'asia/japan',
+  india: 'asia/india',
+  turkey: 'asia/turkey',
+  china: 'asia/china',
+  'saudi arabia': 'middle-east/saudi-arabia',
+  uae: 'middle-east/united-arab-emirates',
+  'united arab emirates': 'middle-east/united-arab-emirates',
+  qatar: 'middle-east/qatar',
+  australia: 'oceania/australia',
+  'new zealand': 'oceania/new-zealand',
+};
+
+function slugify(value) {
+  return String(value || '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+// Reads config/profile.yml -> location.country the same way followup-cadence.mjs
+// reads config/profile.yml (existsSync guard, try/catch parse, silent
+// degradation — a missing or unparsable profile must never crash signal
+// emission, it just means region is 'unknown').
+export function resolveRegion(profilePath = PROFILE_FILE) {
+  if (!profilePath || !existsSync(profilePath)) return 'unknown';
+  let raw;
+  try {
+    raw = yaml.load(readFileSync(profilePath, 'utf-8')) || {};
+  } catch {
+    return 'unknown';
+  }
+  const country = raw?.location?.country;
+  if (!country || typeof country !== 'string') return 'unknown';
+  const mapped = COUNTRY_REGION_MAP[country.trim().toLowerCase()];
+  if (mapped) return mapped;
+  const slug = slugify(country);
+  return slug ? `unmapped/${slug}` : 'unknown';
+}
+
+// package.json version -> "career-ops vX.Y.Z". Missing/unparsable package.json
+// degrades to a version-less emittedBy rather than crashing.
+export function resolveEmittedBy(packagePath = PACKAGE_JSON) {
+  try {
+    const pkg = JSON.parse(readFileSync(packagePath, 'utf-8'));
+    if (pkg && typeof pkg.version === 'string' && pkg.version) {
+      return `career-ops v${pkg.version}`;
+    }
+  } catch {
+    // fall through
+  }
+  return 'career-ops';
+}
+
+// Deterministic (not random) so repeated runs against the same underlying
+// fact produce the same sourceHash — required for downstream dedup. The
+// hashed input is already fully reconstructable from the record's own
+// plaintext fields (companyKey/observedAt/severity/signalType), so the hash
+// adds no additional linkable information beyond what those fields already
+// expose; it is opaque only in the sense that it cannot be reversed back into
+// anything MORE sensitive (raw applicant identity, notes text, etc.) than is
+// already in plaintext.
+export function computeSourceHash({ companyKey, observedAt, severity }) {
+  const raw = `no-response-friction|${companyKey}|${observedAt}|${severity ?? 'null'}`;
+  return `sha256:${createHash('sha256').update(raw).digest('hex')}`;
+}
+
+// One silent fact -> its observedAt month. Uses the date the application
+// actually CROSSED the silence window (appliedDate + silenceWindowDays), not
+// the date the script happened to run — so the same underlying fact emits the
+// same observedAt (and therefore the same sourceHash) on every run, which
+// dedup depends on. Falls back to the appliedDate itself if the arithmetic
+// ever fails to produce a parsable date.
+function silentFactObservedAt(fact, silenceWindowDays) {
+  const appliedDate = parseDate(fact.appliedDate);
+  const crossedAt = appliedDate ? addDays(appliedDate, silenceWindowDays) : null;
+  const source = crossedAt || fact.appliedDate;
+  return typeof source === 'string' && source.length >= 7 ? source.slice(0, 7) : null;
+}
+
+// Builds schema-v1 no-response-friction records for every `silent-on-you`
+// company card. Only `silent-on-you` cards ever produce a record — 'mixed'
+// (silent on some, responded on others), 'responded-before', and 'no-history'
+// cards never do, since the point of this signal is companies that have
+// NEVER answered this candidate.
+//
+// severity: 'single' for exactly one silent fact on the card, 'pattern' for
+// 2+ (the candidate applied more than once and went unanswered more than
+// once at the same company).
+export function buildNoResponseFrictionSignals(result, opts = {}) {
+  const region = opts.region ?? resolveRegion(opts.profilePath);
+  const emittedBy = opts.emittedBy ?? resolveEmittedBy(opts.packagePath);
+  const silenceWindowDays = Number.isFinite(result?.metadata?.silenceWindowDays)
+    ? result.metadata.silenceWindowDays
+    : DEFAULT_SILENCE_WINDOW_DAYS;
+
+  const records = [];
+  for (const card of Array.isArray(result?.companies) ? result.companies : []) {
+    if (card?.responsiveness?.label !== 'silent-on-you') continue;
+
+    const silentFacts = card.responsiveness.facts.filter(f => 'silentDays' in f);
+    if (silentFacts.length === 0) continue; // defensive; label implies >=1
+
+    // Most-recent silent fact anchors observedAt (largest applied num).
+    const anchorFact = silentFacts.reduce((a, b) => (b.num > a.num ? b : a));
+    const observedAt = silentFactObservedAt(anchorFact, silenceWindowDays);
+    if (!observedAt) continue; // unusable date — no record, no crash
+
+    const severity = silentFacts.length >= 2 ? 'pattern' : 'single';
+
+    records.push({
+      companyKey: card.key,
+      region,
+      signalType: 'no-response-friction',
+      severity,
+      sourceHash: computeSourceHash({ companyKey: card.key, observedAt, severity }),
+      observedAt,
+      emittedBy,
+    });
+  }
+
+  records.sort((a, b) => compareCompany(a.companyKey, b.companyKey));
+  return records;
+}
+
 // --- Summary rendering (pure) ---
 const LABEL_ORDER = { 'silent-on-you': 0, mixed: 1, 'responded-before': 2, 'no-history': 3 };
 
@@ -828,13 +999,99 @@ async function runSelfTest() {
     check(!fact.clearInstruction.includes('--note'), 'silent fact clearInstruction does not smuggle the response date into --note free text');
   }
 
+  // --- no-response-friction signal emission (RFC #1506 schema v1, #2787) ---
+  {
+    const fixedOpts = { region: 'north-america/canada', emittedBy: 'career-ops vTEST' };
+
+    // single: exactly one silent fact on the card.
+    const singleResult = buildCompanyCards(
+      { trackerRows: [row(200, 'SingleSilentCo', 'Applied', '2026-05-01')], followupRows: [], repostClusters: [], sourcesLoaded: { tracker: true, followups: false, scanHistory: false, statusLog: false } },
+      { now: NOW, silenceWindowDays: 28 },
+    );
+    const singleSignals = buildNoResponseFrictionSignals(singleResult, fixedOpts);
+    check(singleSignals.length === 1, 'exactly one no-response-friction record emitted for a single silent-on-you card');
+    check(singleSignals[0]?.severity === 'single', 'one silent fact on the card -> severity single');
+    check(singleSignals[0]?.signalType === 'no-response-friction', 'emitted record carries signalType no-response-friction');
+    check(singleSignals[0]?.companyKey === singleResult.companies[0].key, 'emitted companyKey reuses company-history.mjs\'s own normalized key, not a new format');
+    check(singleSignals[0]?.region === 'north-america/canada', 'emitted region matches the resolved region');
+    check(singleSignals[0]?.emittedBy === 'career-ops vTEST', 'emitted emittedBy matches the resolved version string');
+    check(/^\d{4}-\d{2}$/.test(singleSignals[0]?.observedAt || ''), 'observedAt is strictly month-only (YYYY-MM, no day)');
+    check(typeof singleSignals[0]?.sourceHash === 'string' && singleSignals[0].sourceHash.startsWith('sha256:'), 'sourceHash is present and sha256-prefixed');
+
+    // pattern: two SEPARATE applications to the same company, both silent.
+    const patternResult = buildCompanyCards(
+      {
+        trackerRows: [
+          row(201, 'PatternSilentCo', 'Applied', '2026-01-01'),
+          row(202, 'PatternSilentCo', 'Applied', '2026-02-01'),
+        ],
+        followupRows: [], repostClusters: [],
+        sourcesLoaded: { tracker: true, followups: false, scanHistory: false, statusLog: false },
+      },
+      { now: NOW, silenceWindowDays: 28 },
+    );
+    check(patternResult.companies[0].responsiveness.label === 'silent-on-you', 'two-application silent fixture still labels silent-on-you (precondition for the pattern check below)');
+    const patternSignals = buildNoResponseFrictionSignals(patternResult, fixedOpts);
+    check(patternSignals.length === 1, 'still exactly one record per company card, even with 2 silent facts');
+    check(patternSignals[0]?.severity === 'pattern', 'two silent facts on the same card -> severity pattern');
+
+    // no record for responded-before / mixed / no-history cards — only
+    // silent-on-you triggers this signal.
+    const noSignalResult = buildCompanyCards(
+      {
+        trackerRows: [
+          row(210, 'RespondedNoSignalCo', 'Rejected', '2026-06-01'),
+          row(211, 'MixedNoSignalCo', 'Applied', '2026-01-01'),
+          row(212, 'MixedNoSignalCo', 'Rejected', '2026-06-20'),
+          row(213, 'NoHistoryNoSignalCo', 'Evaluated', '2026-06-01'),
+        ],
+        followupRows: [], repostClusters: [],
+        sourcesLoaded: { tracker: true, followups: false, scanHistory: false, statusLog: false },
+      },
+      { now: NOW, silenceWindowDays: 28 },
+    );
+    const labelsPresent = noSignalResult.companies.map(c => c.responsiveness.label);
+    check(labelsPresent.includes('responded-before') && labelsPresent.includes('mixed') && labelsPresent.includes('no-history'), 'no-signal fixture actually exercises responded-before, mixed, and no-history cards');
+    const noSignals = buildNoResponseFrictionSignals(noSignalResult, fixedOpts);
+    check(noSignals.length === 0, 'responded-before, mixed, and no-history cards emit zero no-response-friction records');
+
+    // running WITHOUT --emit-signal semantics: buildNoResponseFrictionSignals
+    // is only ever invoked by the CLI when the flag is passed (verified by
+    // reading the CLI wiring above); at the pure-function level, confirm the
+    // emitted records never carry free text (notes) or a candidate name —
+    // only the enum/hash/date fields in the schema.
+    const allEmitted = [...singleSignals, ...patternSignals];
+    for (const record of allEmitted) {
+      const keys = Object.keys(record).sort();
+      check(
+        JSON.stringify(keys) === JSON.stringify(['companyKey', 'emittedBy', 'observedAt', 'region', 'severity', 'signalType', 'sourceHash']),
+        'emitted record carries exactly the schema-v1 fields, nothing extra (no notes/name leakage)',
+      );
+    }
+
+    // sourceHash is deterministic (dedup-safe): rebuilding the same fixture
+    // twice must produce the same hash for the same underlying fact.
+    const singleSignalsAgain = buildNoResponseFrictionSignals(
+      buildCompanyCards(
+        { trackerRows: [row(200, 'SingleSilentCo', 'Applied', '2026-05-01')], followupRows: [], repostClusters: [], sourcesLoaded: { tracker: true, followups: false, scanHistory: false, statusLog: false } },
+        { now: NOW, silenceWindowDays: 28 },
+      ),
+      fixedOpts,
+    );
+    check(singleSignalsAgain[0]?.sourceHash === singleSignals[0]?.sourceHash, 'sourceHash is deterministic across repeated runs against the same fact (dedup-safe)');
+
+    // resolveRegion / resolveEmittedBy degrade gracefully against a missing file.
+    check(resolveRegion(join(CAREER_OPS, '__does-not-exist__.yml')) === 'unknown', 'resolveRegion degrades to "unknown" when profile.yml is absent');
+    check(resolveEmittedBy(join(CAREER_OPS, '__does-not-exist__.json')) === 'career-ops', 'resolveEmittedBy degrades to a version-less string when package.json is unreadable');
+  }
+
   console.log(`\n  company-history self-test: ${pass} passed, ${fail} failed\n`);
   process.exit(fail > 0 ? 1 : 0);
 }
 
 // --- Run (CLI only; guarded so the module is safely importable for tests) ---
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  const { summaryMode, selfTestMode, company, silenceWindowArg, includeStale, scanHistoryOverride, followupsOverride } =
+  const { summaryMode, selfTestMode, company, silenceWindowArg, includeStale, scanHistoryOverride, followupsOverride, emitSignal } =
     parseArgs(process.argv);
 
   if (selfTestMode) {
@@ -873,13 +1130,22 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
 
       if (company) {
         console.log(JSON.stringify(getCompanyCard(result, company), null, 2));
-        return;
-      }
-
-      if (summaryMode) {
+      } else if (summaryMode) {
         console.log(renderSummary(result));
       } else {
         console.log(JSON.stringify(result, null, 2));
+      }
+
+      // --emit-signal is additive and opt-in only: without the flag, output
+      // above is byte-for-byte identical to pre-#2787 behavior. When passed,
+      // RFC #1506 schema-v1 no-response-friction records print as JSON Lines
+      // (one record per line) after the normal output — nothing is written to
+      // disk and nothing is published anywhere.
+      if (emitSignal) {
+        const signals = buildNoResponseFrictionSignals(result);
+        for (const record of signals) {
+          console.log(JSON.stringify(record));
+        }
       }
     };
 

--- a/company-history.test.mjs
+++ b/company-history.test.mjs
@@ -359,6 +359,20 @@ try {
   ok('unknown flag exits 1', e.status === 1);
 }
 
+// --emit-signal is a bare boolean flag, not a value flag: `--emit-signal=true`
+// must be rejected explicitly, since the unknown-flag check strips the `=`
+// suffix before matching KNOWN_FLAGS (so it would otherwise pass as "known")
+// while the boolean read is an exact-token check that would silently never
+// see it as set — accepted args, signal never emitted.
+for (const bad of ['--emit-signal=true', '--emit-signal=1', '--emit-signal=']) {
+  try {
+    execFileSync('node', [scriptPath, '--summary', bad], { encoding: 'utf-8', timeout: 10000, cwd: dirname(scriptPath) });
+    ok(`"${bad}" exits 1`, false);
+  } catch (e) {
+    ok(`"${bad}" exits 1`, e.status === 1 && /does not accept a value/.test(String(e.stderr)));
+  }
+}
+
 // --silence-window validation: non-numeric, zero, and negative must fail fast
 // (a silent fallback hides typos; a 0/negative window labels everything silent).
 for (const bad of ['abc', '0', '--silence-window=-5']) {


### PR DESCRIPTION
## What

Closes #2787, #3010.

RFC #1506 ratified a `no-response-friction` `signalType` for the local emission schema v1 on 2026-07-16, but nobody wired it up. #1712 (merged 2026-07-28) already ships `company-history.mjs`, which computes a per-company `responsiveness` axis including a `silent-on-you` label from the tracker, `data/follow-ups.md`, and `data/scan-history.tsv`. This PR wires that existing fact into the ratified schema, rather than deriving a second silence detector from scratch.

## What was built

- **`buildNoResponseFrictionSignals(result, opts)`** in `company-history.mjs` — takes the already-built `result` from `buildCompanyCards()` and emits one schema-v1 record per `silent-on-you` company card:

```json
{
  "companyKey": "acme-corp",
  "region": "north-america/canada",
  "signalType": "no-response-friction",
  "severity": "single | pattern | null",
  "sourceHash": "sha256:...",
  "observedAt": "2026-06",
  "emittedBy": "career-ops v1.26.0"
}
```

- **`--emit-signal`** CLI flag (opt-in only). When passed, in addition to the script's normal output (JSON / `--summary` / `--company`), it prints the schema-v1 records as JSON Lines (one record per line) to stdout. **Running the script without the flag is byte-for-byte identical to pre-#2787 output** — verified with `git stash` diff against the old behavior.
- No file writes, no publishing anywhere. This PR only produces local schema-v1-shaped stdout output, exactly as scoped in #2787 and by RFC #1506's "career-ops' job is to define the format and emit into that layer — never to host the pool."

## Design decisions

- **`companyKey`** reuses `company-history.mjs`'s existing normalized key (`normalizeCompany()` / `tracker-utils.mjs`) unchanged. The RFC thread floated an optional `parent:division` compound key, but I confirmed that's never actually been implemented anywhere in the codebase (only discussed) — so there was nothing to reuse there beyond the flat key, and inventing a new key format was explicitly out of scope.
- **`region`** reads `config/profile.yml` → `location.country`, mapped through a small country→region-slug table (`north-america/canada`, `europe/germany`, etc. — covers the markets this repo already has explicit market-mode support for, plus a few common others). Degrades to `unknown` when the profile is missing/unparsable, or `unmapped/{slug}` for a country not in the table — never crashes.
- **`severity`**: `'single'` for a card with exactly one silent fact, `'pattern'` for 2+ (i.e., the candidate applied more than once and went unanswered more than once at the same company).
- **`observedAt`**: month-only (`YYYY-MM`), derived from `appliedDate + silenceWindowDays` — the date the application actually *crossed* into silence — not from "today." This keeps the value (and therefore `sourceHash`) stable across repeated runs, which dedup depends on.
- **`sourceHash`**: deterministic `sha256` over `no-response-friction|companyKey|observedAt|severity` (not random/salted). Deterministic so re-running against the same underlying fact reproduces the same hash — required for downstream dedup. It adds no information beyond what the record's own plaintext fields already expose; it's opaque only in the sense that it can't be reversed into anything *more* sensitive (raw applicant identity, notes text) than what's already visible in `companyKey`/`region`/`observedAt`.
- **`emittedBy`**: `career-ops v${package.json version}`, read live from `package.json`; degrades to `'career-ops'` if unreadable.
- **Threshold**: reuses `company-history.mjs`'s shipped 28-day `DEFAULT_SILENCE_WINDOW_DAYS` (and its `--silence-window` override) rather than introducing a second, undocumented 14-day cutoff from the RFC thread's original proposal. Commented at the point of use in the code so a future reader isn't left looking for a 14-day constant that doesn't exist.
- **Privacy**: an emitted record carries *exactly* the 7 schema fields — no candidate name, no free-text notes, no verbatim quotes, same discipline as `interview-redflag` / `process-friction`. Asserted directly in the self-test (`Object.keys(record)` equality check).

## Test coverage

9 new assertions added to `company-history.mjs`'s existing `runSelfTest()`, reusing its existing fixture-building helpers (`row()`, `buildCompanyCards()`):

- A `silent-on-you` card with exactly one silent fact → `severity: 'single'`.
- A company silent across 2 separate applications → `severity: 'pattern'`.
- `responded-before`, `mixed`, and `no-history` cards → zero records emitted (only `silent-on-you` triggers this signal).
- `observedAt` is strictly `YYYY-MM` (regex-asserted).
- Emitted record's key set is exactly the 7 schema fields — no PII leakage.
- `sourceHash` is deterministic across repeated runs against the same fact.
- `resolveRegion()` / `resolveEmittedBy()` degrade gracefully (no crash) against missing files.

Full suite: `node test-all.mjs --quick` → **3663 passed, 0 failed** (1 pre-existing, unrelated warning: `cv-sync-check.mjs exited with error (expected without user data)`).

Regression check: `node company-history.mjs` output (no flag) diffed byte-for-byte identical before/after this change.

## Additive: `postingChannel` field (closes #3010)

Landed in a follow-up commit on this same branch, rather than a separate PR, since it's a small additive field on the exact record shape this PR already builds.

Raised in [discussion #904](https://github.com/santifer/career-ops/discussions/904#discussioncomment-18058073): a single-criterion structural signal like this one systematically misfires on staffing/recruiting agencies, which legitimately post client roles that never appear on their own careers page (measured in production by @strelov1/freehire.me — restricting by industry made concentration *worse*). Rather than inventing new detection, this wires in a fact career-ops already tracks: the tracker's own tagged `via={Agency}` field (#1596).

- **`resolvePostingChannel(via)`** — new export in `company-history.mjs`. A tagged non-em-dash value → `"staffing-agency"`; the tracker's own em-dash "confirmed direct" convention → `"direct-employer"`; undefined/null/blank → `"unknown"` (never guessed — same "degrade to a real absence" discipline `resolveRegion()` already uses above).
- `computeResponsiveness()`'s silent-fact object now carries `via` through from the raw tracker row so the signal builder can read it without a second join.
- `computeSourceHash()` is untouched — `postingChannel` is not a hash input, for the same reason `severity` isn't (see the design-decision above): it can be corrected/backfilled later without changing the underlying fact's identity.
- Flagged in the schema comment block as additive/pending-review, not part of the RFC-ratified fields above — this field hasn't itself gone through the RFC's own ratification round.
- 5 new self-test assertions (3 end-to-end via `buildNoResponseFrictionSignals`, 2 direct unit checks on `resolvePostingChannel`), plus the existing exact-field-set assertion updated to include it.

## Refs

- RFC #1506 — schema v1, ratified 2026-07-16 (this PR implements the `no-response-friction` half of that ratification)
- #1712 — `company-history.mjs`, the data source this PR consumes (`silent-on-you` responsiveness fact)
- #3010 — `postingChannel` field, closed by the follow-up commit above
- Discussion #904 — where the agency-misfire data point that motivated #3010 was raised

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `--emit-signal` support for generating schema-v1 no-response friction signals in JSON Lines format.
  * Signals include privacy-safe regions, source metadata, deterministic hashes, observation dates, and `single` or `pattern` severity.
  * Supports stale-record filtering and graceful handling of missing or malformed metadata.

* **Bug Fixes**
  * Excludes responded, mixed, and no-history records from signal generation.
  * Existing output remains unchanged unless signal emission is enabled.

* **Tests**
  * Added coverage for signal generation, filtering, deterministic output, and invalid command-line formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
