### PR TITLE
fix(add-entry): reject unknown flags

### DIFF
--- a/add-entry.mjs
+++ b/add-entry.mjs
@@ -52,7 +52,7 @@ const KNOWN_FLAGS = ['--dry-run', '--stdin', '--help', '-h'];
 const USAGE = `Usage:
   node add-entry.mjs <payload.json> [--dry-run]
   node add-entry.mjs --stdin [--dry-run]
-  node add-entry.mjs --help                    # print this usage block and exit`;
+  node add-entry.mjs --help                    # print this usage block and exit (-h is an alias)`;
 
 // Normalize a title/heading for duplicate detection: lowercase, collapse to
 // alphanumerics only. "FraudShield", "Fraud-Shield", "fraud shield" all match.

--- a/add-entry.mjs
+++ b/add-entry.mjs
@@ -47,6 +47,13 @@ const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const CV_FILE = process.env.CAREER_OPS_CV || join(CAREER_OPS, 'cv.md');
 const ARTICLE_DIGEST_FILE = process.env.CAREER_OPS_ARTICLE_DIGEST || join(CAREER_OPS, 'article-digest.md');
 
+const KNOWN_FLAGS = ['--dry-run', '--stdin', '--help', '-h'];
+
+const USAGE = `Usage:
+  node add-entry.mjs <payload.json> [--dry-run]
+  node add-entry.mjs --stdin [--dry-run]
+  node add-entry.mjs --help                    # print this usage block and exit`;
+
 // Normalize a title/heading for duplicate detection: lowercase, collapse to
 // alphanumerics only. "FraudShield", "Fraud-Shield", "fraud shield" all match.
 export function normalizeKey(s) {
@@ -194,12 +201,25 @@ async function readStdin() {
 
 async function main() {
   const args = process.argv.slice(2);
+
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(USAGE);
+    process.exit(0);
+  }
+
+  const unknownFlags = args.filter(a => a.startsWith('-') && !KNOWN_FLAGS.includes(a));
+  if (unknownFlags.length) {
+    console.error(`add-entry: unrecognized flag(s): ${unknownFlags.join(', ')}. Valid flags: ${KNOWN_FLAGS.join(', ')}`);
+    console.error(USAGE);
+    process.exit(1);
+  }
+
   const dryRun = args.includes('--dry-run');
   const useStdin = args.includes('--stdin');
-  const fileArg = args.find(a => !a.startsWith('--'));
+  const fileArg = args.find(a => !a.startsWith('-'));
 
   if (!useStdin && !fileArg) {
-    console.error('Usage: node add-entry.mjs <payload.json> [--dry-run]  (or --stdin)');
+    console.error(USAGE);
     process.exit(1);
   }
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -7692,8 +7692,10 @@ try {
       fail(`add-entry CLI help handling => ${JSON.stringify({ help: { status: helpOut.status, stdout: helpOut.stdout, stderr: helpOut.stderr }, h: { status: hOut.status, stdout: hOut.stdout, stderr: hOut.stderr } })}`);
     }
 
-    const badFlag = spawnSync(NODE, [join(ROOT, 'add-entry.mjs'), '--sumary'], { env, encoding: 'utf-8' });
+    const missingPayloadPath = join(cliTmp, 'missing-payload.json');
+    const badFlag = spawnSync(NODE, [join(ROOT, 'add-entry.mjs'), missingPayloadPath, '--sumary'], { env, encoding: 'utf-8' });
     if (badFlag.status === 1 && badFlag.stderr.includes('--sumary') && badFlag.stderr.includes('Usage:') &&
+        !badFlag.stderr.includes('could not parse payload') &&
         !readFileSync(cvPath, 'utf-8').includes('CliProj') && !existsSync(adPath)) {
       pass('add-entry CLI rejects an unrecognized flag before reading or writing payload data');
     } else {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -7674,15 +7674,46 @@ try {
     const cvPath = join(cliTmp, 'cv.md');
     const adPath = join(cliTmp, 'article-digest.md');
     writeFileSync(cvPath, '# CV\n\n## Projects\n\n- **Existing** (OSS) -- here\n');
-    const payloadPath = join(cliTmp, 'p.json');
-    writeFileSync(payloadPath, JSON.stringify({
+    const payloadPath = join(cliTmp, 'payload-with-dash.json');
+    const cliPayload = {
       cv: { section: 'Projects', dedupKey: 'CliProj', entry: '- **CliProj** (OSS) -- desc' },
       articleDigest: { dedupKey: 'CliProj', entry: '## CliProj -- Tagline\n\n**Hero metrics:** x' },
-    }));
+    };
+    writeFileSync(payloadPath, JSON.stringify(cliPayload));
     const env = { ...process.env, CAREER_OPS_CV: cvPath, CAREER_OPS_ARTICLE_DIGEST: adPath };
 
+    const helpOut = spawnSync(NODE, [join(ROOT, 'add-entry.mjs'), '--help'], { env, encoding: 'utf-8' });
+    const hOut = spawnSync(NODE, [join(ROOT, 'add-entry.mjs'), '-h'], { env, encoding: 'utf-8' });
+    if (helpOut.status === 0 && hOut.status === 0 &&
+        helpOut.stdout.includes('Usage:') && helpOut.stdout.includes('--stdin') &&
+        hOut.stdout === helpOut.stdout) {
+      pass('add-entry CLI --help/-h print usage and exit 0');
+    } else {
+      fail(`add-entry CLI help handling => ${JSON.stringify({ help: { status: helpOut.status, stdout: helpOut.stdout, stderr: helpOut.stderr }, h: { status: hOut.status, stdout: hOut.stdout, stderr: hOut.stderr } })}`);
+    }
+
+    const badFlag = spawnSync(NODE, [join(ROOT, 'add-entry.mjs'), '--sumary'], { env, encoding: 'utf-8' });
+    if (badFlag.status === 1 && badFlag.stderr.includes('--sumary') && badFlag.stderr.includes('Usage:') &&
+        !readFileSync(cvPath, 'utf-8').includes('CliProj') && !existsSync(adPath)) {
+      pass('add-entry CLI rejects an unrecognized flag before reading or writing payload data');
+    } else {
+      fail(`add-entry CLI unknown flag handling => ${JSON.stringify({ status: badFlag.status, stdout: badFlag.stdout, stderr: badFlag.stderr })}`);
+    }
+
+    const stdinDryRun = spawnSync(NODE, [join(ROOT, 'add-entry.mjs'), '--stdin', '--dry-run'], {
+      env,
+      encoding: 'utf-8',
+      input: JSON.stringify(cliPayload),
+    });
+    if (stdinDryRun.status === 0 && JSON.parse(stdinDryRun.stdout).dryRun === true &&
+        !readFileSync(cvPath, 'utf-8').includes('CliProj') && !existsSync(adPath)) {
+      pass('add-entry CLI keeps --stdin and --dry-run working together');
+    } else {
+      fail(`add-entry CLI --stdin --dry-run => ${JSON.stringify({ status: stdinDryRun.status, stdout: stdinDryRun.stdout, stderr: stdinDryRun.stderr })}`);
+    }
+
     execFileSync(NODE, [join(ROOT, 'add-entry.mjs'), payloadPath, '--dry-run'], { env, encoding: 'utf-8' });
-    if (!readFileSync(cvPath, 'utf-8').includes('CliProj') && !existsSync(adPath)) pass('add-entry CLI --dry-run writes nothing');
+    if (!readFileSync(cvPath, 'utf-8').includes('CliProj') && !existsSync(adPath)) pass('add-entry CLI --dry-run writes nothing and accepts a payload path containing dashes');
     else fail('add-entry CLI --dry-run should not write');
 
     const realOut = JSON.parse(execFileSync(NODE, [join(ROOT, 'add-entry.mjs'), payloadPath], { env, encoding: 'utf-8' }));


### PR DESCRIPTION
## What does this PR do?

Adds a single usage block to `add-entry.mjs`, handles `--help` and `-h`, and rejects unknown dash-prefixed flags before reading payload data. Existing `--dry-run`, `--stdin`, and positional payload paths—including names containing dashes—keep their current behavior.

The CLI regression coverage exercises both help spellings, the issue's `--sumary` typo, combined stdin/dry-run behavior, and a dashed payload filename.

## Related issue

Closes #2798

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Validation

- `node test-all.mjs` — 3693 passed, 0 failed, 1 expected warning (`cv-sync-check.mjs` without user data in the fresh clone)
- Exact CLI acceptance smoke: `--help`/`-h` exit 0, `--sumary` exits 1 and names the flag, both existing flags still work, and a dashed positional filename remains valid
- `node --check add-entry.mjs`
- `node --check test-all.mjs`
- `git diff --check`

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

AI assistance disclosure: I used OpenAI Codex to inspect the repository's existing CLI-validation precedents and assist with implementation and test execution. I reviewed the final two-file diff and the full test result before publishing it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--help` and `-h` options with usage guidance.
  * Improved handling of payload paths and combined command options.

* **Bug Fixes**
  * Added clear errors and usage output for unrecognized flags.
  * Prevented invalid flags from triggering file access.
  * Confirmed dry-run operations leave existing digest files unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->