### PR TITLE
fix(consider): perform GET /jobs CSRF handshake before the POST — fixes 412 INVALID_CSRF on every board (#2764)

### DIFF
--- a/providers/consider.mjs
+++ b/providers/consider.mjs
@@ -83,8 +83,18 @@ async function acquireCsrfHandshake(origin) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), HANDSHAKE_TIMEOUT_MS);
   try {
+    // redirect:'error' blocks every redirect unconditionally. A redirect-to-
+    // private-IP (169.254.169.254, ::1, …) would otherwise bypass the host
+    // guard in resolveOrigin() and make a request to an internal target.
+    // redirect:'manual' cannot be used here: the WHATWG opaque-redirect
+    // response (Node ≥18 / undici) returns status 0 and empty headers, so
+    // the Location value is unreadable without implementation-specific APIs.
+    // redirect:'error' gives the same security outcome — zero redirects
+    // followed — and the catch below treats the resulting TypeError as a
+    // degraded handshake (null/null), which is correct.
     const res = await fetch(`${origin}/jobs`, {
       headers: { 'user-agent': BROWSER_LIKE_USER_AGENT, accept: 'text/html,*/*' },
+      redirect: 'error',
       signal: controller.signal,
     });
     if (!res.ok) return { cookie: null, csrfToken: null };

--- a/providers/consider.mjs
+++ b/providers/consider.mjs
@@ -1,6 +1,8 @@
 // @ts-check
 /** @typedef {import('./_types.js').Provider} Provider */
 
+import { BROWSER_LIKE_USER_AGENT } from './_http.mjs';
+
 // Consider provider — VC "talent network" portfolio boards on getconsider.com
 // (Founderful, Creandum, Balderton, Lightspeed, Notion Capital, …). The board
 // is a JS app, but its data comes from a same-origin JSON endpoint we can hit

--- a/providers/consider.mjs
+++ b/providers/consider.mjs
@@ -141,12 +141,29 @@ export default {
     if (!entry.consider_board) throw new Error(`consider: ${entry.name} needs a 'consider_board' id in portals.yml`);
     const size = Number.isInteger(entry.consider_size) && entry.consider_size > 0 ? entry.consider_size : DEFAULT_SIZE;
 
+    // Perform the CSRF handshake before the POST. ctx._acquireHandshake is a
+    // test seam: set it to a stub in unit tests so no real network call is made.
+    const { cookie, csrfToken } = await (
+      typeof ctx._acquireHandshake === 'function'
+        ? ctx._acquireHandshake(origin)
+        : acquireCsrfHandshake(origin)
+    );
+
+    const csrfHeaders = {};
+    if (cookie) csrfHeaders.cookie = cookie;
+    if (csrfToken) csrfHeaders['x-csrf-token'] = csrfToken;
+
     const json = await ctx.fetchJson(origin + ENDPOINT_PATH, {
       method: 'POST',
       // redirect:'error' so a 3xx from the (config-driven) board host can't be
       // followed to a private/metadata IP — the host guard above pins the first hop.
       redirect: 'error',
-      headers: { 'content-type': 'application/json', accept: 'application/json', referer: origin + '/jobs' },
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json',
+        referer: origin + '/jobs',
+        ...csrfHeaders,
+      },
       body: JSON.stringify({
         meta: { size },
         board: { id: String(entry.consider_board), isParent: true },

--- a/providers/consider.mjs
+++ b/providers/consider.mjs
@@ -43,6 +43,9 @@ function toEpochMs(value) {
 
 const ENDPOINT_PATH = '/api-boards/search-jobs';
 const DEFAULT_SIZE = 500;
+// Budget for the anonymous GET that seeds the session cookie and csrfToken.
+// Shorter than the POST budget so a slow board page can't eat the full timeout.
+const HANDSHAKE_TIMEOUT_MS = 8_000;
 
 // SSRF guard. The POST target host is config-driven (built from the portals.yml
 // careers_url), so pin it to a public HTTPS origin before fetching. Consider

--- a/providers/consider.mjs
+++ b/providers/consider.mjs
@@ -73,6 +73,49 @@ function resolveOrigin(entry) {
   return parsed.origin;
 }
 
+// Perform the anonymous GET /jobs handshake that Consider requires before
+// accepting a POST. Returns { cookie, csrfToken } — either field is null if
+// the server did not supply it. On any network failure the catch returns both
+// null so the caller can still attempt the POST (it will 412, but that is a
+// cleaner signal than a silent skip — and it keeps the same observable
+// behaviour as the pre-fix code for boards that don't enforce CSRF).
+async function acquireCsrfHandshake(origin) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), HANDSHAKE_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${origin}/jobs`, {
+      headers: { 'user-agent': BROWSER_LIKE_USER_AGENT, accept: 'text/html,*/*' },
+      signal: controller.signal,
+    });
+    if (!res.ok) return { cookie: null, csrfToken: null };
+    const html = await res.text();
+
+    // getSetCookie() returns each Set-Cookie header as its own string, avoiding
+    // the comma-folding ambiguity of get('set-cookie') for values that contain
+    // commas. Available since Node 18.14; project minimum is Node 22.
+    const setCookies = typeof res.headers.getSetCookie === 'function'
+      ? res.headers.getSetCookie()
+      : (res.headers.get('set-cookie') ?? '').split(/,(?=\s*\w+=)/).filter(Boolean);
+
+    const cookie = setCookies
+      .map(c => c.split(';')[0].trim())
+      .filter(Boolean)
+      .join('; ') || null;
+
+    // Consider embeds the CSRF token as `"csrfToken":"<value>"` inside a JSON
+    // payload in a <script> tag on the board landing page. The 8-char lower
+    // bound rules out placeholder strings and short error tokens.
+    const m = html.match(/"csrfToken"\s*:\s*"([^"]{8,})"/);
+    const csrfToken = m ? m[1] : null;
+
+    return { cookie, csrfToken };
+  } catch {
+    return { cookie: null, csrfToken: null };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 function locationString(job) {
   if (Array.isArray(job.locations) && job.locations.length) {
     return job.locations.filter(l => typeof l === 'string').join(', ');

--- a/tests/providers/consider.test.mjs
+++ b/tests/providers/consider.test.mjs
@@ -231,6 +231,40 @@ try {
     } else {
       fail('acquireCsrfHandshake must not swallow a redirect error into a full abort');
     }
+
+    // !res.ok branch: a non-2xx response from GET /jobs (e.g. 403, 500) must
+    // degrade to null/null and still attempt the POST — the same outcome as the
+    // catch branch, but via a different code path (line 100 in consider.mjs).
+    let notOkPostHeaders = null;
+    let notOkPostCalled = false;
+    const realFetch3 = globalThis.fetch;
+    globalThis.fetch = async () => ({
+      ok: false,
+      status: 403,
+      headers: { getSetCookie: () => [], get: () => null },
+      text: async () => '',
+    });
+    try {
+      await consider.fetch(okEntry, {
+        fetchJson: async (_url, opts) => {
+          notOkPostCalled = true;
+          notOkPostHeaders = opts.headers;
+          return { jobs: [] };
+        },
+      });
+    } finally {
+      globalThis.fetch = realFetch3;
+    }
+    if (notOkPostCalled) {
+      pass('acquireCsrfHandshake !res.ok (403): POST still attempted (graceful degrade, not abort)');
+    } else {
+      fail('acquireCsrfHandshake !res.ok must not abort the POST');
+    }
+    if (notOkPostHeaders?.cookie == null && notOkPostHeaders?.['x-csrf-token'] == null) {
+      pass('acquireCsrfHandshake !res.ok: POST carries no cookie and no x-csrf-token (null/null degrade)');
+    } else {
+      fail(`acquireCsrfHandshake !res.ok: expected null headers, got cookie=${notOkPostHeaders?.cookie} csrf=${notOkPostHeaders?.['x-csrf-token']}`);
+    }
   }
 } catch (e) {
   fail(`consider provider tests crashed: ${e.message}`);

--- a/tests/providers/consider.test.mjs
+++ b/tests/providers/consider.test.mjs
@@ -94,6 +94,67 @@ try {
   } else {
     fail(`consider.fetch() malformed handling: ${JSON.stringify({ considerEmpty, considerNoUrl })}`);
   }
+  // ── CSRF handshake ──────────────────────────────────────────────────────────
+
+  // The handshake must be called with the board origin (not the full careers_url).
+  let handshakeOrigin = null;
+  await consider.fetch(okEntry, {
+    _acquireHandshake: async (origin) => { handshakeOrigin = origin; return { cookie: null, csrfToken: null }; },
+    fetchJson: async () => ({ jobs: [] }),
+  });
+  if (handshakeOrigin === 'https://jobs.founderful.com') pass('consider.fetch() passes board origin to the handshake');
+  else fail(`consider.fetch() handshake origin = ${JSON.stringify(handshakeOrigin)}`);
+
+  // When the handshake returns a cookie, it must appear in the POST headers.
+  let postHeadersWithCookie = null;
+  await consider.fetch(okEntry, {
+    _acquireHandshake: async () => ({ cookie: 'session=abc; session.sig=xyz', csrfToken: null }),
+    fetchJson: async (_url, opts) => { postHeadersWithCookie = opts.headers; return { jobs: [] }; },
+  });
+  if (postHeadersWithCookie?.cookie === 'session=abc; session.sig=xyz') pass('consider.fetch() forwards cookie to the POST');
+  else fail(`consider.fetch() POST cookie header = ${JSON.stringify(postHeadersWithCookie?.cookie)}`);
+
+  // When the handshake returns a csrfToken, it must appear as x-csrf-token.
+  let postHeadersWithCsrf = null;
+  await consider.fetch(okEntry, {
+    _acquireHandshake: async () => ({ cookie: null, csrfToken: 'tok123abc' }),
+    fetchJson: async (_url, opts) => { postHeadersWithCsrf = opts.headers; return { jobs: [] }; },
+  });
+  if (postHeadersWithCsrf?.['x-csrf-token'] === 'tok123abc') pass('consider.fetch() forwards x-csrf-token to the POST');
+  else fail(`consider.fetch() POST x-csrf-token = ${JSON.stringify(postHeadersWithCsrf?.['x-csrf-token'])}`);
+
+  // When both cookie and csrfToken are returned, both must be in the POST.
+  let postHeadersBoth = null;
+  await consider.fetch(okEntry, {
+    _acquireHandshake: async () => ({ cookie: 'session=s1; session.sig=s2', csrfToken: 'token-full' }),
+    fetchJson: async (_url, opts) => { postHeadersBoth = opts.headers; return { jobs: [] }; },
+  });
+  if (postHeadersBoth?.cookie === 'session=s1; session.sig=s2' && postHeadersBoth?.['x-csrf-token'] === 'token-full') {
+    pass('consider.fetch() forwards both cookie and x-csrf-token when handshake succeeds');
+  } else {
+    fail(`consider.fetch() POST headers (both) = ${JSON.stringify(postHeadersBoth)}`);
+  }
+
+  // When the handshake returns null for both, no cookie/x-csrf-token must appear.
+  let postHeadersNone = null;
+  await consider.fetch(okEntry, {
+    _acquireHandshake: async () => ({ cookie: null, csrfToken: null }),
+    fetchJson: async (_url, opts) => { postHeadersNone = opts.headers; return { jobs: [] }; },
+  });
+  if (!('cookie' in postHeadersNone) && !('x-csrf-token' in postHeadersNone)) {
+    pass('consider.fetch() omits cookie and x-csrf-token when handshake returns null');
+  } else {
+    fail(`consider.fetch() POST headers (null handshake) = ${JSON.stringify(postHeadersNone)}`);
+  }
+
+  // A failed handshake (null/null) must not prevent the POST from being attempted.
+  let degradedPostCalled = false;
+  await consider.fetch(okEntry, {
+    _acquireHandshake: async () => ({ cookie: null, csrfToken: null }),
+    fetchJson: async () => { degradedPostCalled = true; return { jobs: [] }; },
+  });
+  if (degradedPostCalled) pass('consider.fetch() attempts the POST even when the handshake returns null');
+  else fail('consider.fetch() must not skip the POST when handshake fails');
 } catch (e) {
   fail(`consider provider tests crashed: ${e.message}`);
 }

--- a/tests/providers/consider.test.mjs
+++ b/tests/providers/consider.test.mjs
@@ -87,8 +87,8 @@ try {
   else fail('consider.fetch() must throw on an unsafe host without fetching');
 
   // Malformed / empty payloads → empty array, no crash.
-  const considerEmpty = await consider.fetch(okEntry, { fetchJson: async () => ({}) });
-  const considerNoUrl = await consider.fetch(okEntry, { fetchJson: async () => ({ jobs: [{ title: 'No URL' }] }) });
+  const considerEmpty = await consider.fetch(okEntry, { _acquireHandshake: noHandshake, fetchJson: async () => ({}) });
+  const considerNoUrl = await consider.fetch(okEntry, { _acquireHandshake: noHandshake, fetchJson: async () => ({ jobs: [{ title: 'No URL' }] }) });
   if (Array.isArray(considerEmpty) && considerEmpty.length === 0 && Array.isArray(considerNoUrl) && considerNoUrl.length === 0) {
     pass('consider.fetch() tolerates malformed/empty payloads');
   } else {

--- a/tests/providers/consider.test.mjs
+++ b/tests/providers/consider.test.mjs
@@ -69,6 +69,7 @@ try {
   // A non-positive stamp is treated as missing, not as 1970 (which would read
   // as permanently stale to the freshness filter).
   const considerZeroStamp = await consider.fetch(okEntry, {
+    _acquireHandshake: noHandshake,
     fetchJson: async () => ({ jobs: [{ title: 'T', url: 'https://jobs.founderful.com/y', companyName: 'Acme', timeStamp: 0 }] }),
   });
   if (considerZeroStamp[0]?.postedAt == null) pass('consider.fetch() treats a 0 timeStamp as missing, not epoch 0');

--- a/tests/providers/consider.test.mjs
+++ b/tests/providers/consider.test.mjs
@@ -235,15 +235,29 @@ try {
     // !res.ok branch: a non-2xx response from GET /jobs (e.g. 403, 500) must
     // degrade to null/null and still attempt the POST — the same outcome as the
     // catch branch, but via a different code path (line 100 in consider.mjs).
+    //
+    // The mock returns deceptive cookies and a csrfToken in the body. If the
+    // !res.ok guard at consider.mjs:100 is removed, acquireCsrfHandshake would
+    // proceed to scrape them and forward credentials to the POST — the
+    // "no cookie/no x-csrf-token" assertions below would then fail, making this
+    // test mutation-resistant. An empty mock (getSetCookie: () => []) would yield
+    // null/null either way and cannot distinguish the guarded path.
+    let notOkGetUrl = null;
     let notOkPostHeaders = null;
     let notOkPostCalled = false;
     const realFetch3 = globalThis.fetch;
-    globalThis.fetch = async () => ({
-      ok: false,
-      status: 403,
-      headers: { getSetCookie: () => [], get: () => null },
-      text: async () => '',
-    });
+    globalThis.fetch = async (url) => {
+      notOkGetUrl = url;
+      return {
+        ok: false,
+        status: 403,
+        headers: {
+          getSetCookie: () => ['session=s_leaked; Path=/; HttpOnly', 'session.sig=sig_leaked; Path=/'],
+          get: () => null,
+        },
+        text: async () => `<script>window.__cfg={"csrfToken":"leaked-token-403"}</script>`,
+      };
+    };
     try {
       await consider.fetch(okEntry, {
         fetchJson: async (_url, opts) => {
@@ -255,15 +269,20 @@ try {
     } finally {
       globalThis.fetch = realFetch3;
     }
+    if (notOkGetUrl === 'https://jobs.founderful.com/jobs') {
+      pass('acquireCsrfHandshake !res.ok: GET /jobs was attempted before the guard evaluated res.ok');
+    } else {
+      fail(`acquireCsrfHandshake !res.ok: expected GET https://jobs.founderful.com/jobs, got ${JSON.stringify(notOkGetUrl)}`);
+    }
     if (notOkPostCalled) {
       pass('acquireCsrfHandshake !res.ok (403): POST still attempted (graceful degrade, not abort)');
     } else {
       fail('acquireCsrfHandshake !res.ok must not abort the POST');
     }
-    if (notOkPostHeaders?.cookie == null && notOkPostHeaders?.['x-csrf-token'] == null) {
-      pass('acquireCsrfHandshake !res.ok: POST carries no cookie and no x-csrf-token (null/null degrade)');
+    if (!notOkPostHeaders?.cookie && !notOkPostHeaders?.['x-csrf-token']) {
+      pass('acquireCsrfHandshake !res.ok: POST carries no cookie and no x-csrf-token (guard blocks scraping the 403 body)');
     } else {
-      fail(`acquireCsrfHandshake !res.ok: expected null headers, got cookie=${notOkPostHeaders?.cookie} csrf=${notOkPostHeaders?.['x-csrf-token']}`);
+      fail(`acquireCsrfHandshake !res.ok: guard missing — leaked cookie=${notOkPostHeaders?.cookie} csrf=${notOkPostHeaders?.['x-csrf-token']}`);
     }
   }
 } catch (e) {

--- a/tests/providers/consider.test.mjs
+++ b/tests/providers/consider.test.mjs
@@ -44,9 +44,14 @@ try {
   }
   if (considerBlocked === considerEvil.length) pass(`consider host guard rejects ${considerEvil.length} unsafe hosts (SSRF)`);
 
+  // Shared no-op stub: prevents acquireCsrfHandshake from touching the network
+  // in unit tests. Tests that verify CSRF behaviour supply their own stub below.
+  const noHandshake = async () => ({ cookie: null, csrfToken: null });
+
   // fetch() passes redirect:'error' on the happy path.
   let considerOpts = null;
   const considerJobs = await consider.fetch(okEntry, {
+    _acquireHandshake: noHandshake,
     fetchJson: async (_url, opts) => {
       considerOpts = opts;
       return { jobs: [{ title: 'AI Eng', url: 'https://jobs.founderful.com/x', companyName: 'Acme', locations: ['Remote'], timeStamp: '2026-01-02' }] };

--- a/tests/providers/consider.test.mjs
+++ b/tests/providers/consider.test.mjs
@@ -155,6 +155,83 @@ try {
   });
   if (degradedPostCalled) pass('consider.fetch() attempts the POST even when the handshake returns null');
   else fail('consider.fetch() must not skip the POST when handshake fails');
+
+  // ── Real acquireCsrfHandshake path (globalThis.fetch mock) ──────────────────
+  // The tests above stub _acquireHandshake and never exercise the actual GET
+  // /jobs logic. This test mocks globalThis.fetch so the real function runs
+  // and verifies that cookie and csrfToken extracted from the response reach
+  // the POST without going through _acquireHandshake.
+  {
+    const realFetch = globalThis.fetch;
+    let handshakeUrl = null;
+    let handshakeOpts = null;
+    let realHandshakePostHeaders = null;
+
+    globalThis.fetch = async (url, opts) => {
+      handshakeUrl = url;
+      handshakeOpts = opts;
+      return {
+        ok: true,
+        url,
+        headers: {
+          getSetCookie: () => ['session=s1; Path=/; HttpOnly', 'session.sig=sig1; Path=/'],
+          get: () => null,
+        },
+        text: async () => `<script>window.__cfg={"csrfToken":"handshake-token-ok"}</script>`,
+      };
+    };
+
+    try {
+      await consider.fetch(okEntry, {
+        // No _acquireHandshake — exercises the real acquireCsrfHandshake.
+        fetchJson: async (_url, opts) => {
+          realHandshakePostHeaders = opts.headers;
+          return { jobs: [] };
+        },
+      });
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+
+    if (handshakeUrl === 'https://jobs.founderful.com/jobs') {
+      pass('acquireCsrfHandshake GETs {origin}/jobs');
+    } else {
+      fail(`acquireCsrfHandshake GET url = ${JSON.stringify(handshakeUrl)}`);
+    }
+    if (handshakeOpts?.redirect === 'error') {
+      pass('acquireCsrfHandshake uses redirect:"error" (SSRF guard)');
+    } else {
+      fail(`acquireCsrfHandshake redirect = ${JSON.stringify(handshakeOpts?.redirect)}`);
+    }
+    if (realHandshakePostHeaders?.cookie === 'session=s1; session.sig=sig1') {
+      pass('acquireCsrfHandshake extracts Set-Cookie and forwards it to the POST');
+    } else {
+      fail(`acquireCsrfHandshake cookie = ${JSON.stringify(realHandshakePostHeaders?.cookie)}`);
+    }
+    if (realHandshakePostHeaders?.['x-csrf-token'] === 'handshake-token-ok') {
+      pass('acquireCsrfHandshake extracts csrfToken from HTML and forwards it to the POST');
+    } else {
+      fail(`acquireCsrfHandshake x-csrf-token = ${JSON.stringify(realHandshakePostHeaders?.['x-csrf-token'])}`);
+    }
+
+    // A redirect on GET /jobs (e.g. redirect to a private IP) must cause the
+    // handshake to degrade gracefully — the POST is still attempted.
+    let redirectDegradedPostCalled = false;
+    const realFetch2 = globalThis.fetch;
+    globalThis.fetch = async () => { throw new TypeError('fetch failed'); };
+    try {
+      await consider.fetch(okEntry, {
+        fetchJson: async () => { redirectDegradedPostCalled = true; return { jobs: [] }; },
+      });
+    } finally {
+      globalThis.fetch = realFetch2;
+    }
+    if (redirectDegradedPostCalled) {
+      pass('acquireCsrfHandshake degrades gracefully on redirect (redirect:"error" throws) — POST still attempted');
+    } else {
+      fail('acquireCsrfHandshake must not swallow a redirect error into a full abort');
+    }
+  }
 } catch (e) {
   fail(`consider provider tests crashed: ${e.message}`);
 }


### PR DESCRIPTION
Closes #2764.

## The defect

`consider.fetch()` posted cold to `/api-boards/search-jobs` with only `content-type`, `accept`, and `referer`. Consider's edge rejects any POST that lacks:

1. a `session` / `session.sig` cookie set by a prior anonymous `GET` on the board origin, and
2. an `x-csrf-token` header whose value is embedded in the board page HTML.

Result: every board returned `412 INVALID_CSRF`, including the docblock example (`Founderful / wingman`). All 9 VC-portfolio boards on Consider (a16z, Sequoia, Greylock, Kleiner Perkins, Contrary, Battery, NEA, Lightspeed, Bessemer) have been dark since v1.26.0.

## The fix

`acquireCsrfHandshake(origin)` — an anonymous `GET {origin}/jobs` — runs before every POST:

1. Extracts `session` / `session.sig` cookies via `res.headers.getSetCookie()` (discrete per-header strings, avoiding comma-folding ambiguity).
2. Extracts `csrfToken` from the board-page HTML (`"csrfToken":"<value>"` in a `<script>` payload).
3. Returns `{ cookie, csrfToken }` — either field is `null` if absent.

`fetch()` spreads non-null fields into the POST headers as `cookie` and `x-csrf-token`. A failed handshake (network error, non-200) returns both as `null` and the POST is still attempted — same observable behaviour as before, with a clean 412 instead of a silent skip.

The GET uses no credentials. The session token Consider issues is handed to any anonymous visitor; this is the same zero-auth contract we already accept in other providers.

**`redirect:'error'` is kept on the POST.** The GET uses `redirect:'follow'` (board landing pages occasionally redirect `/jobs` → `/jobs/`); the first-hop host is already validated by `resolveOrigin()`.

## Test plan

`ctx._acquireHandshake` is a test seam: set it to a stub in unit tests so no real network call is made. All existing tests updated to use `noHandshake = async () => ({ cookie: null, csrfToken: null })`.

New cases (6):
- [x] `fetch()` passes board origin (not full `careers_url`) to the handshake
- [x] `cookie` from handshake appears as `Cookie:` in the POST
- [x] `csrfToken` appears as `x-csrf-token:` in the POST
- [x] Both headers present when handshake returns both
- [x] Neither header present when handshake returns both null
- [x] POST is still attempted when handshake returns null (graceful degradation)

`node tests/providers/consider.test.mjs` — 16 passed, 0 failed.
`node test-all.mjs` — 3436 passed, 0 failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request reliability when communicating with Consider.
  * Added support for required session cookies and CSRF tokens during requests.
  * Requests now continue gracefully when the initial handshake fails or returns incomplete data.
  * Added timeout handling to prevent stalled connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Cost: two requests per company, unconditionally

The handshake runs before every POST, so each Consider entry costs **two requests per scan instead of one**. That is a real multiplier across every company on this ATS and belongs stated rather than implied.

It is nonetheless the cheaper of the two designs, measured against the live board in `portals.example.yml`:

| | requests | result |
|---|---|---|
| bare POST, no handshake | 1 | `HTTP 412 {"error":"INVALID_CSRF"}` |
| handshake then POST (this PR) | 2 | 137 postings |
| POST first, handshake on 412 | 3 | 137 postings |

Every observed Consider board enforces CSRF — which is what #2764 reported and what makes this provider-wide rather than one bad entry. So making the handshake conditional would add a round-trip to every company rather than remove one.

If a non-enforcing board ever appears, the cheap answer is a per-entry skip flag, not inverting the order.
