### PR TITLE
fix: validate plugin-audit CLI arguments

### DIFF
--- a/plugin-audit.mjs
+++ b/plugin-audit.mjs
@@ -45,16 +45,16 @@ const USAGE = `Usage:
 function parseArgs(argv) {
   const args = argv.slice(2);
 
-  if (args.includes('--help') || args.includes('-h')) {
-    console.log(USAGE);
-    process.exit(0);
-  }
-
   const unknownFlags = args.filter(a => a.startsWith('-') && !KNOWN_FLAGS.includes(a));
   if (unknownFlags.length) {
     console.error(`Error: unrecognized flag(s): ${unknownFlags.join(', ')}`);
     console.error(USAGE);
     process.exit(1);
+  }
+
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(USAGE);
+    process.exit(0);
   }
 
   return {

--- a/plugin-audit.mjs
+++ b/plugin-audit.mjs
@@ -35,6 +35,33 @@ const DYN_IMPORT_RE = /\bimport\s*\(\s*["']([^"']+)["']\s*\)/g;
 const REQUIRE_RE = /\brequire\s*\(\s*["']([^"']+)["']\s*\)/g;
 const firewallRe = new RegExp('\\b(' + ['revenue', 'pricing', 'paywall', 'monetiz\\w*', 'moat'].join('|') + ')\\b', 'i');
 
+// --- CLI args ---
+const KNOWN_FLAGS = ['--help', '-h'];
+
+const USAGE = `Usage:
+  node plugin-audit.mjs <plugin-dir>
+  node plugin-audit.mjs --help`;
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(USAGE);
+    process.exit(0);
+  }
+
+  const unknownFlags = args.filter(a => a.startsWith('-') && !KNOWN_FLAGS.includes(a));
+  if (unknownFlags.length) {
+    console.error(`Error: unrecognized flag(s): ${unknownFlags.join(', ')}`);
+    console.error(USAGE);
+    process.exit(1);
+  }
+
+  return {
+    dir: args.find(a => !a.startsWith('-'))
+  };
+}
+
 function collectSpecifiers(src) {
   const specs = [];
   for (const re of [IMPORT_RE, DYN_IMPORT_RE, REQUIRE_RE]) {
@@ -87,8 +114,8 @@ export function auditPlugin(dir) {
 
 // CLI: node plugin-audit.mjs <dir>
 if (import.meta.url === (await import('node:url')).pathToFileURL(process.argv[1] || '').href) {
-  const dir = process.argv[2];
-  if (!dir) { console.error('Usage: node plugin-audit.mjs <plugin-dir>'); process.exit(2); }
+  const { dir } = parseArgs(process.argv);
+  if (!dir) { console.error(USAGE); process.exit(2); }
   let result;
   try { result = auditPlugin(path.resolve(dir)); } catch (e) { console.error('audit failed:', e.message); process.exit(2); }
   if (result.ok) { console.log('✓ audit clean'); process.exit(0); }

--- a/tests/plugin-audit.test.mjs
+++ b/tests/plugin-audit.test.mjs
@@ -1,0 +1,50 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const SCRIPT = join(ROOT, 'plugin-audit.mjs');
+
+function runAudit(...args) {
+  const r = spawnSync(process.execPath, [SCRIPT, ...args], {
+    cwd: ROOT,
+    encoding: 'utf-8',
+    timeout: 10_000,
+  });
+  assert.equal(r.error, undefined, `plugin-audit.mjs failed to spawn: ${r.error?.message}`);
+  assert.equal(r.signal, null, `plugin-audit.mjs was killed by ${r.signal} (timeout?)`);
+  return { ...r, all: `${r.stdout ?? ''}${r.stderr ?? ''}` };
+}
+
+test('--help prints usage and exits 0', () => {
+  const r = runAudit('--help');
+  assert.match(r.stdout, /Usage:/);
+  assert.match(r.stdout, /node plugin-audit\.mjs <plugin-dir>/);
+  assert.equal(r.status, 0, '--help must exit 0');
+});
+
+test('-h prints usage and exits 0', () => {
+  const r = runAudit('-h');
+  assert.match(r.stdout, /Usage:/);
+  assert.match(r.stdout, /node plugin-audit\.mjs <plugin-dir>/);
+  assert.equal(r.status, 0, '-h must exit 0');
+});
+
+test('--bogus unrecognized flag is rejected and exits 1', () => {
+  const r = runAudit('--bogus');
+  assert.match(r.stderr, /Error: unrecognized flag\(s\): --bogus/);
+  assert.match(r.stderr, /Usage:/);
+  assert.notEqual(r.status, 0, 'unrecognized flag must exit non-zero');
+});
+
+test('valid directory runs the audit', () => {
+  // Use a known existing plugin directory from the repository.
+  const r = runAudit('plugins/apify');
+  // It shouldn't print usage or flag errors.
+  assert.doesNotMatch(r.all, /unrecognized flag/);
+  assert.doesNotMatch(r.all, /Usage:/);
+  // apify will probably exit 1 due to global fetch usage, but it shouldn't be a flag error.
+  assert.match(r.all, /direct global fetch/i);
+});

--- a/tests/plugin-audit.test.mjs
+++ b/tests/plugin-audit.test.mjs
@@ -45,8 +45,6 @@ test('valid directory runs the audit', () => {
   // It shouldn't print usage or flag errors.
   assert.doesNotMatch(r.all, /unrecognized flag/);
   assert.doesNotMatch(r.all, /Usage:/);
-  // apify will probably exit 1 due to global fetch usage, but it shouldn't be a flag error.
-  assert.match(r.all, /direct global fetch/i);
 });
 
 test('help exits before checking a missing directory', () => {
@@ -60,6 +58,7 @@ test('help exits before checking a missing directory', () => {
 
 test('--bogus --help is rejected as unknown flag before checking help', () => {
   const r = runAudit('--bogus', '--help');
-  assert.notEqual(r.status, 0);
+  assert.equal(r.status, 1);
+  assert.equal(r.stdout, '');
   assert.match(r.stderr, /Error: unrecognized flag\(s\): --bogus/);
 });

--- a/tests/plugin-audit.test.mjs
+++ b/tests/plugin-audit.test.mjs
@@ -48,3 +48,18 @@ test('valid directory runs the audit', () => {
   // apify will probably exit 1 due to global fetch usage, but it shouldn't be a flag error.
   assert.match(r.all, /direct global fetch/i);
 });
+
+test('help exits before checking a missing directory', () => {
+  for (const flag of ['--help', '-h']) {
+    const r = runAudit(flag, join(ROOT, '__missing_plugin_audit_fixture__'));
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /Usage:/);
+    assert.equal(r.stderr, '');
+  }
+});
+
+test('--bogus --help is rejected as unknown flag before checking help', () => {
+  const r = runAudit('--bogus', '--help');
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /Error: unrecognized flag\(s\): --bogus/);
+});


### PR DESCRIPTION
## What does this PR do?

Adds argument parsing to `plugin-audit.mjs` so `--help` / `-h` display usage information and unrecognized flags are rejected before any filesystem access. Existing positional plugin-directory behavior is preserved, and CLI subprocess regression tests cover the new behavior.

## Related issue

Fixes #2771

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `--help` and `-h` options with usage guidance for the plugin audit command.
  - Added validation to reject unrecognized command-line options.
  - Improved command-line handling for selecting the plugin directory.
  - Help information is displayed appropriately, including when a directory is missing.

- **Tests**
  - Added end-to-end coverage for help output, invalid options, valid plugin directory execution, and combined option scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->