### PR TITLE
fix(providers): route seven RSS decoders through the shared safe entity decoder

### DIFF
--- a/providers/higheredjobs.mjs
+++ b/providers/higheredjobs.mjs
@@ -1,3 +1,4 @@
+import { decodeEntities } from './_html-entities.mjs';
 // @ts-check
 /** @typedef {import('./_types.js').Provider} Provider */
 
@@ -46,33 +47,11 @@ export default {
   },
 };
 
-function fromCodePoint(cp) {
-  try {
-    return String.fromCodePoint(cp);
-  } catch {
-    return '';
-  }
-}
-
-// Decode the XML entities that appear in RSS text: numeric (&#38; / &#x27;)
-// and the named five. Numeric forms are decoded first; &amp; is decoded LAST
-// so a literal "&amp;lt;" yields "&lt;" rather than over-decoding to "<".
-function decodeXmlEntities(s) {
-  return s
-    .replace(/&#x([0-9a-fA-F]+);/g, (_, h) => fromCodePoint(parseInt(h, 16)))
-    .replace(/&#(\d+);/g, (_, d) => fromCodePoint(parseInt(d, 10)))
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&apos;/g, "'")
-    .replace(/&amp;/g, '&');
-}
-
 // Resolve a tag's inner text: unwrap a CDATA section, else decode entities.
 function extractText(inner) {
   const cdata = inner.match(/^\s*<!\[CDATA\[([\s\S]*?)\]\]>\s*$/);
   if (cdata) return cdata[1].trim();
-  return decodeXmlEntities(inner).trim();
+  return decodeEntities(inner).trim();
 }
 
 // Extract the text of the first <tag>...</tag> in a block. Returns '' when absent.

--- a/providers/jobspresso.mjs
+++ b/providers/jobspresso.mjs
@@ -1,3 +1,4 @@
+import { decodeEntities } from './_html-entities.mjs';
 // @ts-check
 /** @typedef {import('./_types.js').Provider} Provider */
 
@@ -53,34 +54,11 @@ export default {
   },
 };
 
-/** Code point → string; '' for out-of-range values instead of throwing. */
-function fromCodePoint(cp) {
-  try {
-    return String.fromCodePoint(cp);
-  } catch {
-    return "";
-  }
-}
-
-// Decode the XML entities that appear in RSS text: numeric (&#38; / &#x27;)
-// and the named five. Numeric forms are decoded first; &amp; is decoded LAST
-// so a literal "&amp;lt;" yields "&lt;" rather than over-decoding to "<".
-function decodeXmlEntities(s) {
-  return s
-    .replace(/&#x([0-9a-fA-F]+);/g, (_, h) => fromCodePoint(parseInt(h, 16)))
-    .replace(/&#(\d+);/g, (_, d) => fromCodePoint(parseInt(d, 10)))
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&apos;/g, "'")
-    .replace(/&amp;/g, "&");
-}
-
 // Resolve a tag's inner text: unwrap a CDATA section, else decode entities.
 function extractText(inner) {
   const cdata = inner.match(/^\s*<!\[CDATA\[([\s\S]*?)\]\]>\s*$/);
   if (cdata) return cdata[1].trim();
-  return decodeXmlEntities(inner).trim();
+  return decodeEntities(inner).trim();
 }
 
 // Extract the text of the first <tag>...</tag> in a block. Returns '' when absent.

--- a/providers/larajobs.mjs
+++ b/providers/larajobs.mjs
@@ -1,3 +1,4 @@
+import { decodeEntities } from './_html-entities.mjs';
 // @ts-check
 /** @typedef {import('./_types.js').Provider} Provider */
 
@@ -58,33 +59,11 @@ export default {
   },
 };
 
-function fromCodePoint(cp) {
-  try {
-    return String.fromCodePoint(cp);
-  } catch {
-    return '';
-  }
-}
-
-// Decode the XML entities that appear in RSS text: numeric (&#38; / &#x27;)
-// and the named five. Numeric forms are decoded first; &amp; is decoded LAST
-// so a literal "&amp;lt;" yields "&lt;" rather than over-decoding to "<".
-function decodeXmlEntities(s) {
-  return s
-    .replace(/&#x([0-9a-fA-F]+);/g, (_, h) => fromCodePoint(parseInt(h, 16)))
-    .replace(/&#(\d+);/g, (_, d) => fromCodePoint(parseInt(d, 10)))
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&apos;/g, "'")
-    .replace(/&amp;/g, '&');
-}
-
 // Resolve a tag's inner text: unwrap a CDATA section, else decode entities.
 function extractText(inner) {
   const cdata = inner.match(/^\s*<!\[CDATA\[([\s\S]*?)\]\]>\s*$/);
   if (cdata) return cdata[1].trim();
-  return decodeXmlEntities(inner).trim();
+  return decodeEntities(inner).trim();
 }
 
 // Extract the text of the first <tag>...</tag> in a block. Returns '' when

--- a/providers/nodesk.mjs
+++ b/providers/nodesk.mjs
@@ -1,3 +1,4 @@
+import { decodeEntities } from './_html-entities.mjs';
 // @ts-check
 /** @typedef {import('./_types.js').Provider} Provider */
 
@@ -54,33 +55,11 @@ export default {
   },
 };
 
-function fromCodePoint(cp) {
-  try {
-    return String.fromCodePoint(cp);
-  } catch {
-    return '';
-  }
-}
-
-// Decode the XML entities that appear in RSS text: numeric (&#38; / &#x27;)
-// and the named five. Numeric forms are decoded first; &amp; is decoded LAST
-// so a literal "&amp;lt;" yields "&lt;" rather than over-decoding to "<".
-function decodeXmlEntities(s) {
-  return s
-    .replace(/&#x([0-9a-fA-F]+);/g, (_, h) => fromCodePoint(parseInt(h, 16)))
-    .replace(/&#(\d+);/g, (_, d) => fromCodePoint(parseInt(d, 10)))
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&apos;/g, "'")
-    .replace(/&amp;/g, '&');
-}
-
 // Resolve a tag's inner text: unwrap a CDATA section, else decode entities.
 function extractText(inner) {
   const cdata = inner.match(/^\s*<!\[CDATA\[([\s\S]*?)\]\]>\s*$/);
   if (cdata) return cdata[1].trim();
-  return decodeXmlEntities(inner).trim();
+  return decodeEntities(inner).trim();
 }
 
 // Extract the text of the first <tag>...</tag> in a block. Returns '' when absent.

--- a/providers/personio.mjs
+++ b/providers/personio.mjs
@@ -1,3 +1,4 @@
+import { decodeEntities } from './_html-entities.mjs';
 // @ts-check
 /** @typedef {import('./_types.js').Provider} Provider */
 
@@ -87,33 +88,11 @@ export default {
   },
 };
 
-function fromCodePoint(cp) {
-  try {
-    return String.fromCodePoint(cp);
-  } catch {
-    return '';
-  }
-}
-
-// Decode the XML entities that appear in Personio job text: numeric (&#38; /
-// &#x27;) and the named five. Numeric forms are decoded first; &amp; is decoded
-// LAST so a literal "&amp;lt;" yields "&lt;" rather than over-decoding to "<".
-function decodeXmlEntities(s) {
-  return s
-    .replace(/&#x([0-9a-fA-F]+);/g, (_, h) => fromCodePoint(parseInt(h, 16)))
-    .replace(/&#(\d+);/g, (_, d) => fromCodePoint(parseInt(d, 10)))
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&apos;/g, "'")
-    .replace(/&amp;/g, '&');
-}
-
 // Resolve a tag's inner text: unwrap a CDATA section, else decode entities.
 function extractText(inner) {
   const cdata = inner.match(/^\s*<!\[CDATA\[([\s\S]*?)\]\]>\s*$/);
   if (cdata) return cdata[1].trim();
-  return decodeXmlEntities(inner).trim();
+  return decodeEntities(inner).trim();
 }
 
 // Looped to a fixed point rather than a single pass: a single global replace
@@ -238,11 +217,11 @@ export function parsePersonioHtml(html, companyName, host) {
 
     const titleMatch = block.match(/<h3\b[^>]*>([\s\S]*?)<\/h3>/);
     if (!titleMatch) continue;
-    const title = decodeXmlEntities(stripTags(titleMatch[1])).trim();
+    const title = decodeEntities(stripTags(titleMatch[1])).trim();
     if (!title) continue;
 
     const locMatch = block.match(/<span\b[^>]*class="[^"]*jobMetaText[^"]*"[^>]*>([\s\S]*?)<\/span>/);
-    const location = locMatch ? decodeXmlEntities(stripTags(locMatch[1])).trim() : '';
+    const location = locMatch ? decodeEntities(stripTags(locMatch[1])).trim() : '';
 
     seen.add(id);
     jobs.push({

--- a/providers/teamtailor.mjs
+++ b/providers/teamtailor.mjs
@@ -1,3 +1,4 @@
+import { decodeEntities } from './_html-entities.mjs';
 // @ts-check
 /** @typedef {import('./_types.js').Provider} Provider */
 
@@ -93,33 +94,11 @@ export default {
   },
 };
 
-function fromCodePoint(cp) {
-  try {
-    return String.fromCodePoint(cp);
-  } catch {
-    return '';
-  }
-}
-
-// Decode the XML entities that appear in RSS text: numeric (&#38; / &#x27;)
-// and the named five. Numeric forms are decoded first; &amp; is decoded LAST
-// so a literal "&amp;lt;" yields "&lt;" rather than over-decoding to "<".
-function decodeXmlEntities(s) {
-  return s
-    .replace(/&#x([0-9a-fA-F]+);/g, (_, h) => fromCodePoint(parseInt(h, 16)))
-    .replace(/&#(\d+);/g, (_, d) => fromCodePoint(parseInt(d, 10)))
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&apos;/g, "'")
-    .replace(/&amp;/g, '&');
-}
-
 // Resolve a tag's inner text: unwrap a CDATA section, else decode entities.
 function extractText(inner) {
   const cdata = inner.match(/^\s*<!\[CDATA\[([\s\S]*?)\]\]>\s*$/);
   if (cdata) return cdata[1].trim();
-  return decodeXmlEntities(inner).trim();
+  return decodeEntities(inner).trim();
 }
 
 // Extract the text of the first <tag>...</tag> in a block. Returns '' when

--- a/providers/weworkremotely.mjs
+++ b/providers/weworkremotely.mjs
@@ -1,3 +1,4 @@
+import { decodeEntities } from './_html-entities.mjs';
 // @ts-check
 /** @typedef {import('./_types.js').Provider} Provider */
 
@@ -54,33 +55,11 @@ export default {
   },
 };
 
-function fromCodePoint(cp) {
-  try {
-    return String.fromCodePoint(cp);
-  } catch {
-    return '';
-  }
-}
-
-// Decode the XML entities that appear in RSS text: numeric (&#38; / &#x27;)
-// and the named five. Numeric forms are decoded first; &amp; is decoded LAST
-// so a literal "&amp;lt;" yields "&lt;" rather than over-decoding to "<".
-function decodeXmlEntities(s) {
-  return s
-    .replace(/&#x([0-9a-fA-F]+);/g, (_, h) => fromCodePoint(parseInt(h, 16)))
-    .replace(/&#(\d+);/g, (_, d) => fromCodePoint(parseInt(d, 10)))
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&apos;/g, "'")
-    .replace(/&amp;/g, '&');
-}
-
 // Resolve a tag's inner text: unwrap a CDATA section, else decode entities.
 function extractText(inner) {
   const cdata = inner.match(/^\s*<!\[CDATA\[([\s\S]*?)\]\]>\s*$/);
   if (cdata) return cdata[1].trim();
-  return decodeXmlEntities(inner).trim();
+  return decodeEntities(inner).trim();
 }
 
 // Extract the text of the first <tag>...</tag> in a block. Returns '' when absent.

--- a/tests/providers/rss-entity-decoding.test.mjs
+++ b/tests/providers/rss-entity-decoding.test.mjs
@@ -1,22 +1,68 @@
-// tests/providers/rss-entity-decoding.test.mjs — the RSS providers that carried
-// a hand-rolled entity decoder emitted NUL / lone surrogates into job titles and
-// silently deleted out-of-range references (#2790). They now share the safe
-// decoder in providers/_html-entities.mjs, so their output must match it.
+// tests/providers/rss-entity-decoding.test.mjs — the seven providers that
+// carried a hand-rolled entity decoder emitted NUL / lone surrogates into job
+// titles and silently deleted out-of-range references (#2790). They now share
+// the safe decoder in providers/_html-entities.mjs, so their output must match
+// it: any non-emittable reference is left as raw text, never a bad code unit.
 import { pass, fail, ROOT } from '../helpers.mjs';
 import { join } from 'path';
 import { pathToFileURL } from 'url';
 
-console.log('\nProviders — RSS entity decoding is illegal-code-point safe (#2790)');
+console.log('\nProviders — entity decoding is illegal-code-point safe (#2790)');
 
 const load = (f) => import(pathToFileURL(join(ROOT, 'providers/' + f)).href);
 const { decodeEntities } = await load('_html-entities.mjs');
 
+// A NUL or a *lone* surrogate must never reach a title. A valid supplementary
+// character is a high surrogate immediately followed by a low surrogate, so a
+// plain [\uD800-\uDFFF] class would false-positive on legitimate emoji/CJK-B —
+// walk the string and only reject surrogates that are not part of a pair.
+function hasNulOrLoneSurrogate(value) {
+  for (let i = 0; i < value.length; i += 1) {
+    const code = value.charCodeAt(i);
+    if (code === 0) return true;
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(i + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        i += 1;
+        continue;
+      }
+      return true;
+    }
+    if (code >= 0xdc00 && code <= 0xdfff) return true;
+  }
+  return false;
+}
+
+// NUL, a lone surrogate, a C0 control, a noncharacter, and an out-of-range code
+// point: the old decoder emitted the first four and deleted the last. The shared
+// decoder leaves each reference as raw text.
+const cases = ['A&#0;B', 'A&#xD800;B', 'A&#1;B', 'A&#xFFFF;B', 'A&#99999999;B'];
+
+// Feed each case through getTitle(rawTitle) and check the result is exactly the
+// shared decoder's output and free of NUL / lone surrogates.
+function checkProvider(label, getTitle) {
+  for (const raw of cases) {
+    const input = `${raw} Engineer`;
+    const title = getTitle(input) ?? '';
+    if (hasNulOrLoneSurrogate(title)) {
+      fail(`${label}: ${raw}: title contains a NUL or lone surrogate`);
+      return;
+    }
+    if (title !== decodeEntities(input)) {
+      fail(`${label}: ${raw}: got ${JSON.stringify(title)}, want ${JSON.stringify(decodeEntities(input))}`);
+      return;
+    }
+  }
+  pass(`${label} leaves illegal entity references as raw text`);
+}
+
+// ── RSS feed parsers ──
 const rss = (title, link) =>
   `<?xml version="1.0"?><rss><channel><item>` +
   `<title>${title}</title><link>${link}</link>` +
   `<description>Location: Remote</description></item></channel></rss>`;
 
-const providers = [
+const rssProviders = [
   ['jobspresso.mjs', 'parseJobspressoFeed', 'https://jobspresso.co/job/x/'],
   ['higheredjobs.mjs', 'parseHigherEdJobsFeed', 'https://www.higheredjobs.com/details.cfm?JobCode=1'],
   ['nodesk.mjs', 'parseNodeskFeed', 'https://nodesk.co/remote-jobs/x/'],
@@ -24,30 +70,27 @@ const providers = [
   ['teamtailor.mjs', 'parseTeamtailorFeed', 'https://x.teamtailor.com/jobs/1'],
   ['weworkremotely.mjs', 'parseWwrFeed', 'https://weworkremotely.com/remote-jobs/x'],
 ];
-
-// NUL, a lone surrogate, a C0 control, a noncharacter, and an out-of-range code
-// point: the old decoder emitted the first four and deleted the last. The
-// shared decoder leaves each reference as raw text.
-const cases = ['A&#0;B', 'A&#xD800;B', 'A&#1;B', 'A&#xFFFF;B', 'A&#99999999;B'];
-
-for (const [file, fn, link] of providers) {
+for (const [file, fn, link] of rssProviders) {
   const parse = (await load(file))[fn];
-  let ok = true;
-  let detail = '';
-  for (const raw of cases) {
-    const input = `${raw} Engineer`;
-    const title = parse(rss(input, link))[0]?.title ?? '';
-    if (/[\u0000\uD800-\uDFFF]/.test(title)) {
-      ok = false;
-      detail = `${raw}: title contains a NUL or lone surrogate`;
-      break;
-    }
-    if (title !== decodeEntities(input)) {
-      ok = false;
-      detail = `${raw}: got ${JSON.stringify(title)}, want ${JSON.stringify(decodeEntities(input))}`;
-      break;
-    }
-  }
-  if (ok) pass(`${fn} leaves illegal entity references as raw text`);
-  else fail(`${fn}: ${detail}`);
+  checkProvider(fn, (input) => parse(rss(input, link))[0]?.title);
 }
+
+// ── personio: title and location decode through the shared decoder on both the
+// XML feed path (tagText → extractText) and the HTML-fallback path. ──
+const { parsePersonioXml, parsePersonioHtml } = await load('personio.mjs');
+
+checkProvider('parsePersonioXml', (input) =>
+  parsePersonioXml(
+    `<workzag-jobs><position><name>${input}</name><id>123</id><office>Remote</office></position></workzag-jobs>`,
+    'Acme',
+    'acme.jobs.personio.de',
+  )[0]?.title,
+);
+
+checkProvider('parsePersonioHtml', (input) =>
+  parsePersonioHtml(
+    `<a class="job-box" href="/job/123"><h3>${input}</h3><span class="jobMetaText">Remote</span></a>`,
+    'Acme',
+    'acme.jobs.personio.de',
+  )[0]?.title,
+);

--- a/tests/providers/rss-entity-decoding.test.mjs
+++ b/tests/providers/rss-entity-decoding.test.mjs
@@ -1,0 +1,53 @@
+// tests/providers/rss-entity-decoding.test.mjs — the RSS providers that carried
+// a hand-rolled entity decoder emitted NUL / lone surrogates into job titles and
+// silently deleted out-of-range references (#2790). They now share the safe
+// decoder in providers/_html-entities.mjs, so their output must match it.
+import { pass, fail, ROOT } from '../helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nProviders — RSS entity decoding is illegal-code-point safe (#2790)');
+
+const load = (f) => import(pathToFileURL(join(ROOT, 'providers/' + f)).href);
+const { decodeEntities } = await load('_html-entities.mjs');
+
+const rss = (title, link) =>
+  `<?xml version="1.0"?><rss><channel><item>` +
+  `<title>${title}</title><link>${link}</link>` +
+  `<description>Location: Remote</description></item></channel></rss>`;
+
+const providers = [
+  ['jobspresso.mjs', 'parseJobspressoFeed', 'https://jobspresso.co/job/x/'],
+  ['higheredjobs.mjs', 'parseHigherEdJobsFeed', 'https://www.higheredjobs.com/details.cfm?JobCode=1'],
+  ['nodesk.mjs', 'parseNodeskFeed', 'https://nodesk.co/remote-jobs/x/'],
+  ['larajobs.mjs', 'parseLarajobsFeed', 'https://larajobs.com/job/1'],
+  ['teamtailor.mjs', 'parseTeamtailorFeed', 'https://x.teamtailor.com/jobs/1'],
+  ['weworkremotely.mjs', 'parseWwrFeed', 'https://weworkremotely.com/remote-jobs/x'],
+];
+
+// NUL, a lone surrogate, a C0 control, a noncharacter, and an out-of-range code
+// point: the old decoder emitted the first four and deleted the last. The
+// shared decoder leaves each reference as raw text.
+const cases = ['A&#0;B', 'A&#xD800;B', 'A&#1;B', 'A&#xFFFF;B', 'A&#99999999;B'];
+
+for (const [file, fn, link] of providers) {
+  const parse = (await load(file))[fn];
+  let ok = true;
+  let detail = '';
+  for (const raw of cases) {
+    const input = `${raw} Engineer`;
+    const title = parse(rss(input, link))[0]?.title ?? '';
+    if (/[\u0000\uD800-\uDFFF]/.test(title)) {
+      ok = false;
+      detail = `${raw}: title contains a NUL or lone surrogate`;
+      break;
+    }
+    if (title !== decodeEntities(input)) {
+      ok = false;
+      detail = `${raw}: got ${JSON.stringify(title)}, want ${JSON.stringify(decodeEntities(input))}`;
+      break;
+    }
+  }
+  if (ok) pass(`${fn} leaves illegal entity references as raw text`);
+  else fail(`${fn}: ${detail}`);
+}


### PR DESCRIPTION
Fixes #2790.

## What

Seven RSS/XML providers (`jobspresso`, `higheredjobs`, `nodesk`, `larajobs`, `personio`, `teamtailor`, `weworkremotely`) each carried a byte-identical hand-rolled `decodeXmlEntities`. Its `fromCodePoint` only `try/catch`'d the `RangeError` for `cp > 0x10FFFF`, and `String.fromCodePoint` doesn't throw for NUL, the C0 controls, lone surrogates, or the noncharacters — so all of those decoded straight into job titles. Out-of-range references were silently deleted (`return ''`).

That's exactly what `providers/_html-entities.mjs` was centralized to prevent, and 13 other providers already use it.

## Fix

Replace each local copy with the shared `decodeEntities`. It gates numeric references on the XML 1.0 §2.2 set and leaves anything non-emittable as raw text — `&#0;` stays visible and inert rather than becoming a NUL, or vanishing. No behaviour change for legitimate titles; it also picks up `&nbsp;` since the shared named-entity table includes it. Net −164/+69, mostly deleting the duplicated decoder.

## Evidence

Before, against `providers/jobspresso.mjs` on `main` (shown as `JSON.stringify` of the parsed title):

```
"A&#0;B"        ->  "A B"    (NUL emitted)
"A&#xD800;B"    ->  "A\uD800B"    (lone surrogate emitted)
"A&#99999999;B" ->  "AB"          (out-of-range deleted)
```

After the change, all three are left as raw text, matching the shared decoder.

New `tests/providers/rss-entity-decoding.test.mjs` drives the six RSS feed parsers with `&#0;`, `&#xD800;`, `&#1;`, `&#xFFFF;` and an out-of-range reference, asserting the parsed title matches `decodeEntities` and contains no NUL or lone surrogate. Reverting any one provider fails only that provider's case, and the existing provider tests still pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RSS feed text decoding across supported job providers.
  * Prevented invalid characters, including NULs, lone surrogates, and out-of-range numeric entities, from appearing in job titles and other feed content.
  * Standardized handling of XML and HTML entities for more consistent job listing data.
* **Tests**
  * Added coverage for malformed and unsafe entity references across multiple RSS providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->