### PR TITLE
feat(cli): add argument parsing for CLI flags and usage instructions

### DIFF
--- a/jd-similarity.mjs
+++ b/jd-similarity.mjs
@@ -135,12 +135,39 @@ export function recommendCvReuse(newJd, previousText, options = {}) {
   return { decision: 'regenerate', score, reason: 'low-similarity' };
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  const [newJdPath, previousPath] = process.argv.slice(2);
-  if (!newJdPath || !previousPath) {
-    console.error('Usage: node jd-similarity.mjs <new-jd.txt> <previous-jd-or-cv.txt>');
+// ── CLI ─────────────────────────────────────────────────────────────
+
+const KNOWN_FLAGS = ['--help', '-h'];
+
+const USAGE = `Usage:
+  node jd-similarity.mjs new-jd.txt previous-jd-or-cv.txt
+  node jd-similarity.mjs --help                    # print this usage block and exit`;
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(USAGE);
+    process.exit(0);
+  }
+  const unknownFlags = args.filter(a => a.startsWith('-') && !KNOWN_FLAGS.includes(a));
+  if (unknownFlags.length) {
+    console.error(`Error: unrecognized flag(s): ${unknownFlags.join(', ')}. Valid flags: ${KNOWN_FLAGS.join(', ')}`);
+    console.error(USAGE);
     process.exit(1);
   }
+  const [newJdPath, previousPath] = args;
+  if (!newJdPath || !previousPath) {
+    console.error('Error: expected two file paths.');
+    console.error(USAGE);
+    process.exit(1);
+  }
+
+  return { newJdPath, previousPath };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const { newJdPath, previousPath } = parseArgs(process.argv);
   try {
     const result = recommendCvReuse(readFileSync(newJdPath, 'utf8'), readFileSync(previousPath, 'utf8'));
     console.log(JSON.stringify(result, null, 2));

--- a/jd-similarity.mjs
+++ b/jd-similarity.mjs
@@ -157,7 +157,7 @@ function parseArgs(argv) {
     process.exit(1);
   }
   const [newJdPath, previousPath] = args;
-  if (!newJdPath || !previousPath) {
+  if (args.length !== 2 || !newJdPath || !previousPath) {
     console.error('Error: expected two file paths.');
     console.error(USAGE);
     process.exit(1);

--- a/jd-similarity.test.mjs
+++ b/jd-similarity.test.mjs
@@ -1,7 +1,9 @@
 import { hardMismatch, jaccardSimilarity, recommendCvReuse, tokenize } from './jd-similarity.mjs';
 import { execFileSync } from 'child_process';
 import { fileURLToPath } from 'url';
-
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 let passed = 0;
 let failed = 0;
 
@@ -31,6 +33,42 @@ try {
   ok('CLI reports missing files cleanly', false);
 } catch (error) {
   ok('CLI reports missing files cleanly', /Unable to read input files/.test(error.stderr));
+}
+
+// --- CLI flag parsing ---
+
+const cliPath = fileURLToPath(new URL('./jd-similarity.mjs', import.meta.url));
+const runCli = (...args) =>
+  execFileSync(process.execPath, [cliPath, ...args], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+
+try {
+  ok('--help prints usage and exits 0', /Usage:/.test(runCli('--help')));
+} catch {
+  ok('--help prints usage and exits 0', false);
+}
+
+try {
+  runCli('--bogus', 'a.md', 'b.md');
+  ok('unknown flag exits non-zero and names the flag', false);
+} catch (error) {
+  ok('unknown flag exits non-zero and names the flag', /--bogus/.test(String(error.stderr)));
+}
+
+const tmpDir = mkdtempSync(join(tmpdir(), 'jd-similarity-test-'));
+try {
+  const NEW_JD = 'Senior React TypeScript Node.js platform engineer, distributed systems';
+  const PREVIOUS = 'Senior React TypeScript Node.js platform engineer, Vue, GraphQL';
+  const newJdPath = join(tmpDir, 'new-jd.txt');
+  const previousPath = join(tmpDir, 'previous-cv.txt');
+  writeFileSync(newJdPath, NEW_JD);
+  writeFileSync(previousPath, PREVIOUS);
+
+  ok('two real paths produce the same output as before',
+    runCli(newJdPath, previousPath).trim() === JSON.stringify(recommendCvReuse(NEW_JD, PREVIOUS), null, 2));
+} catch {
+  ok('two real paths produce the same output as before', false);
+} finally {
+  rmSync(tmpDir, { recursive: true, force: true });
 }
 
 console.log(`jd-similarity: ${passed} passed, ${failed} failed`);

--- a/jd-similarity.test.mjs
+++ b/jd-similarity.test.mjs
@@ -54,6 +54,22 @@ try {
   ok('unknown flag exits non-zero and names the flag', /--bogus/.test(String(error.stderr)));
 }
 
+try {
+  runCli('only-one-path.txt');
+  ok('a single positional path exits 1 with the arity error', false);
+} catch (error) {
+  ok('a single positional path exits 1 with the arity error',
+    error.status === 1 && String(error.stderr).includes('Error: expected two file paths.'));
+}
+
+try {
+  runCli('a.md', 'b.md', 'c.md');
+  ok('a third positional path exits 1 with the arity error', false);
+} catch (error) {
+  ok('a third positional path exits 1 with the arity error',
+    error.status === 1 && /expected two file paths/.test(String(error.stderr)));
+}
+
 const tmpDir = mkdtempSync(join(tmpdir(), 'jd-similarity-test-'));
 try {
   const NEW_JD = 'Senior React TypeScript Node.js platform engineer, distributed systems';


### PR DESCRIPTION
## What does this PR do?

`jd-similarity.mjs` didn't recognize any flags, so `node jd-similarity.mjs --help` tried to open a file called `--help` and failed with a confusing error. This adds a `USAGE` block printed by `--help`/`-h` (exit 0, before any file read), and rejects unknown flags with a message that actually names the flag. Positional paths work exactly as before; added CLI tests to cover it. Also added an error for single and more than 2 path's.

<!-- Describe the change in 1-3 sentences -->

## Related issue
Fixes #2772
<!-- Link the issue this PR addresses, if it has one. Format: Fixes #123 / Closes #123 -->
<!-- Issue-first is asked for NEW FEATURES, new modes/commands, and architecture changes — it saves you from building something we'd have to redirect. -->
<!-- No issue needed, send the PR straight in: bug fixes, new zero-auth scanner providers, docs, and translations. We don't want to slow these down. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--help` and `-h` options with usage guidance.
  * Added clear errors for unrecognized options and missing file paths.
  * Supports successful execution with file-based inputs and consistent output.

* **Tests**
  * Added coverage for help messages, invalid options, file processing, output consistency, and temporary-file cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->