### PR TITLE
Ignore CRLF/LF-only differences when detecting local system edits

### DIFF
--- a/tests/updater-local-system-edits.test.mjs
+++ b/tests/updater-local-system-edits.test.mjs
@@ -320,3 +320,46 @@ const PATHS = ['modes/', 'generate-cover-letter.mjs'];
     fail(`#12 real local edit lost from atRisk: ${JSON.stringify(atRisk)}`);
   }
 }
+
+// ── 13. A file differing from the baseline ONLY by CRLF/LF is not a local edit ──
+//    Reproduces #2817: installs synced before `.gitattributes` (80d104f9) have a
+//    merge-base whose text blobs predate line-ending normalization, so an
+//    untouched file reads as a local edit — inflating the flagged set to ~150
+//    files and silently no-op'ing the whole update. The CR-only difference must
+//    be ignored; a genuine content edit must still be reported.
+{
+  const dir = mkdtempSync(join(tmpdir(), 'co-crlf-'));
+  const g = (...args) => gitIn(dir, ...args);
+  g('init', '-q', '-b', 'main', '.');
+  g('config', 'user.email', 'test@example.com');
+  g('config', 'user.name', 'Test');
+  g('config', 'commit.gpgsign', 'false');
+  g('config', 'core.hooksPath', join(dir, 'no-such-hooks'));
+  g('config', 'core.autocrlf', 'false');
+  g('config', 'core.eol', 'lf');
+  mkdirSync(join(dir, 'modes'), { recursive: true });
+  // Base blobs committed with CRLF, standing in for a pre-`.gitattributes` tree.
+  writeFileSync(join(dir, 'modes', 'pdf.md'), 'shipped pdf\r\nline two\r\n');
+  writeFileSync(join(dir, 'generate-cover-letter.mjs'), 'shipped script\n');
+  g('add', '-A');
+  g('commit', '-qm', 'base (CRLF blobs)');
+  g('branch', 'upstream');
+  // Upstream changes the content of both files.
+  g('checkout', '-q', 'upstream');
+  writeFileSync(join(dir, 'modes', 'pdf.md'), 'shipped pdf v2\r\nline two\r\n');
+  writeFileSync(join(dir, 'generate-cover-letter.mjs'), 'shipped script v2\n');
+  g('commit', '-qam', 'upstream changes');
+  g('checkout', '-q', 'main');
+  // main: pdf.md renormalized to LF (a CR-only diff from the base); the script
+  // carries a genuine local edit.
+  writeFileSync(join(dir, 'modes', 'pdf.md'), 'shipped pdf\nline two\n');
+  writeFileSync(join(dir, 'generate-cover-letter.mjs'), 'local real fix\n');
+
+  const atRisk = locallyModifiedSystemFiles(PATHS, 'upstream', { git: g, root: dir });
+  if (atRisk.length === 1 && atRisk[0] === 'generate-cover-letter.mjs') {
+    pass('a CRLF/LF-only difference from the baseline is not a local edit (#2817)');
+  } else {
+    fail(`#13 expected ['generate-cover-letter.mjs'], got ${JSON.stringify(atRisk)}`);
+  }
+  rmSync(dir, { recursive: true, force: true });
+}

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -750,7 +750,17 @@ export function locallyModifiedSystemFiles(paths, upstreamRef = 'FETCH_HEAD', ct
       // files and silently no-ops the whole update (#2817). This ignores only
       // the carriage return at end of line, so a genuine trailing-whitespace or
       // content edit is still detected.
-      return runGit('diff', '--ignore-cr-at-eol', '--name-only', ref, '--', ...paths).split('\n').map((p) => p.trim()).filter(Boolean);
+      //
+      // `--numstat`, deliberately, NOT `--name-only`: `--name-only` can list a
+      // path on the blob-OID comparison alone, before the textual diff runs, so
+      // a CRLF/LF-only file survives `--ignore-cr-at-eol` and the guard leaks
+      // right back. `--numstat` forces the textual diff, so the ignore rule is
+      // actually applied and a CR-only file drops out of the output entirely.
+      // The path is field 3 (a binary file renders as `-\t-\tpath`, still field
+      // 3). Reads less obviously than `--name-only`; keep it as-is.
+      return runGit('diff', '--ignore-cr-at-eol', '--numstat', ref, '--', ...paths)
+        .split('\n').map((l) => l.trim()).filter(Boolean)
+        .map((l) => l.split('\t')[2]).filter(Boolean);
     } catch {
       // An unreadable ref (shallow clone, unrelated histories) must never abort
       // the update — it degrades the warning, not the checkout.

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -742,7 +742,15 @@ export function locallyModifiedSystemFiles(paths, upstreamRef = 'FETCH_HEAD', ct
 
   const diffNames = (ref) => {
     try {
-      return runGit('diff', '--name-only', ref, '--', ...paths).split('\n').map((p) => p.trim()).filter(Boolean);
+      // `--ignore-cr-at-eol`: a file whose only difference is a CRLF/LF line
+      // ending must not read as a local edit. Installs that last synced before
+      // `.gitattributes` was introduced (80d104f9) have a merge-base predating
+      // it, so every text file not renormalized in that commit differs from the
+      // baseline by line endings alone — which otherwise flags ~150 untouched
+      // files and silently no-ops the whole update (#2817). This ignores only
+      // the carriage return at end of line, so a genuine trailing-whitespace or
+      // content edit is still detected.
+      return runGit('diff', '--ignore-cr-at-eol', '--name-only', ref, '--', ...paths).split('\n').map((p) => p.trim()).filter(Boolean);
     } catch {
       // An unreadable ref (shallow clone, unrelated histories) must never abort
       // the update — it degrades the warning, not the checkout.


### PR DESCRIPTION
Fixes #2817.

## What

`locallyModifiedSystemFiles()` decides which synced files a user has edited by diffing the working tree against the sync ref. That diff was byte-exact on line endings, so any file that differs from the merge-base only by CRLF vs LF counted as a local edit.

Installs that last synced before `.gitattributes` landed (80d104f9) have a merge-base whose blobs predate line-ending normalization. Against that baseline every synced file looks CRLF-vs-LF changed at once — the whole tree reads as "user-modified", the divergence guard from #2448 trips, and the update quietly no-ops instead of writing anything. From the user's side the updater just stops working with no error.

## Fix

Pass `--ignore-cr-at-eol` to that diff. A pure CRLF/LF difference no longer registers as a local edit. A real content change, or a genuine trailing-whitespace edit, still does — the flag only forgives the carriage return at end of line, nothing else.

One line, plus a comment pointing back at 80d104f9 so the reason survives.

## Evidence

New regression test in `tests/updater-local-system-edits.test.mjs` (case 13) builds a repo with a CRLF baseline, an untouched file renormalized to LF, and one genuinely edited file, then asserts only the real edit comes back.

With the fix, all 15 checks in that file pass. Revert the one-line change and case 13 fails as expected — the LF-only file is wrongly reported alongside the real edit:

```
❌ #13 expected ['generate-cover-letter.mjs'], got ["generate-cover-letter.mjs","modes/pdf.md"]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Line-ending-only changes are no longer incorrectly reported as local edits.
  - Genuine content changes and trailing-whitespace edits continue to be detected correctly.

- **Tests**
  - Added coverage to verify correct handling of CRLF/LF differences alongside genuine local modifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->