### PR TITLE
fix(agent-inbox): give concurrent add() a burst-sized lock timeout

### DIFF
--- a/agent-inbox.mjs
+++ b/agent-inbox.mjs
@@ -146,10 +146,23 @@ async function add() {
   // Checking the last byte still happens INSIDE the lock: it decides whether a
   // separating newline is needed, and reading it outside would race with
   // another writer's append between the check and the write.
+  //
+  // timeoutMs is raised from the shared 8s default because this queue's whole
+  // point is bursty concurrent writers (a dashboard, a script, cron all drop
+  // items at once), and lock acquisition is a retry lottery, not a fair queue.
+  // Serving N herded waiters is the coupon-collector problem: ~N·H(N) rounds,
+  // so 30 concurrent adds need ~120 rounds while 8000/80 = 100 only affords
+  // ~100. On the slow, contended windows-latest runner that shortfall makes one
+  // waiter time out and its item is LOST, the exact #2777 drop, reappearing as
+  // a loud LockTimeoutError instead of a silent overwrite. Jitter in
+  // pipeline-lock.mjs cuts the collision rate ~6x but is explicitly "not a
+  // cure"; the fit-for-purpose budget for a burst-write queue is the contained
+  // fix. 30s gives ~375 rounds of headroom, well past the herd's worst case,
+  // while the critical section itself is a single sub-millisecond append.
   await withPipelineLock(PATH, () => {
     const separator = needsLeadingNewline(PATH) ? '\n' : '';
     appendFileSync(PATH, `${separator}- [ ] ${stamp()} — ${text}\n`);
-  });
+  }, { timeoutMs: 30_000 });
   process.stdout.write(`Queued: ${text}\n`);
 }
 


### PR DESCRIPTION
Fixes #2824.

## What

`agent-inbox-tests.mjs` section 7 ("concurrent adds do not lose items") flakes on `test (windows-latest)`, and only there: one of 30 concurrent `add` processes drops its item, giving `kept=29 of 30` with 1 non-zero exit. It surfaced on an unrelated PR's CI run (#2820), passes on ubuntu and macos, and is not caused by any single PR.

## Root cause

Each `add()` appends one line under `withPipelineLock` (`agent-inbox.mjs`) with no options, inheriting the shared 8s timeout / 80ms retry from `pipeline-lock.mjs`. Lock acquisition is a retry lottery, not a fair queue: serving N herded waiters is coupon-collector, about N·H(N) rounds, so 30 adds need roughly 120 rounds while 8000/80 only affords about 100. On the slow, contended Windows runner one waiter never wins inside 8s, throws `LockTimeoutError`, exits non-zero, and its item is never appended. The failing child's stderr is a clean lock timeout, no filesystem error:

```
LockTimeoutError: pipeline lock timeout: ...\agent-inbox.md.lock held > 100ms
    at acquirePipelineLock (pipeline-lock.mjs:165)
```

The retry jitter from #2777 is already present and cuts collisions, but is documented there as "not a cure"; the remaining gap is the acquisition-timeout budget.

## Fix

One line, contained to the `add()` call site: pass `{ timeoutMs: 30_000 }` so a burst-write queue gets a burst-sized budget (about 375 rounds of headroom). The critical section is a single sub-millisecond append, so the larger budget only ever spends time that would otherwise be a lost item. An explicit call-site `timeoutMs` overrides both the env lever and the shared default, so no other lock caller (scan-history, portal-health, tracker) is disturbed and `pipeline-lock.mjs` is untouched. The test is unchanged.

## Validation

- Reproduced RED with the existing `CAREER_OPS_PIPELINE_LOCK_TIMEOUT_MS` lever at N=30: 200ms drops one item on about half of runs, 100ms more. GREEN after the fix over 20 runs with the same lever: 0 failures (the call-site value overrides the lever).
- `node agent-inbox-tests.mjs` run 12 times: all green (19 passed, 0 failed each).
- Lock regression suites pass: `test/pipeline-lock.test.mjs`, `tests/scan-history-lock.test.mjs`, `tests/portal-health-lock.test.mjs`.
- `node test-all.mjs --quick`: 3691 passed, 0 failed (1 pre-existing unrelated warning).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when adding items to the queue by allowing the pipeline lock to wait up to 30 seconds before timing out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->