### PR TITLE
docs(apply-autofill): label the Lever captcha bullet for what the agent does

### DIFF
--- a/docs/APPLY_AUTOFILL.md
+++ b/docs/APPLY_AUTOFILL.md
@@ -17,7 +17,7 @@ We have field-tested the auto-fill flow across several major ATS platforms (Ashb
 
 ### Lever
 
-- **Captcha Avoidance:** Lever often pops an hCaptcha challenge if checkboxes or radio buttons are clicked programmatically. To avoid this, the agent only auto-fills text, textareas, and standard select dropdowns. It will list any skipped checkboxes or radio buttons with recommended values so you can tick them manually and solve the captcha before submitting.
+- **Checkboxes and the Captcha Stay Yours:** Lever often pops an hCaptcha challenge when checkboxes or radio buttons are clicked programmatically. The agent therefore auto-fills text, textareas, and standard select dropdowns only, and never touches the checkboxes, the radio buttons, or the captcha widget. It lists every field it skipped along with recommended values, and you tick them, solve the captcha, and submit.
 
 ### Workable
 


### PR DESCRIPTION
The bullet at `docs/APPLY_AUTOFILL.md:20` was titled **Captcha Avoidance** while its body described the opposite behaviour: the agent deliberately does *not* click checkboxes or radio buttons, because doing so is what pops the challenge, and the candidate ticks them and solves the captcha before submitting.

`modes/apply.md:254-258`, which is the authoritative source this page summarises, already says it plainly: *"Skip all checkboxes, radio buttons, and the captcha widget"* and *"Candidate: Completes the checkboxes, solves the captcha, and clicks Submit."* Only the summary carried the misleading label.

Headings are what get quoted, indexed and read out of context, so this one now asserts the behaviour rather than naming the thing being steered around. No behaviour change; documentation only.

Swept the rest of `docs/` for headings promising avoidance or bypass while I was here: the only other matches are "avoid hitting token limits", "AI writing patterns to avoid" and a grammar term, all fine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that autofill leaves checkboxes, radio buttons, and captchas unchanged.
  * Confirmed that text fields, textareas, and standard dropdowns continue to be autofilled.
  * Added guidance for completing skipped fields manually.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->