### PR TITLE
fix(web): emit the posting URL in the tracker-additions TSV so web runs join the dedup

### DIFF
--- a/web/src/lib/run-prompts.mjs
+++ b/web/src/lib/run-prompts.mjs
@@ -85,6 +85,20 @@ If NO slug variant resolves, say so clearly and leave portals.yml unchanged. Nev
 End with EXACTLY one final line: VERDICT: {5 if now live, else 1}/5 — {what you changed, ≤12 words}`;
   }
   // evaluate (default) — run the REAL oferta mode + persist canonically
+  //
+  // The TSV row carries 10 fields, the 10th being the posting URL that
+  // merge-tracker dedupes on (#1298). The web is a WRITER of that file, not only
+  // a reader: emitting 9 fields stays valid forever, so nothing would ever go
+  // red — every job evaluated from the web would simply sit outside the
+  // URL dedup. Compatible and half-dead at once, which is the failure mode with
+  // no symptom.
+  //
+  // ALWAYS 10 fields, empty when there is no URL, deliberately: an
+  // unconditional template is one an agent follows, "emit 9 or 10 depending"
+  // is one it sometimes forgets. Empty and absent are byte-identical in the
+  // written row (verified against merge-tracker), so the robust instruction
+  // costs nothing. Not "N/A" either — parseTsvExtras drops placeholders
+  // precisely so they can't be misread as the row's LOCATION.
   return `You are running the OFFICIAL career-ops job evaluation, HEADLESS, on the user's own machine. Today is ${today}. Run the REAL career-ops evaluation — do NOT improvise your own scoring.
 
 1. Read modes/oferta.md and follow it EXACTLY (blocks A–F, G posting-legitimacy, and the Machine Summary). Ground the fit in THIS person: read cv.md, config/profile.yml and modes/_profile.md. Use WebFetch to read the posting (you are headless — Playwright is unavailable, so use WebFetch and mark the report header "Verification: unconfirmed (batch mode)").
@@ -92,8 +106,8 @@ End with EXACTLY one final line: VERDICT: {5 if now live, else 1}/5 — {what yo
 2. Persist the result CANONICALLY so the web and the CLI share ONE source of truth:
    a. Reserve a report number: run \`node reserve-report-num.mjs\` — its stdout is a 3-digit number (e.g. 035).
    b. Write the full report to reports/{num}-{company-slug}-${today}.md  (company-slug = company lowercased, non-alphanumerics → hyphens).
-   c. Append ONE row of 9 TAB-separated columns to batch/tracker-additions/{num}-{company-slug}.tsv, in THIS exact order (real \\t tabs, status BEFORE score):
-      {num}\t${today}\t{Company}\t{Role}\t{CanonicalStatus e.g. Evaluated}\t{score}/5\t❌\t[{num}](reports/{num}-{company-slug}-${today}.md)\t{one-line note}
+   c. Append ONE row of 10 TAB-separated columns to batch/tracker-additions/{num}-{company-slug}.tsv, in THIS exact order (real \\t tabs, status BEFORE score). ALWAYS write all 10 fields — leave the last one EMPTY if there is no posting URL, never "N/A" or "-":
+      {num}\t${today}\t{Company}\t{Role}\t{CanonicalStatus e.g. Evaluated}\t{score}/5\t❌\t[{num}](reports/{num}-{company-slug}-${today}.md)\t{one-line note}\t{posting URL, or empty}
    d. Merge into the tracker: run \`node merge-tracker.mjs\` (it dedupes by company+role+report-num, validates the status, and writes data/applications.md — NEVER edit applications.md by hand).
 
 3. NEVER submit an application, fill no forms, contact no one. This is evaluation + persistence ONLY.${mem}

--- a/web/tests/lib/run-prompts.test.mjs
+++ b/web/tests/lib/run-prompts.test.mjs
@@ -158,3 +158,41 @@ test("isShellSafeCompanyName: refuses anything that could close the quote", () =
   assert.equal(isShellSafeCompanyName("x".repeat(81)), false);
   assert.equal(isShellSafeCompanyName(undefined), false);
 });
+
+// ── the tracker-additions TSV row (#1298) ───────────────────────────────────
+//
+// The web is a WRITER of batch/tracker-additions/*.tsv, not just a reader of the
+// tracker. merge-tracker accepts 9 fields forever, so a stale template can never
+// go red — it just silently leaves every web-evaluated job out of the URL dedup.
+// Nothing else in this repo can catch that, which is why it is asserted here.
+
+/** The example row the evaluate prompt tells the agent to append. */
+function exampleTsvRow(prompt) {
+  const line = prompt.split("\n").find((l) => l.includes("\t"));
+  assert.ok(line, "the evaluate prompt must contain a literal tab-separated example row");
+  return line.trim().split("\t");
+}
+
+test("buildPrompt: the evaluate prompt's TSV row carries all 10 fields, url last", () => {
+  // Given an evaluate run
+  const prompt = buildPrompt({ kind: "evaluate", input: "https://acme.com/jobs/7", memory: "", today: "2026-08-04" });
+  const fields = exampleTsvRow(prompt);
+
+  // Then the row has the 10 fields merge-tracker reads, with the posting URL last
+  assert.equal(fields.length, 10, `expected 10 tab-separated fields, got ${fields.length}: ${JSON.stringify(fields)}`);
+  assert.match(fields[9], /posting URL/i, "the 10th field must be the posting URL");
+  // ...and the prose agrees, so the agent is not told "9" while shown 10
+  assert.match(prompt, /10 TAB-separated columns/);
+});
+
+test("buildPrompt: the evaluate prompt demands an EMPTY url field, never a placeholder", () => {
+  // Given merge-tracker's parseTsvExtras drops "N/A"/"-" precisely so they can't
+  // be misread as the row's LOCATION, and an unconditional template is one an
+  // agent actually follows
+  const prompt = buildPrompt({ kind: "evaluate", input: "https://acme.com/jobs/7", memory: "", today: "2026-08-04" });
+
+  // Then the instruction says to write all 10 fields and leave the last empty
+  assert.match(prompt, /ALWAYS write all 10 fields/i);
+  assert.match(prompt, /EMPTY if there is no posting URL/i);
+  assert.match(prompt, /never "N\/A"/i);
+});


### PR DESCRIPTION
## What does this PR do?

Follow-up to **#1298**, which added a 10th optional `url` field to `batch/tracker-additions/*.tsv` and made `merge-tracker` dedupe on it.

The web is a **writer** of that file, not only a reader of the tracker: `web/src/lib/run-prompts.mjs` gives the agent the exact row to append, and it still said *9 TAB-separated columns*. So #1298 was compatible with the web and, at the same time, did nothing for it.

**Nothing would ever have gone red.** `merge-tracker` accepts 9 fields forever by design, so the stale template stays permanently valid while every job evaluated from the web sits outside the URL dedup — on the surface most users arrive through. Compatible and half-dead at once, which is the failure mode with no symptom.

## Why the field is always present and empty

Empty and absent are byte-identical in the written row (verified below), so the choice is purely about which instruction an agent reliably follows:

- *"emit 10 fields, last one empty if there's no URL"* — unconditional, one rule
- *"emit 9 or 10 depending"* — conditional, and sometimes forgotten

Not `"N/A"` either: `parseTsvExtras` drops placeholders precisely so they can't be misread as the row's **LOCATION**, and the prompt now says so explicitly.

## Verified end-to-end against the real `merge-tracker.mjs`

Not a mock — a sandbox tracker with a 10-column header, the real script via its own `CAREER_OPS_TRACKER`/`_ADDITIONS` overrides:

| TSV row written | resulting URL cell |
|---|---|
| 10 fields, real URL | `https://acme.com/jobs/7` ✅ |
| 10 fields, url **empty** | empty ✅ |
| **9 fields** (the web's previous output) | empty — still merges ✅ |
| 10 fields, url `N/A` | empty — **not** recorded as a location ✅ |

## Test plan

- [x] `web` 135/135, `npm run typecheck` clean, `npm run build` clean
- [x] `node test-all.mjs` — 3783 passed, 0 failed (1 known warning: `cv-sync-check` without user data)
- [x] **Mutation-verified**: reverting the template to 9 fields turns the new test red, naming the count it found — a guard I haven't seen fail is a hypothesis

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] My PR does not include personal data
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the Data Contract (no modifications to user-layer files)
- [x] My changes align with the project roadmap


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved evaluation output instructions to include posting URLs in tracker-addition records.
  * Records without a URL now require an empty final field instead of placeholder values such as “N/A” or “-”.

* **Tests**
  * Added coverage to verify the required 10-field tab-separated format and URL handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->