### PR TITLE
test(agent-inbox): print the failing child's error when a concurrent add is lost

### DIFF
--- a/agent-inbox-tests.mjs
+++ b/agent-inbox-tests.mjs
@@ -172,7 +172,11 @@ console.log('7. concurrent adds do not lose items (append, not rewrite)');
       || lines.find((s) => /\b(EPERM|EBUSY|EACCES|ENOENT|EEXIST)\b/.test(s))
       || lines.slice(-1)[0]
       || '(no stderr)';
-    console.log(`      ↳ ${l.item} exited ${l.code}: ${cause.slice(0, 200)}`);
+    // Generous, because the owner record pipeline-lock.mjs appends to a
+    // LockTimeoutError is the diagnostic payload; truncating it away would
+    // leave the same symptom-without-mechanism this instrumentation exists
+    // to end.
+    console.log(`      ↳ ${l.item} exited ${l.code}: ${cause.slice(0, 500)}`);
   }
   const body = readFileSync(inbox, 'utf8');
   const pending = body.split('\n').filter((l) => l.startsWith('- [ ]'));

--- a/agent-inbox-tests.mjs
+++ b/agent-inbox-tests.mjs
@@ -138,16 +138,42 @@ console.log('7. concurrent adds do not lose items (append, not rewrite)');
   const N = 30;
   // spawn(), not spawnSync() — a synchronous loop would serialize the adds and
   // pass even against the buggy rewrite, proving nothing.
-  const exits = await Promise.all(
+  // Capture each child's stderr, and PRINT the losers' when the case fails.
+  // Without this the only evidence a failure leaves is `kept=29 of 30`, which
+  // names the symptom and hides the mechanism: a lock-acquisition timeout, a
+  // Windows EPERM/EBUSY on the lock directory and a crash in the append all
+  // look identical from out here. This case has failed on windows-latest
+  // repeatedly, including after #2825 raised the acquisition budget to 30s,
+  // and every one of those failures cost a round trip because the log said
+  // what was lost and never why. A sub-millisecond append that cannot get the
+  // lock inside 30 SECONDS is not simply a crowded queue, so the distinction
+  // is the whole diagnosis.
+  const results = await Promise.all(
     Array.from({ length: N }, (_, i) => new Promise((res) => {
       const p = spawn(NODE, [CLI, 'add', `item-${i}`], {
         cwd: dir, env: { ...process.env, CAREER_OPS_INBOX: inbox }, stdio: ['pipe', 'pipe', 'pipe'],
       });
-      p.on('exit', (code) => res(code));
+      let err = '';
+      p.stderr.on('data', (chunk) => { err += chunk; });
+      p.on('exit', (code) => res({ item: `item-${i}`, code, err }));
     })),
   );
-  const failedSpawn = exits.filter((c) => c !== 0).length;
+  const exits = results.map((r) => r.code);
+  const losers = results.filter((r) => r.code !== 0);
+  const failedSpawn = losers.length;
   check('every concurrent add exited cleanly', failedSpawn === 0, `${failedSpawn} non-zero exits`);
+  for (const l of losers) {
+    // Node prints the offending SOURCE LINE before the error itself, so taking
+    // the first lines verbatim buries the one fact worth having. Pull out the
+    // `SomeError: message` line, which is what separates the hypotheses, and
+    // keep a truncated tail as a fallback when nothing matches.
+    const lines = l.err.trim().split('\n').map((s) => s.trim()).filter(Boolean);
+    const cause = lines.find((s) => /^[A-Za-z_$][\w$]*(Error|Exception):/.test(s))
+      || lines.find((s) => /\b(EPERM|EBUSY|EACCES|ENOENT|EEXIST)\b/.test(s))
+      || lines.slice(-1)[0]
+      || '(no stderr)';
+    console.log(`      ↳ ${l.item} exited ${l.code}: ${cause.slice(0, 200)}`);
+  }
   const body = readFileSync(inbox, 'utf8');
   const pending = body.split('\n').filter((l) => l.startsWith('- [ ]'));
   const kept = pending.length;

--- a/pipeline-lock.mjs
+++ b/pipeline-lock.mjs
@@ -162,7 +162,31 @@ export async function acquirePipelineLock(pipelinePath, options = {}) {
         }
       }
 
-      if (Date.now() > deadline) throw new LockTimeoutError(lockDir, timeoutMs);
+      if (Date.now() > deadline) {
+        // Attach who was holding it. A timeout on a critical section that is a
+        // single sub-millisecond append has two very different explanations,
+        // and the owner record separates them in one line:
+        //   - no owner, or an owner whose PID is dead: contention, the queue
+        //     really is that crowded and a fair queue is the answer.
+        //   - an owner whose PID is ALIVE and is not plausibly still inside a
+        //     sub-millisecond append: the directory outlived its holder. On
+        //     Windows `rmSync` of the lock can fail with EPERM/EBUSY while a
+        //     handle is open and release() swallows it by design, and Windows
+        //     recycles PIDs aggressively, so a burst of 30 short-lived
+        //     processes can hand a dead owner's PID to a live sibling. Then
+        //     lockCanRecover() reads "still running", judges the lock fresh
+        //     forever, and no budget is large enough.
+        // Diagnostic only: it never changes whether the error is thrown.
+        const err = new LockTimeoutError(lockDir, timeoutMs);
+        try {
+          const owner = readLockOwner(lockDir);
+          err.owner = owner
+            ? { pid: owner.pid, alive: processIsAlive(owner.pid), started_at: owner.started_at, heldMs: Date.parse(owner.started_at) ? Date.now() - Date.parse(owner.started_at) : null }
+            : { pid: null, alive: null, note: existsSync(lockDir) ? 'lock exists with no readable owner.json' : 'lock vanished before it could be read' };
+          err.message += ` — owner=${JSON.stringify(err.owner)}`;
+        } catch { /* diagnosis must never mask the timeout it describes */ }
+        throw err;
+      }
       // Jitter, because a FIXED retry makes every waiter wake at the same
       // instant and re-race, and whoever loses is picked at random rather than
       // queued. With N waiters that is the coupon-collector problem: serving


### PR DESCRIPTION
Relates to #2777, follows #2824 / #2825.

## Why now

The `kept=29 of 30` failure **is still happening with #2825 merged**. It fired twice in the last hour on bases that contain the 30s budget: once on my machine right after an unrelated one-line docs merge, and once on a fresh CI run created at 21:29 UTC.

So the burst-sized budget cut this a long way and did not remove it, which is what both #2825 and the jitter comment before it predicted in writing.

## What is missing, and it is not a fix

Every one of these failures leaves exactly the same evidence: `kept=29 of 30`. That is the symptom. From outside the child, a lock-acquisition timeout, a Windows `EPERM`/`EBUSY` on the lock directory and a crash inside the append all look identical, and they have completely different fixes.

The distinction matters more now than it did at 8s: **a sub-millisecond append that cannot acquire the lock within 30 seconds is not simply a crowded queue.** If the next Windows failure still says `LockTimeoutError`, the answer is a fair queue. If it says `EPERM`, the lock directory is the problem and the budget was never the issue.

## What this does

Captures each child's stderr and prints the error line per lost item on failure. Node prints the offending source line before the error itself, so the `SomeError: message` line is extracted rather than the first lines taken verbatim, with an `EPERM|EBUSY|EACCES` fallback and the last line as a last resort.

Verified by forcing the timeout to 1ms: the case goes red and prints `LockTimeoutError: pipeline lock timeout: …held > 1ms` per lost item. Restored, green, and green runs print nothing new. Suite: 3783 passed, 0 failed.

@Scott-Emberson you have the most context on this one after #2824, so flagging it rather than assuming: this deliberately does not touch the budget or the lock. I would rather the next red tell us which of the two mechanisms it is than guess again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Lock timeout errors now include detailed ownership diagnostics, such as process status, start time, and lock duration.
  * Diagnostic information remains available even when ownership data is missing or unreadable.

* **Tests**
  * Improved concurrent-add test diagnostics by capturing process error output.
  * Test failures now report clearer error causes while preserving existing item-survival checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->