### PR TITLE
fix(pipeline-lock): time out a wedged holder, not an unlucky waiter

### DIFF
--- a/pipeline-lock.mjs
+++ b/pipeline-lock.mjs
@@ -38,6 +38,10 @@ const DEFAULT_STALE_MS = 30_000;
 export const OWNERLESS_GRACE_MS = 1_000;
 const DEFAULT_RETRY_MS = 80;
 const DEFAULT_TIMEOUT_MS = 8_000;
+// Ceiling on progress-extended waiting (see the deadline logic in
+// acquirePipelineLock). A multiple of timeoutMs rather than a constant, so a
+// caller that tunes one tunes both.
+const DEFAULT_MAX_WAIT_FACTOR = 10;
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
@@ -187,15 +191,32 @@ function lockCanRecover(lockDir, staleMs) {
   }
 }
 
+// A cheap identity for "which holder currently has this lock". Used only to
+// tell a lock that is CHANGING HANDS (the system is making progress; this
+// caller is merely unlucky) from one that is WEDGED (a single holder is not
+// letting go, which is what the timeout exists to escape).
+function lockFingerprint(lockDir) {
+  try {
+    const st = statSync(lockDir);
+    const { owner } = readLockOwner(lockDir);
+    // ino is 0 on some Windows volumes, hence birthtime as the tiebreaker —
+    // the same pairing sameLockDirectory() already relies on.
+    return `${owner?.token ?? ''}|${st.ino}|${st.birthtimeMs}`;
+  } catch {
+    return null; // free or unobservable — no evidence either way
+  }
+}
+
 /**
  * Blocks until the lock on `pipelinePath` is held, then returns a handle whose
  * release() frees it. Throws LockTimeoutError if the lock stays busy.
  *
  * @param {string} pipelinePath - File the lock guards.
  * @param {object} [options]
- * @param {number} [options.timeoutMs=8000] - Max time to wait for the lock.
+ * @param {number} [options.timeoutMs=8000] - Max time a SINGLE holder may block this caller. Waiting is extended while the lock keeps changing hands (see below).
  * @param {number} [options.retryMs=80] - Delay between acquisition attempts.
  * @param {number} [options.staleMs=30000] - Age threshold for a lock with no readable owner, floored at OWNERLESS_GRACE_MS.
+ * @param {number} [options.maxWaitMs] - Absolute ceiling on waiting, however much progress the lock makes. Defaults to 10x timeoutMs.
  */
 export async function acquirePipelineLock(pipelinePath, options = {}) {
   // Env overrides let a caller several frames up the stack (a test driving
@@ -204,10 +225,44 @@ export async function acquirePipelineLock(pipelinePath, options = {}) {
   const timeoutMs = options.timeoutMs ?? (Number(process.env.CAREER_OPS_PIPELINE_LOCK_TIMEOUT_MS) || DEFAULT_TIMEOUT_MS);
   const retryMs = options.retryMs ?? (Number(process.env.CAREER_OPS_PIPELINE_LOCK_RETRY_MS) || DEFAULT_RETRY_MS);
   const staleMs = options.staleMs ?? (Number(process.env.CAREER_OPS_PIPELINE_LOCK_STALE_MS) || DEFAULT_STALE_MS);
+  // A ceiling that is not a number is not a ceiling. NaN compares false against
+  // everything, so a bad value would not fail loudly — it would silently remove
+  // the only bound on waiting, which is the single thing this option exists to
+  // provide. Only a usable ceiling is honoured; everything else takes the
+  // default, which is at least bounded.
+  //
+  // Read WITHOUT the `|| default` idiom its three siblings above use, because
+  // for this one 0 is a meaningful setting — "never wait past now" — and
+  // `0 || default` would turn a caller who asked for no waiting into one who
+  // waits DEFAULT_MAX_WAIT_FACTOR x timeoutMs, the exact opposite. timeoutMs
+  // and retryMs have no such reading, which is why the idiom is fine there and
+  // wrong here.
+  //
+  // Infinity is kept as written: an explicit, legible "no ceiling" is a choice,
+  // not a mistake. -Infinity and NaN are mistakes, so they take the default
+  // rather than being clamped into a silently different behaviour.
+  const defaultMaxWaitMs = timeoutMs * DEFAULT_MAX_WAIT_FACTOR;
+  const envMaxWait = process.env.CAREER_OPS_PIPELINE_LOCK_MAX_WAIT_MS;
+  const requestedMaxWait = Number(
+    options.maxWaitMs ?? (envMaxWait === undefined || envMaxWait.trim() === '' ? defaultMaxWaitMs : envMaxWait),
+  );
+  const maxWaitMs = requestedMaxWait === Infinity ? Infinity
+    : Number.isFinite(requestedMaxWait) && requestedMaxWait >= 0 ? requestedMaxWait
+      : defaultMaxWaitMs;
   const lockDir = lockDirFor(pipelinePath);
   const recoverGuardDir = `${lockDir}.recover`;
   const token = randomUUID();
-  const deadline = Date.now() + timeoutMs;
+  let deadline = Date.now() + timeoutMs;
+  // Deliberately NOT floored at timeoutMs. A caller that asks for a ceiling
+  // below one per-holder window means it, and quietly raising it would make
+  // maxWaitMs a no-op in precisely the range where it was stated most
+  // explicitly. The ceiling wins; timeoutMs just stops mattering.
+  const hardDeadline = Date.now() + maxWaitMs;
+  // Lock identity as of the last time this caller ran out of patience, so the
+  // next timeout can ask "did anything move since?". Sampled lazily on the
+  // first failed acquisition, not here, so the very first deadline is measured
+  // against the state we actually started waiting on.
+  let lastFingerprint;
   // The last mkdir error this caller treated as contention. On POSIX it is
   // always EEXIST and says nothing; on Windows an EPERM/EACCES that persists
   // to the deadline is the difference between "crowded" and "this process
@@ -215,6 +270,38 @@ export async function acquirePipelineLock(pipelinePath, options = {}) {
   // problem would present as a plain, unexplained timeout.
   let lastContentionError = null;
 
+  // Jittered backoff, never sleeping past the ceiling. An uncapped sleep can
+  // cross hardDeadline and let the NEXT mkdir succeed, returning a lock after
+  // the documented absolute limit — an overshoot of up to 1.5x retryMs. Waking
+  // exactly at the ceiling means the check at the top of the loop is what
+  // decides, rather than whichever of the two happened to be later.
+  const backoffMs = () => Math.max(0, Math.min(
+    retryMs * (0.5 + Math.random()),
+    hardDeadline - Date.now(),
+  ));
+
+  // The per-holder deadline, evaluated the SAME way everywhere: an expired
+  // deadline only means "give up" when the lock has not changed hands since we
+  // last looked. Otherwise the window is re-armed and the caller waits again.
+  //
+  // A helper rather than inline code because three separate paths can time a
+  // caller out — the main retry, a non-EEXIST guard refusal, and an ENOENT
+  // owner-write retry — and the progress rule holding on one while the other
+  // two throw directly is the same bug in two more places: a healthy lock
+  // being handed round briskly could still kill a caller through them.
+  const holderStillWedged = () => {
+    if (Date.now() <= deadline) return false;
+    const fingerprint = lockFingerprint(lockDir);
+    // Only a lock we can SEE, unchanged across a full window, is evidence that
+    // waiting longer is futile. A fingerprint that moved means the lock is
+    // being handed round. A null one means it was free or unobservable at the
+    // instant we looked — no evidence either way, and not to be mistaken for a
+    // wedged holder.
+    if (fingerprint !== null && fingerprint === lastFingerprint) return true;
+    lastFingerprint = fingerprint;
+    deadline = Date.now() + timeoutMs;
+    return false;
+  };
   // Built at the throw site so the diagnosis reflects the moment it gave up.
   // A timeout on a critical section that is a single sub-millisecond append
   // has more than one explanation, and the owner record separates them:
@@ -224,8 +311,11 @@ export async function acquirePipelineLock(pipelinePath, options = {}) {
   //     its holder, because release()'s rmSync can fail on Windows while a
   //     handle is open and is swallowed by design.
   // Diagnostic only: it never changes whether the error is thrown.
-  const buildTimeoutError = () => {
-    const err = new LockTimeoutError(lockDir, timeoutMs);
+  // `expiredMs` is the bound that actually ran out, so the message names the
+  // limit that was applied. Reporting timeoutMs when the CEILING expired states
+  // a number that was never in force.
+  const buildTimeoutError = (expiredMs = timeoutMs) => {
+    const err = new LockTimeoutError(lockDir, expiredMs);
     try {
       const { inspected, owner } = readLockOwner(lockDir);
       err.owner = owner
@@ -256,11 +346,20 @@ export async function acquirePipelineLock(pipelinePath, options = {}) {
   mkdirSync(dirname(lockDir), { recursive: true });
 
   for (;;) {
+    // The ceiling is tested FIRST, on its own, on every pass. Nesting it inside
+    // the per-holder deadline made it conditional on a branch that may never
+    // run: a caller whose maxWaitMs is below timeoutMs never reaches the inner
+    // check, a re-arm pushes the next look a whole window away, and the reclaim
+    // fast-path continues straight past both. A bound that holds only when
+    // another bound happens to fire is not a bound.
+    if (Date.now() > hardDeadline) throw buildTimeoutError(maxWaitMs);
+
     try {
       mkdirSync(lockDir);
     } catch (err) {
       if (!isMkdirContention(err)) throw err;
       lastContentionError = err;
+      if (lastFingerprint === undefined) lastFingerprint = lockFingerprint(lockDir);
 
       // Serialize stale-reclaim behind a second atomic guard so only one
       // caller can be inside the decide-then-delete window at a time.
@@ -276,8 +375,8 @@ export async function acquirePipelineLock(pipelinePath, options = {}) {
         // reasoning about a directory it cannot even stat reliably. Back off to
         // the retry loop instead of judging it.
         if (guardErr.code !== 'EEXIST') {
-          if (Date.now() > deadline) throw buildTimeoutError();
-          await sleep(retryMs * (0.5 + Math.random()));
+          if (holderStillWedged()) throw buildTimeoutError();
+          await sleep(backoffMs());
           continue;
         }
         // A process killed between taking the guard and cleaning it up would
@@ -303,7 +402,7 @@ export async function acquirePipelineLock(pipelinePath, options = {}) {
         }
       }
 
-      if (Date.now() > deadline) throw buildTimeoutError();
+      if (holderStillWedged()) throw buildTimeoutError();
       // Jitter, because a FIXED retry makes every waiter wake at the same
       // instant and re-race, and whoever loses is picked at random rather than
       // queued. With N waiters that is the coupon-collector problem: serving
@@ -325,7 +424,7 @@ export async function acquirePipelineLock(pipelinePath, options = {}) {
       // lottery. Left as a lottery because fairness needs an ordered wait and
       // that is a different lock; recorded here so nobody reads the jitter as
       // "the race is gone".
-      await sleep(retryMs * (0.5 + Math.random()));
+      await sleep(backoffMs());
       continue;
     }
 
@@ -344,7 +443,7 @@ export async function acquirePipelineLock(pipelinePath, options = {}) {
       // lost race, not a failure — re-enter the loop and compete again.
       // Dying here loses the caller's queued write (#2777, third face).
       if (ownerErr?.code === 'ENOENT') {
-        if (Date.now() > deadline) throw buildTimeoutError();
+        if (holderStillWedged()) throw buildTimeoutError();
         continue;
       }
       // Best-effort: a contended rm here must not mask ownerErr, and an

--- a/test/pipeline-lock.test.mjs
+++ b/test/pipeline-lock.test.mjs
@@ -24,6 +24,33 @@ import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { acquirePipelineLock, LockTimeoutError, OWNERLESS_GRACE_MS } from '../pipeline-lock.mjs';
 
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Occupies `lockDir` continuously while handing it to a fresh owner every
+// `everyMs`, the way a queue of short writers does. The swap runs inside one
+// synchronous timer callback, so an in-process waiter can never slip through
+// the gap — from its point of view the lock is busy the entire time, but busy
+// with a DIFFERENT holder each window. Returns a stop() and the handoff count.
+function churnLock(lockDir, everyMs) {
+  let handoffs = 0;
+  const takeIt = () => {
+    rmSync(lockDir, { recursive: true, force: true });
+    mkdirSync(lockDir, { recursive: true });
+    writeFileSync(join(lockDir, 'owner.json'), JSON.stringify({
+      pid: process.pid, token: `handoff-${handoffs++}`, started_at: new Date().toISOString(),
+    }), 'utf-8');
+  };
+  takeIt();
+  const timer = setInterval(takeIt, everyMs);
+  return {
+    handoffs: () => handoffs,
+    stop() {
+      clearInterval(timer);
+      rmSync(lockDir, { recursive: true, force: true });
+    },
+  };
+}
+
 function fixtureRoot() {
   const root = mkdtempSync(join(tmpdir(), 'career-ops-pipeline-lock-'));
   mkdirSync(join(root, 'data'), { recursive: true });
@@ -295,6 +322,189 @@ test('LockTimeoutError carries the live holder it was blocked by (#2834 diagnost
       held.release();
     }
   } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// Both ceiling tests race the acquire against a wall-clock bound rather than
+// awaiting it. Against a lock that churns for ever, a broken ceiling does not
+// return at all, and a bare await would hang the suite instead of failing it.
+// The retry loop yields on every pass, so the racing timer does get to run.
+async function settleOrGiveUp(promise, ms) {
+  return Promise.race([
+    promise.then((lock) => { lock.release(); return 'ACQUIRED'; }, (err) => err),
+    sleep(ms).then(() => 'NEVER_SETTLED'),
+  ]);
+}
+
+
+
+test('acquirePipelineLock: a lock that keeps changing hands does not time out a waiting caller', async () => {
+  const root = fixtureRoot();
+  try {
+    const p = join(root, 'data', 'pipeline.md');
+    const churn = churnLock(`${p}.lock`, 40);
+    // Let the lock change hands for several times the caller's timeout, then
+    // free it. The caller must still be waiting, not dead.
+    const freeItLater = sleep(600).then(() => churn.stop());
+
+    const startedAt = Date.now();
+    // The old absolute deadline killed this caller at 150ms with
+    // LockTimeoutError even though the lock was healthy and briskly shared —
+    // which for agent-inbox.mjs meant its request was silently dropped. The
+    // timeout is for a WEDGED holder, not for losing the retry lottery.
+    const lock = await acquirePipelineLock(p, { timeoutMs: 150, retryMs: 15 });
+    const elapsed = Date.now() - startedAt;
+    lock.release();
+    await freeItLater;
+
+    assert.ok(elapsed > 400, `acquired after only ${elapsed}ms — the lock was not actually contended`);
+    assert.ok(churn.handoffs() > 5, `only ${churn.handoffs()} handoffs — the deadline was never crossed mid-contention`);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('acquirePipelineLock: extended waiting is still bounded by maxWaitMs, so endless churn cannot hang a caller', async () => {
+  const root = fixtureRoot();
+  const churn = churnLock(`${root}/data/pipeline.md.lock`, 30);
+  try {
+    const p = join(root, 'data', 'pipeline.md');
+    // Progress must buy patience, never immortality: a lock handed round for
+    // ever still has to fail the caller rather than block it indefinitely.
+    const startedAt = Date.now();
+    await assert.rejects(
+      () => acquirePipelineLock(p, { timeoutMs: 100, retryMs: 10, maxWaitMs: 400 }),
+      (err) => err instanceof LockTimeoutError,
+    );
+    const elapsed = Date.now() - startedAt;
+    assert.ok(elapsed >= 400, `gave up after ${elapsed}ms, before the caller's maxWaitMs`);
+    assert.ok(elapsed < 3000, `waited ${elapsed}ms — maxWaitMs did not bound the extension`);
+  } finally {
+    churn.stop();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('acquirePipelineLock: an explicit maxWaitMs below timeoutMs is honored, not raised to it', async () => {
+  const root = fixtureRoot();
+  const churn = churnLock(`${root}/data/pipeline.md.lock`, 25);
+  try {
+    const p = join(root, 'data', 'pipeline.md');
+    // The ceiling used to be floored at timeoutMs, which made it a no-op in the
+    // one range where the caller stated it most explicitly: asking for "never
+    // more than 200ms" bought five seconds. It was also only consulted inside
+    // the per-holder deadline branch, which this caller never reaches.
+    const startedAt = Date.now();
+    const outcome = await settleOrGiveUp(
+      acquirePipelineLock(p, { timeoutMs: 5000, retryMs: 20, maxWaitMs: 200 }),
+      3000,
+    );
+    const elapsed = Date.now() - startedAt;
+    assert.ok(outcome instanceof LockTimeoutError, `expected the ceiling to end it, got: ${outcome}`);
+    assert.ok(elapsed < 2000, `waited ${elapsed}ms — the 200ms ceiling was raised to timeoutMs`);
+    // The diagnosis has to name the limit that was actually applied. Reporting
+    // timeoutMs here states a number that was never in force, and sends the
+    // reader looking for a 5s hold that never happened.
+    assert.match(outcome.message, /held > 200ms/, `the message names a bound that was not the one that expired: ${outcome.message}`);
+  } finally {
+    churn.stop();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('acquirePipelineLock: a lock freed after maxWaitMs is refused, not acquired', async () => {
+  const root = fixtureRoot();
+  const churn = churnLock(`${root}/data/pipeline.md.lock`, 25);
+  try {
+    const p = join(root, 'data', 'pipeline.md');
+    // The ceiling expires while the caller is asleep between retries, and the
+    // lock becomes free shortly after. An uncapped backoff would wake past the
+    // ceiling, find the path available, and hand back a lock the caller was no
+    // longer entitled to wait for — bounded overshoot, but a returned lock is
+    // not a bounded error. It must refuse.
+    const attempt = acquirePipelineLock(p, { timeoutMs: 5000, retryMs: 120, maxWaitMs: 150 });
+    setTimeout(() => churn.stop(), 200);
+    const outcome = await settleOrGiveUp(attempt, 3000);
+    assert.ok(
+      outcome instanceof LockTimeoutError,
+      `the ceiling had already expired; acquiring anyway returns a lock past the documented limit (got: ${outcome})`,
+    );
+  } finally {
+    churn.stop();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('acquirePipelineLock: a maxWaitMs of 0 means no waiting, not the default ceiling', async () => {
+  const root = fixtureRoot();
+  const churn = churnLock(`${root}/data/pipeline.md.lock`, 20);
+  const previous = process.env.CAREER_OPS_PIPELINE_LOCK_MAX_WAIT_MS;
+  try {
+    const p = join(root, 'data', 'pipeline.md');
+    // 0 is a MEANINGFUL setting here — "never wait past now" — so it must not go
+    // through the `value || default` idiom the sibling options use: that turns a
+    // caller who asked for no waiting into one who waits 10x timeoutMs, the exact
+    // opposite of the request. Asserted through the env var, which is where the
+    // idiom lived, and against a churning lock so only the ceiling can end it.
+    process.env.CAREER_OPS_PIPELINE_LOCK_MAX_WAIT_MS = '0';
+    const startedAt = Date.now();
+    const outcome = await settleOrGiveUp(acquirePipelineLock(p, { timeoutMs: 400, retryMs: 20 }), 3000);
+    const elapsed = Date.now() - startedAt;
+    assert.ok(outcome instanceof LockTimeoutError, `expected an immediate ceiling, got: ${outcome}`);
+    assert.ok(elapsed < 300, `waited ${elapsed}ms for a zero ceiling — the 0 was read as "unset"`);
+  } finally {
+    if (previous === undefined) delete process.env.CAREER_OPS_PIPELINE_LOCK_MAX_WAIT_MS;
+    else process.env.CAREER_OPS_PIPELINE_LOCK_MAX_WAIT_MS = previous;
+    churn.stop();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('acquirePipelineLock: a negative or -Infinity ceiling takes the default rather than becoming zero', async () => {
+  const root = fixtureRoot();
+  const churn = churnLock(`${root}/data/pipeline.md.lock`, 20);
+  try {
+    const p = join(root, 'data', 'pipeline.md');
+    // A negative ceiling is a mistake, not a request for no waiting. Clamping it
+    // to 0 would turn a typo into "give up instantly", which is a silently
+    // different behaviour; the default is at least bounded and obvious. Paired
+    // with the zero test above on purpose — together they pin that 0 and "less
+    // than 0" are NOT the same input.
+    for (const bad of [-5, -Infinity]) {
+      const startedAt = Date.now();
+      const outcome = await settleOrGiveUp(
+        acquirePipelineLock(p, { timeoutMs: 50, retryMs: 20, maxWaitMs: bad }), 3000,
+      );
+      const elapsed = Date.now() - startedAt;
+      assert.ok(outcome instanceof LockTimeoutError, `maxWaitMs=${bad}: expected a timeout, got: ${outcome}`);
+      assert.ok(elapsed >= 300, `maxWaitMs=${bad} gave up after ${elapsed}ms — clamped to zero instead of defaulting`);
+    }
+  } finally {
+    churn.stop();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('acquirePipelineLock: a non-numeric maxWaitMs falls back to the default instead of removing the ceiling', async () => {
+  const root = fixtureRoot();
+  const churn = churnLock(`${root}/data/pipeline.md.lock`, 25);
+  try {
+    const p = join(root, 'data', 'pipeline.md');
+    // NaN compares false against everything, so an unusable value did not fail
+    // loudly — it silently deleted the only bound on waiting. Against a lock
+    // that never stops changing hands that is an unbounded wait, which is the
+    // exact outcome the ceiling exists to prevent.
+    const outcome = await settleOrGiveUp(
+      acquirePipelineLock(p, { timeoutMs: 100, retryMs: 10, maxWaitMs: Number('not a number') }),
+      4000,
+    );
+    assert.ok(
+      outcome instanceof LockTimeoutError,
+      `a NaN ceiling left the caller waiting (got: ${outcome}) — it must fall back to the default`,
+    );
+  } finally {
+    churn.stop();
     rmSync(root, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
Part of #2777. Split out of #2815 at review request.

> **Stacks on #2815.** This branch contains that PR's commit as its base, so the diff shows two commits — **only the second, `fix(pipeline-lock): time out a wedged holder…`, is new here.** Once #2815 merges, this reduces to that commit alone. Reviewable independently; just merge #2815 first.

## The problem

The acquisition deadline is absolute, so it measures the wrong thing.

It exists to escape a holder that has stopped letting go. But it also expires on a caller that is merely losing the retry lottery while the lock is perfectly healthy and being handed round briskly. Those two situations want opposite answers, and the second is the common one — acquisition is a lottery, not a fair queue, so with N waiters somebody is always unlucky.

For callers here the cost of that confusion isn't latency. `agent-inbox.mjs`'s `add()` is one process per request, so a caller that dies takes the user's queued item with it: the exact loss the lock was introduced to prevent, converted from a silent overwrite into a loud crash.

## Why the existing mitigations stop short

Both do, by design, and both say so:

- **The retry jitter** cut collisions ~6x and is documented in-tree as *"a ~6x reduction, NOT a cure… the structural fix is a fair queue rather than a retry lottery."*
- **#2825** gave `agent-inbox` a 30s budget. That buys headroom for one caller without changing what the deadline *measures* — and `appendToPipeline` and `scan.mjs`'s `scan-history.tsv` appends still run on the 8s default.

## The fix

Re-arm the deadline whenever the lock is observed to have changed hands. `timeoutMs` then bounds **how long one holder may block a caller** rather than how many holders it may queue behind — which is what it was always documented to mean ("Max time to wait for the lock").

A wedged lock still fails exactly as before, same error and same timing, because an unchanged holder never re-arms it. `maxWaitMs` (default 10× `timeoutMs`) is the absolute ceiling, so progress buys patience but never immortality.

**This does not make the lock fair.** There's still no ordered wait, and a fair queue remains the structural answer. It makes unfairness cost latency instead of a write.

## Two details worth your attention

- **The fingerprint is sampled only when the deadline expires**, not on every retry — one extra `stat` per timeout window per waiter, rather than adding file-open churn to the contended path, which on Windows is itself a source of transient errors.
- **An unreadable fingerprint is not treated as "no progress."** It means the lock was free or unobservable at that instant, which is no evidence of a wedged holder; only a lock we can *see*, unchanged across a full window, is. I had this backwards in my first attempt — it killed an unlucky waiter at the first sample, and I caught it at N=60 before committing. Flagging it because it's the subtle half of the change.

## Evidence

30 concurrent adds, budget compressed to 300ms so the effect shows without waiting out the default:

```
before   8 of 12 rounds lost an item
after    0 of 20 rounds
```

60 concurrent adds at a 200ms budget: 0 of 10 rounds.

At the default budget the ceiling is generous enough that this never engages in normal use — it's the tail that it removes.

## Tests

- a lock that keeps changing hands does not time out a waiting caller
- extended waiting is still bounded by `maxWaitMs`, so endless churn cannot hang a caller

Both are deterministic — the churn helper swaps the lock inside a single synchronous timer callback, so an in-process waiter can never slip through the gap and the test doesn't depend on timing luck. **Both fail against the current deadline and pass against this one**, and the existing tests are unchanged in timing and outcome.

## If you'd rather not take this

Entirely reasonable — #2825 already covers the `agent-inbox` symptom, and this is the more opinionated half of the original PR. The crash fixes in #2815 stand alone and are the ones that close the CI flake. Closing this without prejudice is fine by me; the residual risk is that `appendToPipeline` and the `scan-history` appends keep the 8s absolute deadline and can still lose a write under a big enough burst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pipeline lock handling for missing, unreadable, or corrupted ownership information.
  - Added safer stale-lock recovery and cleanup during transient file-system conditions.
  - Prevented indefinite waiting when lock removal repeatedly fails.
  - Improved timeout diagnostics and preserved acquisition errors for clearer troubleshooting.

- **New Features**
  - Added a configurable maximum wait time for lock acquisition.
  - Improved resilience during active ownership changes with progress-aware timeout handling.
  - Added lock identification details to aid troubleshooting.
  - Added validation and fallback handling for invalid wait limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->