### PR TITLE
test(classify-tier): pin guard (b) scoping with negative cases

### DIFF
--- a/tests/classify-tier-position.test.mjs
+++ b/tests/classify-tier-position.test.mjs
@@ -100,6 +100,14 @@ try {
   check('Junior Talent Director', 'senior');
   check('Junior Talent Lead', 'senior');
   check('Entry-Level Program Director', 'senior');
+
+  // ── Guard (b) scoping: bridge noun present but NO trailing senior noun → stays at level marker ──
+  // These cases prove the guard does not overreach. Removing the trailing-noun
+  // requirement at classify-tier.mjs:119 would flip all three to 'senior' and
+  // a junior candidate would silently lose intern-programme roles.
+  check('Intern Program Coordinator', 'intern');
+  check('Graduate Scheme Analyst', 'intern');
+  check('Trainee Program Engineer', 'intern');
 } catch (error) {
   fail(`classify-tier.mjs tests could not run: ${error.message}`);
 }


### PR DESCRIPTION
## Summary

Follow-up to #2737 (merged). @Scott-Emberson  noted in code review that guard (b) was only tested in the positive direction (bridge noun + senior noun → `senior`). The scoping condition — that no senior noun must follow for the guard to not fire — was unasserted, leaving a silent regression path.

- Add three negative cases to `tests/classify-tier-position.test.mjs`:
  - `Intern Program Coordinator` → `intern`
  - `Graduate Scheme Analyst` → `intern`
  - `Trainee Program Engineer` → `intern`
- These prove the trailing-noun check at `classify-tier.mjs:119` is load-bearing. Removing it would flip all three to `senior`, causing junior candidates to silently lose intern-programme roles.

## Test plan

- [ ] `node tests/classify-tier-position.test.mjs` — all 44 assertions pass (3 new negatives added)
- [ ] No production code changed; risk is zero

Closes the gap flagged in Scott-Emberson's review of #2737.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the original seniority classification for intern, graduate, and trainee roles when bridge nouns appear without a trailing senior-role noun.
* **Tests**
  * Added regression coverage for these job-title classification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->