### PR TITLE
test(updater-rollback): isolate the fixture from global commit signing

### DIFF
--- a/tests/updater-rollback-behavior.test.mjs
+++ b/tests/updater-rollback-behavior.test.mjs
@@ -23,6 +23,20 @@ function makeRepo() {
   g('init', '-q', '-b', 'main', '.');
   g('config', 'user.email', 'test@example.com');
   g('config', 'user.name', 'Test');
+  // `gitIn` inherits the environment, so the contributor's GLOBAL git config
+  // applies inside this throwaway repo. With `commit.gpgsign = true` set
+  // globally (1Password's ssh signer, gpg-agent, a hardware key) every commit
+  // below fails, and because these are execFileSync calls the failure is not a
+  // red assertion: the process DIES here and every later section of the suite
+  // silently never runs, so `Results:` never prints (#2754). A global
+  // `core.hooksPath` breaks it the same way.
+  //
+  // The sibling fixture in updater-local-system-edits.test.mjs has carried
+  // these two lines since a CodeRabbit review flagged the same thing; this one
+  // was left behind, which is why the failure looks environment-specific
+  // instead of structural.
+  g('config', 'commit.gpgsign', 'false');
+  g('config', 'core.hooksPath', join(dir, 'no-such-hooks'));
   return { dir, g, ctx: { git: g, root: dir } };
 }
 


### PR DESCRIPTION
Fixes #2754.

## Reproduced, and it is worse than a failing test

`gitIn` inherits the environment, so a contributor's **global** git config applies inside the throwaway repo this fixture builds. With `commit.gpgsign = true` set globally, every commit in the fixture fails.

Because these are `execFileSync` calls, that is not a red assertion: **the process dies and every later section of `test-all.mjs` silently never runs**, so the `Results:` line never prints. @ringo380 measured roughly 3400 assertions past the abort point. From the contributor's side it reads as "career-ops crashes on my machine", not "one test needs fixing".

Simulated a global signing config to confirm:

| | outcome |
|---|---|
| before | aborts inside this file, `Results:` **never printed** |
| after | `3787 passed, 0 failed`, same environment |

## Why it was only this one file

The sibling fixture in `tests/updater-local-system-edits.test.mjs` has carried exactly these two lines since a CodeRabbit review flagged the same hazard, with the reasoning in a comment. Confirmed by running both under the simulated config: the sibling passes 14 green, this one dies. So the fix already existed in the house and one fixture was left behind, which is why the failure looks environment-specific instead of structural.

`core.hooksPath` is included for the same reason the sibling includes it: a global hooks path breaks the fixture's commits identically.

Thanks @ringo380 for a report that named the mechanism and the line number: this took longer to reproduce than to fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved rollback test reliability by isolating Git configuration from the local environment.
  * Prevented failures caused by global commit-signing settings or unavailable repository hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->