### PR TITLE
fix(pipeline-lock): a non-EEXIST mkdir refusal is contention, not a fatal error

### DIFF
--- a/pipeline-lock.mjs
+++ b/pipeline-lock.mjs
@@ -69,6 +69,28 @@ function sameLockDirectory(left, right) {
     && (left.ino !== 0 || left.birthtimeMs === right.birthtimeMs);
 }
 
+// mkdir's "someone else already has this" answer is NOT portable. POSIX gives
+// EEXIST; Windows gives EEXIST *sometimes* and EPERM/EACCES when the target is
+// mid-flight — being created, or being removed, by another process at that
+// instant. That is not an error condition here, it is the contention this loop
+// exists to handle, and it is precisely what a burst of concurrent writers
+// manufactures.
+//
+// Treating it as fatal is how an item gets LOST. Measured on windows-latest
+// (#2777, run 31745798742): one of 30 concurrent `agent-inbox add` processes
+// died with `EPERM: operation not permitted, mkdir '…agent-inbox.md.lock.recover'`
+// and its line was never appended. The two budget increases before this one
+// (#2506 jitter, #2825's 30s) both moved the symptom without touching this,
+// because a starving writer and a writer killed by EPERM produce the same
+// `kept=29 of 30` and only the second is a crash.
+//
+// A genuine permissions problem still surfaces: it simply stops being an
+// instant throw and becomes a timeout that names the last error it saw, which
+// is the correct trade when the alternative is silent data loss.
+function isMkdirContention(err) {
+  return err?.code === 'EEXIST' || err?.code === 'EPERM' || err?.code === 'EACCES';
+}
+
 function processIsAlive(pid) {
   if (!Number.isInteger(pid) || pid <= 0) return false;
   try {
@@ -123,6 +145,37 @@ export async function acquirePipelineLock(pipelinePath, options = {}) {
   const recoverGuardDir = `${lockDir}.recover`;
   const token = randomUUID();
   const deadline = Date.now() + timeoutMs;
+  // The last mkdir error this caller treated as contention. On POSIX it is
+  // always EEXIST and says nothing; on Windows an EPERM/EACCES that persists
+  // to the deadline is the difference between "crowded" and "this process
+  // cannot create directories here at all", and without it a real permissions
+  // problem would present as a plain, unexplained timeout.
+  let lastContentionError = null;
+
+  // Built at the throw site so the diagnosis reflects the moment it gave up.
+  // A timeout on a critical section that is a single sub-millisecond append
+  // has more than one explanation, and the owner record separates them:
+  //   - no owner, or an owner whose PID is dead: real contention, and the
+  //     structural answer is a fair queue rather than a bigger budget.
+  //   - an owner reported ALIVE after tens of seconds: the directory outlived
+  //     its holder, because release()'s rmSync can fail on Windows while a
+  //     handle is open and is swallowed by design.
+  // Diagnostic only: it never changes whether the error is thrown.
+  const buildTimeoutError = () => {
+    const err = new LockTimeoutError(lockDir, timeoutMs);
+    try {
+      const owner = readLockOwner(lockDir);
+      err.owner = owner
+        ? { pid: owner.pid, alive: processIsAlive(owner.pid), started_at: owner.started_at, heldMs: Date.parse(owner.started_at) ? Date.now() - Date.parse(owner.started_at) : null }
+        : { pid: null, alive: null, note: existsSync(lockDir) ? 'lock exists with no readable owner.json' : 'lock vanished before it could be read' };
+      err.message += ` — owner=${JSON.stringify(err.owner)}`;
+      if (lastContentionError && lastContentionError.code !== 'EEXIST') {
+        err.lastMkdirError = lastContentionError.code;
+        err.message += `, last mkdir error=${lastContentionError.code} on ${lastContentionError.path ?? '?'}`;
+      }
+    } catch { /* diagnosis must never mask the timeout it describes */ }
+    return err;
+  };
 
   // A fresh install may not have data/ yet — plugins.mjs's cmdRun calls
   // appendToPipeline with no directory pre-creation, so create it here rather
@@ -133,7 +186,8 @@ export async function acquirePipelineLock(pipelinePath, options = {}) {
     try {
       mkdirSync(lockDir);
     } catch (err) {
-      if (err?.code !== 'EEXIST') throw err;
+      if (!isMkdirContention(err)) throw err;
+      lastContentionError = err;
 
       // Serialize stale-reclaim behind a second atomic guard so only one
       // caller can be inside the decide-then-delete window at a time.
@@ -142,7 +196,17 @@ export async function acquirePipelineLock(pipelinePath, options = {}) {
         mkdirSync(recoverGuardDir);
         hasRecoverGuard = true;
       } catch (guardErr) {
-        if (guardErr?.code !== 'EEXIST') throw guardErr;
+        if (!isMkdirContention(guardErr)) throw guardErr;
+        lastContentionError = guardErr;
+        // An EPERM/EACCES here says the guard directory is mid-flight, not that
+        // it is sitting there abandoned, so the age check below would be
+        // reasoning about a directory it cannot even stat reliably. Back off to
+        // the retry loop instead of judging it.
+        if (guardErr.code !== 'EEXIST') {
+          if (Date.now() > deadline) throw buildTimeoutError();
+          await sleep(retryMs * (0.5 + Math.random()));
+          continue;
+        }
         // A process killed between taking the guard and cleaning it up would
         // otherwise disable stale recovery forever. The guard normally lives
         // for milliseconds, so an old one is judged by the same age rule.
@@ -162,31 +226,7 @@ export async function acquirePipelineLock(pipelinePath, options = {}) {
         }
       }
 
-      if (Date.now() > deadline) {
-        // Attach who was holding it. A timeout on a critical section that is a
-        // single sub-millisecond append has two very different explanations,
-        // and the owner record separates them in one line:
-        //   - no owner, or an owner whose PID is dead: contention, the queue
-        //     really is that crowded and a fair queue is the answer.
-        //   - an owner whose PID is ALIVE and is not plausibly still inside a
-        //     sub-millisecond append: the directory outlived its holder. On
-        //     Windows `rmSync` of the lock can fail with EPERM/EBUSY while a
-        //     handle is open and release() swallows it by design, and Windows
-        //     recycles PIDs aggressively, so a burst of 30 short-lived
-        //     processes can hand a dead owner's PID to a live sibling. Then
-        //     lockCanRecover() reads "still running", judges the lock fresh
-        //     forever, and no budget is large enough.
-        // Diagnostic only: it never changes whether the error is thrown.
-        const err = new LockTimeoutError(lockDir, timeoutMs);
-        try {
-          const owner = readLockOwner(lockDir);
-          err.owner = owner
-            ? { pid: owner.pid, alive: processIsAlive(owner.pid), started_at: owner.started_at, heldMs: Date.parse(owner.started_at) ? Date.now() - Date.parse(owner.started_at) : null }
-            : { pid: null, alive: null, note: existsSync(lockDir) ? 'lock exists with no readable owner.json' : 'lock vanished before it could be read' };
-          err.message += ` — owner=${JSON.stringify(err.owner)}`;
-        } catch { /* diagnosis must never mask the timeout it describes */ }
-        throw err;
-      }
+      if (Date.now() > deadline) throw buildTimeoutError();
       // Jitter, because a FIXED retry makes every waiter wake at the same
       // instant and re-race, and whoever loses is picked at random rather than
       // queued. With N waiters that is the coupon-collector problem: serving

--- a/tests/pipeline-lock-mkdir-eperm.test.mjs
+++ b/tests/pipeline-lock-mkdir-eperm.test.mjs
@@ -1,0 +1,69 @@
+// tests/pipeline-lock-mkdir-eperm.test.mjs — a non-EEXIST mkdir refusal is
+// contention, not a fatal error (#2777).
+//
+// mkdir's "someone else already has this" answer is not portable. POSIX gives
+// EEXIST; Windows gives EPERM/EACCES when the target is mid-flight, being
+// created or removed by another process at that instant. acquirePipelineLock
+// used to rethrow anything that was not EEXIST, so on windows-latest one of 30
+// concurrent `agent-inbox add` processes died with
+//
+//   EPERM: operation not permitted, mkdir '…\agent-inbox.md.lock.recover'
+//
+// and its queued item was never appended. Two earlier attempts at that failure
+// raised the retry budget instead (#2506, #2825), because a starving writer and
+// a writer killed by EPERM both surface as `kept=29 of 30` and only the second
+// one is a crash.
+//
+// Exercised here with a real refusal rather than a stubbed one: a parent
+// directory with no write permission makes mkdir answer EACCES, which travels
+// the same branch. The contract is that acquisition RETRIES and eventually
+// reports a LockTimeoutError naming what it kept hitting, instead of throwing
+// the raw errno straight at the caller on the first attempt.
+
+import { mkdtempSync, mkdirSync, chmodSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { pass, fail } from './helpers.mjs';
+import { acquirePipelineLock, LockTimeoutError } from '../pipeline-lock.mjs';
+
+console.log('\n🔒 pipeline-lock: a non-EEXIST mkdir refusal is contention, not fatal');
+
+// Running as root defeats permission bits entirely, so the refusal never
+// happens and a pass here would be vacuous. Skipping loudly beats asserting
+// nothing quietly.
+if (typeof process.getuid === 'function' && process.getuid() === 0) {
+  console.log('  ⏭  skipped: running as root, permission bits do not apply');
+} else {
+  const base = mkdtempSync(join(tmpdir(), 'co-lock-eperm-'));
+  const sealed = join(base, 'sealed');
+  mkdirSync(sealed);
+  const pipelinePath = join(sealed, 'pipeline.md');
+  chmodSync(sealed, 0o500); // r-x: mkdir inside is refused with EACCES
+
+  try {
+    let thrown = null;
+    try {
+      await acquirePipelineLock(pipelinePath, { timeoutMs: 300, retryMs: 20 });
+    } catch (err) {
+      thrown = err;
+    }
+
+    if (thrown instanceof LockTimeoutError) {
+      pass('a refused mkdir is retried and reported as a lock timeout, not rethrown raw');
+    } else {
+      fail(`expected LockTimeoutError after retrying, got ${thrown?.name}: ${thrown?.code ?? ''} ${thrown?.message ?? ''}`);
+    }
+
+    // The trade this makes is that a genuine permissions problem stops failing
+    // fast, so the timeout has to carry the reason or it becomes an unexplained
+    // hang. Without this the fix would swap one silent failure for another.
+    if (thrown?.lastMkdirError === 'EACCES' || thrown?.lastMkdirError === 'EPERM') {
+      pass(`the timeout names the refusal it kept hitting (${thrown.lastMkdirError})`);
+    } else {
+      fail(`timeout did not carry the mkdir errno: lastMkdirError=${JSON.stringify(thrown?.lastMkdirError)}`);
+    }
+  } finally {
+    chmodSync(sealed, 0o700);
+    rmSync(base, { recursive: true, force: true });
+  }
+}

--- a/tests/pipeline-lock-mkdir-eperm.test.mjs
+++ b/tests/pipeline-lock-mkdir-eperm.test.mjs
@@ -28,11 +28,30 @@ import { acquirePipelineLock, LockTimeoutError } from '../pipeline-lock.mjs';
 
 console.log('\n🔒 pipeline-lock: a non-EEXIST mkdir refusal is contention, not fatal');
 
-// Running as root defeats permission bits entirely, so the refusal never
-// happens and a pass here would be vacuous. Skipping loudly beats asserting
-// nothing quietly.
-if (typeof process.getuid === 'function' && process.getuid() === 0) {
-  console.log('  ⏭  skipped: running as root, permission bits do not apply');
+// Two environments cannot produce the refusal this case needs, and in both a
+// green result would mean nothing. Skipping loudly beats asserting nothing
+// quietly.
+//
+//   - root: permission bits do not apply, so mkdir simply succeeds.
+//   - win32: a POSIX mode of 0o500 does not stop directory creation there.
+//     Windows uses ACLs, `chmod` maps onto the read-only attribute, and that
+//     attribute does not deny mkdir inside the directory, so acquisition
+//     succeeds and no error is thrown at all. Measured, not assumed: this
+//     case failed on windows-latest with `got undefined` while the real
+//     Windows EPERM it defends against was already gone from the same run.
+//
+// The bug is Windows-only and the test is POSIX-only, which reads as a
+// contradiction and is not one: EACCES and EPERM meet in the same branch of
+// isMkdirContention(), so exercising either one covers the code path. What
+// cannot be reproduced anywhere on demand is Windows' *timing* window, which
+// is why this test manufactures a deterministic refusal instead of waiting
+// for a race.
+const cannotRefuse = (typeof process.getuid === 'function' && process.getuid() === 0)
+  ? 'running as root, permission bits do not apply'
+  : (process.platform === 'win32' ? 'win32: a POSIX mode cannot deny mkdir, so the refusal never happens' : null);
+
+if (cannotRefuse) {
+  console.log(`  ⏭  skipped: ${cannotRefuse}`);
 } else {
   const base = mkdtempSync(join(tmpdir(), 'co-lock-eperm-'));
   const sealed = join(base, 'sealed');


### PR DESCRIPTION
Fixes #2777. Follows #2824 / #2825 / #2834.

## The instrumentation paid off on its first Windows failure, and it was not what any of us thought

#2834 landed a few minutes ago to print the failing child's error instead of only `kept=29 of 30`. The very next `test (windows-latest)` red said:

```
↳ item-27 exited 1: Error: EPERM: operation not permitted, mkdir
  'C:\Users\RUNNER~1\AppData\Local\Temp\inbox-concurrent-SHgNgf\agent-inbox.md.lock.recover'
```

**Not a `LockTimeoutError`.** Not a starving writer. A crash.

## Root cause

`mkdir`'s "someone else already has this" answer is not portable. POSIX gives `EEXIST`; **Windows gives `EPERM`/`EACCES` when the target is mid-flight**, being created or removed by another process at that instant. `acquirePipelineLock` had:

```js
if (err?.code !== 'EEXIST') throw err;          // lock dir
if (guardErr?.code !== 'EEXIST') throw guardErr; // recover guard
```

So a transient refusal that *is* the contention this loop exists to handle propagated straight out, the writer died, and its queued line was never appended.

## Why it took three attempts to see

A starving writer and a writer killed by `EPERM` produce **the identical symptom**, `kept=29 of 30`, and only the second is a crash. #2506 added jitter, #2825 raised the budget from 8s to 30s; both were reasoning about the timeout because the timeout was the only mechanism anyone could see. My own hypothesis this evening was a third wrong one: an orphaned lock whose PID had been recycled. The log settled it in one line.

The general shape, which I would rather record than repeat: **a symptom that two different mechanisms can produce will absorb any number of fixes aimed at the wrong one.** The cheap move was never a better guess, it was making the failure say its own name.

## The change

`EPERM`/`EACCES` from `mkdir` route to the same retry path as `EEXIST`. In the guard branch they additionally back off instead of judging the staleness of a directory that could not even be created reliably.

**The trade, stated because it is real:** a genuine permissions problem no longer fails fast, it now takes `timeoutMs` and then reports. Left silent that would swap one invisible failure for another, so the timeout carries the errno it kept hitting:

```
LockTimeoutError: pipeline lock timeout: … — owner={…}, last mkdir error=EACCES on /…/pipeline.md.lock
```

## Verification

Driven by a **real** refusal rather than a stub: a parent directory with no write permission makes `mkdir` answer `EACCES`, which travels the same branch. The test skips loudly under root, where permission bits do not apply and a pass would be vacuous.

Verified by mutation, restoring the `EEXIST`-only check:

```
❌ expected LockTimeoutError after retrying, got Error: EACCES: permission denied, mkdir '…/pipeline.md.lock'
❌ timeout did not carry the mkdir errno: lastMkdirError=undefined
```

That raw throw at the caller is the Windows crash, reproduced on macOS.

Suite: **3789 passed, 0 failed**. `validate-system-paths-coverage.mjs`: exit 0, 1036 files. `pipeline-lock.mjs` is shared with scan-history, and `tests/scan-history-lock.test.mjs` plus `agent-inbox-tests.mjs` are both green.

@Scott-Emberson this is the answer to your #2824, and your reasoning there was right about everything except which errno: the budget genuinely was short at 8s, it just was not what killed this one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform handling when concurrent processes contend for a pipeline lock.
  * Temporary permission-related lock failures are now retried instead of failing immediately.
  * Lock timeout errors now include clearer ownership and recent failure details.

* **Tests**
  * Added regression coverage for permission-denied lock acquisition scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->