### PR TITLE
fix(scan-ats-full): single-host ATSs swept at 20 concurrent get throttled

### DIFF
--- a/scan-ats-full.mjs
+++ b/scan-ats-full.mjs
@@ -61,7 +61,21 @@ const CACHE_TTL_HOURS = 24;
 // careers_url and drops anything that doesn't resolve to the ATS's own host —
 // so a tampered dataset can at worst name boards that don't exist.
 const DATASET_BASE = 'https://raw.githubusercontent.com/Feashliaa/job-board-aggregator/main/data';
+
+// Default fan-out. Correct for sources whose boards each live on their OWN
+// host — workday is {tenant}.{instance}.myworkdayjobs.com, so 20 in flight is
+// 20 different servers and the resolver, not any one vendor, is the limit.
 const CONCURRENCY = 20;
+
+// Greenhouse, Lever and Ashby each serve their ENTIRE directory from a single
+// hostname (boards-api.greenhouse.io, api.lever.co, api.ashbyhq.com), so the
+// default is 20 sustained connections to ONE API across thousands of boards.
+// That earns an HTTP throttle, and a throttled sweep loses live boards rather
+// than failing loudly: two full sweeps an hour apart saw lever's unreachable
+// count go 2,436 -> 4,100 and ashby's 683 -> 1,675, then recover to 2,525 / 684
+// after a cooldown with no change to the dataset. The boards were never dead —
+// they were refused, and the matches on them were silently missed.
+const SINGLE_HOST_CONCURRENCY = 6;
 // A refusing resolver fails every lookup in milliseconds, so a sweep that
 // keeps going just feeds it (#2229). Stop after this many consecutive
 // resolver-level failures — high enough that a handful of unlucky boards
@@ -157,6 +171,8 @@ export function entryOnHost(name, careersUrl, isCanonicalHost) {
 export const SOURCES = {
   greenhouse: {
     provider: greenhouse,
+    // Whole directory behind one host — see SINGLE_HOST_CONCURRENCY.
+    concurrency: SINGLE_HOST_CONCURRENCY,
     dataset: `${DATASET_BASE}/greenhouse_companies.json`,
     toEntry: (slug) => SLUG_RE.test(String(slug))
       ? entryOnHost(String(slug), `https://job-boards.greenhouse.io/${slug}`, h => h === 'job-boards.greenhouse.io')
@@ -164,6 +180,8 @@ export const SOURCES = {
   },
   lever: {
     provider: lever,
+    // Whole directory behind one host — see SINGLE_HOST_CONCURRENCY.
+    concurrency: SINGLE_HOST_CONCURRENCY,
     dataset: `${DATASET_BASE}/lever_companies.json`,
     toEntry: (slug) => SLUG_RE.test(String(slug))
       ? entryOnHost(String(slug), `https://jobs.lever.co/${slug}`, h => h === 'jobs.lever.co')
@@ -171,6 +189,8 @@ export const SOURCES = {
   },
   ashby: {
     provider: ashby,
+    // Whole directory behind one host — see SINGLE_HOST_CONCURRENCY.
+    concurrency: SINGLE_HOST_CONCURRENCY,
     dataset: `${DATASET_BASE}/ashby_companies.json`,
     toEntry: (slug) => SLUG_RE.test(String(slug))
       ? entryOnHost(String(slug), `https://jobs.ashbyhq.com/${slug}`, h => h === 'jobs.ashbyhq.com')
@@ -773,7 +793,7 @@ async function main() {
     let lastDone = 0;
     let lastResumeAt = 0;
     const truncated = [];
-    await parallelEach(entries, CONCURRENCY, async (entry) => {
+    await parallelEach(entries, source.concurrency ?? CONCURRENCY, async (entry) => {
       try {
         // The whole per-company unit — fetch AND processJobs (which may issue
         // per-job detail-page requests via provider.enrichDate) — runs inside


### PR DESCRIPTION
## The bug

`scan-ats-full.mjs` sweeps every source at `CONCURRENCY = 20`. That is the right number for Workday and iCIMS, where each board lives on its own host (`{tenant}.{instance}.myworkdayjobs.com`, `careers-{slug}.icims.com`) — 20 in flight is 20 different servers.

Greenhouse, Lever and Ashby are not like that. Each serves its **entire directory from a single hostname**:

| Source | Host | Boards in dataset |
|---|---|---|
| greenhouse | `boards-api.greenhouse.io` | 8,333 |
| lever | `api.lever.co` | 4,368 |
| ashby | `api.ashbyhq.com` | 3,161 |
| workday | `{tenant}.{instance}.myworkdayjobs.com` | 12,884 (distinct hosts) |
| icims | `careers-{slug}.icims.com` | distinct hosts |

So for those three, the sweep holds 20 sustained connections against one API for thousands of consecutive requests. That earns a throttle — and the failure is silent, because a refused board is counted the same as a board that does not exist.

## Evidence

Two full sweeps roughly an hour apart, same 24h-cached dataset, nothing else changed:

| | sweep 1 | sweep 2 (immediately after) | after a cooldown |
|---|---|---|---|
| lever unreachable | 2,436 | **4,100** | 2,525 |
| ashby unreachable | 683 | **1,675** | 684 |

Ashby returned to 684 against a first-run 683 — one board apart. Those ~2,650 boards were never dead; they were refused, and every posting on them was missed for that sweep. In my own run the throttled sweep missed a live Senior Android Engineer posting that the cooled-down rerun found.

A `--verbose` run confirms the steady-state failures are genuine 404s rather than refusals, which is what the recovered numbers should look like:

```
2,376  HTTP 404 Not Found   (lever)
  684  HTTP 404             (ashby)
  149  operation aborted    (lever — timeouts on very large boards)
```

## The fix

Give each source its own concurrency and drop the single-host three to 6, leaving Workday and iCIMS at 20:

```js
const CONCURRENCY = 20;              // per-tenant hosts: workday, icims
const SINGLE_HOST_CONCURRENCY = 6;   // whole directory behind one host
```

`parallelEach(entries, source.concurrency ?? CONCURRENCY, ...)` — sources without the field are unaffected, so this is additive.

## Trade-off

The single-host sources take longer in wall-clock terms at 6 than at 20. That is the intended trade: a slower sweep that reads every board beats a faster one that silently drops thousands of them, since the whole point of the reverse scan is coverage. 6 is deliberately conservative rather than tuned — it is one constant, and if a vendor demonstrably tolerates more it can be raised without touching the structure.

## Testing

- `node test-all.mjs` — full suite green
- Verified against live sweeps: greenhouse unreachable 3,025 / 3,010 (at 20) → 3,004 (at 6), no regression
- No new files, no new dependencies, no data-format change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved scanning reliability for ATS providers that share a host by limiting concurrent requests.
  * Preserved higher concurrency for sources that are not subject to shared-host limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->