### PR TITLE
fix: themuse retry, scan --help, dashboard sentinel score, i18n guardrails (#2681 #2717 #2756 #2803 #2270 #2758 #2395)

### DIFF
--- a/dashboard/internal/data/career.go
+++ b/dashboard/internal/data/career.go
@@ -108,10 +108,13 @@ func ParseApplications(careerOpsPath string) []model.CareerApplication {
 			HasPDF:  strings.Contains(at("pdf"), "\u2705"),
 		}
 
-		// Parse score from the Score column.
+		// Parse score from the Score column. HasScore distinguishes a genuine
+		// numeric score from a sentinel (—, N/A, -) so the renderer and sorter
+		// can treat unevaluated rows correctly (#2758).
 		app.ScoreRaw = at("score")
 		if sm := reScoreValue.FindStringSubmatch(at("score")); sm != nil {
 			app.Score, _ = strconv.ParseFloat(sm[1], 64)
+			app.HasScore = true
 		}
 
 		// Parse report link. Tracker links are written relative to the

--- a/dashboard/internal/data/career_test.go
+++ b/dashboard/internal/data/career_test.go
@@ -539,3 +539,62 @@ func TestUpdateApplicationStatusRefusesUnrecognizableCell(t *testing.T) {
 		t.Errorf("file was modified despite refusal, now:\n%s", string(out))
 	}
 }
+
+// TestHasScoreDistinguishesSentinelFromNumeric verifies that HasScore is true
+// for rows with a numeric score and false for the three AGENTS.md sentinels
+// (—, N/A, -), so the renderer never displays "0.0" for unevaluated rows
+// (#2758).
+func TestHasScoreDistinguishesSentinelFromNumeric(t *testing.T) {
+	tempDir := t.TempDir()
+	dataDir := filepath.Join(tempDir, "data")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatalf("failed to create data dir: %v", err)
+	}
+
+	tracker := `# Applications Tracker
+
+| # | Date | Company | Role | Score | Status | PDF | Report | Notes |
+|---|------|---------|------|-------|--------|-----|--------|-------|
+| 1 | 2026-06-01 | Acme | Engineer | 4.2/5 | Applied | ✅ | [1](reports/001.md) | scored |
+| 2 | 2026-06-02 | Beta | Designer | — | Applied | ❌ | [2](reports/002.md) | em dash sentinel |
+| 3 | 2026-06-03 | Gamma | PM | N/A | Applied | ❌ | [3](reports/003.md) | N/A sentinel |
+| 4 | 2026-06-04 | Delta | CTO | - | Applied | ❌ | [4](reports/004.md) | hyphen sentinel |
+`
+	path := filepath.Join(dataDir, "applications.md")
+	if err := os.WriteFile(path, []byte(tracker), 0o644); err != nil {
+		t.Fatalf("failed to write tracker: %v", err)
+	}
+
+	apps := ParseApplications(tempDir)
+	if len(apps) != 4 {
+		t.Fatalf("expected 4 apps, got %d", len(apps))
+	}
+
+	// Row 1: numeric score — HasScore must be true and Score populated.
+	if !apps[0].HasScore {
+		t.Errorf("app[0] (4.2/5): HasScore = false, want true")
+	}
+	if apps[0].Score != 4.2 {
+		t.Errorf("app[0] Score = %v, want 4.2", apps[0].Score)
+	}
+
+	// Rows 2-4: sentinels — HasScore must be false and Score must be zero.
+	sentinelRows := []struct {
+		index    int
+		company  string
+		scoreRaw string
+	}{
+		{1, "Beta", "—"},
+		{2, "Gamma", "N/A"},
+		{3, "Delta", "-"},
+	}
+	for _, row := range sentinelRows {
+		app := apps[row.index]
+		if app.HasScore {
+			t.Errorf("app[%d] (%s, raw=%q): HasScore = true, want false (sentinel must not set HasScore)", row.index, row.company, row.scoreRaw)
+		}
+		if app.Score != 0 {
+			t.Errorf("app[%d] (%s): Score = %v, want 0 (sentinel must leave Score at zero)", row.index, row.company, app.Score)
+		}
+	}
+}

--- a/dashboard/internal/model/career.go
+++ b/dashboard/internal/model/career.go
@@ -8,6 +8,7 @@ type CareerApplication struct {
 	Role         string
 	Status       string
 	Score        float64
+	HasScore     bool   // false when ScoreRaw holds a sentinel (—, N/A, -) rather than a numeric score
 	ScoreRaw     string
 	HasPDF       bool
 	ReportPath   string

--- a/dashboard/internal/ui/screens/pipeline.go
+++ b/dashboard/internal/ui/screens/pipeline.go
@@ -1203,7 +1203,14 @@ func (m PipelineModel) sortLess() func(a, b model.CareerApplication) bool {
 		// Most recent contact first; empty dates sink to the bottom.
 		return func(a, b model.CareerApplication) bool { return a.LastContact > b.LastContact }
 	default: // sortScore
-		return func(a, b model.CareerApplication) bool { return a.Score > b.Score }
+		// Unevaluated rows (HasScore == false) float to the top — "needs
+		// evaluating" is more actionable than "scored badly" (#2758).
+		return func(a, b model.CareerApplication) bool {
+			if a.HasScore != b.HasScore {
+				return !a.HasScore // unscored first
+			}
+			return a.Score > b.Score
+		}
 	}
 }
 
@@ -1680,9 +1687,20 @@ func (m PipelineModel) renderAppLine(app model.CareerApplication, selected bool)
 	}
 	numStyle := lipgloss.NewStyle().Foreground(m.theme.Blue).Bold(true).Width(cw.num)
 
-	// Score with color
-	scoreStyle := m.scoreStyle(app.Score)
-	score := scoreStyle.Render(fmt.Sprintf("%.1f", app.Score))
+	// Score with color. Unevaluated rows (sentinel — / N/A / -) render dimmed
+	// rather than as "0.0", which is indistinguishable from a genuine zero (#2758).
+	var score string
+	if app.HasScore {
+		scoreStyle := m.scoreStyle(app.Score)
+		score = scoreStyle.Render(fmt.Sprintf("%.1f", app.Score))
+	} else {
+		sentinelStyle := lipgloss.NewStyle().Foreground(m.theme.Subtext)
+		raw := app.ScoreRaw
+		if raw == "" {
+			raw = "—"
+		}
+		score = sentinelStyle.Render(raw)
+	}
 
 	// Company (truncate)
 	company := truncateRunes(app.Company, cw.company)

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -333,9 +333,12 @@ function mergeNotes(existingNotes, addition, oldScore, newScore, extraMarker = '
     ? ''
     : prevRaw.replace(/\s*\.\s*$/, '');
   const incoming = String(addition.notes ?? '').trim();
+  const scoreArrow = newScore === null
+    ? `${oldScore ?? '—'} (score preserved — N/A re-eval)`
+    : `${oldScore ?? '—'}→${newScore}`;
   const marker = extraMarker
-    ? `Re-eval ${addition.date} (${oldScore}→${newScore}) — ${extraMarker}`
-    : `Re-eval ${addition.date} (${oldScore}→${newScore})`;
+    ? `Re-eval ${addition.date} (${scoreArrow}) — ${extraMarker}`
+    : `Re-eval ${addition.date} (${scoreArrow})`;
   // Re-running the same evaluation would otherwise repeat its own text; the
   // marker still records that the re-evaluation happened. Repeats are detected
   // per CLAUSE — the same '. ' separator this function joins with — not by raw
@@ -359,11 +362,14 @@ function mergeNotes(existingNotes, addition, oldScore, newScore, extraMarker = '
  * details, so only the first numeric value is used.
  *
  * @param {string} s - Raw score cell such as `4.2/5`.
- * @returns {number} Parsed score, or 0 when no numeric value is present.
+ * @returns {number | null} Parsed score, or null when no numeric value is present
+ *   (sentinel values like N/A, —, -). Returning null instead of 0 lets callers
+ *   distinguish "no score" from a genuine 0, preventing N/A re-evaluations from
+ *   overwriting real scores in the duplicate-update path (#2803).
  */
 function parseScore(s) {
   const m = s.replace(/\*\*/g, '').match(/([\d.]+)/);
-  return m ? parseFloat(m[1]) : 0;
+  return m ? parseFloat(m[1]) : null;
 }
 
 /**
@@ -1044,20 +1050,29 @@ for (const file of tsvFiles) {
     // merged/ as if it had landed (#2411). Equal scores write through too, since
     // the notes and report link are still fresher than what the row holds.
     //
+    // EXCEPTION: an unscoreable incoming row (N/A / — / - sentinel, giving
+    // newScore === null) must never overwrite a real score — null means the
+    // fetch failed, not that the evaluation produced a lower number. Status,
+    // notes, report link, PDF, and date still write through; only the score
+    // cell is preserved from the existing row (#2803).
+    //
     // Because the fuzzy matcher can mis-pair genuinely different roles (see
     // role-matcher.mjs — "Senior" is a stopword and short tokens are dropped), a
     // downgrade records the superseded report number so a bad match stays
     // recoverable from the tracker alone. mergeNotes() keeps the existing cell
     // verbatim and first, so a second downgrade preserves the earlier marker
     // rather than overwriting it.
-    const downgrade = newScore < oldScore;
+    const downgrade = newScore !== null && oldScore !== null && newScore < oldScore;
     const oldReportNum = extractReportNum(duplicate.report);
     const supersededNote = downgrade && oldReportNum && oldReportNum !== reportNum
       ? `Superseded report [${oldReportNum}] (was ${oldScore}/5)`
       : '';
 
+    const scoreDisplay = newScore === null
+      ? `${oldScore ?? '—'} (preserved — incoming N/A)`
+      : `${oldScore ?? '—'}→${newScore}`;
     console.log(
-      `${downgrade ? '🔽' : '🔄'} Update: #${duplicate.num} ${addition.company} — ${addition.role} (${oldScore}→${newScore})`
+      `${downgrade ? '🔽' : '🔄'} Update: #${duplicate.num} ${addition.company} — ${addition.role} (${scoreDisplay})`
       + (downgrade ? ' — DOWNGRADE, re-eval scored lower' : ''),
     );
     // The PDF flag describes THE ROW'S REPORT, and this branch replaces that
@@ -1085,7 +1100,11 @@ for (const file of tsvFiles) {
       role: (reportNumMatched || dupReason === 'url') ? addition.role : duplicate.role,
       via: addition.via || duplicate.via || '—',
       location: addition.location || duplicate.location || '—',
-      score: addition.score, status: duplicate.status, pdf,
+      // Preserve the existing score when the incoming one is unscoreable (N/A /
+      // — / sentinel); see parseScore and #2803. Everything else (status, notes,
+      // report link, PDF, date) still writes through from the re-evaluation.
+      score: newScore === null ? duplicate.score : addition.score,
+      status: duplicate.status, pdf,
       report: addition.report,
       notes: mergeNotes(duplicate.notes, addition, oldScore, newScore, supersededNote),
       // Carry the key forward. Without this the update path rewrites the row

--- a/modes/_shared.md
+++ b/modes/_shared.md
@@ -29,7 +29,9 @@ See "Untrusted External Content" in `AGENTS.md` / `CLAUDE.md` / `CODEX.md` for t
 **RULE: For article/project metrics, article-digest.md takes precedence over cv.md.**
 **RULE: Read _profile.md AFTER this file. User customizations in _profile.md override defaults here.**
 **RULE: Read _custom.md (if it exists) AFTER _profile.md and honor its house rules in every mode.** It is where the user's persistent instructions live ("use this date format", "never reorder section X", "always include Y in summaries") — an instruction recorded there is NOT optional and does not expire between sessions or between items in a batch. It can override workflow/style/procedural defaults, but it never introduces factual claims about the candidate. When the user states a lasting preference in conversation, write it to `modes/_custom.md` so it survives the session.
+<!-- guardrail:authorship -->
 **RULE: NEVER claim the user authored a project, repo, library, tool, framework, or open-source artefact unless explicitly attributed to them in cv.md or article-digest.md.** Tool-of-trade conflation (user uses X → user built X) is the most common fabrication pattern and is forbidden.
+<!-- guardrail:no-fabrication -->
 **RULE: Keywords get reformulated, never fabricated.** Reorder, reframe, emphasise — but never invent. If a claim isn't backed by an in-scope file, ask the user. If no answer, omit. Silence on a topic beats manufactured detail.
 
 ---

--- a/modes/ar/_shared.md
+++ b/modes/ar/_shared.md
@@ -22,6 +22,11 @@
 **قاعدة: بالنسبة للمشاريع والمقالات، يكون لملف article-digest.md الأولوية على cv.md.**
 **قاعدة: اقرأ ملف _profile.md بعد قراءة هذا الملف. إعدادات وتخصيصات المستخدم في _profile.md تلغي وتتفوق على الإعدادات الافتراضية هنا.**
 
+<!-- guardrail:authorship -->
+**RULE: NEVER claim the user authored a project, repo, library, tool, framework, or open-source artefact unless explicitly attributed to them in cv.md or article-digest.md.** Tool-of-trade conflation (user uses X → user built X) is the most common fabrication pattern and is forbidden.
+<!-- guardrail:no-fabrication -->
+**RULE: Keywords get reformulated, never fabricated.** Reorder, reframe, emphasise — but never invent. If a claim isn't backed by an in-scope file, ask the user. If no answer, omit. Silence on a topic beats manufactured detail.
+
 ---
 
 ## نظام التقييم (Scoring System)

--- a/modes/da/_shared.md
+++ b/modes/da/_shared.md
@@ -22,6 +22,11 @@
 **REGEL: Aldrig hardcode metrics fra proof points.** Læs dem fra `cv.md` og `article-digest.md` på evalueringstidspunktet.
 **REGEL: For metrics om artikler/projekter har `article-digest.md` forrang frem for `cv.md`** (`cv.md` kan indeholde ældre tal).
 
+<!-- guardrail:authorship -->
+**RULE: NEVER claim the user authored a project, repo, library, tool, framework, or open-source artefact unless explicitly attributed to them in cv.md or article-digest.md.** Tool-of-trade conflation (user uses X → user built X) is the most common fabrication pattern and is forbidden.
+<!-- guardrail:no-fabrication -->
+**RULE: Keywords get reformulated, never fabricated.** Reorder, reframe, emphasise — but never invent. If a claim isn't backed by an in-scope file, ask the user. If no answer, omit. Silence on a topic beats manufactured detail.
+
 ---
 
 ## North Star -- Målroller

--- a/modes/de/_shared.md
+++ b/modes/de/_shared.md
@@ -22,6 +22,11 @@
 **REGEL: Niemals Kennzahlen aus Proof Points hartcodieren.** Lies sie zur Bewertungszeit aus `cv.md` und `article-digest.md`.
 **REGEL: Bei Kennzahlen zu Artikeln/Projekten hat `article-digest.md` Vorrang vor `cv.md`** (in `cv.md` können ältere Zahlen stehen).
 
+<!-- guardrail:authorship -->
+**RULE: NEVER claim the user authored a project, repo, library, tool, framework, or open-source artefact unless explicitly attributed to them in cv.md or article-digest.md.** Tool-of-trade conflation (user uses X → user built X) is the most common fabrication pattern and is forbidden.
+<!-- guardrail:no-fabrication -->
+**RULE: Keywords get reformulated, never fabricated.** Reorder, reframe, emphasise — but never invent. If a claim isn't backed by an in-scope file, ask the user. If no answer, omit. Silence on a topic beats manufactured detail.
+
 ---
 
 ## North Star -- Zielrollen

--- a/modes/es/_shared.md
+++ b/modes/es/_shared.md
@@ -22,6 +22,11 @@
 **REGLA: NUNCA codificar métricas de los proof points en duro.** Leerlas desde `cv.md` y `article-digest.md` en el momento de la evaluación.
 **REGLA: Para métricas de artículos/proyectos, `article-digest.md` tiene prioridad sobre `cv.md`** (`cv.md` puede contener cifras más antiguas).
 
+<!-- guardrail:authorship -->
+**RULE: NEVER claim the user authored a project, repo, library, tool, framework, or open-source artefact unless explicitly attributed to them in cv.md or article-digest.md.** Tool-of-trade conflation (user uses X → user built X) is the most common fabrication pattern and is forbidden.
+<!-- guardrail:no-fabrication -->
+**RULE: Keywords get reformulated, never fabricated.** Reorder, reframe, emphasise — but never invent. If a claim isn't backed by an in-scope file, ask the user. If no answer, omit. Silence on a topic beats manufactured detail.
+
 ---
 
 ## North Star -- Roles objetivo

--- a/modes/fr/_shared.md
+++ b/modes/fr/_shared.md
@@ -22,6 +22,11 @@
 **REGLE : Ne JAMAIS coder en dur des metriques issues des proof points.** Les lire depuis `cv.md` et `article-digest.md` au moment de l'evaluation.
 **REGLE : Pour les metriques d'articles/projets, `article-digest.md` a priorite sur `cv.md`** (`cv.md` peut contenir des chiffres plus anciens).
 
+<!-- guardrail:authorship -->
+**RULE: NEVER claim the user authored a project, repo, library, tool, framework, or open-source artefact unless explicitly attributed to them in cv.md or article-digest.md.** Tool-of-trade conflation (user uses X → user built X) is the most common fabrication pattern and is forbidden.
+<!-- guardrail:no-fabrication -->
+**RULE: Keywords get reformulated, never fabricated.** Reorder, reframe, emphasise — but never invent. If a claim isn't backed by an in-scope file, ask the user. If no answer, omit. Silence on a topic beats manufactured detail.
+
 ---
 
 ## North Star -- Roles cibles

--- a/modes/hi/_shared.md
+++ b/modes/hi/_shared.md
@@ -22,6 +22,11 @@
 **नियम: proof points की metrics को कभी hardcode न करें।** इन्हें मूल्यांकन के समय `cv.md` और `article-digest.md` से पढ़ें।
 **नियम: article/project metrics के लिए, `article-digest.md` को `cv.md` से प्राथमिकता दें** (`cv.md` में पुराने आंकड़े हो सकते हैं)।
 
+<!-- guardrail:authorship -->
+**RULE: NEVER claim the user authored a project, repo, library, tool, framework, or open-source artefact unless explicitly attributed to them in cv.md or article-digest.md.** Tool-of-trade conflation (user uses X → user built X) is the most common fabrication pattern and is forbidden.
+<!-- guardrail:no-fabrication -->
+**RULE: Keywords get reformulated, never fabricated.** Reorder, reframe, emphasise — but never invent. If a claim isn't backed by an in-scope file, ask the user. If no answer, omit. Silence on a topic beats manufactured detail.
+
 ---
 
 ## North Star -- लक्षित भूमिकाएं

--- a/modes/id/_shared.md
+++ b/modes/id/_shared.md
@@ -22,6 +22,11 @@
 **ATURAN: JANGAN PERNAH menuliskan metrik dari proof point secara hardcode.** Baca metrik dari `cv.md` dan `article-digest.md` pada saat evaluasi.
 **ATURAN: Untuk metrik artikel/proyek, `article-digest.md` lebih diutamakan daripada `cv.md`** (`cv.md` bisa memuat angka yang lebih lama).
 
+<!-- guardrail:authorship -->
+**RULE: NEVER claim the user authored a project, repo, library, tool, framework, or open-source artefact unless explicitly attributed to them in cv.md or article-digest.md.** Tool-of-trade conflation (user uses X → user built X) is the most common fabrication pattern and is forbidden.
+<!-- guardrail:no-fabrication -->
+**RULE: Keywords get reformulated, never fabricated.** Reorder, reframe, emphasise — but never invent. If a claim isn't backed by an in-scope file, ask the user. If no answer, omit. Silence on a topic beats manufactured detail.
+
 ---
 
 ## North Star -- Role target

--- a/modes/it/_shared.md
+++ b/modes/it/_shared.md
@@ -22,6 +22,11 @@
 **REGOLA: Non hardcodare MAI metriche provenienti dai proof point.** Leggerle da `cv.md` e `article-digest.md` al momento della valutazione.
 **REGOLA: Per metriche di articoli/progetti, `article-digest.md` ha priorità su `cv.md`** (`cv.md` può contenere dati meno recenti).
 
+<!-- guardrail:authorship -->
+**RULE: NEVER claim the user authored a project, repo, library, tool, framework, or open-source artefact unless explicitly attributed to them in cv.md or article-digest.md.** Tool-of-trade conflation (user uses X → user built X) is the most common fabrication pattern and is forbidden.
+<!-- guardrail:no-fabrication -->
+**RULE: Keywords get reformulated, never fabricated.** Reorder, reframe, emphasise — but never invent. If a claim isn't backed by an in-scope file, ask the user. If no answer, omit. Silence on a topic beats manufactured detail.
+
 ---
 
 ## North Star -- Ruoli target

--- a/modes/ja/_shared.md
+++ b/modes/ja/_shared.md
@@ -25,7 +25,9 @@
 **ルール：proof point のメトリクスを絶対にハードコードしない。** 評価時に `cv.md` と `article-digest.md` から読み取ること。
 **ルール：記事・プロジェクトのメトリクスは、`article-digest.md` が `cv.md` より優先される。**
 **ルール：このファイルの後に `_profile.md` を読む。`_profile.md` のユーザーカスタマイズはここのデフォルト値を上書きする。**
+<!-- guardrail:authorship -->
 **ルール：`cv.md` または `article-digest.md` で明示されていない限り、ユーザーが project、repo、library、tool、framework、open-source artifact を authored したと主張してはならない。** 「使ったツール」を「作ったもの」と混同するのが最も多い捏造パターンであり、禁止。
+<!-- guardrail:no-fabrication -->
 **ルール：Keywords get reformulated, never fabricated.** 並べ替える、言い換える、強調するのはよい。ただし発明しない。根拠が in-scope file にない claim はユーザーに確認する。答えがない場合は省く。沈黙は捏造よりよい。
 
 ---

--- a/modes/ko/_shared.md
+++ b/modes/ko/_shared.md
@@ -22,6 +22,11 @@
 **규칙: proof point의 metric을 절대 하드코딩하지 않습니다.** 평가 시점에 `cv.md`와 `article-digest.md`에서 읽습니다.
 **규칙: article/project metric은 `article-digest.md`가 `cv.md`보다 우선합니다** (`cv.md`에는 더 오래된 수치가 있을 수 있음).
 
+<!-- guardrail:authorship -->
+**RULE: NEVER claim the user authored a project, repo, library, tool, framework, or open-source artefact unless explicitly attributed to them in cv.md or article-digest.md.** Tool-of-trade conflation (user uses X → user built X) is the most common fabrication pattern and is forbidden.
+<!-- guardrail:no-fabrication -->
+**RULE: Keywords get reformulated, never fabricated.** Reorder, reframe, emphasise — but never invent. If a claim isn't backed by an in-scope file, ask the user. If no answer, omit. Silence on a topic beats manufactured detail.
+
 ---
 
 ## North Star -- 목표 역할

--- a/modes/nl/_shared.md
+++ b/modes/nl/_shared.md
@@ -29,7 +29,9 @@ Alleen de onderstaande bestanden mogen worden gebruikt voor kandidaatgerichte in
 **REGEL: Voor artikel-/projectmetrics heeft `article-digest.md` voorrang op `cv.md`.**
 **REGEL: Lees `_profile.md` NA dit bestand; persoonlijke instellingen daarin hebben voorrang op de standaardwaarden hier.**
 **REGEL: Lees `_custom.md` (indien aanwezig) NA `_profile.md` en volg die blijvende procedurele regels in elke modus. `_custom.md` mag geen nieuwe feitelijke claims over de kandidaat introduceren.**
+<!-- guardrail:authorship -->
 **REGEL: Schrijf een project, repository, library, tool of framework alleen aan de gebruiker toe als `cv.md` of `article-digest.md` dat expliciet ondersteunt.**
+<!-- guardrail:no-fabrication -->
 **REGEL: Herformuleer trefwoorden, maar verzin ze nooit. Als een claim niet door een toegestane bron wordt ondersteund, vraag het de gebruiker of laat de claim weg.**
 
 ---

--- a/modes/pl/_shared.md
+++ b/modes/pl/_shared.md
@@ -22,6 +22,11 @@
 **REGUŁA: NIGDY nie zakodowuj na sztywno metryk pochodzących z proof points.** Czytaj je z `cv.md` i `article-digest.md` w momencie oceny.
 **REGUŁA: Dla metryk z artykułów/projektów `article-digest.md` ma priorytet nad `cv.md`** (`cv.md` może zawierać starsze liczby).
 
+<!-- guardrail:authorship -->
+**RULE: NEVER claim the user authored a project, repo, library, tool, framework, or open-source artefact unless explicitly attributed to them in cv.md or article-digest.md.** Tool-of-trade conflation (user uses X → user built X) is the most common fabrication pattern and is forbidden.
+<!-- guardrail:no-fabrication -->
+**RULE: Keywords get reformulated, never fabricated.** Reorder, reframe, emphasise — but never invent. If a claim isn't backed by an in-scope file, ask the user. If no answer, omit. Silence on a topic beats manufactured detail.
+
 ---
 
 ## North Star -- Docelowe role

--- a/modes/pt/_shared.md
+++ b/modes/pt/_shared.md
@@ -21,6 +21,11 @@
 **REGRA: Para métricas de artigos/projetos, `article-digest.md` tem prioridade sobre `cv.md`** (`cv.md` pode conter números desatualizados).
 **REGRA: Leia `_profile.md` DEPOIS deste arquivo. As personalizações do usuário em `_profile.md` sobrescrevem os valores padrão aqui.**
 
+<!-- guardrail:authorship -->
+**RULE: NEVER claim the user authored a project, repo, library, tool, framework, or open-source artefact unless explicitly attributed to them in cv.md or article-digest.md.** Tool-of-trade conflation (user uses X → user built X) is the most common fabrication pattern and is forbidden.
+<!-- guardrail:no-fabrication -->
+**RULE: Keywords get reformulated, never fabricated.** Reorder, reframe, emphasise — but never invent. If a claim isn't backed by an in-scope file, ask the user. If no answer, omit. Silence on a topic beats manufactured detail.
+
 ---
 
 ## Sistema de Pontuação

--- a/modes/ru/_shared.md
+++ b/modes/ru/_shared.md
@@ -31,6 +31,11 @@
 **ПРАВИЛО: НИКОГДА не приписывать пользователю авторство проекта, репозитория, библиотеки, инструмента, фреймворка или open-source артефакта, если это явно не подтверждено в `cv.md` или `article-digest.md`. Пользоваться инструментом — не значит создать его.**
 **ПРАВИЛО: Переформулировать ключевые слова, но никогда их не выдумывать. Если утверждение о кандидате не подкреплено разрешённым источником — спросить пользователя; нет ответа — опустить. Молчание по теме лучше выдуманной детали.**
 
+<!-- guardrail:authorship -->
+**RULE: NEVER claim the user authored a project, repo, library, tool, framework, or open-source artefact unless explicitly attributed to them in cv.md or article-digest.md.** Tool-of-trade conflation (user uses X → user built X) is the most common fabrication pattern and is forbidden.
+<!-- guardrail:no-fabrication -->
+**RULE: Keywords get reformulated, never fabricated.** Reorder, reframe, emphasise — but never invent. If a claim isn't backed by an in-scope file, ask the user. If no answer, omit. Silence on a topic beats manufactured detail.
+
 ---
 
 ## North Star — Целевые роли

--- a/modes/tr/_shared.md
+++ b/modes/tr/_shared.md
@@ -21,6 +21,11 @@
 **KURAL: Makale/proje metrikleri için `article-digest.md`, `cv.md`'ye göre önceliklidir.**
 **KURAL: `_profile.md`'yi bu dosyadan SONRA oku. Kullanıcının `_profile.md`'deki özelleştirmeleri buradaki varsayılanları geçersiz kılar.**
 
+<!-- guardrail:authorship -->
+**RULE: NEVER claim the user authored a project, repo, library, tool, framework, or open-source artefact unless explicitly attributed to them in cv.md or article-digest.md.** Tool-of-trade conflation (user uses X → user built X) is the most common fabrication pattern and is forbidden.
+<!-- guardrail:no-fabrication -->
+**RULE: Keywords get reformulated, never fabricated.** Reorder, reframe, emphasise — but never invent. If a claim isn't backed by an in-scope file, ask the user. If no answer, omit. Silence on a topic beats manufactured detail.
+
 ---
 
 ## Puanlama Sistemi

--- a/modes/ua/_shared.md
+++ b/modes/ua/_shared.md
@@ -31,6 +31,11 @@
 **ПРАВИЛО: НІКОЛИ не приписувати користувачеві авторство проєкту, репозиторію, бібліотеки, інструмента, фреймворку чи open-source артефакту, якщо це явно не підтверджено в `cv.md` або `article-digest.md`. Користуватися інструментом — не означає створити його.**
 **ПРАВИЛО: Переформульовувати ключові слова, але ніколи їх не вигадувати. Якщо твердження про кандидата не підкріплене дозволеним джерелом — запитати користувача; немає відповіді — не згадувати. Мовчання про тему краще за вигадану деталь.**
 
+<!-- guardrail:authorship -->
+**RULE: NEVER claim the user authored a project, repo, library, tool, framework, or open-source artefact unless explicitly attributed to them in cv.md or article-digest.md.** Tool-of-trade conflation (user uses X → user built X) is the most common fabrication pattern and is forbidden.
+<!-- guardrail:no-fabrication -->
+**RULE: Keywords get reformulated, never fabricated.** Reorder, reframe, emphasise — but never invent. If a claim isn't backed by an in-scope file, ask the user. If no answer, omit. Silence on a topic beats manufactured detail.
+
 ---
 
 ## Система оцінювання

--- a/modes/update.md
+++ b/modes/update.md
@@ -42,7 +42,7 @@ Present to the user as a clear summary:
 > - Other: {N} files changed
 >
 > **Changelog:**
-> {changelog from update-system.mjs check output}
+> {If changelog is non-empty, render it here. If changelog is empty (git ls-remote fallback — curl-blocked machine), write: "*(changelog unavailable — release notes require network access to GitHub API)*" instead of leaving a blank blockquote line.}
 >
 > Your personal files (CV, profile, tracker, reports) will NOT be touched.
 

--- a/modes/zh-TW/_shared.md
+++ b/modes/zh-TW/_shared.md
@@ -21,6 +21,11 @@
 **規則：關於文章與專案指標，`article-digest.md` 的優先權高於 `cv.md`。**
 **規則：一律在讀完本檔之後才讀 `_profile.md`。`_profile.md` 中的使用者自訂內容會覆蓋此處的預設值。**
 
+<!-- guardrail:authorship -->
+**RULE: NEVER claim the user authored a project, repo, library, tool, framework, or open-source artefact unless explicitly attributed to them in cv.md or article-digest.md.** Tool-of-trade conflation (user uses X → user built X) is the most common fabrication pattern and is forbidden.
+<!-- guardrail:no-fabrication -->
+**RULE: Keywords get reformulated, never fabricated.** Reorder, reframe, emphasise — but never invent. If a claim isn't backed by an in-scope file, ask the user. If no answer, omit. Silence on a topic beats manufactured detail.
+
 ---
 
 ## 評分系統 (Scoring System)

--- a/modes/zh/_shared.md
+++ b/modes/zh/_shared.md
@@ -21,6 +21,11 @@
 **规则：对于文章和项目指标，`article-digest.md` 的优先级高于 `cv.md`。**
 **规则：始终在此文件之后读取 `_profile.md`。`_profile.md` 中的用户自定义内容将覆盖此处的默认值。**
 
+<!-- guardrail:authorship -->
+**RULE: NEVER claim the user authored a project, repo, library, tool, framework, or open-source artefact unless explicitly attributed to them in cv.md or article-digest.md.** Tool-of-trade conflation (user uses X → user built X) is the most common fabrication pattern and is forbidden.
+<!-- guardrail:no-fabrication -->
+**RULE: Keywords get reformulated, never fabricated.** Reorder, reframe, emphasise — but never invent. If a claim isn't backed by an in-scope file, ask the user. If no answer, omit. Silence on a topic beats manufactured detail.
+
 ---
 
 ## 评分系统 (Scoring System)

--- a/providers/themuse.mjs
+++ b/providers/themuse.mjs
@@ -6,7 +6,14 @@
 // Response shape: { results: [...], page: n, page_count: N }
 // All pages are fetched sequentially and aggregated before normalizing.
 //
+// Each page fetch is retried on a transient failure (429/5xx/timeout-abort)
+// via fetchJsonWithRetry (#2681). A later-page failure after retries truncates
+// gracefully — keeping what was already collected — so a single blip mid-sweep
+// doesn't silently discard every listing gathered up to that point.
+//
 // Wire in via a `job_boards:` entry with `provider: themuse`.
+
+import { fetchJsonWithRetry } from './_http.mjs';
 
 const FEED_BASE = 'https://www.themuse.com/api/public/jobs';
 const TRUSTED_HOST = 'www.themuse.com';
@@ -68,8 +75,23 @@ export default {
     let pageCount = 1;
     for (let page = 0; page < pageCount; page++) {
       const url = `${FEED_BASE}?page=${page}`;
-      // redirect:'error' prevents SSRF via server-side redirects
-      const json = await ctx.fetchJson(url, { redirect: 'error' });
+      let json;
+      try {
+        // Retried on transient failures (429/5xx/timeout-abort) so one blip
+        // mid-sweep doesn't discard every listing already collected (#2681).
+        // redirect:'error' prevents SSRF via server-side redirects.
+        json = await fetchJsonWithRetry(ctx, url, { redirect: 'error' });
+      } catch (err) {
+        const cause = err instanceof Error ? err.message : String(err);
+        if (page === 0) {
+          // First page failing after retries means the feed itself is down —
+          // re-throw so the caller can distinguish "dead feed" from "0 jobs".
+          throw err instanceof Error ? err : new Error(cause);
+        }
+        // A later page failing after retries: keep what was fetched so far.
+        console.error(`⚠️  themuse: truncated at page ${page} after retries (${allResults.length} results): ${cause}`);
+        break;
+      }
       if (!json || !Array.isArray(json.results)) {
         throw new Error(
           `themuse: unexpected API response on page ${page} — expected { results: [...] }, got keys: [${json ? Object.keys(json).join(', ') : 'null'}]`,

--- a/scan.mjs
+++ b/scan.mjs
@@ -2130,8 +2130,56 @@ function guardStatusFor(code) {
   return 'skipped_invalid_url';
 }
 
+const SCAN_HELP = `\
+Usage: node scan.mjs [options]
+
+Options:
+  --dry-run               Preview scan output without writing files
+  --company <name>        Scan only one company (case-insensitive substring match)
+  --verify                Playwright-check each new URL; drop expired postings
+  --headed-fallback       Retry anti-bot-blocked URLs in a headed browser (needs display)
+  --throttle[=<ms>]       Jittered gap between --verify checks (default 5000 ms)
+  --rediscover-404        On 404/410, search for the moved role before marking expired
+  --include-blacklisted   Let blacklisted companies through (annotated with reason)
+  --posted-after <date>   Absolute lower bound on posting date (YYYY-MM-DD)
+  --posted-before <date>  Absolute upper bound on posting date (YYYY-MM-DD)
+  --since <days>          Relative lower bound on posting date (e.g. --since 7)
+  --quiet                 Suppress manifesto prompt after a successful scan
+  -h, --help              Show this help and exit
+
+Writes to: data/pipeline.md, data/scan-history.tsv
+`.trimEnd();
+
+// Flags that consume the NEXT token as their operand (besides the --flag=value form).
+const SCAN_FLAGS_WITH_VALUE = new Set(['--company', '--posted-after', '--posted-before', '--since']);
+
+// All recognized flag tokens (including both forms of value-taking flags).
+const SCAN_KNOWN_FLAGS = new Set([
+  '--dry-run', '--verify', '--headed-fallback', '--throttle',
+  '--rediscover-404', '--include-blacklisted', '--quiet',
+  '--company', '--posted-after', '--posted-before', '--since',
+  '--help', '-h',
+]);
+
 async function main() {
   const args = process.argv.slice(2);
+
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(SCAN_HELP);
+    process.exit(0);
+  }
+
+  // Reject unrecognized flags early so a typo (e.g. --dryrun, --dry_run) does
+  // not silently run a full scan and write to user-layer data files (#2270).
+  const unknownFlags = args.filter(
+    (a) => a.startsWith('-') && !SCAN_KNOWN_FLAGS.has(a.split('=')[0]),
+  );
+  if (unknownFlags.length > 0) {
+    console.error(`Error: unknown option(s): ${unknownFlags.join(', ')}`);
+    console.error('Run: node scan.mjs --help');
+    process.exit(1);
+  }
+
   const dryRun = args.includes('--dry-run');
   const verify = args.includes('--verify');
   // Opt-in: on an anti-bot challenge (e.g. pracuj.pl Cloudflare wall), retry the

--- a/scan.mjs
+++ b/scan.mjs
@@ -2171,8 +2171,11 @@ async function main() {
 
   // Reject unrecognized flags early so a typo (e.g. --dryrun, --dry_run) does
   // not silently run a full scan and write to user-layer data files (#2270).
+  // Only double-dash tokens are checked: single-dash tokens are either known
+  // aliases (-h) or value operands (e.g. --since -5 passes "-5" as a number,
+  // not a flag), and we must not reject those.
   const unknownFlags = args.filter(
-    (a) => a.startsWith('-') && !SCAN_KNOWN_FLAGS.has(a.split('=')[0]),
+    (a) => a.startsWith('--') && !SCAN_KNOWN_FLAGS.has(a.split('=')[0]),
   );
   if (unknownFlags.length > 0) {
     console.error(`Error: unknown option(s): ${unknownFlags.join(', ')}`);

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -3767,6 +3767,29 @@ if (
   }
 }
 
+// ── #2395: guardrail markers must be present in every localized _shared.md ──
+// The authorship RULE and the no-fabrication RULE were missing from 16 of 18
+// localized _shared.md files. A stable machine-readable marker lets the test
+// survive translation — the translator must carry the comment across.
+{
+  const langSharedFiles = readdirSync(join(ROOT, 'modes'), { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => ({ lang: e.name, path: `modes/${e.name}/_shared.md` }))
+    .filter(({ path }) => existsSync(join(ROOT, path)));
+  const missingAuthorship = langSharedFiles.filter(({ path }) => !readFile(path).includes('<!-- guardrail:authorship -->'));
+  const missingNoFab = langSharedFiles.filter(({ path }) => !readFile(path).includes('<!-- guardrail:no-fabrication -->'));
+  if (missingAuthorship.length === 0) {
+    pass(`all ${langSharedFiles.length} localized _shared.md files carry the authorship guardrail marker (#2395)`);
+  } else {
+    fail(`localized _shared.md missing authorship guardrail marker: ${missingAuthorship.map(({ lang }) => lang).join(', ')}`);
+  }
+  if (missingNoFab.length === 0) {
+    pass(`all ${langSharedFiles.length} localized _shared.md files carry the no-fabrication guardrail marker (#2395)`);
+  } else {
+    fail(`localized _shared.md missing no-fabrication guardrail marker: ${missingNoFab.map(({ lang }) => lang).join(', ')}`);
+  }
+}
+
 if (readFile('DATA_CONTRACT.md').includes('data/blacklist.md')) {
   pass('DATA_CONTRACT.md registers data/blacklist.md as user layer (#1742)');
 } else {

--- a/tests/merge-tracker.test.mjs
+++ b/tests/merge-tracker.test.mjs
@@ -22,8 +22,8 @@ const TRACKER_HEADER = [
 ].join('\n');
 
 // One merge run in an isolated workspace. Returns the merged tracker text.
-function runMerge(additions) {
-  return runMergeDetailed(additions).tracker;
+function runMerge(additions, opts = {}) {
+  return runMergeDetailed(additions, opts).tracker;
 }
 
 /**

--- a/tests/merge-tracker.test.mjs
+++ b/tests/merge-tracker.test.mjs
@@ -575,3 +575,45 @@ try {
 } catch (e) {
   fail(`merge-tracker same-run num collision tests crashed: ${e.message}`);
 }
+
+// ── #2803: N/A re-evaluation must not overwrite a real score ────────────────
+// A re-evaluation whose fetch failed produces an N/A sentinel, which parseScore
+// previously treated as 0 — causing merge-tracker to report a 4.0 → 0 downgrade
+// and silently erase the real score from the tracker.
+console.log('\nmerge-tracker.mjs — N/A score preservation (#2803)');
+try {
+  function dataRows2803(tracker) {
+    return tracker.split('\n').filter(l => /^\|/.test(l) && !/^[|\s-]+$/.test(l) && !/^[|]?\s*#/.test(l));
+  }
+
+  // Baseline: a real score of 4.0/5 in the tracker, then a re-eval with N/A.
+  const naSentinels = ['N/A', '—', '-'];
+  for (const sentinel of naSentinels) {
+    const result = runMerge({
+      [`4-dd.tsv`]: `4\t2026-06-25\tDoorDash\tSenior Associate\tEvaluated\t${sentinel}\t❌\t[4](reports/4-dd.md)\tfetch failed\n`,
+    }, {
+      rows: `| 4 | 2026-06-01 | DoorDash | Senior Associate | 4.0/5 | Evaluated | ❌ | [4](reports/4-dd.md) | good |\n`,
+    });
+    const rows = dataRows2803(result);
+    if (rows.length === 1 && /4\.0\/5/.test(rows[0])) {
+      pass(`merge-tracker preserves 4.0/5 when re-eval carries sentinel "${sentinel}" (#2803)`);
+    } else {
+      fail(`merge-tracker overwrote score with sentinel "${sentinel}": ${rows[0]}`);
+    }
+  }
+
+  // Control: a real score (e.g. 3.0/5) from a re-eval still writes through.
+  const upgradeResult = runMerge({
+    '4-dd.tsv': `4\t2026-06-25\tDoorDash\tSenior Associate\tEvaluated\t3.0/5\t❌\t[4](reports/4-dd.md)\trescore\n`,
+  }, {
+    rows: `| 4 | 2026-06-01 | DoorDash | Senior Associate | 4.0/5 | Evaluated | ❌ | [4](reports/4-dd.md) | good |\n`,
+  });
+  const upgradeRows = dataRows2803(upgradeResult);
+  if (upgradeRows.length === 1 && /3\.0\/5/.test(upgradeRows[0])) {
+    pass('merge-tracker still writes through a lower real score (downgrade is not suppressed by the N/A guard)');
+  } else {
+    fail(`merge-tracker did not write through the 3.0/5 downgrade: ${upgradeRows[0]}`);
+  }
+} catch (e) {
+  fail(`merge-tracker N/A score preservation tests crashed: ${e.message}`);
+}

--- a/tests/providers/themuse.test.mjs
+++ b/tests/providers/themuse.test.mjs
@@ -163,6 +163,57 @@ try {
   if (badResponseThrew) pass('themuse.fetch() throws on unexpected API response shape');
   else fail('themuse.fetch() should throw when results array is absent');
 
+  // A transient failure on the first page (after retries) must re-throw — the
+  // feed is unreachable and returning [] would misreport it as "0 jobs" (#2681).
+  let museFirstPageThrew = false;
+  try {
+    await themuse.fetch(
+      { name: 'X', provider: 'themuse' },
+      { sleep: async () => {}, fetchJson: async () => { throw new Error('connection reset'); } },
+    );
+  } catch (e) { museFirstPageThrew = /connection reset/.test(e.message); }
+  if (museFirstPageThrew) pass('themuse.fetch() re-throws when the first page fails after exhausting retries (#2681)');
+  else fail('themuse.fetch() should re-throw on first-page failure, not return []');
+
+  // A transient failure on a LATER page (after retries) keeps every result
+  // already collected from earlier pages (#2681 — "partial failure tolerance").
+  const musePageZeroResult = { name: 'Eng', refs: { landing_page: 'https://www.themuse.com/jobs/x/y' }, company: { name: 'X' }, locations: [] };
+  const museLaterPageFail = await themuse.fetch(
+    { name: 'Y', provider: 'themuse' },
+    {
+      sleep: async () => {},
+      fetchJson: async (url) => {
+        const page = Number(new URL(url).searchParams.get('page'));
+        if (page === 0) return { results: [musePageZeroResult], page: 0, page_count: 3 };
+        throw new Error('upstream 503');
+      },
+    },
+  );
+  if (museLaterPageFail.length === 1 && museLaterPageFail[0].title === 'Eng') {
+    pass('themuse.fetch() keeps page-0 results when a later page fails after retries (#2681)');
+  } else {
+    fail(`themuse.fetch() later-page truncation: expected 1 job from page 0, got ${JSON.stringify(museLaterPageFail)}`);
+  }
+
+  // A transient failure that recovers within the retry window must be transparent.
+  let museRetryAttempts = 0;
+  const museRecovered = await themuse.fetch(
+    { name: 'Z', provider: 'themuse' },
+    {
+      sleep: async () => {},
+      fetchJson: async () => {
+        museRetryAttempts++;
+        if (museRetryAttempts < 3) throw new Error('timeout');
+        return { results: [musePageZeroResult], page: 0, page_count: 1 };
+      },
+    },
+  );
+  if (museRetryAttempts === 3 && museRecovered.length === 1) {
+    pass(`themuse.fetch() retries a transient failure and recovers (${museRetryAttempts} attempts) (#2681)`);
+  } else {
+    fail(`themuse.fetch() retry recovery: ${museRetryAttempts} attempts, ${museRecovered.length} jobs`);
+  }
+
 } catch (e) {
   fail(`themuse provider tests crashed: ${e.message}`);
 }

--- a/tests/providers/themuse.test.mjs
+++ b/tests/providers/themuse.test.mjs
@@ -214,6 +214,19 @@ try {
     fail(`themuse.fetch() retry recovery: ${museRetryAttempts} attempts, ${museRecovered.length} jobs`);
   }
 
+  // A non-Error rejection (plain string) on the first page must rethrow without
+  // crashing the catch block itself (primitive rejection in strict mode throws
+  // when you attempt to set a property on it — `.attempts` assignment in withRetry).
+  let museNonErrorThrew = false;
+  try {
+    await themuse.fetch(
+      { name: 'Q', provider: 'themuse' },
+      { sleep: async () => {}, fetchJson: async () => { throw 'plain string rejection'; } },
+    );
+  } catch (e) { museNonErrorThrew = /plain string rejection/.test(e?.message || String(e)); }
+  if (museNonErrorThrew) pass('themuse.fetch() re-throws a non-Error first-page rejection safely (wraps into Error) (#2681)');
+  else fail('themuse.fetch() should rethrow a non-Error rejection on first-page failure');
+
 } catch (e) {
   fail(`themuse provider tests crashed: ${e.message}`);
 }

--- a/tests/scan-flag-forms.test.mjs
+++ b/tests/scan-flag-forms.test.mjs
@@ -83,3 +83,41 @@ test('--company with no operand is rejected', () => {
   assert.match(r.all, /--company requires a value/);
   assert.notEqual(r.status, 0);
 });
+
+// ── #2270: --help / -h and unknown-flag rejection ─────────────────────────
+
+test('--help exits 0 and prints usage without running a scan (#2270)', () => {
+  const r = runScan('--help');
+  assert.equal(r.status, 0, '--help must exit 0');
+  assert.match(r.stdout, /Usage: node scan\.mjs/, '--help must print usage');
+  // Proof it never reached the scan: no portals-missing error, no scan output.
+  assert.doesNotMatch(r.all, /portals\.yml not found|Scanning/i);
+});
+
+test('-h exits 0 and prints usage without running a scan (#2270)', () => {
+  const r = runScan('-h');
+  assert.equal(r.status, 0, '-h must exit 0');
+  assert.match(r.stdout, /Usage: node scan\.mjs/, '-h must print usage');
+  assert.doesNotMatch(r.all, /portals\.yml not found|Scanning/i);
+});
+
+test('unknown --flag exits 1 with an error, not a silent scan (#2270)', () => {
+  const r = runScan('--dryrun');
+  assert.notEqual(r.status, 0, '--dryrun must be rejected, not silently ignored');
+  assert.match(r.stderr, /unknown option.*--dryrun/, 'error must name the bad flag');
+  assert.match(r.stderr, /--help/, 'error must hint at --help');
+});
+
+test('unknown flag spelled with underscore is rejected (#2270)', () => {
+  const r = runScan('--dry_run');
+  assert.notEqual(r.status, 0, '--dry_run is not a known flag and must be rejected');
+  assert.match(r.stderr, /unknown option.*--dry_run/);
+});
+
+test('multiple unknown flags are all listed in the error (#2270)', () => {
+  const r = runScan('--verbose', '--output=json');
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /unknown option/);
+  assert.match(r.stderr, /--verbose/);
+  assert.match(r.stderr, /--output/);
+});

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -68,6 +68,11 @@ const SYSTEM_PATHS = [
   // on an existing install, silently (once text=auto is live, git status stays
   // clean and only a second update would repair it).
   '.gitattributes',
+  // .gitignore must be kept in sync with upstream so that new ignore rules
+  // (e.g. new output or temp directories) actually take effect on existing
+  // installs — without this entry every rule added after clone is silently
+  // absent from those installs (#2756).
+  '.gitignore',
   'modes/README.md',
   'modes/_shared.md',
   'modes/_writing.md',


### PR DESCRIPTION
## Summary

Addresses 7 confirmed bugs across providers, dashboard, CLI, and i18n:

- **#2681** `themuse`: use `fetchJsonWithRetry` so transient failures retry; later-page failures truncate gracefully (preserving page-0 results) instead of silently dropping all results; first-page failures re-throw so a dead feed is not misreported as "0 jobs"
- **#2717** `modes/update.md`: handle empty changelog when `git ls-remote` fallback is used (curl-blocked machine) — renders a note instead of a blank blockquote line
- **#2756** `update-system.mjs`: add `.gitignore` to `SYSTEM_PATHS` so new upstream ignore rules actually reach existing installs
- **#2803** `merge-tracker`: `parseScore` returns `null` (not `0`) for sentinel values (`—`, `N/A`, `-`); `buildRow` preserves the existing score when the re-evaluation is unscoreable — fixes the "4.0 → 0.0 downgrade" data-loss bug; `runMerge` test helper forwards opts so isolation tests work correctly
- **#2270** `scan.mjs`: add `--help`/`-h` (exits 0 with usage before any scan) and reject unrecognized `--` flags with a clear error (exits 1) — stops typos like `--dryrun` from silently running a full scan and mutating user-layer data files
- **#2758** `dashboard`: `CareerApplication.HasScore` distinguishes a numeric score from a sentinel at parse time; renderer shows the sentinel dimmed instead of "0.0"; `sortScore` floats unscored rows to the top ("needs evaluating" ranks above "scored badly")
- **#2395** (p1) All 18 localized `_shared.md` files now carry the authorship and no-fabrication guardrail rules with machine-readable HTML comment markers (`<!-- guardrail:authorship -->`, `<!-- guardrail:no-fabrication -->`); a new `test-all.mjs` check asserts the markers are present in all language directories

## Test plan

- [ ] `node test-all.mjs` passes (3797 tests, 0 failures)
- [ ] `node --test tests/providers/themuse.test.mjs` — 4 new tests: first-page re-throw, later-page truncation, retry recovery, non-Error rejection
- [ ] `node --test tests/merge-tracker.test.mjs` — 4 new tests: N/A/—/- sentinel preservation, real-score downgrade still writes through
- [ ] `node --test tests/scan-flag-forms.test.mjs` — 5 new tests: `--help` exits 0, `-h` exits 0, `--dryrun` rejected, `--dry_run` rejected, multiple unknown flags listed
- [ ] `node scan.mjs --help` prints usage without running a scan
- [ ] Dashboard sentinel row renders dimmed `—`/`N/A` instead of `0.0`; unscored rows sort above scored ones
- [ ] `go test ./dashboard/...` covers `TestHasScoreDistinguishesSentinelFromNumeric` (requires Go runtime)
- [ ] All 18 localized `_shared.md` files contain both guardrail markers (asserted by `test-all.mjs`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Unevaluated applications now appear before scored applications, retain their original score labels, and no longer affect score comparisons as zero.
  - Re-evaluations preserve existing scores when incoming values are unavailable or invalid.
  - Job listing retrieval now retries temporary failures and preserves results already collected.
  - Update screens display a clear fallback when changelog information is unavailable.

- **New Features**
  - Scan commands now provide help and reject unknown options with actionable guidance.
  - Added safeguards against unsupported authorship claims and fabricated resume details across languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->