### PR TITLE
fix(add-entry): a non-Latin CV can't use /career-ops add — the dedupKey you supplied is rejected as empty

### DIFF
--- a/add-entry.mjs
+++ b/add-entry.mjs
@@ -41,6 +41,7 @@
 import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
+import { normalizeTextKey } from './tracker-parse.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 
@@ -55,9 +56,22 @@ const USAGE = `Usage:
   node add-entry.mjs --help                    # print this usage block and exit (-h is an alias)`;
 
 // Normalize a title/heading for duplicate detection: lowercase, collapse to
-// alphanumerics only. "FraudShield", "Fraud-Shield", "fraud shield" all match.
+// letters and digits. "FraudShield", "Fraud-Shield", "fraud shield" all match.
+//
+// Delegates to the shared normalizeTextKey rather than keeping a private
+// `[^a-z0-9]` strip. That strip deleted every non-Latin character, so a CV
+// written in Japanese, Russian or Hindi keyed EVERY heading and dedup key to
+// '' — which made `add` unusable rather than inaccurate: the non-empty-dedupKey
+// guard below rejected a key the user had actually supplied ("payload.cv
+// requires a non-empty dedupKey"), and two different section headings both
+// keying to '' matched each other, so an entry could land under the wrong
+// heading (#2849).
+//
+// Latin behaviour is unchanged except that an accented word now keys
+// faithfully: "Café" was truncated to "caf" (it never matched "Cafe" either
+// way), and now keys as "café".
 export function normalizeKey(s) {
-  return typeof s === 'string' ? s.toLowerCase().replace(/[^a-z0-9]+/g, '') : '';
+  return typeof s === 'string' ? normalizeTextKey(s) : '';
 }
 
 // Split a markdown doc into the block belonging to a `## <section>` heading:

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -7733,6 +7733,51 @@ try {
     rmSync(cliTmp, { recursive: true, force: true });
   }
 
+  // Non-Latin CVs (#2849). normalizeKey stripped [^a-z0-9], so every heading and
+  // dedupKey in a Japanese/Russian/Hindi CV keyed to '' — which made `add`
+  // UNUSABLE, not inaccurate: the non-empty-dedupKey guard rejected a key the
+  // user had supplied, and two different headings both keying to '' matched
+  // each other, so an entry could land under the wrong section.
+  {
+    const jpTmp = mkdtempSync(join(tmpdir(), 'career-ops-add-jp-'));
+    try {
+      const cvPath = join(jpTmp, 'cv.md');
+      writeFileSync(cvPath, '# CV\n\n## \u30D7\u30ED\u30B8\u30A7\u30AF\u30C8\n\n- \u65E2\u5B58\n\n## \u8077\u52D9\u7D4C\u6B74\n\n- \u65E2\u5B58\n');
+      const payloadPath = join(jpTmp, 'p.json');
+      writeFileSync(payloadPath, JSON.stringify({ cv: {
+        section: '\u30D7\u30ED\u30B8\u30A7\u30AF\u30C8',
+        dedupKey: '\u30D5\u30E9\u30A6\u30C9\u30B7\u30FC\u30EB\u30C9',
+        entry: '- **\u30D5\u30E9\u30A6\u30C9\u30B7\u30FC\u30EB\u30C9**',
+      } }));
+      const env = { ...process.env, CAREER_OPS_CV: cvPath };
+      const out = JSON.parse(execFileSync(NODE, [join(ROOT, 'add-entry.mjs'), payloadPath], { env, encoding: 'utf-8' }));
+      out.cv.status === 'added'
+        ? pass('add-entry: a non-Latin dedupKey is accepted and the entry is added (#2849)')
+        : fail(`add-entry: non-Latin payload => ${JSON.stringify(out.cv)}`);
+
+      const rerun = JSON.parse(execFileSync(NODE, [join(ROOT, 'add-entry.mjs'), payloadPath], { env, encoding: 'utf-8' }));
+      rerun.cv.status === 'duplicate'
+        ? pass('add-entry: a non-Latin entry is idempotent on re-run (#2849)')
+        : fail(`add-entry: non-Latin re-run => ${JSON.stringify(rerun.cv)}`);
+
+      // A different heading must not collide via a shared empty key.
+      const p2 = join(jpTmp, 'p2.json');
+      writeFileSync(p2, JSON.stringify({ cv: {
+        section: '\u8077\u52D9\u7D4C\u6B74',
+        dedupKey: '\u5225\u30D7\u30ED\u30B8\u30A7\u30AF\u30C8',
+        entry: '- **\u5225\u30D7\u30ED\u30B8\u30A7\u30AF\u30C8**',
+      } }));
+      execFileSync(NODE, [join(ROOT, 'add-entry.mjs'), p2], { env, encoding: 'utf-8' });
+      const finalCv = readFileSync(cvPath, 'utf-8');
+      const [projSection, workSection] = finalCv.split('## \u8077\u52D9\u7D4C\u6B74');
+      (workSection || '').includes('\u5225\u30D7\u30ED\u30B8\u30A7\u30AF\u30C8') && !projSection.includes('\u5225\u30D7\u30ED\u30B8\u30A7\u30AF\u30C8')
+        ? pass('add-entry: two different non-Latin sections stay distinct (#2849)')
+        : fail(`add-entry: entry landed under the wrong non-Latin section:\n${finalCv}`);
+    } finally {
+      rmSync(jpTmp, { recursive: true, force: true });
+    }
+  }
+
 } catch (e) {
   fail(`add-entry tests crashed: ${e.message}`);
 }


### PR DESCRIPTION
Closes #2849.

`normalizeKey()` strips `[^a-z0-9]+`, so every non-Latin string keys to `''`. That key gates section matching, dedup **and the payload validation** — and validation bites first:

```js
if (!normalizeKey(dedupKey)) throw new Error('payload.cv requires a non-empty dedupKey …');
```

Measured, same payload in two languages:

```console
$ node add-entry.mjs payload.json     # section: プロジェクト, dedupKey: フラウドシールド
add-entry: payload.cv requires a non-empty dedupKey (used for dedup/idempotency)

$ node add-entry.mjs english.json
{ "dryRun": false, "cv": { "status": "added", "section": "Projects" } }
```

`/career-ops add` is the documented path for adding a finished project, paper or role to `cv.md`. For a non-English CV it's **not usable at all**, and the error blames the user's input for something the tool couldn't read.

**Second consequence past the guard:** `normalizeKey('プロジェクト') === normalizeKey('職務経歴')` is `true`, so an entry can be inserted under the wrong heading — a write to `cv.md`, the user-layer file the Data Contract protects hardest.

## Fix

Delegate to the shared `normalizeTextKey()` instead of a private `[a-z0-9]` strip — same remedy as #2429, #2502, #2518, #2587, #2781.

After:

```
{ "cv": { "status": "added", "section": "プロジェクト" } }     # first run
{ "cv": { "status": "duplicate" } }                          # idempotent re-run
別プロジェクト lands under 職務経歴, not under プロジェクト      # no empty-key collision
```

## Latin path

Unchanged across everything I checked — `FraudShield` / `Fraud-Shield` / `fraud shield` → `fraudshield`, `C++ Tooling` → `ctooling`, `Node.js` → `nodejs`, `A/B Testing` → `abtesting`, `  Spaced  ` → `spaced`.

One difference, and it's a repair rather than a change: `Café` was truncated to `caf` and now keys as `café`. It never matched `Cafe` under either implementation, so nothing that used to dedup stops deduping — the old value was just corruption.

## Tests

Three assertions driven through the real CLI (add → idempotent re-run → no cross-section collision). On `main` the first two fail with the CLI erroring before it emits any JSON.

`node test-all.mjs --quick` → **3802 passed, 0 failed**.

## Note on the failing Windows check

If `test (windows-latest)` goes red here it's the `agent-inbox` concurrency race from #2777, not this change — it's currently failing on every open PR. I reported the post-`a7f65b6` evidence there.

2 commits (fix + test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of accented and non-Latin text in entries and section headings.
  * Prevented valid non-Latin content from being lost or assigned to incorrect sections.
  * Improved deduplication to avoid unintended collisions.

* **Tests**
  * Added coverage confirming Japanese entries are added successfully and remain idempotent when processed repeatedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->