### PR TITLE
Don't let an unscoreable (N/A) re-eval overwrite a real score

### DIFF
--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -367,6 +367,22 @@ function parseScore(s) {
 }
 
 /**
+ * True when a Score cell is a documented "no score" sentinel rather than a
+ * number. AGENTS.md names `N/A`, `—` and `-` as the values a row carries when it
+ * was added without an evaluation, or when a re-eval could not be scored (#1799).
+ *
+ * parseScore() maps all of these to 0, so the merge path cannot tell them apart
+ * from a genuine zero on its own — callers that must not treat "no score" as
+ * "scored zero" ask here first (#2803).
+ *
+ * @param {string} s - Raw score cell.
+ * @returns {boolean}
+ */
+function isUnscoreable(s) {
+  return ['—', '-', 'N/A'].includes(String(s).replace(/\*\*/g, '').trim());
+}
+
+/**
  * Load the optional generated-PDF manifest.
  *
  * data/pdf-index.tsv is gitignored and only exists after generate-pdf.mjs has
@@ -1031,6 +1047,22 @@ for (const file of tsvFiles) {
   }
 
   if (duplicate) {
+    // An unscoreable re-eval (N/A/—/-) carries no score to write through. Its
+    // score parses to 0, so the downgrade path below would read it as a genuine
+    // zero and overwrite a real score with the sentinel — unrecoverably, since
+    // the tracker is gitignored and no .bak is written (#2803). A failed fetch is
+    // "no new score", not "scored zero": leave the row's score, report and PDF as
+    // they stand. When the row itself is not yet scored there is nothing to lose,
+    // so let the normal path refresh its date/notes/report from the re-eval.
+    if (isUnscoreable(addition.score) && !isUnscoreable(duplicate.score)) {
+      console.log(
+        `⏭️  Skipping ${file}: re-eval of #${duplicate.num} ${addition.company} — `
+        + `${addition.role} produced no score (${String(addition.score).trim()}); `
+        + `keeping ${duplicate.score}`,
+      );
+      skipped++;
+      continue;
+    }
     const newScore = parseScore(addition.score);
     const oldScore = parseScore(duplicate.score);
 

--- a/tests/merge-tracker.test.mjs
+++ b/tests/merge-tracker.test.mjs
@@ -211,6 +211,30 @@ try {
   } else {
     fail(`equal-score re-eval mishandled: ${sameRow.trim()} | ${same.output.trim()}`);
   }
+
+  // --- An unscoreable (N/A) re-eval must NOT overwrite a real score (#2803) ---
+  // parseScore('N/A') is 0, so a re-eval that failed to fetch used to read as a
+  // genuine zero, trip the downgrade path above, and overwrite the real score
+  // with the sentinel — unrecoverably, since the tracker is gitignored and no
+  // .bak is written. "No score" is not "scored zero": the row must be left as is.
+  const NA_SEED = '| 4 | 2026-06-01 | DoorDash | Senior Associate, Finance & Strategy | 4.0/5 | Evaluated | ❌ | '
+    + '[4](../reports/4-dd.md) | good |\n';
+  const naReeval = runMergeDetailed({
+    '4-dd.tsv': '4\t2026-06-25\tDoorDash\tSenior Associate, Finance & Strategy\tEvaluated\tN/A\t❌\t[4](reports/4-dd.md)\tfetch failed\n',
+  }, { rows: NA_SEED });
+  const naRow = naReeval.tracker.split('\n').find(l => /DoorDash/.test(l)) || '';
+
+  if (/\|\s*4\.0\/5\s*\|/.test(naRow) && !/\|\s*N\/A\s*\|/.test(naRow)) {
+    pass('an unscoreable (N/A) re-eval keeps the existing real score (#2803)');
+  } else {
+    fail(`N/A re-eval overwrote the real score: ${naRow.trim()}`);
+  }
+
+  if (/⏭️1 skipped/.test(naReeval.output) && !/🔄1 updated/.test(naReeval.output) && !/DOWNGRADE/.test(naReeval.output)) {
+    pass('an unscoreable re-eval is skipped, not applied as a downgrade (#2803)');
+  } else {
+    fail(`N/A re-eval was not skipped cleanly: ${naReeval.output.trim()}`);
+  }
 } catch (e) {
   fail(`merge-tracker.mjs tests crashed: ${e.message}`);
 }

--- a/tests/merge-tracker.test.mjs
+++ b/tests/merge-tracker.test.mjs
@@ -247,10 +247,17 @@ try {
   const naOntoNa = runMergeDetailed({
     '6-globex.tsv': '6\t2026-06-25\tGlobex\tData Eng\tEvaluated\tN/A\t❌\t[6](reports/6-globex.md)\trefetch, still no score\n',
   }, { rows: NOSCORE_SEED });
-  if (/🔄1 updated/.test(naOntoNa.output) && !/⏭️1 skipped/.test(naOntoNa.output)) {
-    pass('a sentinel re-eval of an already-unscored row still writes through (nothing to lose)');
+  const naOntoNaRow = naOntoNa.tracker.split('\n').find(l => /Globex/.test(l)) || '';
+  const wroteThrough = /🔄1 updated/.test(naOntoNa.output) && !/⏭️1 skipped/.test(naOntoNa.output);
+  // Counters alone can lie — assert the row actually took the re-eval's date,
+  // report and notes (keeping the existing note first, per mergeNotes #2483).
+  const refreshed = /\|\s*2026-06-25\s*\|/.test(naOntoNaRow)
+    && /\[6\]\(reports\/6-globex\.md\)/.test(naOntoNaRow)
+    && /pending eval\. Re-eval 2026-06-25.*refetch, still no score/.test(naOntoNaRow);
+  if (wroteThrough && refreshed) {
+    pass('a sentinel re-eval of an already-unscored row writes through, refreshing date/report/notes (nothing to lose)');
   } else {
-    fail(`sentinel re-eval of an unscored row was mishandled: ${naOntoNa.output.trim()}`);
+    fail(`sentinel re-eval of an unscored row was mishandled: ${naOntoNaRow.trim()} | ${naOntoNa.output.trim()}`);
   }
 } catch (e) {
   fail(`merge-tracker.mjs tests crashed: ${e.message}`);

--- a/tests/merge-tracker.test.mjs
+++ b/tests/merge-tracker.test.mjs
@@ -212,28 +212,45 @@ try {
     fail(`equal-score re-eval mishandled: ${sameRow.trim()} | ${same.output.trim()}`);
   }
 
-  // --- An unscoreable (N/A) re-eval must NOT overwrite a real score (#2803) ---
-  // parseScore('N/A') is 0, so a re-eval that failed to fetch used to read as a
-  // genuine zero, trip the downgrade path above, and overwrite the real score
-  // with the sentinel — unrecoverably, since the tracker is gitignored and no
-  // .bak is written. "No score" is not "scored zero": the row must be left as is.
+  // --- Unscoreable re-evals must NOT overwrite a real score (#2803) -----------
+  // parseScore() maps every documented no-score sentinel (N/A / — / -, AGENTS.md
+  // #1799) to 0, so a re-eval that failed to fetch used to read as a genuine
+  // zero, trip the downgrade path above, and overwrite the real score with the
+  // sentinel — unrecoverably, since the tracker is gitignored and no .bak is
+  // written. "No score" is not "scored zero": the row must be left untouched.
   const NA_SEED = '| 4 | 2026-06-01 | DoorDash | Senior Associate, Finance & Strategy | 4.0/5 | Evaluated | ❌ | '
     + '[4](../reports/4-dd.md) | good |\n';
-  const naReeval = runMergeDetailed({
-    '4-dd.tsv': '4\t2026-06-25\tDoorDash\tSenior Associate, Finance & Strategy\tEvaluated\tN/A\t❌\t[4](reports/4-dd.md)\tfetch failed\n',
-  }, { rows: NA_SEED });
-  const naRow = naReeval.tracker.split('\n').find(l => /DoorDash/.test(l)) || '';
-
-  if (/\|\s*4\.0\/5\s*\|/.test(naRow) && !/\|\s*N\/A\s*\|/.test(naRow)) {
-    pass('an unscoreable (N/A) re-eval keeps the existing real score (#2803)');
-  } else {
-    fail(`N/A re-eval overwrote the real score: ${naRow.trim()}`);
+  for (const sentinel of ['N/A', '—', '-']) {
+    // The re-eval carries a DIFFERENT report number ([9]) so the assertion can
+    // prove the row keeps its own report link rather than adopting the re-eval's.
+    const r = runMergeDetailed({
+      '9-dd.tsv': `9\t2026-06-25\tDoorDash\tSenior Associate, Finance & Strategy\tEvaluated\t${sentinel}\t❌\t[9](reports/9-dd.md)\tfetch failed\n`,
+    }, { rows: NA_SEED });
+    const row = r.tracker.split('\n').find(l => /DoorDash/.test(l)) || '';
+    const scoreKept = /\|\s*4\.0\/5\s*\|/.test(row);
+    const reportKept = /\[4\]\(/.test(row) && !/\[9\]/.test(row);
+    const skippedCleanly = /⏭️1 skipped/.test(r.output)
+      && !/🔄1 updated/.test(r.output) && !/DOWNGRADE/.test(r.output);
+    if (scoreKept && reportKept && skippedCleanly) {
+      pass(`an unscoreable "${sentinel}" re-eval keeps the score and report link, and is skipped (#2803)`);
+    } else {
+      fail(`"${sentinel}" re-eval mishandled — row: ${row.trim()} | out: ${r.output.trim()}`);
+    }
   }
 
-  if (/⏭️1 skipped/.test(naReeval.output) && !/🔄1 updated/.test(naReeval.output) && !/DOWNGRADE/.test(naReeval.output)) {
-    pass('an unscoreable re-eval is skipped, not applied as a downgrade (#2803)');
+  // The guard only fires when a real score would be lost. A sentinel re-eval of a
+  // row that is itself unscored has nothing to lose, so it still writes through
+  // and refreshes the row (date/notes/report) rather than being skipped — the
+  // documented sentinel contract for backfilled rows (#1799) is preserved.
+  const NOSCORE_SEED = '| 6 | 2026-06-01 | Globex | Data Eng | N/A | Evaluated | ❌ | '
+    + '[6](../reports/6-globex.md) | pending eval |\n';
+  const naOntoNa = runMergeDetailed({
+    '6-globex.tsv': '6\t2026-06-25\tGlobex\tData Eng\tEvaluated\tN/A\t❌\t[6](reports/6-globex.md)\trefetch, still no score\n',
+  }, { rows: NOSCORE_SEED });
+  if (/🔄1 updated/.test(naOntoNa.output) && !/⏭️1 skipped/.test(naOntoNa.output)) {
+    pass('a sentinel re-eval of an already-unscored row still writes through (nothing to lose)');
   } else {
-    fail(`N/A re-eval was not skipped cleanly: ${naReeval.output.trim()}`);
+    fail(`sentinel re-eval of an unscored row was mishandled: ${naOntoNa.output.trim()}`);
   }
 } catch (e) {
   fail(`merge-tracker.mjs tests crashed: ${e.message}`);


### PR DESCRIPTION
Fixes #2803.

## The bug

A re-evaluation that produced no score overwrites a real score on the tracker, unrecoverably.

`parseScore('N/A')` is `0`. Since #2411 made re-evaluations write through in both directions, a re-eval whose fetch failed — carrying the `N/A` sentinel that AGENTS.md documents for an unscoreable row (#1799) — reads as a genuine zero, trips the downgrade path, and writes the sentinel over the row's real score. The TSV is then archived as merged. There's no way back: the tracker is gitignored with no `.bak`, and the superseded-report marker only fires when the report number changes, which a same-report refetch doesn't.

Reproduced on a clean checkout, a `4.0/5` row against an `N/A` refetch:

```
🔽 Update: #4 DoorDash — Senior Associate (4→0) — DOWNGRADE, re-eval scored lower
📊 Summary: +0 added, 🔄1 updated, ⏭️0 skipped

| 4 | 2026-06-25 | DoorDash | Senior Associate | N/A | Evaluated | ❌ | [4](reports/4-dd.md) | good. Re-eval 2026-06-25 (4→0): fetch failed |
```

The `4.0/5` is gone.

## The fix

Add `isUnscoreable()` for the documented no-score sentinels (`N/A` / `—` / `-`). When a re-eval is unscoreable **and** the existing row holds a real score, skip it — log it, count it, and leave the score, report and PDF as they stand. "No score" is not "scored zero".

The carve-out is deliberately narrow. It only triggers when a real score would be lost:

- Incoming real score (higher, lower, or equal) → unchanged write-through, including the intentional lower-score path from #2411.
- Incoming `N/A` onto a row that has no score yet → nothing to lose, so the normal path still refreshes date/notes/report.
- Incoming `N/A` onto a real score → skipped, the score preserved.

Same input, after:

```
⏭️  Skipping 4-dd.tsv: re-eval of #4 DoorDash — Senior Associate produced no score (N/A); keeping 4.0/5
📊 Summary: +0 added, 🔄0 updated, ⏭️1 skipped

| 4 | 2026-06-01 | DoorDash | Senior Associate | 4.0/5 | Evaluated | ❌ | [4](../reports/4-dd.md) | good |
```

## Tests

`tests/merge-tracker.test.mjs` gains two assertions in the re-eval section: an `N/A` re-eval keeps the existing `4.0/5`, and it's counted as skipped rather than a downgrade. Both fail on `main` and pass with the fix. The existing lower / higher / equal write-through cases still pass, so the numeric score path is untouched. Full file: 38 pass, 0 fail.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented re-evaluations with unavailable scores such as “N/A”, “—”, or “-” from replacing existing scored results.
  * Preserved associated reports and PDFs when an unscored re-evaluation is skipped.
  * Ensured skipped re-evaluations are not counted as updates or downgrades.

* **Tests**
  * Added regression coverage for preserving valid scores during unscored re-evaluations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->