### PR TITLE
fix(update): reconcile .gitignore on apply so new ignore rules reach existing installs

### DIFF
--- a/tests/gitignore-reconcile.test.mjs
+++ b/tests/gitignore-reconcile.test.mjs
@@ -140,3 +140,23 @@ const ok = (cond, msg) => (cond ? pass(msg) : fail(msg));
   eq(added.length, 0, 'the shipped .gitignore reconciled against itself adds nothing');
   eq(text, shipped, 'and is returned byte-identical');
 }
+
+// ── The upstream blob is read untrimmed ──────────────────────────────────────
+// reconcileGitignore()'s verbatim guarantee is only as good as its input. The
+// updater's general-purpose git helpers call .trim() on stdout, which is right
+// for SHAs and pathspecs and wrong for file content: it strips a significant
+// backslash-escaped trailing space off the blob's LAST line, which is exactly
+// where a freshly appended upstream rule sits. Every assertion above would
+// still pass with a trimming read, so this is a source-level guard, matching
+// tests/js-yaml-import-form.test.mjs and tests/source-no-nul-bytes.test.mjs.
+{
+  const src = readFileSync(join(ROOT, 'update-system.mjs'), 'utf-8');
+
+  const readCall = src.match(/const upstreamGitignore = (\w+)\(/);
+  if (!readCall) fail('could not find the upstreamGitignore read in update-system.mjs — update this test');
+  else eq(readCall[1], 'gitShowRaw', 'the upstream .gitignore is read with gitShowRaw, not a trimming helper');
+
+  const body = src.match(/function gitShowRaw\([^)]*\) \{[\s\S]*?\n\}/);
+  if (!body) fail('could not find gitShowRaw() in update-system.mjs — update this test');
+  else ok(!/\.trim\(\)/.test(body[0]), 'gitShowRaw() does not trim, so the blob reaches the reconciler byte-exact');
+}

--- a/tests/gitignore-reconcile.test.mjs
+++ b/tests/gitignore-reconcile.test.mjs
@@ -31,7 +31,7 @@ const ok = (cond, msg) => (cond ? pass(msg) : fail(msg));
   for (const userRule of ['my-scratch-notes/', '*.secret']) {
     ok(lines.includes(userRule), `user rule survives: ${userRule}`);
   }
-  ok(text.startsWith(local.replace(/\s*$/, '')), 'the original file is a prefix of the result (nothing above was rewritten)');
+  ok(text.startsWith(local), 'the original file is a byte-for-byte prefix of the result (no line above was touched)');
   eq(added.join(','), 'data/*,!data/.gitkeep', 'both missing upstream rules were appended');
   ok(!added.includes('cv.md'), 'a rule already present is not duplicated');
 }
@@ -109,6 +109,18 @@ const ok = (cond, msg) => (cond ? pass(msg) : fail(msg));
   ok(text.split('\n').includes('secret\\ '), 'but written back verbatim, with its escaped trailing space intact');
   const again = reconcileGitignore(text, upstream);
   eq(again.added.length, 0, 'and the verbatim line is still recognized on the next pass (no re-add loop)');
+}
+
+// ── A local rule's significant trailing space survives verbatim ────────────────────────
+// The mirror of the case above: normalization is for MATCHING only. Trimming
+// the local file's tail would modify a line the user wrote, which is the one
+// thing this function promises never to do.
+{
+  const local = 'cv.md\nsecret\\ ';   // no trailing newline, escaped space is significant
+  const { text } = reconcileGitignore(local, 'cv.md\ndata/*\n');
+  ok(text.startsWith(local), 'the local file is preserved byte-for-byte, escaped trailing space included');
+  ok(text.split(/\r?\n/).includes('secret\\ '), 'and the user rule keeps its significant trailing space');
+  ok(text.split(/\r?\n/).includes('data/*'), 'while the missing upstream rule is still appended');
 }
 
 // ── An empty local file gets no leading blank lines ──────────────────────────

--- a/tests/gitignore-reconcile.test.mjs
+++ b/tests/gitignore-reconcile.test.mjs
@@ -1,0 +1,130 @@
+// tests/gitignore-reconcile.test.mjs
+//
+// .gitignore was absent from the updater's manifest for 43 releases' worth of
+// commits, so every ignore rule added upstream in that window reached this
+// repository and no existing install (#2756). The file cannot simply join
+// SYSTEM_PATHS: it is the one system file users also write to, and the raw
+// `git checkout` the update stage performs would delete their rules silently.
+//
+// reconcileGitignore() appends only what is missing. These tests pin both
+// halves of that contract: the system rules arrive, and nothing the user wrote
+// is modified, reordered or removed.
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { pass, fail, ROOT } from './helpers.mjs';
+import { reconcileGitignore } from '../update-system.mjs';
+
+console.log('\n🔁 .gitignore reconcile (append-if-missing)');
+
+const eq = (actual, expected, msg) =>
+  (actual === expected ? pass(msg) : fail(`${msg} — expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`));
+const ok = (cond, msg) => (cond ? pass(msg) : fail(msg));
+
+// ── The headline requirement: a user-authored rule survives an update ────────
+{
+  const local = ['cv.md', 'my-scratch-notes/', '*.secret'].join('\n') + '\n';
+  const upstream = ['cv.md', 'data/*', '!data/.gitkeep'].join('\n') + '\n';
+  const { text, added } = reconcileGitignore(local, upstream);
+  const lines = text.split('\n');
+
+  for (const userRule of ['my-scratch-notes/', '*.secret']) {
+    ok(lines.includes(userRule), `user rule survives: ${userRule}`);
+  }
+  ok(text.startsWith(local.replace(/\s*$/, '')), 'the original file is a prefix of the result (nothing above was rewritten)');
+  eq(added.join(','), 'data/*,!data/.gitkeep', 'both missing upstream rules were appended');
+  ok(!added.includes('cv.md'), 'a rule already present is not duplicated');
+}
+
+// ── Idempotency: a second pass is a byte-identical no-op ─────────────────────
+{
+  const local = 'cv.md\nmy-notes/\n';
+  const upstream = 'cv.md\ndata/*\n';
+  const first = reconcileGitignore(local, upstream);
+  const second = reconcileGitignore(first.text, upstream);
+  eq(second.added.length, 0, 'second pass appends nothing');
+  eq(second.text, first.text, 'second pass leaves the file byte-identical');
+}
+
+// ── A file that already has everything is untouched ──────────────────────────
+{
+  const local = '# mine\ncv.md\ndata/*\n';
+  const { text, added } = reconcileGitignore(local, 'cv.md\ndata/*\n');
+  eq(added.length, 0, 'nothing missing means nothing added');
+  eq(text, local, 'and the file is returned byte-identical (no spurious update commit)');
+}
+
+// ── Presence beats position: moved/reordered system rules do not come back ───
+{
+  const local = ['data/*', '# my own section', 'notes/', 'cv.md'].join('\n') + '\n';
+  const upstream = ['cv.md', 'data/*'].join('\n') + '\n';
+  const { added } = reconcileGitignore(local, upstream);
+  eq(added.length, 0, 'rules the user reordered are found anywhere in the file, not by position');
+}
+
+// ── Rationale comments travel with their rule, but are not duplicated ────────
+{
+  const upstream = ['# holds PII, never commit', 'documents/*', '!documents/.gitkeep'].join('\n') + '\n';
+  const { text } = reconcileGitignore('cv.md\n', upstream);
+  ok(text.includes('# holds PII, never commit'), 'the comment explaining a rule is carried across with it');
+  const withComment = reconcileGitignore(`cv.md\n# holds PII, never commit\n`, upstream);
+  eq(
+    (withComment.text.match(/# holds PII, never commit/g) || []).length, 1,
+    'a comment already present is not copied a second time',
+  );
+}
+
+// ── Negations keep their position relative to the pattern they negate ────────
+{
+  const upstream = ['reports/*', '!reports/.gitkeep'].join('\n') + '\n';
+  const { text } = reconcileGitignore('cv.md\n', upstream);
+  const lines = text.split('\n');
+  ok(
+    lines.indexOf('reports/*') !== -1 && lines.indexOf('reports/*') < lines.indexOf('!reports/.gitkeep'),
+    'an appended negation lands after the pattern it negates (order is significant in .gitignore)',
+  );
+}
+
+// ── CRLF checkouts stay CRLF (Windows, core.autocrlf=true) ───────────────────
+{
+  const { text } = reconcileGitignore('cv.md\r\nmy-notes/\r\n', 'cv.md\ndata/*\n');
+  ok(text.includes('data/*'), 'the missing rule is appended to a CRLF file');
+  ok(!/[^\r]\n/.test(text), 'and every appended line uses CRLF, so git diff does not report the whole file as changed');
+}
+
+// ── A missing trailing newline does not glue two rules together ──────────────
+{
+  const { text } = reconcileGitignore('cv.md', 'cv.md\ndata/*\n');
+  ok(text.split('\n').includes('data/*'), 'the appended rule is on its own line even with no trailing newline locally');
+}
+
+// ── Patterns are emitted verbatim, matched normalized ────────────────────────
+// A trailing space is only significant in .gitignore when backslash-escaped.
+// Matching has to normalize (so indentation drift does not cause a re-add), but
+// writing back the normalized form would corrupt the pattern.
+{
+  const upstream = 'cv.md\nsecret\\ \n';
+  const { text, added } = reconcileGitignore('cv.md\n', upstream);
+  ok(added.includes('secret\\'), 'the escaped-space pattern is matched in normalized form');
+  ok(text.split('\n').includes('secret\\ '), 'but written back verbatim, with its escaped trailing space intact');
+  const again = reconcileGitignore(text, upstream);
+  eq(again.added.length, 0, 'and the verbatim line is still recognized on the next pass (no re-add loop)');
+}
+
+// ── An empty local file gets no leading blank lines ──────────────────────────
+{
+  const { text, added } = reconcileGitignore('', 'cv.md\n');
+  ok(added.length > 0, 'an empty file receives the missing rules');
+  ok(!text.startsWith('\n'), 'and the result does not open with blank lines');
+  eq(reconcileGitignore(text, 'cv.md\n').added.length, 0, 'and is idempotent from there');
+}
+
+// ── The shipped .gitignore is self-consistent ────────────────────────────────
+// Reconciling the real file against itself must be a no-op. If it is not, the
+// reconciler would rewrite .gitignore on every single update forever.
+{
+  const shipped = readFileSync(join(ROOT, '.gitignore'), 'utf-8');
+  const { text, added } = reconcileGitignore(shipped, shipped);
+  eq(added.length, 0, 'the shipped .gitignore reconciled against itself adds nothing');
+  eq(text, shipped, 'and is returned byte-identical');
+}

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -1117,6 +1117,100 @@ async function check() {
   }));
 }
 
+// ── .gitignore RECONCILE ────────────────────────────────────────
+
+// The header the appended block is written under. Purely cosmetic: the
+// reconciler keys off pattern presence, never off this marker, so a user who
+// deletes or moves it loses nothing.
+const GITIGNORE_BLOCK_HEADER = [
+  '# Added by career-ops update-system.mjs.',
+  '# System-owned ignore rules that were missing from this file. Your own rules',
+  '# are never modified, reordered or removed: the updater only appends patterns',
+  '# it cannot already find somewhere in this file. Reordering these lines, or',
+  '# moving them elsewhere in the file, is safe and will not bring them back.',
+  '# Deleting or commenting one out is not: they are system-owned, several of',
+  '# them guard files holding personal data, and the next update re-adds any',
+  '# that is no longer present as a live pattern.',
+];
+
+/**
+ * Reconcile a local .gitignore against the upstream one by appending only the
+ * system-owned patterns it is missing.
+ *
+ * .gitignore cannot join SYSTEM_PATHS: unlike every other system file it is
+ * co-owned. Users add their own rules to it, and the raw `git checkout` the
+ * update stage performs would delete those silently, which is a worse bug than
+ * the one this fixes. So it gets the append-if-missing treatment
+ * agent-inbox.mjs:ensureGitignored() already applies to its own single rule,
+ * generalized to the whole upstream rule set.
+ *
+ * Deliberately append-only. An upstream rule that was REMOVED or REWRITTEN
+ * (e.g. `*.bak` becoming `*.bak*`) leaves the superseded line in place, because
+ * there is no way to tell a stale system rule from a user rule the same shape.
+ * A redundant ignore rule is harmless; deleting a user's is not.
+ *
+ * Ordering caveat: missing patterns are appended at the end in upstream order,
+ * which preserves each negation's position relative to the pattern it negates
+ * *within the appended block*. A user-authored negation earlier in the file can
+ * still be overridden by a newly appended pattern, since later lines win in
+ * .gitignore. That is the correct precedence for a system rule, and it is the
+ * only ordering that does not require rewriting lines we do not own.
+ *
+ * @param {string} localText - Current .gitignore content.
+ * @param {string} upstreamText - Upstream .gitignore content (FETCH_HEAD).
+ * @returns {{ text: string, added: string[] }} Reconciled content and the
+ *   patterns appended. `added` is empty and `text` is byte-identical to
+ *   `localText` when nothing was missing, which is what makes repeated runs
+ *   idempotent and keeps a no-op update out of the commit.
+ */
+export function reconcileGitignore(localText, upstreamText) {
+  // One set for both patterns and comments. A comment can never collide with a
+  // pattern (only comments start with '#'), so membership answers both "does
+  // this install already have this rule?" and "has this rationale block already
+  // been copied by an earlier update?" with no second structure to keep in sync.
+  const seen = new Set(localText.split(/\r?\n/).map((l) => l.trim()).filter((l) => l !== ''));
+
+  const block = [];
+  const added = [];
+  let pendingComments = [];
+  for (const raw of upstreamText.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (line === '') { pendingComments = []; continue; }
+    if (line.startsWith('#')) { pendingComments.push([raw, line]); continue; }
+    if (seen.has(line)) { pendingComments = []; continue; }
+    // Carry the rule's own rationale across with it. Several of these comments
+    // are the only record of WHY a path is ignored (which ones hold PII, why a
+    // glob has a trailing `*`), and an install that gets the pattern without
+    // the reason is one edit away from removing it as noise.
+    for (const [rawComment, comment] of pendingComments) {
+      if (!seen.has(comment)) { block.push(rawComment); seen.add(comment); }
+    }
+    pendingComments = [];
+    // Emitted verbatim, compared normalized. A pattern whose trailing space is
+    // backslash-escaped (`secret\ `) is significant in .gitignore and would be
+    // corrupted by writing back the trimmed form used for matching.
+    block.push(raw);
+    added.push(line);
+    // Guard against an upstream file that lists the same pattern twice.
+    seen.add(line);
+  }
+
+  if (added.length === 0) return { text: localText, added };
+
+  // Match the local file's dominant line ending. A checkout on Windows under
+  // `core.autocrlf=true` leaves CRLF on disk, and appending LF-only lines to it
+  // makes `git diff` show the whole file as changed.
+  const crlfCount = (localText.match(/\r\n/g) || []).length;
+  const lfCount = (localText.match(/\n/g) || []).length - crlfCount;
+  const eol = crlfCount > lfCount ? '\r\n' : '\n';
+  const body = [...GITIGNORE_BLOCK_HEADER, ...block].join(eol);
+  // An empty (or whitespace-only) local file takes no separator, or the result
+  // would open with two blank lines.
+  const head = localText.replace(/\s*$/, '');
+  const separator = head === '' ? '' : `${eol}${eol}`;
+  return { text: `${head}${separator}${body}${eol}`, added };
+}
+
 // ── APPLY ───────────────────────────────────────────────────────
 
 async function apply() {
@@ -1349,6 +1443,59 @@ async function apply() {
         // silently skipping the prune step.
         console.error(`Stale-file prune step failed for ${prunePrefix}: ${err.message}`);
       }
+    }
+
+    // 3c. Reconcile .gitignore (#2756). Every other system file is checked out
+    // above; this one cannot be, because it is the one system file users also
+    // write to. A raw checkout would delete their rules silently — the same
+    // failure shape as the bug being fixed. Append what is missing, touch
+    // nothing else. The consequence of skipping it entirely for 43 releases was
+    // that new ignore rules never reached an existing install, so a candidate's
+    // CV or tracker could sit unignored in a fork after a reflexive `git add .`
+    // — exactly what tests/user-layer-gitignored.test.mjs exists to prevent,
+    // and what it could only prevent inside this repository.
+    try {
+      const gitignorePath = join(ROOT, '.gitignore');
+      const upstreamGitignore = gitQuiet('show', 'FETCH_HEAD:.gitignore');
+      // Uncommitted local edits to .gitignore are the user's, and that is a
+      // routine state rather than an exotic one: agent-inbox.mjs's own
+      // ensureGitignored() appends a rule without committing it. Such a file
+      // must stay OUT of `updated`, for the two reasons #2337 established for
+      // system files. `updated` is the rollback pathspec, and revertPaths()
+      // runs a bare `git checkout HEAD -- <path>` whose protectedPaths guard
+      // covers only newly ADDED files, so a tracked .gitignore would be hard
+      // reset and the user's uncommitted rules destroyed. `updated` is also the
+      // commit pathspec, so their edit would be swept in under an "auto-update
+      // system files" message. The reconciled rules are live on disk either
+      // way, which is all that ignoring actually requires.
+      const gitignoreWasDirty = initialStatusPaths.has('.gitignore');
+      const trackGitignore = () => {
+        if (!gitignoreWasDirty) {
+          updated.push('.gitignore');
+          return;
+        }
+        console.log('.gitignore had uncommitted local changes. The new rules are applied but left');
+        console.log('  unstaged, so they land in your own commit rather than in this update.');
+      };
+      if (!existsSync(gitignorePath)) {
+        // No local file at all (deleted by hand, or a checkout predating it).
+        // Nothing is co-owned yet, so the upstream copy can be written whole.
+        writeFileSync(gitignorePath, `${upstreamGitignore}\n`);
+        trackGitignore();
+        console.log('Restored .gitignore (it was missing).');
+      } else {
+        const { text, added } = reconcileGitignore(readFileSync(gitignorePath, 'utf-8'), upstreamGitignore);
+        if (added.length > 0) {
+          writeFileSync(gitignorePath, text);
+          trackGitignore();
+          console.log(`.gitignore: appended ${added.length} missing rule(s): ${added.join(', ')}`);
+        }
+      }
+    } catch (err) {
+      // Never abort an update over this, but never swallow it either: a silent
+      // skip here is precisely how the original bug stayed invisible.
+      console.error(`Could not reconcile .gitignore: ${err.message}`);
+      console.error('Your own rules were left untouched. Compare manually with: git diff FETCH_HEAD -- .gitignore');
     }
 
     // Lazy import: keep update-system.mjs self-loading (see the top-of-file

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -20,7 +20,7 @@
  */
 
 import { execFile, execFileSync, execSync } from 'child_process';
-import { copyFileSync, readFileSync, writeFileSync, existsSync, unlinkSync, rmSync } from 'fs';
+import { copyFileSync, readFileSync, writeFileSync, existsSync, unlinkSync, rmSync, renameSync } from 'fs';
 import { join, dirname, posix as pathPosix } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 
@@ -1134,6 +1134,31 @@ const GITIGNORE_BLOCK_HEADER = [
 ];
 
 /**
+ * Write .gitignore atomically: temp file on the same filesystem, then rename.
+ *
+ * writeFileSync opens with O_TRUNC, so a crash or I/O error partway through
+ * leaves the file empty or half-written. For most files that is an annoyance.
+ * For this one it un-ignores everything the truncated portion covered, turning
+ * a failed update into exactly the exposure the file exists to prevent, and
+ * doing it silently. Mirrors discover-ats.mjs and followup-seed.mjs.
+ *
+ * @param {string} filePath - Absolute path to write.
+ * @param {string} content - Full file content.
+ * @returns {void}
+ */
+function writeGitignoreAtomic(filePath, content) {
+  const tmpPath = `${filePath}.tmp-${process.pid}`;
+  try {
+    writeFileSync(tmpPath, content);
+    renameSync(tmpPath, filePath);
+  } catch (err) {
+    // The original is still intact: the rename either happened or it did not.
+    try { rmSync(tmpPath, { force: true }); } catch { /* already gone */ }
+    throw err;
+  }
+}
+
+/**
  * Reconcile a local .gitignore against the upstream one by appending only the
  * system-owned patterns it is missing.
  *
@@ -1204,11 +1229,15 @@ export function reconcileGitignore(localText, upstreamText) {
   const lfCount = (localText.match(/\n/g) || []).length - crlfCount;
   const eol = crlfCount > lfCount ? '\r\n' : '\n';
   const body = [...GITIGNORE_BLOCK_HEADER, ...block].join(eol);
-  // An empty (or whitespace-only) local file takes no separator, or the result
-  // would open with two blank lines.
-  const head = localText.replace(/\s*$/, '');
-  const separator = head === '' ? '' : `${eol}${eol}`;
-  return { text: `${head}${separator}${body}${eol}`, added };
+  // localText is concatenated verbatim, never trimmed. A local rule whose
+  // trailing space is backslash-escaped is significant, and stripping it would
+  // MODIFY a user's line, which is the one thing this function promises not to
+  // do. Only the separator varies: none for an empty file, one EOL when the
+  // file already ends in a newline, two when it does not.
+  const separator = localText === ''
+    ? ''
+    : (/\r?\n$/.test(localText) ? eol : `${eol}${eol}`);
+  return { text: `${localText}${separator}${body}${eol}`, added };
 }
 
 // ── APPLY ───────────────────────────────────────────────────────
@@ -1480,13 +1509,13 @@ async function apply() {
       if (!existsSync(gitignorePath)) {
         // No local file at all (deleted by hand, or a checkout predating it).
         // Nothing is co-owned yet, so the upstream copy can be written whole.
-        writeFileSync(gitignorePath, `${upstreamGitignore}\n`);
+        writeGitignoreAtomic(gitignorePath, `${upstreamGitignore}\n`);
         trackGitignore();
         console.log('Restored .gitignore (it was missing).');
       } else {
         const { text, added } = reconcileGitignore(readFileSync(gitignorePath, 'utf-8'), upstreamGitignore);
         if (added.length > 0) {
-          writeFileSync(gitignorePath, text);
+          writeGitignoreAtomic(gitignorePath, text);
           trackGitignore();
           console.log(`.gitignore: appended ${added.length} missing rule(s): ${added.join(', ')}`);
         }

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -1134,6 +1134,34 @@ const GITIGNORE_BLOCK_HEADER = [
 ];
 
 /**
+ * Read a blob from a git ref verbatim, with no trimming.
+ *
+ * `gitQuiet()` calls `.trim()` on stdout, which is right for the SHAs and
+ * pathspecs every other caller reads and wrong for file CONTENT: it strips a
+ * significant backslash-escaped trailing space from the blob's final line, and
+ * the final newline with it. For .gitignore that silently defeats the verbatim
+ * guarantee reconcileGitignore() is built on, at the one line most likely to be
+ * a freshly appended rule.
+ *
+ * @param {string} spec - A `<ref>:<path>` blob spec, e.g. `FETCH_HEAD:.gitignore`.
+ * @returns {string} The blob's exact bytes as UTF-8, untrimmed.
+ */
+function gitShowRaw(spec) {
+  const args = ['show', spec];
+  const timeout = gitTimeoutMs(args);
+  try {
+    return execFileSync('git', args, {
+      cwd: ROOT, encoding: 'utf-8', timeout, stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch (err) {
+    if (isTimeoutLikeError(err)) {
+      throw new Error(`${describeGitCommand(args)} timed out after ${timeoutSeconds(timeout)}s. If your network is slow, retry or set ${gitTimeoutEnvVar(args)} to a larger value.`);
+    }
+    throw err;
+  }
+}
+
+/**
  * Write .gitignore atomically: temp file on the same filesystem, then rename.
  *
  * writeFileSync opens with O_TRUNC, so a crash or I/O error partway through
@@ -1485,7 +1513,7 @@ async function apply() {
     // and what it could only prevent inside this repository.
     try {
       const gitignorePath = join(ROOT, '.gitignore');
-      const upstreamGitignore = gitQuiet('show', 'FETCH_HEAD:.gitignore');
+      const upstreamGitignore = gitShowRaw('FETCH_HEAD:.gitignore');
       // Uncommitted local edits to .gitignore are the user's, and that is a
       // routine state rather than an exotic one: agent-inbox.mjs's own
       // ensureGitignored() appends a rule without committing it. Such a file
@@ -1509,7 +1537,11 @@ async function apply() {
       if (!existsSync(gitignorePath)) {
         // No local file at all (deleted by hand, or a checkout predating it).
         // Nothing is co-owned yet, so the upstream copy can be written whole.
-        writeGitignoreAtomic(gitignorePath, `${upstreamGitignore}\n`);
+        // Written exactly as upstream has it. The read is untrimmed, so the blob
+        // already carries its own final newline; the guard is only for a blob that
+        // somehow lacks one.
+        const seed = upstreamGitignore.endsWith('\n') ? upstreamGitignore : `${upstreamGitignore}\n`;
+        writeGitignoreAtomic(gitignorePath, seed);
         trackGitignore();
         console.log('Restored .gitignore (it was missing).');
       } else {

--- a/validate-system-paths-coverage.mjs
+++ b/validate-system-paths-coverage.mjs
@@ -43,7 +43,6 @@ const EXCLUDES = [
   '.coderabbit.yaml',
   '.editorconfig',
   '.envrc',
-  '.gitignore',
   '.npmignore',
   '.release-please-manifest.json',
   'release-please-config.json',
@@ -55,6 +54,19 @@ const EXCLUDES = [
   'interview-prep/.gitkeep',
 ];
 
+// .gitignore is excluded from the manifest but NOT from installs, and the
+// difference is the whole of #2756. It cannot join SYSTEM_PATHS: it is the one
+// system file users also write to, so the raw `git checkout` that ships every
+// other path would delete their own rules. It reaches installs by a different
+// route instead — update-system.mjs's reconcileGitignore(), which appends the
+// system-owned rules an install is missing and touches nothing else.
+//
+// Kept in its own group rather than folded in above, because the entries above
+// genuinely never reach an install and this one does. Reading it as the same
+// kind of exclusion is what let 43 releases' worth of new ignore rules stay in
+// this repository only, leaving a candidate's CV stageable in every fork.
+const RECONCILED_NOT_CHECKED_OUT = ['.gitignore'];
+
 // Trees that live in the repo but deliberately OUTSIDE the updater's world:
 // web/ is the experimental web UI — its own release-please component, never
 // shipped by update-system.mjs, never in the npm package. Excluding it here is
@@ -64,6 +76,7 @@ const EXCLUDE_PREFIXES = ['web/'];
 function covered(file) {
   // If explicitly excluded, it is covered
   if (EXCLUDES.includes(file)) return true;
+  if (RECONCILED_NOT_CHECKED_OUT.includes(file)) return true;
   if (EXCLUDE_PREFIXES.some((p) => file.startsWith(p))) return true;
 
   return ALL_PATHS.some((path) =>


### PR DESCRIPTION
## What does this PR do?

Makes `update-system.mjs apply` reconcile `.gitignore` instead of skipping it, by appending the system-owned rules an install is missing and leaving every other line alone. Adds a test that a user-authored rule survives an update, and moves `.gitignore` out of the coverage validator's generic exclusion list into its own documented group.

## Related issue

Fixes #2756

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## The bug

`.gitignore` is in neither `SYSTEM_PATHS` nor `BOOTSTRAP_PATHS`, so no ignore rule added upstream has ever reached an existing install. 43 commits touched it in the last 90 days and none of them shipped.

The consequence is sharper than "new rules are missing". Reconciling a real April 2026 `.gitignore` against today's appends **62** rules, and `cv.md` is among them. An install last updated before 2026-04-19 has the candidate's CV itself unignored, one reflexive `git add .` from a public fork.

`tests/` is in `SYSTEM_PATHS` and so is `AGENTS.md`, so an update ships `tests/user-layer-gitignored.test.mjs`, ships the newer `AGENTS.md` whose User Layer list that test reads, and withholds the `.gitignore` the test then checks against. The repo delivers the assertion and keeps the thing being asserted, which is why this never showed up as a red test.

## The approach

`.gitignore` cannot simply join `SYSTEM_PATHS`. It is the one system file users also write to, and the raw checkout that ships every other path would delete their rules, which is a worse bug landing the same silent way.

So it uses the append-if-missing shape `agent-inbox.mjs:ensureGitignored()` already applies to its own single rule, generalized to the whole upstream rule set:

- Append only the system-owned patterns an install lacks, in upstream order.
- Idempotent by **pattern presence**, not by position, so a user can reorder or relocate the appended lines and they will not come back.
- Carry each rule's own rationale comment across with it, deduplicated, since several of those comments are the only record of which paths hold PII.
- Compare normalized, emit verbatim, so a pattern whose trailing space is backslash-escaped is not corrupted on the way in.
- Preserve the file's dominant line ending, so a CRLF checkout does not show the whole file as changed.

Deliberately append-only. A rule upstream removed or rewrote leaves the superseded line in place, because a stale system rule and a user rule of the same shape are indistinguishable. A redundant ignore rule is harmless; deleting a user's is not.

## Two details worth your eye

**The reconciled file is kept out of `updated` when `.gitignore` was already dirty.** `updated` is both the rollback pathspec and the commit pathspec, and `revertPaths()` runs a bare `git checkout HEAD -- <path>` whose `protectedPaths` guard only covers newly *added* files. Without this guard an abort would hard reset `.gitignore` and destroy the user's uncommitted rules, and a success would sweep their edit in under the update's commit message, which is the same thing #2337 established for system files. This is a routine state rather than an exotic one: `ensureGitignored()` writes to `.gitignore` without committing it. The rules are live on disk either way, which is all that ignoring actually requires.

**`validate-system-paths-coverage.mjs` is part of the fix, not incidental.** It listed `.gitignore` in an undifferentiated `EXCLUDES` array next to `renovate.json` and `.editorconfig`. Those genuinely never reach an install and this one now does, so reading it as the same kind of exclusion is how the gap stayed invisible in the one tool built to catch coverage gaps. It moves to its own named group with the reasoning and a pointer to `reconcileGitignore()`.

## Testing

New `tests/gitignore-reconcile.test.mjs`, 24 assertions. The headline one is the case you asked for: a user-authored rule survives, and the original file is a prefix of the result, so nothing above the appended block was rewritten. Also covers idempotency across two passes, byte-identical no-op when nothing is missing, moved and reordered rules not being re-added, comment carry-across and dedup, negation ordering, CRLF preservation, missing trailing newline, verbatim emission of an escaped trailing space, empty local file, and the shipped `.gitignore` reconciled against itself being a no-op.

`node test-all.mjs` passes, with one unrelated pre-existing exception: `tests/intake.test.mjs` fails on my Windows machine with `EPERM` on `symlinkSync` (needs Developer Mode). It fails identically on a pristine `upstream/main` checkout, so it is environmental and not from this change. CI on Linux should be clean.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass (see the environmental exception above)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved `.gitignore` updates to append missing standard rules while preserving existing local rules, comments, ordering, line endings, and negations.
  * Automatically restores a missing `.gitignore` during system updates.
  * Keeps locally modified files unstaged while including unchanged files in update commits.
* **Bug Fixes**
  * Prevented duplicate rules and unnecessary file changes during repeated updates.
  * Update operations now report `.gitignore` reconciliation issues without stopping the entire update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->