### PR TITLE
fix(getro): pace paginated requests for WAF safety

### DIFF
--- a/providers/getro.mjs
+++ b/providers/getro.mjs
@@ -74,10 +74,10 @@ const HARD_MAX_PAGES = 1500;
 const DEFAULT_MAX_AGE_DAYS = 90;   // pagination bound only; global filter does the real cut
 
 // Delay between successive pages of one tenant's own pagination loop (not
-// between tenants). Getro showed no rate-limit evidence in manual testing,
-// but a large board is still a long burst of same-host requests without some
-// pacing.
-const INTER_PAGE_DELAY_MS = 150;
+// between tenants). 150 ms was observed to trigger Datadog WAF bans when
+// several boards were scanned back-to-back (3 boards returned 403 and stayed
+// blocked for hours). Keep a 250 ms floor (#2706).
+const INTER_PAGE_DELAY_MS = 250;
 
 function sleep(ms, ctx) {
   if (typeof ctx?.sleep === 'function') return ctx.sleep(ms);

--- a/tests/providers/getro.test.mjs
+++ b/tests/providers/getro.test.mjs
@@ -219,6 +219,24 @@ try {
   if (getroProbePages === 1) pass('getro.fetch() honors ctx.maxPages as a health-probe cap');
   else fail(`getro.fetch() made ${getroProbePages} requests despite ctx.maxPages=1`);
 
+  // A multi-page board must pace same-board POSTs; 150 ms was enough to
+  // trigger the observed Datadog WAF ban (#2706).
+  const getroDelays = [];
+  let getroPagedCalls = 0;
+  await getro.fetch(okEntry, {
+    maxPages: 2,
+    sleep: async (ms) => { getroDelays.push(ms); },
+    fetchJson: async () => {
+      getroPagedCalls++;
+      return { results: { count: 21, jobs: [{ title: `P${getroPagedCalls}`, url: `https://jobs.examplevc.example/p${getroPagedCalls}`, organization: { name: 'Acme' } }] } };
+    },
+  });
+  if (getroPagedCalls === 2 && getroDelays.length === 1 && getroDelays[0] >= 250) {
+    pass(`getro.fetch() paces follow-up pages at >= 250 ms (${getroDelays[0]} ms) (#2706)`);
+  } else {
+    fail(`getro.fetch() WAF pacing: calls=${getroPagedCalls}, delays=${JSON.stringify(getroDelays)}`);
+  }
+
   // Postings older than getro_max_age_days stop the walk (newest-first pagination bound).
   const staleCreatedAt = Math.floor((Date.now() - 200 * 86_400_000) / 1000);
   let getroAgePages = 0;


### PR DESCRIPTION
Closes #2706. Raise Getro same-board inter-page pacing from 150ms to 250ms, and add a behavioral regression test that verifies the delay is applied between pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Getro pagination reliability by increasing the minimum delay between page requests.
  * Reduced the likelihood of requests being blocked during rapid multi-page scans.

* **Tests**
  * Added coverage to verify the required delay when loading multiple pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->