### PR TITLE
fix(updater): detect tree drift and prune retired files

### DIFF
--- a/tests/updater-rollback-behavior.test.mjs
+++ b/tests/updater-rollback-behavior.test.mjs
@@ -13,7 +13,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { pass, fail } from './helpers.mjs';
-import { gitIn, removeAdditionsNotInHead } from '../update-system.mjs';
+import { gitIn, removeAdditionsNotInHead, staleSystemFiles } from '../update-system.mjs';
 
 // A throwaway git repo plus a ctx that binds the rollback helper's git runner
 // and filesystem root to it, so nothing touches the real working tree.
@@ -33,6 +33,25 @@ function stagedPaths(g) {
 }
 
 console.log('\n🧪 Testing updater rollback behavior (#2015)...');
+
+// ── 0. system-file pruning is complete but user-safe (#2532) ──
+{
+  const local = ['plugins-registry.json', 'tests/old.test.mjs', 'data/applications.md', 'scratch.txt'];
+  const remote = ['tests/new.test.mjs', 'data/applications.md'];
+  const system = ['plugins-registry.json', 'tests/', 'data/'];
+  const user = ['data/'];
+  const stale = staleSystemFiles(local, remote, system, user);
+  if (stale.length === 2 && stale.includes('plugins-registry.json') && stale.includes('tests/old.test.mjs')) {
+    pass('stale system pruning removes upstream-deleted root files and system descendants');
+  } else {
+    fail(`stale system pruning selected the wrong files: ${JSON.stringify(stale)}`);
+  }
+  if (staleSystemFiles(local, [], system, user).length === 0) {
+    pass('stale system pruning never treats an empty remote tree as a delete-all signal');
+  } else {
+    fail('stale system pruning would delete files from an empty remote tree');
+  }
+}
 
 // ── 1. protectedPaths: a user's pre-staged work survives a rollback ──
 {

--- a/tests/updater-rollback-behavior.test.mjs
+++ b/tests/updater-rollback-behavior.test.mjs
@@ -51,6 +51,18 @@ console.log('\n🧪 Testing updater rollback behavior (#2015)...');
   } else {
     fail('stale system pruning would delete files from an empty remote tree');
   }
+
+  const userDeleted = staleSystemFiles(
+    ['data/applications.md', 'tests/old.test.mjs'],
+    ['tests/new.test.mjs'],
+    ['tests/', 'data/'],
+    ['data/'],
+  );
+  if (userDeleted.includes('tests/old.test.mjs') && !userDeleted.includes('data/applications.md')) {
+    pass('stale system pruning excludes an upstream-deleted user-layer file');
+  } else {
+    fail(`stale system pruning would select a user-layer file: ${JSON.stringify(userDeleted)}`);
+  }
 }
 
 // ── 1. protectedPaths: a user's pre-staged work survives a rollback ──

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -632,6 +632,26 @@ function mergePathLists(...lists) {
   return merged;
 }
 
+function normalizeRepoPath(value) {
+  return String(value || '').replace(/\\/g, '/').replace(/^\.\//, '');
+}
+
+function pathMatchesManifest(file, entry) {
+  const normalizedFile = normalizeRepoPath(file);
+  const normalizedEntry = normalizeRepoPath(entry).replace(/\/$/, '');
+  return normalizedFile === normalizedEntry || normalizedFile.startsWith(`${normalizedEntry}/`);
+}
+
+export function staleSystemFiles(localFiles, remoteFiles, systemPaths, userPaths = USER_PATHS) {
+  const remote = new Set([...remoteFiles].map(normalizeRepoPath));
+  if (remote.size === 0) return [];
+  return [...localFiles]
+    .map(normalizeRepoPath)
+    .filter((file) => !remote.has(file))
+    .filter((file) => systemPaths.some((entry) => pathMatchesManifest(file, entry)))
+    .filter((file) => !userPaths.some((entry) => pathMatchesManifest(file, entry)));
+}
+
 // Files the self-reexec stage must check out so the TARGET update-system.mjs
 // loads without a missing-module crash. Today this is the entry plus its only
 // local import; resolveReexecCheckout derives the real set from the fetched
@@ -950,6 +970,8 @@ async function check() {
   let remote = '';
   let releaseVersion = '';
   let changelog = '';
+  let localCommit = '';
+  let remoteCommit = '';
 
   // Use curl instead of fetch() so the check works inside the Claude Code
   // sandbox (see curlGet() above for rationale).  Two sources are tried;
@@ -961,6 +983,21 @@ async function check() {
       '--header', 'User-Agent: career-ops-update-checker',
     ]),
   ]);
+
+  // VERSION is release metadata, not a complete description of the system
+  // tree. Compare the installed commit with main as well, so same-version
+  // manifest/file drift is visible (#2630). A failed commit lookup is
+  // deliberately conservative: version checks still work offline/behind a
+  // restricted git transport.
+  try { localCommit = gitQuiet('rev-parse', 'HEAD'); } catch { /* no git checkout */ }
+  const remoteRef = await curlGet('https://api.github.com/repos/santifer/career-ops/git/ref/heads/main', [
+    '--header', 'Accept: application/vnd.github+json',
+    '--header', 'User-Agent: career-ops-update-checker',
+  ]);
+  if (remoteRef !== null) {
+    try { remoteCommit = String(JSON.parse(remoteRef)?.object?.sha || '').trim(); } catch { /* malformed API response */ }
+  }
+  const systemTreeDrift = Boolean(localCommit && remoteCommit && localCommit !== remoteCommit);
 
   if (rawVersion !== null) {
     try {
@@ -1004,8 +1041,8 @@ async function check() {
     remote = releaseVersion;
   }
 
-  if (compareVersions(local, remote) >= 0) {
-    console.log(JSON.stringify({ status: 'up-to-date', local, remote }));
+  if (compareVersions(local, remote) >= 0 && !systemTreeDrift) {
+    console.log(JSON.stringify({ status: 'up-to-date', local, remote, local_commit: localCommit || undefined, remote_commit: remoteCommit || undefined }));
     return;
   }
 
@@ -1013,6 +1050,9 @@ async function check() {
     status: 'update-available',
     local,
     remote,
+    reason: systemTreeDrift ? 'system-files-changed' : 'version-changed',
+    local_commit: localCommit || undefined,
+    remote_commit: remoteCommit || undefined,
     changelog: changelog.slice(0, 500),
   }));
 }
@@ -1197,6 +1237,37 @@ async function apply() {
     }
     if (skippedPaths.length > 0) {
       console.log(`Skipped ${skippedPaths.length} path(s) absent upstream: ${skippedPaths.join(', ')}`);
+    }
+
+    // All tracked system files need the same stale-file treatment. In
+    // particular, root-level system files removed upstream (for example an
+    // old plugins-registry.json) are not covered by a directory-only prune.
+    // Never infer a deletion from an empty/failed tree lookup, and never touch
+    // untracked files or paths explicitly classified as user data (#2532).
+    try {
+      let remoteFiles = new Set();
+      try {
+        remoteFiles = new Set(
+          git('ls-tree', '-r', '--name-only', 'FETCH_HEAD')
+            .split('\n').filter(Boolean).map((p) => p.replace(/\\/g, '/'))
+        );
+      } catch {
+        // A failed tree lookup is not evidence that the target is empty.
+      }
+      if (remoteFiles.size > 0) {
+        const localFiles = git('ls-files').split('\n').filter(Boolean);
+        for (const f of staleSystemFiles(localFiles, remoteFiles, SYSTEM_PATHS)) {
+          try {
+            unlinkSync(join(ROOT, f));
+            updated.push(f);
+            console.log(`Pruned stale system file: ${f}`);
+          } catch (err) {
+            console.error(`Failed to prune stale system file ${f}: ${err.message}`);
+          }
+        }
+      }
+    } catch (err) {
+      console.error(`Stale system-file prune step failed: ${err.message}`);
     }
 
     // tests/ and test-fixtures/ are both auto-discovered and EXECUTED


### PR DESCRIPTION
Closes #2630 and #2532. The update check now compares the installed commit with upstream main so same-version system-file drift is reported. Apply prunes tracked upstream-removed system files, including root-level files, while protecting user paths and refusing empty/failed remote-tree lookups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Update checks now detect upstream system-file changes using version and commit information.
  * Removed upstream system files are automatically pruned during updates.
  * Update results include commit metadata and system-tree change details.
* **Bug Fixes**
  * User-owned files are preserved during cleanup.
  * Empty remote trees no longer incorrectly mark all local files for deletion.
  * File deletion and remote-tree lookup failures are handled safely.
* **Tests**
  * Added coverage for system-file pruning and user-file protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->