### PR TITLE
test: a discovered suite that fails to load must not decapitate the run

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -150,7 +150,37 @@ async function runDiscovered(filter = null) {
       fail(`${f.slice(ROOT.length + 1)} calls finish() — only test-all.mjs may print the global summary; discovered suites use pass/fail and return`);
       continue;
     }
-    await import(pathToFileURL(f).href);
+    // A throw at import time is the fourth member of the family this loop
+    // already guards against, and the most expensive: unguarded, one suite
+    // that cannot even load takes down the WHOLE run, so every later section
+    // never executes and the global summary never prints. From outside it
+    // does not read as "one test failed", it reads as "career-ops crashes on
+    // my machine".
+    //
+    // It is not hypothetical and it is not rare. Three instances in one day:
+    // a fixture inheriting global commit signing (#2754, ~3400 assertions
+    // lost), `tests/intake.test.mjs` calling symlinkSync unguarded on a
+    // Windows box without Developer Mode, which is the DEFAULT configuration
+    // (#2828, reported as 56% of the checks hidden), and a lock timeout in a
+    // spawned child. Each was fixed one at a time; this is the class.
+    //
+    // Every one of those is environment-shaped, so the person who hits it is
+    // a contributor on a machine unlike CI — exactly the person least able to
+    // tell "the suite is broken" from "I broke it", and the one whose first
+    // contribution it costs.
+    //
+    // Reporting it as a failed suite keeps the run red (the loading failure
+    // IS a failure) while letting the other ~90 suites report. What was a
+    // silent decapitation becomes one named line.
+    try {
+      await import(pathToFileURL(f).href);
+    } catch (err) {
+      fail(`${rel} — suite failed to load: ${err?.constructor?.name}: ${String(err?.message ?? err).split('\n')[0].slice(0, 200)}`);
+      // The first stack frame usually names the offending call, which is the
+      // difference between "it threw" and "it threw at symlinkSync:187".
+      const frame = String(err?.stack ?? '').split('\n').find((l) => l.trim().startsWith('at '));
+      if (frame) console.log(`      ${frame.trim().slice(0, 160)}`);
+    }
   }
 }
 


### PR DESCRIPTION
Relates to #2828 and #2754. This does not fix either bug; it fixes the reason both of them were so expensive.

## The class

The discovered-suite loop in `test-all.mjs` already carries three guards, each added after an incident where one file forged or truncated the global verdict:

- a suite calling `process.exit()` → refused (#1916)
- a `node:test` suite → run in a child, because importing it discards the result
- a suite calling `finish()` → refused, it prints a forged summary

`await import(pathToFileURL(f).href)` was unguarded, and it is the fourth member of the same family. A suite that throws at **load** time takes the whole run with it: every later section never executes, `Results:` never prints.

## Three instances in one day

| | cost |
|---|---|
| #2754 — fixture inherits global `commit.gpgsign` | reporter measured ~3400 assertions never run |
| #2828 — `tests/intake.test.mjs` calls `symlinkSync` unguarded; Windows without Developer Mode is the **default** | reported as 56% of the checks hidden |
| the `agent-inbox` lock timeout, in a spawned child | surfaced as `kept=29 of 30` for weeks |

Each was fixed one at a time. All three are **environment-shaped**, so the person who hits one is a contributor on a machine unlike CI: the person least equipped to tell *"the suite is broken"* from *"I broke it"*, and the one for whom it is a first impression.

## What changes

The load failure is reported as a failed suite, named, with the first stack frame. The run stays red, because a suite that cannot load **is** a failure. It just stops taking the other ninety with it.

Verified with a deliberately throwing fixture dropped into `tests/`:

```
before   process dies, `Results:` never printed, last line is "Node.js v25.9.0"
after    ❌ tests/zzz-throwing-fixture.test.mjs — suite failed to load: Error: deliberate load failure
         📊 Results: 3860 passed, 1 failed        (exit 1)
```

Fixture removed; clean run is 3860 passed, 0 failed.

Note the deliberate non-goal: this makes the failure **legible**, not tolerated. Exit stays non-zero and the suite is named, so CI is exactly as strict as before. What it removes is the silent part.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Test runs now continue when an individual suite fails during loading.
  * Import-time failures are clearly reported as failed suites with concise error details and relevant stack information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->