### PR TITLE
fix(updater): ignore line-ending-only system drift

### DIFF
--- a/update-system.mjs
+++ b/update-system.mjs
@@ -743,7 +743,11 @@ export function locallyModifiedSystemFiles(paths, upstreamRef = 'FETCH_HEAD', ct
 
   const diffNames = (ref) => {
     try {
-      return runGit('diff', '--name-only', ref, '--', ...paths).split('\n').map((p) => p.trim()).filter(Boolean);
+      // A pre-.gitattributes install can differ from the normalized upstream
+      // blob only by CRLF/LF at end of line. That is not a user edit and must
+      // not make every system file look locally modified (#2817).
+      return runGit('diff', '--ignore-space-at-eol', '--name-only', ref, '--', ...paths)
+        .split('\n').map((p) => p.trim()).filter(Boolean);
     } catch {
       // An unreadable ref (shallow clone, unrelated histories) must never abort
       // the update — it degrades the warning, not the checkout.

--- a/updater-migration-tests.mjs
+++ b/updater-migration-tests.mjs
@@ -45,6 +45,12 @@ const systemPaths = extractArray('SYSTEM_PATHS');
 const userPaths = extractArray('USER_PATHS');
 const bootstrapPaths = extractArray('BOOTSTRAP_PATHS');
 
+if (/diff', '--ignore-space-at-eol', '--name-only'/.test(source)) {
+  pass('local system edit detection ignores CRLF/LF-only drift from .gitattributes (#2817)');
+} else {
+  fail('local system edit detection can misclassify CRLF/LF-only drift as user edits (#2817)');
+}
+
 // Every concrete (non-directory) manifest entry (SYSTEM_PATHS or
 // BOOTSTRAP_PATHS) must exist in the working tree. A path deleted upstream
 // but left in the manifest survives as a permanent `error: pathspec ...` in


### PR DESCRIPTION
Closes #2817. Ignore CRLF/LF-only differences when detecting locally edited system files, preventing pre-.gitattributes installs from treating the entire system manifest as user-modified and silently skipping updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system file change detection to ignore line-ending differences, preventing CRLF/LF normalization from being incorrectly reported as user edits.

* **Tests**
  * Added coverage to verify that line-ending-only changes are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->