### PR TITLE
fix(invite-match): validate CLI flags and add a usage block

### DIFF
--- a/invite-match.mjs
+++ b/invite-match.mjs
@@ -38,6 +38,7 @@ import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { execFileSync } from 'child_process';
 import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
+import { validateFlags } from './lib/cli-flags.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const APPS_FILE = existsSync(join(CAREER_OPS, 'data/applications.md'))
@@ -46,6 +47,29 @@ const APPS_FILE = existsSync(join(CAREER_OPS, 'data/applications.md'))
 
 // --- CLI args ---
 const args = process.argv.slice(2);
+
+// --help fell through to the matcher and printed a JSON match report (#2853's
+// sibling, #2854). Handled via lib/cli-flags.mjs's validateFlags() (#2775).
+//
+// The call itself is deliberately NOT here at module scope: scan.mjs,
+// detect-reposts.mjs and tracker-sync-check.mjs all import normalizeCompanyName
+// from this file, so a module-scope check would read THEIR argv and exit the
+// process on their own perfectly valid flags. It runs inside the CLI-only guard
+// at the bottom instead.
+const KNOWN_FLAGS = ['--file', '--id', '--apply', '--json', '--summary', '--self-test', '--help', '-h'];
+
+// Flags whose value is the next argv token.
+const VALUE_FLAGS = ['--file', '--id'];
+
+const USAGE = `Usage:
+  node invite-match.mjs "<pasted invite text>"   # match an invite against the tracker
+  node invite-match.mjs --file <path>            # read the invite from a file
+  node invite-match.mjs --id <tracker#>          # force a specific tracker row
+  node invite-match.mjs --apply                  # advance the matched row to Rejected
+  node invite-match.mjs --summary                # human-readable output (default: JSON)
+  node invite-match.mjs --self-test              # run the inline self-test
+  node invite-match.mjs --help                   # show this message`;
+
 const summaryMode = args.includes('--summary');
 const selfTestMode = args.includes('--self-test');
 const fileIdx = args.indexOf('--file');
@@ -1072,6 +1096,7 @@ function runSelfTest() {
 
 // --- Run (CLI only; guarded so the module is safely importable for tests) ---
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  validateFlags(args, KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS });
   if (selfTestMode) {
     runSelfTest();
   } else {


### PR DESCRIPTION
Closes #2854.

`node invite-match.mjs --help` fell through to the matcher and printed a JSON match report at exit 0. `--bogus` did the same.

## What changed

Argv goes through `validateFlags()` from `lib/cli-flags.mjs` (#2775). `--file` and `--id` are declared in `valueFlags` so their operands aren't misread as unrecognized flags.

**One thing worth flagging in review:** the call is inside the CLI-only guard at the bottom, *not* at module scope next to the other argv reads. This file is imported for `normalizeCompanyName`/`companySimilarity` by three other scripts —

- `scan.mjs:53`
- `detect-reposts.mjs:30`
- `tracker-sync-check.mjs:63`

— and `validateFlags` reads `process.argv` and calls `process.exit()`. At module scope it would validate the *importer's* argv against invite-match's flag list, so `node scan.mjs --dry-run` would exit 1 with "unrecognized flag: --dry-run" while importing a name-normalizer. I verified the guard holds:

```
$ node -e "process.argv=['node','other.mjs','--dry-run','--company','X']; import('./invite-match.mjs').then(m=>console.log('imported ok'))"
imported ok
```

The pre-existing module-scope `--file requires a path` / `--id requires a tracker #` checks are untouched — they only fire when those flags are actually present, so they were already import-safe.

## Acceptance

| Check | Result |
|---|---|
| `node invite-match.mjs --help` | prints usage, exit 0 |
| `node invite-match.mjs --bogus` | `Error: unrecognized flag(s): --bogus. …`, exit 1 |
| normal run byte-identical | ✅ `diff` clean before/after on a real invite string |
| `node invite-match.mjs --self-test` | 110 passed, 0 failed |
| `node invite-match.test.mjs` | 89 passed, 0 failed |

## Local test run

`node test-all.mjs` does not complete on this machine — `tests/intake.test.mjs:187` calls `fs.symlinkSync`, refused by Windows without developer mode (`EPERM`). Pre-existing: pristine `main` fails at the identical line. The two suites that do cover this file are green above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for command-line flags.
  * Unrecognized or improperly formatted options now display usage guidance instead of being processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->