### PR TITLE
fix(check-table-freshness): validate CLI flags and add a usage block

### DIFF
--- a/check-table-freshness.mjs
+++ b/check-table-freshness.mjs
@@ -54,7 +54,7 @@ import { readFileSync, readdirSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import * as yaml from 'js-yaml';
-import { flagValue } from './lib/cli-flags.mjs';
+import { flagValue, validateFlags } from './lib/cli-flags.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = join(CAREER_OPS, 'templates');
@@ -62,6 +62,25 @@ const DEFAULT_MAX_AGE_MONTHS = 12;
 
 // --- CLI args ---
 const args = process.argv.slice(2);
+
+// --help fell through to a full freshness scan and printed the report (#2855).
+// Handled via lib/cli-flags.mjs's validateFlags() (#2775), which also rejects
+// unrecognized flags before --help so `--help --bogus` still errors.
+const KNOWN_FLAGS = ['--summary', '--self-test', '--max-age-months', '--today', '--help', '-h'];
+
+// Both take their value as the next argv token.
+const VALUE_FLAGS = ['--max-age-months', '--today'];
+
+const USAGE = `Usage:
+  node check-table-freshness.mjs                       # JSON freshness report
+  node check-table-freshness.mjs --summary             # human-readable table
+  node check-table-freshness.mjs --max-age-months <n>  # review-due threshold (default: 12)
+  node check-table-freshness.mjs --today <YYYY-MM-DD>  # evaluate as of a fixed date
+  node check-table-freshness.mjs --self-test           # run the inline self-test
+  node check-table-freshness.mjs --help                # show this message
+
+Exits 1 when any row is expired (past next_effective without re-verification).`;
+
 const summaryMode = args.includes('--summary');
 const selfTestMode = args.includes('--self-test');
 const maxAgeRaw = flagValue(args, '--max-age-months') ?? null;
@@ -539,6 +558,7 @@ function runSelfTest() {
 
 // --- Run (CLI only; guarded so the module is safely importable for tests) ---
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  validateFlags(args, KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS });
   if (selfTestMode) {
     runSelfTest();
   }


### PR DESCRIPTION
Closes #2855.

`node check-table-freshness.mjs --help` ran a full freshness scan and printed the JSON report at exit 0. `--bogus` did the same — so a mistyped `--max-age-month` silently reported against the 12-month default instead of the threshold the caller asked for.

## What changed

Argv goes through `validateFlags()` from `lib/cli-flags.mjs` (#2775). This file already imported `flagValue` from that module, so it's the same helper, not a new dependency. `--max-age-months` and `--today` are declared in `valueFlags`.

The call sits inside the existing CLI-only guard so the module stays importable — `parsePositiveInt` and the parsing helpers are exported.

## Acceptance

| Check | Result |
|---|---|
| `node check-table-freshness.mjs --help` | prints usage, exit 0 |
| `node check-table-freshness.mjs --bogus` | `Error: unrecognized flag(s): --bogus. …`, exit 1 |
| `node check-table-freshness.mjs --help --bogus` | exit 1 — flag check runs first |
| normal run byte-identical | ✅ see note below |
| `node check-table-freshness.mjs --self-test` | 46 passed, 0 failed |

On byte-identical: `--summary` output diffs clean. The default JSON differs by exactly one line, `"generatedAt"`, which is a wall-clock stamp and differs between any two runs — excluding that line the two are identical, and exit codes match (0 → 0) on both modes.

## Local test run

`node test-all.mjs` does not complete here — `tests/intake.test.mjs:187` calls `fs.symlinkSync`, refused by Windows without developer mode (`EPERM`). Pre-existing: pristine `main` fails at the identical line. This script's own `--self-test`, which `test-all.mjs` shells out to, is green above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for command-line options before running freshness checks.
  * Unknown options and invalid option combinations are now rejected with usage guidance.
  * Help requests containing unrecognized options are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->