### PR TITLE
fix(doctor): validate CLI flags and add a usage block

### DIFF
--- a/doctor.mjs
+++ b/doctor.mjs
@@ -14,9 +14,36 @@ import dotenv from 'dotenv';
 import { discoverPlugins, pluginRoots, pluginStatus } from './plugins/_engine.mjs';
 import { resolveExtractorMode } from './browser-extract.mjs';
 import { parseConfigByExtension } from './jsonc-parse.mjs';
+import { validateFlags } from './lib/cli-flags.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const argv = process.argv.slice(2);
+
+// CLIs the doctor recognises.
+const VALID_CLIS = ['claude', 'codex', 'opencode', 'antigravity', 'grok', 'qwen', 'kimi', 'copilot', 'gemini'];
+
+// --help ran the full diagnostic and printed the report at exit 0 (#2856), so
+// a mistyped flag was indistinguishable from a clean run — and --targe
+// silently diagnosed THIS checkout instead of the one asked for. Handled via
+// lib/cli-flags.mjs's validateFlags() (#2775), which rejects unrecognized
+// flags before --help so `--help --bogus` still errors.
+const KNOWN_FLAGS = ['--target', '--json', '--strict', '--cli', '--help', '-h'];
+
+// Both take their value as the next argv token.
+const VALUE_FLAGS = ['--target', '--cli'];
+
+const USAGE = `Usage:
+  node doctor.mjs                    # run the setup diagnostic
+  node doctor.mjs --json             # machine-readable onboarding state
+  node doctor.mjs --strict           # also probe portals.yml ATS slugs (network)
+  node doctor.mjs --target <path>    # diagnose another career-ops checkout
+  node doctor.mjs --cli <name>       # check a specific CLI's integration
+  node doctor.mjs --help             # show this message
+
+CLIs: ${VALID_CLIS.join(', ')}`;
+
+validateFlags(argv, KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS });
+
 const targetIdx = argv.indexOf('--target');
 const projectRoot =
   targetIdx !== -1 && argv[targetIdx + 1] ? argv[targetIdx + 1] : __dirname;
@@ -24,9 +51,6 @@ const JSON_OUT = argv.includes('--json');
 // --strict adds a live ATS-slug probe of portals.yml (network). Opt-in so the
 // default `npm run doctor` stays fast and fully offline.
 const STRICT = argv.includes('--strict');
-
-// CLIs the doctor recognises.
-const VALID_CLIS = ['claude', 'codex', 'opencode', 'antigravity', 'grok', 'qwen', 'kimi', 'copilot', 'gemini'];
 
 const cliIdx = argv.indexOf('--cli');
 const cliFlag = cliIdx !== -1 ? argv[cliIdx + 1] : null;


### PR DESCRIPTION
Closes #2856.

`node doctor.mjs --help` ran the full diagnostic and printed the report at exit 0.

The mistyped-flag half is worse here than in the sibling scripts: `--target` picks the checkout being diagnosed, so `node doctor.mjs --targe /other/checkout` fell through to the default `projectRoot` and diagnosed **this** checkout while the caller believed they were looking at the other one.

## What changed

Argv goes through `validateFlags()` from `lib/cli-flags.mjs` (#2775). `--target` and `--cli` are declared in `valueFlags`.

`VALID_CLIS` moves a few lines up, above the validation block, so `USAGE` can list the recognised CLIs — referencing it from its original position would hit the temporal dead zone. No other code moves.

## Acceptance

| Check | Result |
|---|---|
| `node doctor.mjs --help` | prints usage, exit 0 |
| `node doctor.mjs --bogus` | `Error: unrecognized flag(s): --bogus. …`, exit 1 |
| `node doctor.mjs --help --bogus` | exit 1 — flag check runs first |
| `node doctor.mjs` byte-identical | ✅ diff clean |
| `node doctor.mjs --json` byte-identical | ✅ diff clean |

A note on how I checked the last one, since it initially looked like a regression. The first before/after comparison differed in `autoCopied`: `["modes/_profile.md","modes/_custom.md","modes/_brief.md"]` vs `[]`. That is doctor's own side effect — the first invocation copies the customization templates, so any second invocation reports none, whichever version runs second. Re-running both with that state already settled gives byte-identical output. Worth knowing if you ever diff `--json` output across versions.

`--json` is the path `AGENTS.md` has agents run on the first message of every session, so I checked it specifically.

## Local test run

`node test-all.mjs` does not complete here — `tests/intake.test.mjs:187` calls `fs.symlinkSync`, refused by Windows without developer mode (`EPERM`). Pre-existing: pristine `main` fails at the identical line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for command-line options.
  * Unrecognized options are now rejected before diagnostics begin.
  * Updated usage guidance to clarify supported options and value requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->