### PR TITLE
fix(web): enforce that no runtime grants itself blanket write permission

### DIFF
--- a/web/src/lib/clis.ts
+++ b/web/src/lib/clis.ts
@@ -14,6 +14,29 @@ export type CliSpec = {
   args: (prompt: string) => string[];
 };
 
+/**
+ * NO RUNTIME HERE MAY GRANT ITSELF MORE PERMISSION THAN THE AUDITED ONE.
+ *
+ * The permission model is per-worker AND per-CLI, but only one axis is written
+ * down: WRITE_CAPABLE_TOOLS and the per-kind deny lists live in
+ * claude-invocation.mjs — i.e. on Claude's path. A new CLI arriving with a
+ * blanket auto-approve flag (`--always-approve`, `--yolo`,
+ * `--dangerously-skip-permissions`, `--yes`) is not breaking that rule; it is
+ * entering where the rule does not exist.
+ *
+ * Concretely: the `pdf` worker has Bash explicitly denied and must never regain
+ * it. Pair Grok with `--always-approve` and that same worker gets Write and
+ * Bash auto-approved — so the user's choice of runtime silently changes what a
+ * worker may do to their files, while both paths look identical in the UI.
+ *
+ * If a CLI has no per-tool deny list to pair with, the answer is NOT to
+ * auto-approve: it is to withhold the workers that write. Needing such a flag
+ * to make a runtime work is a core architecture issue, not a line inside a
+ * CLI-support PR.
+ *
+ * Enforced by tests/lib/clis-permissions.test.mjs, because a rule that only
+ * lives in a comment is a rule the next contributor may never read.
+ */
 export const KNOWN: CliSpec[] = [
   { id: "claude", name: "Claude Code", bin: "claude", run: "claude -p", url: "https://claude.ai/code", args: (p) => ["-p", p] },
   { id: "codex", name: "Codex", bin: "codex", run: "codex exec", url: "https://github.com/openai/codex", args: (p) => ["exec", p] },

--- a/web/tests/lib/clis-permissions.test.mjs
+++ b/web/tests/lib/clis-permissions.test.mjs
@@ -1,0 +1,78 @@
+// No runtime in KNOWN may grant itself blanket write permission.
+//
+// The web's permission model is per-worker AND per-CLI, but only the worker
+// axis is written down: WRITE_CAPABLE_TOOLS and the per-kind deny lists live in
+// claude-invocation.mjs, on Claude's path. So a CLI entry carrying a global
+// auto-approve flag does not break a rule — it enters where the rule does not
+// exist, and nothing goes red.
+//
+// The concrete failure: `pdf` has Bash explicitly denied (#2172). Pair a CLI
+// with `--always-approve` and that same worker gets Write and Bash
+// auto-approved, so the user's runtime choice silently changes what a worker
+// may do to their files — with both paths identical in the UI.
+//
+// clis.ts is TypeScript and this test is .mjs, so KNOWN is read as text. Same
+// deliberate choice as clis-coverage.test.mjs: a regex over the shipped source
+// is enough to catch a forgotten flag and needs no build step.
+//
+// Run:  node --test tests/lib/clis-permissions.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CLIS_TS = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "src", "lib", "clis.ts");
+const src = readFileSync(CLIS_TS, "utf8");
+
+/** The KNOWN array body — the shipped argv, not the surrounding prose. A flag
+ *  named in the header comment as forbidden must not make this test fail. */
+function knownBody(text) {
+  const start = text.indexOf("export const KNOWN");
+  if (start === -1) return "";
+  const open = text.indexOf("[", start);
+  const close = text.indexOf("\n];", open);
+  return open === -1 || close === -1 ? "" : text.slice(open, close);
+}
+
+/** Flags that hand a CLI blanket approval for write-capable tools. */
+const AUTO_APPROVE = [
+  "--always-approve",
+  "--dangerously-skip-permissions",
+  "--yolo",
+  "--auto-approve",
+  "--approve-all",
+  "--skip-permissions",
+  "--no-confirm",
+];
+
+const body = knownBody(src);
+
+test("the fixture this guard reads still looks like itself", () => {
+  // Without this, a refactor that moves or renames KNOWN would leave every
+  // check below scanning an empty string and passing vacuously — green by
+  // measuring nothing, which is the failure mode this whole file exists for.
+  assert.notEqual(body, "", "KNOWN not found in clis.ts — has the file changed shape?");
+  const entries = [...body.matchAll(/id:\s*"([^"]+)"/g)].length;
+  assert.ok(entries >= 7, `KNOWN parsed as ${entries} entries — the regex has stopped seeing the array`);
+});
+
+test("no runtime grants itself blanket write permission", () => {
+  const found = AUTO_APPROVE.filter((flag) => body.includes(flag));
+  assert.deepEqual(
+    found,
+    [],
+    `KNOWN contains auto-approve flag(s): ${found.join(", ")}. A CLI with no per-tool deny list must be given fewer workers, not blanket approval — see the comment above KNOWN and claude-invocation.mjs.`,
+  );
+});
+
+test("the guard actually fires (mutation check)", () => {
+  // A guard nobody has seen fail is a hypothesis. Prove this one discriminates.
+  const mutated = body.replace(/args:\s*\(p\)\s*=>\s*\[/, 'args: (p) => ["--always-approve", ');
+  assert.notEqual(mutated, body, "mutation did not apply — the args shape changed, revisit this test");
+  assert.ok(
+    AUTO_APPROVE.some((flag) => mutated.includes(flag)),
+    "the mutated source should trip the check above",
+  );
+});

--- a/web/tests/lib/clis-permissions.test.mjs
+++ b/web/tests/lib/clis-permissions.test.mjs
@@ -27,13 +27,17 @@ const CLIS_TS = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "src",
 const src = readFileSync(CLIS_TS, "utf8");
 
 /** The KNOWN array body — the shipped argv, not the surrounding prose. A flag
- *  named in the header comment as forbidden must not make this test fail. */
+ *  named in the header comment as forbidden must not make this test fail.
+ *
+ *  Anchored past the `=` on purpose: `indexOf("[")` finds the bracket in the
+ *  TYPE (`CliSpec[]`), not the array literal. That still produced the right
+ *  answer, since the extra four characters carry no flags and the closing
+ *  `\n];` is the real one — but a parser that is accidentally correct is the
+ *  thing this whole file exists to distrust. `[^=]*` skips the annotation, so
+ *  `CliSpec[]`, `Array<CliSpec>` and `readonly CliSpec[]` all land on the
+ *  literal itself. (Caught by career-ops-maintainer in review.) */
 function knownBody(text) {
-  const start = text.indexOf("export const KNOWN");
-  if (start === -1) return "";
-  const open = text.indexOf("[", start);
-  const close = text.indexOf("\n];", open);
-  return open === -1 || close === -1 ? "" : text.slice(open, close);
+  return text.match(/export const KNOWN[^=]*=\s*\[([\s\S]*?)\n\];/)?.[1] ?? "";
 }
 
 /** Flags that hand a CLI blanket approval for write-capable tools. */


### PR DESCRIPTION
## What does this PR do?

Makes an unwritten permission rule enforceable, and writes it where the next contributor will meet it.

**The gap.** The web's permission model is per-worker **and** per-CLI, but only one axis is written down: `WRITE_CAPABLE_TOOLS` and the per-kind deny lists live in `claude-invocation.mjs` — i.e. on Claude's path. A new CLI entry arriving with a blanket auto-approve flag is not breaking that rule. **It enters where the rule does not exist**, and nothing goes red.

**Why it matters, concretely.** The `pdf` worker has `Bash` explicitly denied and must never regain it. Pair a runtime with `--always-approve` and that same worker gets Write and Bash auto-approved — so **the user's choice of runtime silently changes what a worker may do to their files**, while both paths look identical in the UI.

Found while reviewing **#2663**, which proposed exactly that flag for Grok. That PR is not at fault: it was solving a genuine headless problem at the only place the rule was visible to it. The fix belongs here, not there.

## What it does not do

It does not decide how a CLI without a per-tool deny list should run headlessly. The position it encodes is only: **withhold the workers that write, don't grant blanket approval.** If a runtime genuinely needs such a flag, that is a core architecture question, not a line inside a CLI-support PR.

## The guard

- reads the shipped `KNOWN` array **as text** (same approach as `clis-coverage.test.mjs`, no build step)
- **excludes the header comment** deliberately, so naming the forbidden flags in prose can't trip it
- carries an **anti-vacuity check**: if a refactor moves or renames `KNOWN`, the regex would otherwise scan an empty string and pass by measuring nothing

## Test plan

- [x] **Mutation-verified with the real entry from #2663**, not an invented one — the guard goes red naming `--always-approve`, and green again once removed
- [x] `web` 152/152 · `npm run typecheck` clean
- [x] `node test-all.mjs` — 3860 passed, 0 failed (1 known warning: `cv-sync-check` without user data)

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] My PR does not include personal data
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the Data Contract (no modifications to user-layer files)
- [x] My changes align with the project roadmap


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance clarifying CLI runtime permission constraints and approval risks.

* **Tests**
  * Added coverage to validate CLI permission definitions.
  * Added checks that prevent unsafe blanket auto-approval settings and detect invalid permission changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->