### PR TITLE
feat(cv): make Work Experience an optional section

### DIFF
--- a/cv-sections-core.mjs
+++ b/cv-sections-core.mjs
@@ -1,18 +1,27 @@
 // Shared optional-section stripping for the CV builders (build-cv-html.mjs,
 // build-cv-latex.mjs).
 //
-// Core competencies, projects, education, certifications, awards, and skills
-// are the genuinely optional CV sections: a competency tag row is often
-// redundant with the summary and experience bullets that prove the same
-// claims, a candidate's projects are often already covered under Work
+// Core competencies, work experience, projects, education, certifications,
+// awards, and skills are the genuinely optional CV sections: a competency tag
+// row is often redundant with the summary and experience bullets that prove
+// the same claims, a student or career-switcher has no professional history
+// to list yet, a candidate's projects are often already covered under Work
 // Experience, not every candidate has a degree, not every application carries
 // a certification worth listing, most candidates have no award to name, and
 // plenty of candidates list no skills section at all. The templates wrap all
-// six unconditionally, so a payload with no entries renders a bare section
+// seven unconditionally, so a payload with no entries renders a bare section
 // header with nothing under it. The builders' buildCompetencies()/
-// buildProjects()/buildEducation()/buildCertifications()/buildAwards()/
-// buildSkills() correctly return '' — nothing removes the surrounding
-// wrapper, which is what this module does.
+// buildExperience()/buildProjects()/buildEducation()/buildCertifications()/
+// buildAwards()/buildSkills() correctly return '' — nothing removes the
+// surrounding wrapper, which is what this module does.
+//
+// Work experience (#2504) is optional for the people this tool is aimed at —
+// new graduates, career changers, and anyone leading with projects or
+// education — not because the section is unimportant. Note that the payload
+// key being optional says nothing about the template placeholder:
+// cv-templates.mjs still requires `{{EXPERIENCE}}` to be present in any custom
+// template, exactly as before. What changed is that an empty `experience` no
+// longer leaves the wrapper behind.
 //
 // Certifications has no marker in the LaTeX template (cv-template.tex has no
 // Certifications section at all), so PATTERNS.tex has no `certifications` key
@@ -100,6 +109,7 @@ const TEX_END_SENTINEL = String.raw`(?=^%{4,}\s)`;
 const PATTERNS = {
   html: {
     competencies: new RegExp(String.raw`<!--\s+CORE COMPETENCIES\s+-->[\s\S]*?` + HTML_BOUNDARY),
+    experience: new RegExp(String.raw`<!--\s+WORK EXPERIENCE\s+-->[\s\S]*?` + HTML_BOUNDARY),
     projects: new RegExp(String.raw`<!--\s+PROJECTS\s+-->[\s\S]*?` + HTML_BOUNDARY),
     education: new RegExp(String.raw`<!--\s+EDUCATION\s+-->[\s\S]*?` + HTML_BOUNDARY),
     certifications: new RegExp(String.raw`<!--\s+CERTIFICATIONS\s+-->[\s\S]*?` + HTML_BOUNDARY),
@@ -107,6 +117,9 @@ const PATTERNS = {
     skills: new RegExp(String.raw`<!--\s+SKILLS\s+-->[\s\S]*?` + HTML_END_SENTINEL),
   },
   tex: {
+    // The LaTeX banner is `%%%%  Experience  %%%%` — mixed case, and not the
+    // "WORK EXPERIENCE" the HTML templates use.
+    experience: new RegExp(String.raw`%{4,}\s+Experience\s+%{4,}[\s\S]*?` + TEX_BOUNDARY),
     projects: new RegExp(String.raw`%{4,}\s+PROJECTS\s+%{4,}[\s\S]*?` + TEX_BOUNDARY),
     education: new RegExp(String.raw`%{4,}\s+Education\s+%{4,}[\s\S]*?` + TEX_BOUNDARY),
     awards: new RegExp(String.raw`%{4,}\s+AWARDS\s+%{4,}[\s\S]*?` + TEX_BOUNDARY),
@@ -114,7 +127,7 @@ const PATTERNS = {
   },
 };
 
-export const OPTIONAL_SECTIONS = ['competencies', 'projects', 'education', 'certifications', 'awards', 'skills'];
+export const OPTIONAL_SECTIONS = ['competencies', 'experience', 'projects', 'education', 'certifications', 'awards', 'skills'];
 
 export function isEmptySection(payload, section) {
   const entries = payload?.[section];

--- a/modes/latex.md
+++ b/modes/latex.md
@@ -96,6 +96,7 @@ Write a JSON file with this structure. `build-cv-latex.mjs` handles template mer
 | `education[].degree` | string | Degree name |
 | `education[].dates` | string | Date range |
 | `education[].coursework` | string[] | Optional — generates a coursework line if present |
+| `experience[]` | object[] | Optional — omit the key or pass `[]` and the Work Experience section is dropped, header included. For candidates with no professional history yet (students, new graduates, career changers); never drop it to hide a gap |
 | `experience[].company` | string | From cv.md Experience |
 | `experience[].role` | string | Job title |
 | `experience[].location` | string | Work location |
@@ -136,7 +137,7 @@ Write a JSON file with this structure. `build-cv-latex.mjs` handles template mer
 
 - Single-column layout (enforced by template)
 - Standard section headers: Education, Work Experience, Personal Projects, Awards & Honors, Technical Skills
-- Optional sections (Personal Projects, Education, Awards & Honors) are dropped entirely — header included — when their array is empty or absent
+- Optional sections (Work Experience, Personal Projects, Education, Awards & Honors, Technical Skills) are dropped entirely — header included — when their array is empty or absent
 - UTF-8, machine-readable via `\pdfgentounicode=1`
 - Keywords distributed: first bullet of each role, skills section
 - No images, no graphics, no color in body text

--- a/modes/pdf.md
+++ b/modes/pdf.md
@@ -61,6 +61,7 @@ Run `npm run jd:similarity -- {bundle-root}/jd/current.md {bundle-root}/jd/previ
 
 - Single-column layout (no sidebars, no parallel columns)
 - Standard headers: "Professional Summary", "Work Experience", "Education", "Skills", "Certifications", "Projects"
+- Optional sections (Core Competencies, Work Experience, Projects, Education, Certifications, Awards & Honors, Skills) are dropped entirely — header included — when their array is empty or absent
 - No text in images/SVGs
 - No critical info in PDF headers/footers (ATS ignores them)
 - UTF-8, selectable text (not rasterized)
@@ -201,7 +202,7 @@ Write a JSON file with this structure, then run `node build-cv-html.mjs <input.j
 | `sections` | object | Optional localized section titles; any omitted key falls back to the English default shown above. |
 | `summary` | string | Personalized summary with keywords. |
 | `competencies` | string[] | 6-8 keyword phrases → competency tags. |
-| `experience[]` | object | `company`, `role`, `location` (optional), `dates`, `bullets` (reordered, keyword-injected). |
+| `experience[]` | object | `company`, `role`, `location` (optional), `dates`, `bullets` (reordered, keyword-injected). Optional section — omit the key or pass `[]` and the whole block is dropped, header included. Only for candidates with no professional history to list (students, new graduates, career changers); never drop it to hide a gap. |
 | `projects[]` | object | `name`, `badge` (optional), `tech` (optional), `description` (a `bullets` array is also accepted and joined into the description line). |
 | `education[]` | object | `title` (degree), `org` (institution), `year`, `description` (optional). |
 | `certifications[]` | object | `title`, `org`, `year`. |

--- a/templates/README.md
+++ b/templates/README.md
@@ -27,7 +27,7 @@ The HTML template rendered by Playwright into PDF. Uses placeholder tokens (`{{N
 
 **Customization:** Edit this file to change colors, spacing, or section order. The placeholder tokens are documented in `batch/batch-prompt.md` under "Template placeholders."
 
-**Optional sections:** Core Competencies, Projects, Education, Certifications, Awards & Honors, and Skills are dropped in full — section header included — when the payload carries no entries for them (see `cv-sections-core.mjs`). Their markers (`<!-- PROJECTS -->`, `<!-- AWARDS -->`, …) are what the strip matches on, so renaming or removing a marker disables the strip for that section.
+**Optional sections:** Core Competencies, Work Experience, Projects, Education, Certifications, Awards & Honors, and Skills are dropped in full — section header included — when the payload carries no entries for them (see `cv-sections-core.mjs`). Their markers (`<!-- WORK EXPERIENCE -->`, `<!-- PROJECTS -->`, `<!-- AWARDS -->`, …) are what the strip matches on, so renaming or removing a marker disables the strip for that section. Note that Work Experience being *strippable* does not make `{{EXPERIENCE}}` optional in a custom template — `cv-templates.mjs` still requires the placeholder; it is the payload's `experience` array that may be empty.
 
 **The `<!-- END -->` sentinel (custom templates, read this):** Skills is the last section in the shipped templates, so it has no following section marker for the strip to stop at. A template that renders a Skills section must therefore place a literal `<!-- END -->` comment immediately after it (`%%%%  END  %%%%` in the LaTeX template) — that sentinel is what bounds the strip.
 

--- a/tests/cv-named-templates.test.mjs
+++ b/tests/cv-named-templates.test.mjs
@@ -37,7 +37,14 @@ const NAMED = [
 
 // Every optional section empty: each marker must be gone and the document must
 // still close. Awards and skills are the two that regressed historically.
-const EMPTY = { competencies: [], projects: [], education: [], certifications: [], awards: [], skills: [] };
+// `experience` is deliberately POPULATED here while every other optional
+// section is empty. It is the canary for an over-reaching strip: it sits in the
+// middle of the document, so a boundary that runs too far takes it out and the
+// `{{EXPERIENCE}}` assertion below catches it. Since #2504 experience is itself
+// strippable, which makes the canary stronger rather than obsolete — the
+// all-empty case (experience included) is covered against all nine shipped
+// templates in tests/cv-optional-sections.test.mjs.
+const EMPTY = { competencies: [], experience: [{ company: 'Canary' }], projects: [], education: [], certifications: [], awards: [], skills: [] };
 const MARKERS = ['CORE COMPETENCIES', 'PROJECTS', 'EDUCATION', 'CERTIFICATIONS', 'AWARDS', 'SKILLS'];
 
 const PAYLOAD = {
@@ -102,8 +109,9 @@ for (const { name, displayName } of NAMED) {
   else fail(`${name}: closing skeleton was swallowed — check the <!-- END --> sentinel`);
 
   if (stripEmptySections(html, {
-    competencies: ['x'], projects: [{ name: 'p' }], education: [{ degree: 'd' }],
-    certifications: [{ title: 'c' }], awards: [{ title: 'a' }], skills: [{ category: 's', items: 'x' }],
+    competencies: ['x'], experience: [{ company: 'e' }], projects: [{ name: 'p' }],
+    education: [{ degree: 'd' }], certifications: [{ title: 'c' }],
+    awards: [{ title: 'a' }], skills: [{ category: 's', items: 'x' }],
   }, 'html') === html) pass(`${name}: a fully populated payload strips nothing`);
   else fail(`${name}: strip removed content from a populated payload`);
 

--- a/tests/cv-optional-sections.test.mjs
+++ b/tests/cv-optional-sections.test.mjs
@@ -39,7 +39,7 @@
 //     valid without the sentinel — cv-templates.mjs requires only
 //     NAME/EXPERIENCE/EDUCATION — so this case must degrade to the cosmetic
 //     bare-header bug, never to a truncated CV.
-import { readFileSync } from 'fs';
+import { readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
 import { pass, fail, ROOT } from './helpers.mjs';
 import { stripEmptySections } from '../cv-sections-core.mjs';
@@ -71,8 +71,44 @@ function check(label, actual, expected) {
 const TEMPLATES = [
   { file: 'templates/cv-template.html', format: 'html', after: '<!-- END -->', hasCertifications: true, hasCompetencies: true },
   { file: 'templates/resume-template.html', format: 'html', after: '<!-- END -->', hasCertifications: false, hasCompetencies: true },
+  { file: 'templates/cv-template.zh-minimal.html', format: 'html', after: '<!-- END -->', hasCertifications: true, hasCompetencies: true },
+  { file: 'templates/cv-template.compact.html', format: 'html', after: '<!-- END -->', hasCertifications: true, hasCompetencies: true },
+  { file: 'templates/cv-template.executive.html', format: 'html', after: '<!-- END -->', hasCertifications: true, hasCompetencies: true },
+  { file: 'templates/cv-template.jake.html', format: 'html', after: '<!-- END -->', hasCertifications: true, hasCompetencies: true },
+  { file: 'templates/cv-template.leadership.html', format: 'html', after: '<!-- END -->', hasCertifications: true, hasCompetencies: true },
+  { file: 'templates/cv-template.modern.html', format: 'html', after: '<!-- END -->', hasCertifications: true, hasCompetencies: true },
   { file: 'templates/cv-template.tex', format: 'tex', after: '%%%%  END  %%%%', hasCertifications: false, hasCompetencies: false },
 ];
+
+// --- Coverage guard: no shipped CV template may sit outside the matrix ------
+// The matrix above is hand-written, which is what makes it worth trusting —
+// `hasCertifications: false` is a claim about resume-template.html, not an
+// observation of it, so a template that loses its `<!-- CERTIFICATIONS -->`
+// marker fails instead of being quietly reclassified. The cost of a hand-
+// written list is that it silently goes stale: `cv-template.zh-minimal.html`
+// shipped a full marker set and was never covered here, and #2954 then added
+// five named templates at once. Neither omission could fail a test, because an
+// uncovered template runs no assertions at all.
+//
+// So the list of templates is declared, and membership is checked against
+// disk. A CV template is identified by the `{{EXPERIENCE}}` placeholder that
+// cv-templates.mjs requires of every one (see `required` there), which is why
+// cover-letter-template.html is correctly not swept up. Adding a template
+// without adding it here fails loudly, right here, naming the file.
+const shippedCvTemplates = readdirSync(join(ROOT, 'templates'))
+  .filter((f) => /\.(html|tex)$/.test(f))
+  .filter((f) => readFileSync(join(ROOT, 'templates', f), 'utf-8').includes('{{EXPERIENCE}}'))
+  .map((f) => `templates/${f}`)
+  .sort();
+const covered = new Set(TEMPLATES.map((t) => t.file));
+const uncovered = shippedCvTemplates.filter((f) => !covered.has(f));
+const phantom = [...covered].filter((f) => !shippedCvTemplates.includes(f));
+
+if (uncovered.length === 0) pass(`every shipped CV template is in the matrix (${shippedCvTemplates.length} on disk)`);
+else fail(`shipped CV templates missing from TEMPLATES — they run zero assertions: ${uncovered.join(', ')}`);
+
+if (phantom.length === 0) pass('every template in the matrix exists on disk');
+else fail(`TEMPLATES names templates that are not on disk: ${phantom.join(', ')}`);
 
 for (const { file, format, after, hasCertifications, hasCompetencies } of TEMPLATES) {
   const template = readFileSync(join(ROOT, file), 'utf-8');

--- a/tests/cv-optional-sections.test.mjs
+++ b/tests/cv-optional-sections.test.mjs
@@ -1,7 +1,7 @@
 // tests/cv-optional-sections.test.mjs — the optional CV sections
-// (competencies, projects, education, certifications, awards, skills) must
-// vanish entirely when they have no entries, rather than rendering a bare
-// section header with nothing under it.
+// (competencies, experience, projects, education, certifications, awards,
+// skills) must vanish entirely when they have no entries, rather than
+// rendering a bare section header with nothing under it.
 //
 // #1879 fixed this for projects; education is the same bug (not every
 // candidate has a degree). Certifications was fixed once directly in
@@ -14,11 +14,16 @@
 // bullets, so payloads legitimately omit it — and like certifications it has
 // no LaTeX marker, so it is html-only. Skills (#2515) is optional for the
 // plainest reason of all: plenty of candidates simply have no skills section.
-// All six are delimited by marker matching rather than parsed, so the
-// boundary pattern is the whole correctness story — see the header comment in
-// cv-sections-core.mjs for the failure modes exercised here.
+// Work experience (#2504) is the last of the seven and the one that sounds
+// wrong until you name the people it is for: students, new graduates, and
+// career changers with no professional history to list, who lead with
+// projects or education instead and would otherwise ship a CV with an empty
+// "Work Experience" title on it. All seven are delimited by marker matching
+// rather than parsed, so the boundary pattern is the whole correctness story
+// — see the header comment in cv-sections-core.mjs for the failure modes
+// exercised here.
 //
-// Skills carries one extra burden the other five do not. It is the LAST
+// Skills carries one extra burden the other six do not. It is the LAST
 // section in every shipped template, so it may have no following section marker
 // to stop at; with the shared `…|$` boundary, stripping it would run to
 // end-of-file and swallow the closing document skeleton. Its patterns therefore
@@ -41,9 +46,10 @@ import { stripEmptySections } from '../cv-sections-core.mjs';
 
 console.log('\ncv-sections-core.mjs — optional sections leave no bare header');
 
-const EMPTY = { competencies: [], projects: [], education: [], certifications: [], awards: [], skills: [] };
+const EMPTY = { competencies: [], experience: [], projects: [], education: [], certifications: [], awards: [], skills: [] };
 const FULL = {
   competencies: ['Tag'],
+  experience: [{ company: 'E' }],
   projects: [{ name: 'P' }],
   education: [{ degree: 'D' }],
   certifications: [{ title: 'C' }],
@@ -80,6 +86,11 @@ for (const { file, format, after, hasCertifications, hasCompetencies } of TEMPLA
   const competenciesMarker = '<!-- CORE COMPETENCIES -->'; // html-only; no LaTeX Competencies section exists
   const awardsMarker = format === 'html' ? '<!-- AWARDS -->' : 'AWARDS  %';
   const skillsMarker = format === 'html' ? '<!-- SKILLS -->' : 'Technical Skills  %';
+  // The LaTeX banner reads "Experience" while its \section reads "Work
+  // Experience"; the HTML marker is "WORK EXPERIENCE". They are not the same
+  // string, which is exactly the kind of drift these template-backed
+  // assertions exist to catch.
+  const experienceMarker = format === 'html' ? '<!-- WORK EXPERIENCE -->' : 'Experience  %';
 
   check(`${name}: empty payload removes the projects block`, stripped.includes(projectsMarker), false);
   check(`${name}: empty payload removes the education block`, stripped.includes(educationMarker), false);
@@ -91,9 +102,13 @@ for (const { file, format, after, hasCertifications, hasCompetencies } of TEMPLA
   }
   check(`${name}: empty payload removes the awards block`, stripped.includes(awardsMarker), false);
   check(`${name}: empty payload removes the skills block`, stripped.includes(skillsMarker), false);
+  check(`${name}: empty payload removes the work-experience block`, stripped.includes(experienceMarker), false);
   check(`${name}: the trailing sentinel survives`, stripped.includes(after), true);
   check(`${name}: the closing document skeleton survives`, stripped.trimEnd().endsWith(closingSkeleton), true);
-  check(`${name}: {{EXPERIENCE}} is untouched`, stripped.includes('{{EXPERIENCE}}'), true);
+  // Removing the block takes its placeholder with it. Note this is about the
+  // *payload* key being empty, not about the template: cv-templates.mjs still
+  // requires `{{EXPERIENCE}}` to exist in any custom template.
+  check(`${name}: empty payload removes {{EXPERIENCE}} with its block`, stripped.includes('{{EXPERIENCE}}'), false);
 
   // Populated payload must be a no-op — the strip only ever removes.
   check(`${name}: populated payload leaves the template unchanged`,
@@ -144,6 +159,55 @@ for (const { file, format, after, hasCertifications, hasCompetencies } of TEMPLA
     check(`${name}: empty competencies alone keeps awards`, onlyComp.includes(awardsMarker), true);
     check(`${name}: empty competencies alone keeps skills`, onlyComp.includes(skillsMarker), true);
   }
+
+  // Experience empty on its own — the #2504 case. It sits mid-document with
+  // populated sections on both sides, so an over-greedy boundary here does
+  // not truncate a tail, it eats Projects (and in the shipped HTML templates,
+  // everything after it up to the next marker it happens to reach). Assert
+  // every neighbour survives, not just the immediate one.
+  const onlyExp = stripEmptySections(template, { ...FULL, experience: [] }, format);
+  check(`${name}: empty experience alone drops the work-experience marker`, onlyExp.includes(experienceMarker), false);
+  check(`${name}: empty experience alone drops {{EXPERIENCE}}`, onlyExp.includes('{{EXPERIENCE}}'), false);
+  check(`${name}: empty experience alone keeps projects`, onlyExp.includes(projectsMarker), true);
+  check(`${name}: empty experience alone keeps education`, onlyExp.includes(educationMarker), true);
+  check(`${name}: empty experience alone keeps awards`, onlyExp.includes(awardsMarker), true);
+  check(`${name}: empty experience alone keeps skills`, onlyExp.includes(skillsMarker), true);
+  check(`${name}: empty experience alone keeps the closing document skeleton`,
+    onlyExp.trimEnd().endsWith(closingSkeleton), true);
+  if (hasCompetencies) {
+    check(`${name}: empty experience alone keeps competencies`, onlyExp.includes(competenciesMarker), true);
+  }
+  if (hasCertifications) {
+    check(`${name}: empty experience alone keeps certifications`, onlyExp.includes(certificationsMarker), true);
+  }
+
+  // The new-graduate payload the issue is actually about: no experience AND
+  // no competencies, i.e. two adjacent empty sections. Stripping the first
+  // removes the marker the second's boundary would otherwise have stopped at,
+  // so this is where a boundary that names its successor breaks — and it is
+  // the combination a student CV actually produces, not a synthetic one.
+  if (hasCompetencies) {
+    const newGrad = stripEmptySections(template, { ...FULL, competencies: [], experience: [] }, format);
+    check(`${name}: new-grad payload drops competencies`, newGrad.includes(competenciesMarker), false);
+    check(`${name}: new-grad payload drops work experience`, newGrad.includes(experienceMarker), false);
+    check(`${name}: new-grad payload keeps projects`, newGrad.includes(projectsMarker), true);
+    check(`${name}: new-grad payload keeps education`, newGrad.includes(educationMarker), true);
+    check(`${name}: new-grad payload keeps skills`, newGrad.includes(skillsMarker), true);
+    check(`${name}: new-grad payload keeps the closing document skeleton`,
+      newGrad.trimEnd().endsWith(closingSkeleton), true);
+  }
+
+  // An omitted `experience` key must behave identically to an explicit empty
+  // array — a payload built for a candidate with no history is far more
+  // likely to omit the key than to pass [].
+  const withoutExperience = { ...FULL };
+  delete withoutExperience.experience;
+  const omittedExperience = stripEmptySections(template, withoutExperience, format);
+  check(`${name}: omitted experience key removes the work-experience block`,
+    omittedExperience.includes(experienceMarker), false);
+  check(`${name}: omitted experience key keeps projects`, omittedExperience.includes(projectsMarker), true);
+  check(`${name}: omitted experience key keeps the closing document skeleton`,
+    omittedExperience.trimEnd().endsWith(closingSkeleton), true);
 
   // Skills empty on its own: every other populated section survives, and the
   // closing document skeleton is not swallowed with it — Skills is last, so


### PR DESCRIPTION
## What does this PR do?

Makes Work Experience an optional CV section: a payload with no `experience` entries now drops the whole block, section header included, instead of rendering a bare "Work Experience" title with nothing under it. A payload that has experience renders byte-identically to before.

The markers already exist in every shipped template and both builders' `buildExperience()` already returned `''` for an empty array, so this is two patterns and one `OPTIONAL_SECTIONS` entry — no template changes. Experience sits mid-document in every shipped template and each carries the `<!-- END -->` / `%%%%  END  %%%%` sentinel, so it can never run to end-of-input and uses the shared boundary rather than Skills' marker-only one.

### Marker coverage, and what happens to a template added later

Confirming the two things asked for above. It is now **nine** shipped CV templates, not four — #2954 added five named variants after this PR was opened — and all nine carry the marker (`<!-- WORK EXPERIENCE -->`, or `%%%%  Experience  %%%%` in LaTeX): `cv-template.html`, `resume-template.html`, `cv-template.zh-minimal.html`, `cv-template.{compact,executive,jake,leadership,modern}.html`, `cv-template.tex`.

All nine are now in the `TEMPLATES` matrix in `cv-optional-sections.test.mjs`. Three were covered before; `cv-template.zh-minimal.html` shipped a full marker set and had never been in it, which is the gap raised in review.

A tenth template added later **fails loudly rather than rendering the old way** — but the loud failure is in CI, not at runtime, and the distinction matters. At runtime a template with no marker is a deliberate no-op (`stripEmptySections` only ever removes; the fail-safe reasoning is in the module header and unchanged by this PR). The enforcement is a coverage guard in the test suite: it enumerates CV templates on disk by the `{{EXPERIENCE}}` placeholder `cv-templates.mjs` requires of every one, and fails by filename when one is not in the matrix — in both directions, so a matrix entry with no file behind it fails too. I verified both cases by adding a throwaway template with markers and one without; each turns the suite red naming the file.

### Verification

I broke it on purpose before trusting it — renamed the HTML marker (3 assertions red), renamed the LaTeX banner (2 red), swapped the boundary for one naming `<!-- EDUCATION -->` (the over-greedy case eats Projects in all three HTML templates, red) — restoring after each. Byte-identical-when-present is checked end-to-end as well as in the unit assertion: I built HTML and `.tex` from a populated payload with this module and with the current `main` module, and `diff` is clean for both formats. A new-graduate payload compiles under `pdflatex` to a real 1-page PDF. `node test-all.mjs`: 4762 passed, 0 failed.

One knock-on: `cv-named-templates.test.mjs` used `{{EXPERIENCE}}` surviving an all-empty strip as its canary for an over-reaching boundary. Experience is strippable now, so its payloads populate experience explicitly — the canary keeps working instead of passing by accident.

## Related issue

Closes #2504

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Work Experience is now treated as an optional CV section.
  * Empty or omitted Work Experience sections are automatically removed, including their headers and placeholders.
  * Supported consistently across HTML, LaTeX, and PDF outputs.

* **Documentation**
  * Updated schemas and template guidance to explain when Work Experience may be omitted.

* **Bug Fixes**
  * Improved handling of empty optional sections while preserving surrounding content and document structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->