### PR TITLE
fix(velocity): count a web-written transition as an observation

### DIFF
--- a/funnel-velocity.mjs
+++ b/funnel-velocity.mjs
@@ -51,10 +51,13 @@ const summaryMode = args.includes('--summary');
 const selfTestMode = args.includes('--self-test');
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
-const VALID_SOURCES = new Set(['set-status', 'correction', 'backfill', 'manual']);
+// `web` sits alongside `set-status` because it is the same class of event: a
+// status change made in the web app is recorded as the user makes it, not
+// reconstructed afterwards. Only the door differs.
+const VALID_SOURCES = new Set(['set-status', 'web', 'correction', 'backfill', 'manual']);
 // Sources whose dates are trusted for day-math. backfill/manual are parsed and
 // counted but excluded: they are reconstructed after the fact, not observed.
-const DAY_MATH_SOURCES = new Set(['set-status', 'correction']);
+const DAY_MATH_SOURCES = new Set(['set-status', 'web', 'correction']);
 
 // The hops a candidate can measure from their own tracker. Applied→Rejected is
 // tracked separately from the forward hops — a "days to terminal" number that
@@ -485,6 +488,29 @@ function selfTest() {
   check(unknownSources.length === 1 && unknownSources[0].source === 'future-import', 'parser: unknown source counted');
   check(observations.find(o => o.source === 'future-import')?.dayMath === false, 'parser: unknown source excluded from day-math');
   check(observations.find(o => o.num === 2 && o.from === null), 'parser: "-" from-state parses as null');
+
+  // A status change made from the web app is observed live, at the moment the
+  // user makes it — the same event as a set-status transition entering through
+  // a different door. Excluding it does not drop the rows, which is what makes
+  // the failure quiet: they are parsed, counted, flagged under unknownSources,
+  // and contribute nothing to the hop figures, so a web-driven install reads as
+  // an empty funnel rather than a broken one. Its own fixture so the counts
+  // pinned above stay pinned.
+  const WEB_FIXTURE = [
+    '1\t2026-06-01\tEvaluated\tApplied\tweb\t',
+    '1\t2026-06-08\tApplied\tResponded\tweb\t',
+  ].join('\n');
+  const web = parseStatusLog(WEB_FIXTURE, states);
+  check(web.unknownSources.length === 0, `parser: web is a recognized source (got ${web.unknownSources.length} unknown)`);
+  check(web.observations.length === 2 && web.observations.every(o => o.dayMath === true),
+    'parser: web observations are trusted for day-math');
+
+  // The rows above are a clean 7-day Applied→Responded hop. Asserting the
+  // parse alone would not have caught this: the defect was never that the rows
+  // failed to parse, it was that a parsed row reached no figure.
+  const webVelocity = computeVelocity(foldObservations(web.observations), TODAY);
+  check(webVelocity.appliedToResponded.n === 1,
+    `velocity: a web transition reaches the hop figures (expected n=1, got ${webVelocity.appliedToResponded.n})`);
 
   // -- fold --
   const timelines = foldObservations(observations);


### PR DESCRIPTION
## What does this PR do?

Adds `web` to `VALID_SOURCES` and `DAY_MATH_SOURCES` in `funnel-velocity.mjs`, so a status-log row written from the web app is treated as a first-hand observation instead of an unrecognized one. Two lines and three self-test assertions.

## Related issue

Closes #2897

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---

## The defect

The two allow-lists gate every status-log row, and `web` is in neither:

```js
const VALID_SOURCES = new Set(['set-status', 'correction', 'backfill', 'manual']);
const DAY_MATH_SOURCES = new Set(['set-status', 'correction']);
```

The rows are **not** discarded, which is what makes this quiet:

```js
if (!VALID_SOURCES.has(source)) {
  unknownSources.push({ line: i + 1, num, source });
  observations.push({ …, dayMath: false });   // counted, but never fed to day-math
  continue;
}
```

A web-written transition is parsed, counted as an observation, flagged under `dataQuality.unknownSources`, and contributes nothing to "days between states". An install driven from the web app reads as an *empty* funnel rather than a broken one — the failure mode least likely to get reported.

## Why `web` belongs in both sets, not just the first

The comment above `DAY_MATH_SOURCES` states the criterion for exclusion: *"they are reconstructed after the fact, not observed."* That is true of `backfill` and `manual`. It is not true of `web` — a web status change is recorded at the moment the user makes it. It is the same event as a `set-status` transition entering through a different door. Admitting it to `VALID_SOURCES` while withholding it from `DAY_MATH_SOURCES` would clear the `unknownSources` flag and still leave every figure empty.

## `company-history.mjs` needs no change

It reads the same ledger but has no allow-list of its own: it loads it by dynamic import of this module and consumes this reader's output, so it inherits the fix rather than repeating it. Worth stating explicitly, since a second copy of the list is the obvious thing to go looking for.

## Tests

Three self-test assertions, each written and seen failing first:

```
SELF-TEST FAIL: parser: web is a recognized source (got 2 unknown)
SELF-TEST FAIL: parser: web observations are trusted for day-math
SELF-TEST FAIL: velocity: a web transition reaches the hop figures (expected n=1, got 0)
```

The third is the one that matters. Asserting the parse alone would not have caught this, because the rows always parsed — what failed was that a parsed row reached no figure. It folds the observations and asserts the hop registers, so writer and reader are checked against each other rather than each against itself.

The fixture is separate from `LOG_FIXTURE` so the counts that fixture pins stay pinned.

`node test-all.mjs` → **3877 passed, 0 failed**.

## Scope

Reader half only, deliberately. No writer changes, so it stands on its own regardless of what happens to any writer PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Web-sourced status changes are now recognized correctly.
  * Web observations contribute accurately to velocity calculations.
  * Prevented unnecessary unknown-source warnings for web data.

* **Tests**
  * Added validation for parsing web-sourced transitions and calculating velocity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->