### PR TITLE
fix(web): carry the posted: segment so web evaluations reach the POSTED column

### DIFF
--- a/web/src/app/api/run/route.ts
+++ b/web/src/app/api/run/route.ts
@@ -8,7 +8,7 @@ import path from "node:path";
 import { resolveCli } from "@/lib/clis";
 import { accumulateTokens, hasNewCompletedReport, isFatalGenericStderr } from "@/lib/run-cli-support.mjs";
 import { spawnHeadlessCli } from "@/lib/spawn-cli.mjs";
-import { careerOpsRoot, readMemory, findReportFile } from "@/lib/career-ops";
+import { careerOpsRoot, readMemory, findReportFile, readInbox, readScanDates } from "@/lib/career-ops";
 import { resolvePdfPaths, type PdfPaths } from "@/lib/pdf-paths.mjs";
 import { renderAndMarkPdf, writeCvHtml, pdfRunOutcome } from "@/lib/pdf-render.mjs";
 import { createCvEnvelopeFilter, type CvEnvelope } from "@/lib/cv-envelope.mjs";
@@ -92,7 +92,17 @@ export async function POST(req: Request) {
     pdfPaths = pathsResult.paths;
   }
 
-  const prompt = buildPrompt({ kind, input, memory: readMemory(), today });
+  // Resolve the posting date HERE rather than asking the agent for it. The
+  // scanner already wrote it from the provider's own `offer.postedAt`, so this
+  // copies a recorded value instead of inviting a guess — and modes/oferta.md is
+  // explicit that a guessed date is worse than an absent one (the POSTED column
+  // renders absent as `—`, a wrong date as a fresh req). Unknown URL → undefined
+  // → the prompt writes no segment at all.
+  const postedAt =
+    kind === "evaluate"
+      ? readInbox().find((j) => j.url === input)?.postedAt ?? readScanDates().get(input)
+      : undefined;
+  const prompt = buildPrompt({ kind, input, memory: readMemory(), today, postedAt });
 
   const isClaude = cliId === "claude";
   // Which tools each kind gets, and the whole claude argv, live in

--- a/web/src/lib/run-prompts.mjs
+++ b/web/src/lib/run-prompts.mjs
@@ -48,7 +48,10 @@ const SAFE_COMPANY_NAME = /^[\p{L}\p{N} .,&'()+/-]+$/u;
  * @param {{kind: string, input: string, memory: string, today: string}} args
  * @returns {string}
  */
-export function buildPrompt({ kind, input, memory, today }) {
+/** ISO calendar date, the only form the dashboard's POSTED column parses. */
+const ISO_DATE_RE = /^20\d{2}-\d{2}-\d{2}$/;
+
+export function buildPrompt({ kind, input, memory, today, postedAt }) {
   const mem = memory.trim() ? `\n\nDurable notes about the user (from their profile):\n${memory.trim()}\n` : "";
   if (kind === "research") {
     return `You are investigating the user's OWN work / portfolio to surface job-search-relevant strengths, headless. Investigate the target (use WebFetch for URLs; read local files if referenced) and report: what it is, why it is impressive, and how to leverage it in their job search — which roles/claims it supports and how to frame it on a CV. Be specific, honest, and encouraging. Report only: never submit, send, or click Apply anywhere, and contact no one — you are investigating the user's own work, not acting on it.${mem}
@@ -84,6 +87,24 @@ If NO slug variant resolves, say so clearly and leave portals.yml unchanged. Nev
 
 End with EXACTLY one final line: VERDICT: {5 if now live, else 1}/5 — {what you changed, ≤12 words}`;
   }
+  // The posting date is INTERPOLATED, not asked for. The scanner wrote it into
+  // pipeline.md from the provider's own `offer.postedAt`; the server already has
+  // it (readScanDates/readInbox) and passes it here, so the agent copies a value
+  // rather than deriving one. modes/oferta.md is explicit that a guessed date is
+  // worse than none — the dashboard's POSTED column renders an absent date as
+  // `—`, and an invented one reports a months-old req as fresh.
+  //
+  // Canonical form, taken from the regex that CONSUMES it (dashboard's
+  // rePostedOn) rather than from prose: its own trailing segment after `; `,
+  // anchored to a separator, ISO `YYYY-MM-DD`. Mid-sentence mentions are
+  // deliberately not metadata there, so this must be a segment or nothing.
+  //
+  // Absent → the empty string, so the row is byte-identical to today's. Same
+  // reason the url field is always written but may be empty: the shape an agent
+  // reliably follows is one unconditional template, and here the CONTENT is
+  // conditional precisely because "write nothing" is the required behaviour.
+  const postedSegment = ISO_DATE_RE.test(String(postedAt ?? "")) ? `; posted: ${postedAt}` : "";
+
   // evaluate (default) — run the REAL oferta mode + persist canonically
   //
   // The TSV row carries 10 fields, the 10th being the posting URL that
@@ -107,7 +128,7 @@ End with EXACTLY one final line: VERDICT: {5 if now live, else 1}/5 — {what yo
    a. Reserve a report number: run \`node reserve-report-num.mjs\` — its stdout is a 3-digit number (e.g. 035).
    b. Write the full report to reports/{num}-{company-slug}-${today}.md  (company-slug = company lowercased, non-alphanumerics → hyphens).
    c. Append ONE row of 10 TAB-separated columns to batch/tracker-additions/{num}-{company-slug}.tsv, in THIS exact order (real \\t tabs, status BEFORE score). ALWAYS write all 10 fields — leave the last one EMPTY if there is no posting URL, never "N/A" or "-":
-      {num}\t${today}\t{Company}\t{Role}\t{CanonicalStatus e.g. Evaluated}\t{score}/5\t❌\t[{num}](reports/{num}-{company-slug}-${today}.md)\t{one-line note}\t{posting URL, or empty}
+      {num}\t${today}\t{Company}\t{Role}\t{CanonicalStatus e.g. Evaluated}\t{score}/5\t❌\t[{num}](reports/{num}-{company-slug}-${today}.md)\t{one-line note}${postedSegment}\t{posting URL, or empty}
    d. Merge into the tracker: run \`node merge-tracker.mjs\` (it dedupes by company+role+report-num, validates the status, and writes data/applications.md — NEVER edit applications.md by hand).
 
 3. NEVER submit an application, fill no forms, contact no one. This is evaluation + persistence ONLY.${mem}

--- a/web/tests/lib/run-prompts.test.mjs
+++ b/web/tests/lib/run-prompts.test.mjs
@@ -196,3 +196,38 @@ test("buildPrompt: the evaluate prompt demands an EMPTY url field, never a place
   assert.match(prompt, /EMPTY if there is no posting URL/i);
   assert.match(prompt, /never "N\/A"/i);
 });
+
+// ── the posted: segment (#2692) ─────────────────────────────────────────────
+//
+// The dashboard's POSTED column parses this out of the tracker's Notes cell.
+// The date is interpolated by the server from what the scanner recorded, never
+// requested from the agent: modes/oferta.md is explicit that a guessed date is
+// worse than an absent one, because the column renders absent as `—` and would
+// render an invented one as a fresh requisition.
+
+test("buildPrompt: a known posting date becomes its own trailing segment", () => {
+  const prompt = buildPrompt({ kind: "evaluate", input: "https://acme.com/jobs/7", memory: "", today: "2026-08-14", postedAt: "2026-08-07" });
+  const fields = exampleTsvRow(prompt);
+
+  assert.equal(fields.length, 10, "the row must still carry all 10 fields");
+  // Canonical form, from the regex that CONSUMES it: separator-anchored `; `,
+  // label, colon, ISO date. A mid-sentence mention is deliberately not metadata.
+  assert.match(fields[8], /; posted: 2026-08-07$/);
+});
+
+test("buildPrompt: no known date writes NO segment, never a guess", () => {
+  for (const postedAt of [undefined, null, "", "unknown", "7 Aug 2026", "2026-8-7", "1999-01-01"]) {
+    const prompt = buildPrompt({ kind: "evaluate", input: "https://acme.com/jobs/7", memory: "", today: "2026-08-14", postedAt });
+    const fields = exampleTsvRow(prompt);
+    assert.equal(fields.length, 10, `field count changed for ${JSON.stringify(postedAt)}`);
+    assert.ok(!/posted:/.test(fields[8]), `wrote a posted segment for ${JSON.stringify(postedAt)}: ${fields[8]}`);
+  }
+});
+
+test("buildPrompt: the row without a date is byte-identical to before the feature", () => {
+  // The segment is the ONLY difference between the two prompts, so a run with no
+  // recorded date cannot drift from what the CLI has always produced.
+  const withDate = buildPrompt({ kind: "evaluate", input: "u", memory: "", today: "2026-08-14", postedAt: "2026-08-07" });
+  const without = buildPrompt({ kind: "evaluate", input: "u", memory: "", today: "2026-08-14" });
+  assert.equal(withDate.replace("; posted: 2026-08-07", ""), without);
+});


### PR DESCRIPTION
## What does this PR do?

Follow-up to **#2692**, which made `modes/oferta.md` carry `; posted: YYYY-MM-DD` from `pipeline.md` into the tracker's Notes cell, where the dashboard's **POSTED** column reads it as requisition age.

The web is a **writer** of that row — `run-prompts.mjs` dictates the exact TSV the agent appends — so without this, every job evaluated from the web would show `—` in that column forever.

**Nothing would have gone red.** The segment is optional, no test fails, the column is simply empty by that door. Same shape as #1298/#2833 with the posting URL, which is how it was caught: by checking the writer as well as the reader.

## The date is interpolated, not requested

`route.ts` resolves it by URL (`readInbox`, falling back to `readScanDates`) and passes it in, so the agent **copies a recorded value rather than deriving one**. The scanner already wrote it from the provider's own `offer.postedAt`.

That matters because `modes/oferta.md` is explicit that a guessed date is worse than an absent one:

> when the entry has no segment, write nothing rather than inferring a date, since the column renders an absent date as `—` and a guessed one would report a months-old req as fresh.

## Canonical form

Taken from the regex that **consumes** it — the dashboard's `rePostedOn` — rather than from prose: its own trailing segment after `; `, separator-anchored, ISO `YYYY-MM-DD`. A mid-sentence mention is deliberately not metadata there, so this is a segment or nothing.

Unknown or malformed input → **no segment**, and the prompt is then byte-identical to today's.

## Test plan

- [x] **Mutation-verified in both directions** — dropping the segment fails the positive test; emitting it unconditionally fails the two negative ones, including for `"2026-8-7"` and `"1999-01-01"`
- [x] A test asserting the no-date prompt is byte-identical to the pre-feature one
- [x] `web` 246/246 · `npm run typecheck` clean
- [x] `node test-all.mjs` — 3877 passed, 0 failed (1 known warning: `cv-sync-check` without user data)

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] My PR does not include personal data
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the Data Contract (no modifications to user-layer files)
- [x] My changes align with the project roadmap


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Evaluation prompts now include the posting date when reliable inbox or scan data is available.
  * Invalid or unavailable dates are safely omitted, preserving existing prompt behavior.
  * Evaluation data continues to maintain the expected format and structure.

* **Tests**
  * Added coverage for valid, invalid, and missing posting dates in evaluation prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->