### PR TITLE
test(providers): fail on a re-introduced private entity decoder at the source

### DIFF
--- a/providers/_html-entities.mjs
+++ b/providers/_html-entities.mjs
@@ -19,6 +19,20 @@
 // point of a shared decoder — the improvement should not have had to live in
 // one provider.
 //
+// A fourth round (#2790) migrated the seven RSS/XML providers — jobspresso,
+// higheredjobs, nodesk, larajobs, personio, teamtailor, weworkremotely — that
+// had never been in scope for any of the above. Their private copies guarded
+// only with a try/catch, which catches the RangeError above 0x10FFFF and
+// nothing else, so NUL, the C0 controls, lone surrogates and the
+// noncharacters decoded into job titles; the catch then returned '', deleting
+// the malformed reference rather than leaving it visible.
+//
+// Each round has migrated whichever copies were in front of the contributor at
+// the time, which is why there were four. tests/providers/rss-entity-decoding
+// .test.mjs now asserts at the source level that no importer of this module
+// also declares its own decoder, so the next re-introduction fails on the
+// commit that adds it instead of drifting quietly for a year.
+//
 // The hex/decimal alternatives are matched separately (not "#x?[0-9a-fA-F]+")
 // so a decimal entity can never absorb trailing hex letters — "&#1a2;" no
 // longer silently parses as codepoint 1 and drops "a2"; it just fails to

--- a/tests/providers/rss-entity-decoding.test.mjs
+++ b/tests/providers/rss-entity-decoding.test.mjs
@@ -70,27 +70,93 @@ const rssProviders = [
   ['teamtailor.mjs', 'parseTeamtailorFeed', 'https://x.teamtailor.com/jobs/1'],
   ['weworkremotely.mjs', 'parseWwrFeed', 'https://weworkremotely.com/remote-jobs/x'],
 ];
+// Every (label, getTitle) pair checked above, reused by the decode-equivalence
+// pass at the bottom so it covers the same set without re-deriving it.
+const checked = [];
+
 for (const [file, fn, link] of rssProviders) {
   const parse = (await load(file))[fn];
-  checkProvider(fn, (input) => parse(rss(input, link))[0]?.title);
+  const getTitle = (input) => parse(rss(input, link))[0]?.title;
+  checkProvider(fn, getTitle);
+  checked.push([fn, getTitle]);
 }
 
 // ── personio: title and location decode through the shared decoder on both the
 // XML feed path (tagText → extractText) and the HTML-fallback path. ──
 const { parsePersonioXml, parsePersonioHtml } = await load('personio.mjs');
 
-checkProvider('parsePersonioXml', (input) =>
+const personioXmlTitle = (input) =>
   parsePersonioXml(
     `<workzag-jobs><position><name>${input}</name><id>123</id><office>Remote</office></position></workzag-jobs>`,
     'Acme',
     'acme.jobs.personio.de',
-  )[0]?.title,
-);
+  )[0]?.title;
 
-checkProvider('parsePersonioHtml', (input) =>
+const personioHtmlTitle = (input) =>
   parsePersonioHtml(
     `<a class="job-box" href="/job/123"><h3>${input}</h3><span class="jobMetaText">Remote</span></a>`,
     'Acme',
     'acme.jobs.personio.de',
-  )[0]?.title,
-);
+  )[0]?.title;
+
+checkProvider('parsePersonioXml', personioXmlTitle);
+checkProvider('parsePersonioHtml', personioHtmlTitle);
+checked.push(['parsePersonioXml', personioXmlTitle], ['parsePersonioHtml', personioHtmlTitle]);
+
+// ── Legitimate references must still decode, the same way the shared decoder
+// decodes them. The cases above prove a provider rejects what it should; on
+// their own they are also satisfied by a provider that has stopped decoding
+// altogether, since `decodeEntities` leaves every one of them as raw text too.
+//
+// These also pin the two places the private copies used to differ from the
+// shared decoder, so a re-introduced copy that only gets *these* wrong still
+// fails: they knew five named entities and matched them case-sensitively, so
+// `&nbsp;` survived as literal text and `&AMP;` / `&#Xfc;` never decoded.
+const decodingCases = ['R&amp;D f&#252;r Z&#xfc;rich', 'A&nbsp;B', 'A&AMP;B', 'Z&#Xfc;rich'];
+
+for (const [label, getTitle] of checked) {
+  let ok = true;
+  for (const raw of decodingCases) {
+    const input = `${raw} Engineer`;
+    const title = getTitle(input) ?? '';
+    if (title !== decodeEntities(input)) {
+      fail(`${label}: ${raw}: got ${JSON.stringify(title)}, want ${JSON.stringify(decodeEntities(input))}`);
+      ok = false;
+      break;
+    }
+  }
+  if (ok) pass(`${label} decodes legitimate references exactly as the shared decoder does`);
+}
+
+// ── Source-level guard ──
+// Everything above compares a provider's output to the shared decoder on a
+// fixed set of inputs, which catches a private copy that behaves differently
+// *today*. But the failure this bug class keeps having is a copy that is
+// correct when it lands and drifts afterwards — #1555, #1639 and #2623 were
+// each a copy that had been right at some point. So assert it at the source:
+// a provider that imports the shared decoder must not also declare its own,
+// and the commit that re-introduces one fails here rather than years later.
+//
+// Scoped to importers on purpose. providers/jobvite.mjs still carries a
+// private decoder (a correct one — isEmittableCodePoint was upstreamed from
+// it in #2623) and does not import the shared module, so it is legitimately
+// outside this set rather than silently excused by an exception list.
+{
+  const { readdirSync, readFileSync } = await import('fs');
+  const dir = join(ROOT, 'providers');
+  const offenders = [];
+  for (const file of readdirSync(dir)) {
+    if (!file.endsWith('.mjs') || file === '_html-entities.mjs') continue;
+    const src = readFileSync(join(dir, file), 'utf-8');
+    if (!src.includes("from './_html-entities.mjs'")) continue;
+    // Declarations only — remotli.mjs names String.fromCodePoint in a comment
+    // explaining why it uses the shared decoder, which is not a private copy.
+    const local = src.match(/function\s+(decodeEntities|decodeXmlEntities|fromCodePoint)\b/);
+    if (local) offenders.push(`${file} (declares ${local[1]})`);
+  }
+  if (offenders.length === 0) {
+    pass('no provider both imports the shared decoder and declares a private one');
+  } else {
+    fail(`private entity decoder re-introduced in: ${offenders.join(', ')}`);
+  }
+}

--- a/tests/providers/rss-entity-decoding.test.mjs
+++ b/tests/providers/rss-entity-decoding.test.mjs
@@ -156,10 +156,17 @@ for (const [label, getTitle] of checked) {
 {
   const { readdirSync, readFileSync } = await import('fs');
   const dir = join(ROOT, 'providers');
-  const SHARED_IMPORT = "from './_html-entities.mjs'";
-  const PRIVATE_DECL = /function\s+(decodeEntities|decodeXmlEntities|fromCodePoint)\b/;
+  // Every provider on main writes the import one way, but the guard must not
+  // depend on that: quote style and `const`/arrow declarations are exactly the
+  // cosmetic variations a re-introduced copy would arrive with, and matching
+  // one spelling would let it back in (CodeRabbit on this PR).
+  const SHARED_IMPORT = /\bfrom\s*['"]\.\/_html-entities\.mjs['"]/;
+  const PRIVATE_DECL =
+    /(?:function\s*\*?\s+|(?:const|let|var)\s+)(decodeEntities|decodeXmlEntities|fromCodePoint)\b/;
   // Declarations only — remotli.mjs names String.fromCodePoint in a comment
   // explaining why it uses the shared decoder, which is not a private copy.
+  // A destructure (`const { decodeEntities } = …`) has a brace after `const`
+  // and so does not match either.
 
   const MIGRATED = [
     'jobspresso.mjs', 'higheredjobs.mjs', 'nodesk.mjs', 'larajobs.mjs',
@@ -185,7 +192,7 @@ for (const [label, getTitle] of checked) {
         offenders.push(`${file} (unreadable: ${e.message})`);
         continue;
       }
-      if (!src.includes(SHARED_IMPORT)) {
+      if (!SHARED_IMPORT.test(src)) {
         offenders.push(`${file} (no longer imports the shared decoder)`);
         continue;
       }
@@ -196,8 +203,14 @@ for (const [label, getTitle] of checked) {
     for (const file of files) {
       if (!file.endsWith('.mjs') || file === '_html-entities.mjs') continue;
       if (MIGRATED.includes(file)) continue; // already asserted, and more strictly
-      const src = readFileSync(join(dir, file), 'utf-8');
-      if (!src.includes(SHARED_IMPORT)) continue;
+      let src;
+      try {
+        src = readFileSync(join(dir, file), 'utf-8');
+      } catch (e) {
+        offenders.push(`${file} (unreadable: ${e.message})`);
+        continue;
+      }
+      if (!SHARED_IMPORT.test(src)) continue;
       const local = src.match(PRIVATE_DECL);
       if (local) offenders.push(`${file} (declares ${local[1]})`);
     }

--- a/tests/providers/rss-entity-decoding.test.mjs
+++ b/tests/providers/rss-entity-decoding.test.mjs
@@ -137,26 +137,75 @@ for (const [label, getTitle] of checked) {
 // a provider that imports the shared decoder must not also declare its own,
 // and the commit that re-introduces one fails here rather than years later.
 //
-// Scoped to importers on purpose. providers/jobvite.mjs still carries a
-// private decoder (a correct one — isEmittableCodePoint was upstreamed from
-// it in #2623) and does not import the shared module, so it is legitimately
-// outside this set rather than silently excused by an exception list.
+// Two passes, because "imports the shared decoder" alone is escapable: a
+// provider that DROPS the import while restoring a private copy would simply
+// fall out of a discovery sweep, and a correct-looking copy passes every
+// output case above (CodeRabbit on this PR).
+//
+//   1. The seven files #2818 migrated are named explicitly. That set is
+//      historical and does not move, so a hardcoded list is the right shape:
+//      each MUST still import the shared module, and dropping the import is
+//      itself the failure.
+//   2. Every other importer is swept dynamically, so a provider added later
+//      that grows its own copy is caught without anyone updating a list.
+//
+// providers/jobvite.mjs is in neither set: it still carries a private decoder
+// (a correct one — isEmittableCodePoint was upstreamed from it in #2623) and
+// does not import the shared module, so it is legitimately outside this guard
+// rather than silently excused by an exception list.
 {
   const { readdirSync, readFileSync } = await import('fs');
   const dir = join(ROOT, 'providers');
-  const offenders = [];
-  for (const file of readdirSync(dir)) {
-    if (!file.endsWith('.mjs') || file === '_html-entities.mjs') continue;
-    const src = readFileSync(join(dir, file), 'utf-8');
-    if (!src.includes("from './_html-entities.mjs'")) continue;
-    // Declarations only — remotli.mjs names String.fromCodePoint in a comment
-    // explaining why it uses the shared decoder, which is not a private copy.
-    const local = src.match(/function\s+(decodeEntities|decodeXmlEntities|fromCodePoint)\b/);
-    if (local) offenders.push(`${file} (declares ${local[1]})`);
+  const SHARED_IMPORT = "from './_html-entities.mjs'";
+  const PRIVATE_DECL = /function\s+(decodeEntities|decodeXmlEntities|fromCodePoint)\b/;
+  // Declarations only — remotli.mjs names String.fromCodePoint in a comment
+  // explaining why it uses the shared decoder, which is not a private copy.
+
+  const MIGRATED = [
+    'jobspresso.mjs', 'higheredjobs.mjs', 'nodesk.mjs', 'larajobs.mjs',
+    'personio.mjs', 'teamtailor.mjs', 'weworkremotely.mjs',
+  ];
+
+  let files;
+  try {
+    files = readdirSync(dir);
+  } catch (e) {
+    files = null;
+    fail(`cannot read ${dir}: ${e.message}`);
   }
-  if (offenders.length === 0) {
-    pass('no provider both imports the shared decoder and declares a private one');
-  } else {
-    fail(`private entity decoder re-introduced in: ${offenders.join(', ')}`);
+
+  if (files) {
+    const offenders = [];
+
+    for (const file of MIGRATED) {
+      let src;
+      try {
+        src = readFileSync(join(dir, file), 'utf-8');
+      } catch (e) {
+        offenders.push(`${file} (unreadable: ${e.message})`);
+        continue;
+      }
+      if (!src.includes(SHARED_IMPORT)) {
+        offenders.push(`${file} (no longer imports the shared decoder)`);
+        continue;
+      }
+      const local = src.match(PRIVATE_DECL);
+      if (local) offenders.push(`${file} (declares ${local[1]})`);
+    }
+
+    for (const file of files) {
+      if (!file.endsWith('.mjs') || file === '_html-entities.mjs') continue;
+      if (MIGRATED.includes(file)) continue; // already asserted, and more strictly
+      const src = readFileSync(join(dir, file), 'utf-8');
+      if (!src.includes(SHARED_IMPORT)) continue;
+      const local = src.match(PRIVATE_DECL);
+      if (local) offenders.push(`${file} (declares ${local[1]})`);
+    }
+
+    if (offenders.length === 0) {
+      pass('no provider both imports the shared decoder and declares a private one');
+    } else {
+      fail(`private entity decoder re-introduced in: ${offenders.join(', ')}`);
+    }
   }
 }


### PR DESCRIPTION
> **Rescoped.** This PR originally migrated the seven RSS providers onto the shared decoder. @gunjanjaswal got there first in #2818 and did it well — that work is merged and this branch is now rebased on top of it. What's left below is the part their PR didn't cover. Credit for the fix is theirs; the issue (#2790) is already closed by it.

## What this adds

#2818's tests compare each provider's output to `decodeEntities` across five illegal references. That catches a private copy that **behaves differently today**.

The failure this bug class keeps having is a different one: a copy that is *correct when it lands* and drifts afterwards. #1555, #1639 and #2623 were each a copy that had been right at some point — four rounds, same shape. A behavioural check can't see that, because on the day it's introduced the copy passes.

So this asserts it at the source instead: a provider that imports `providers/_html-entities.mjs` must not also declare `decodeEntities` / `decodeXmlEntities` / `fromCodePoint`.

I checked this is a real gap rather than a theoretical one — a private copy that merely delegates to the shared decoder is behaviourally identical and invisible to every existing assertion:

```
$ # larajobs.mjs: import { decodeEntities as shared } … + function decodeEntities(x){return shared(x);}
$ node tests/providers/rss-entity-decoding.test.mjs
  ❌ private entity decoder re-introduced in: larajobs.mjs (declares decodeEntities)
```

Currently clean across all 22 importers.

**Scoped to importers on purpose.** `providers/jobvite.mjs` still carries its own decoder — a correct one, since `isEmittableCodePoint` was upstreamed from it in #2623 — and doesn't import the shared module, so it sits outside the set rather than being excused by an exception list. Happy to migrate it separately if you want the set closed completely; I left it out because it's a refactor, not a fix.

## Two smaller additions

**A decode-equivalence pass** over the same eight parsers. All five illegal references are left as raw text by the shared decoder too, so on their own those assertions are equally satisfied by a provider that has stopped decoding altogether — I verified that by reverting one provider's `extractText` to a no-op and watching its guard assertions still pass. The cases chosen are the two places the private copies used to differ from the shared decoder: they knew five named entities and matched them case-sensitively, so `&nbsp;` survived as literal text and `&AMP;` / `&#Xfc;` never decoded.

```
$ # nodesk.mjs: return inner.trim();  (decoding removed)
$ node tests/providers/rss-entity-decoding.test.mjs
  ❌ parseNodeskFeed: R&amp;D f&#252;r Z&#xfc;rich: got "R&amp;D f&#252;r Z&#xfc;rich Engineer", want "R&D für Zürich Engineer"
```

**The ledger comment** at the top of `_html-entities.mjs` — the running record of this bug class — now covers the #2790 round and points at the guard. It was the thing that let me find the history in the first place, so it seemed worth keeping current.

## Verification

- `node test-all.mjs --quick` → **3946 passed, 0 failed** (1 pre-existing warning)
- Both new assertions verified in the failing direction, output above
- No production code changed — `_html-entities.mjs` is comment-only, everything else is the test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for consistent HTML entity decoding across RSS/XML integrations.
  - Documented handling of malformed, named, numeric, hexadecimal, case-insensitive, and non-breaking-space references.

- **Bug Fixes**
  - Improved consistency when displaying titles and content containing HTML entity references across supported RSS/XML integrations.

- **Tests**
  - Expanded coverage for equivalent decoding behavior, including malformed and valid references.
  - Added safeguards against inconsistent duplicate decoding implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->