### PR TITLE
fix(build-cv-latex): numeric year/date scalars are still dropped — #2641 fixed only the HTML mirror

### DIFF
--- a/lib/latex-escape.mjs
+++ b/lib/latex-escape.mjs
@@ -10,10 +10,18 @@
  * @returns {string}
  */
 export function escapeLatex(text, mode = 'text') {
-  if (typeof text !== 'string') return '';
-  if (mode === 'url') return text;
+  // Blank out only truly absent/structural values, and coerce scalars — the
+  // same rule #2641 applied to escapeHtml, which this function mirrors.
+  // `typeof text !== 'string' -> ''` silently dropped NUMBERS: a payload with
+  // `year: 2019` or `dates: 2024` (JSON numbers, not strings) rendered an empty
+  // \resumeSubheading date field while the section stayed present, so the .tex
+  // shipped without employment dates or graduation years — and the builder
+  // still reported "valid": true and exited 0.
+  if (text === null || text === undefined || typeof text === 'object') return '';
+  const value = String(text);
+  if (mode === 'url') return value;
   const out = [];
-  for (const ch of text) {
+  for (const ch of value) {
     switch (ch) {
       case '\\': out.push('\\textbackslash{}'); break;
       case '{': case '}': out.push('\\' + ch); break;

--- a/tests/cv-latex-numeric-scalars.test.mjs
+++ b/tests/cv-latex-numeric-scalars.test.mjs
@@ -1,0 +1,66 @@
+// tests/cv-latex-numeric-scalars.test.mjs — the LaTeX mirror of #2641.
+//
+// #2641 removed `typeof text !== 'string' -> ''` from escapeHtml because a
+// machine-authored payload with `dates: 2024` (a JSON number, not "2024")
+// rendered an empty field while the section stayed present. escapeLatex — the
+// function build-cv-latex.mjs runs every value through — kept the same guard,
+// so the .tex shipped without employment dates, education dates, project dates
+// or award years, and the builder still reported "valid": true and exited 0.
+//
+// End-to-end through the real builder and the shipped template, because
+// build-cv-latex.mjs exports nothing. Field names are the ones THIS builder
+// reads (education uses `dates`, awards use `year`) — they differ from the HTML
+// builder's in places, which is a schema question this test does not touch.
+import { pass, fail, ROOT, NODE, run, lastRunFailure } from './helpers.mjs';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+console.log('\nbuild-cv-latex — numeric scalars');
+
+// Numbers on purpose: every date/year below is a JSON number, not a string.
+const PAYLOAD = {
+  lang: 'en',
+  page_format: 'letter',
+  candidate: { name: 'Numeric Scalars', email: 'num@example.com' },
+  summary: 'Summary.',
+  competencies: ['Competency'],
+  experience: [{ company: 'Corp', role: 'Engineer', dates: 2024, bullets: ['Did a thing'] }],
+  education: [{ institution: 'Uni', degree: 'BSc Computing', dates: 2019 }],
+  awards: [{ title: 'Prize', year: 2025 }],
+  projects: [{ name: 'Proj', dates: 2023, bullets: ['Built a thing'] }],
+};
+
+const dir = mkdtempSync(join(tmpdir(), 'cv-latex-numeric-'));
+try {
+  const input = join(dir, 'num.json');
+  const output = join(dir, 'num.tex');
+  writeFileSync(input, JSON.stringify(PAYLOAD));
+
+  if (run(NODE, [join(ROOT, 'build-cv-latex.mjs'), input, output]) === null) {
+    const f = lastRunFailure();
+    fail(`build-cv-latex.mjs crashed (exit ${f?.status}) - ${(f?.stderr || '').trim().split('\n').pop()}`);
+  } else if (!existsSync(output)) {
+    fail('build-cv-latex.mjs exited 0 but wrote no output file');
+  } else {
+    const tex = readFileSync(output, 'utf-8');
+    const missing = [
+      ['experience dates', '2024'],
+      ['education dates', '2019'],
+      ['award year', '2025'],
+      ['project dates', '2023'],
+    ].filter(([, value]) => !tex.includes(value));
+
+    missing.length === 0
+      ? pass('numeric date/year scalars render into the .tex instead of vanishing')
+      : fail(`numeric scalars dropped from the .tex: ${missing.map(([what, v]) => `${what} (${v})`).join(', ')}`);
+
+    // The empty-field shape this produced, asserted directly: a dropped date
+    // leaves `{Corp}{}` rather than `{Corp}{2024}`.
+    /\{Corp\}\{2024\}/.test(tex)
+      ? pass('the experience subheading carries its date rather than an empty brace pair')
+      : fail(`experience subheading lost its date: ${(tex.match(/\{Corp\}\{[^}]*\}/) || ['(not found)'])[0]}`);
+  }
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}


### PR DESCRIPTION
Closes #2915.

#2641 removed `if (typeof text !== 'string') return '';` from `escapeHtml`, because a payload with `dates: 2024` (a JSON number, not `"2024"`) rendered an empty field while the section stayed `present`.

`escapeLatex` kept that guard, and `build-cv-latex.mjs` runs **every** value through it.

## Measured, end-to-end through the real builder

```
                        BEFORE   AFTER
experience dates 2024      0        1
education  dates 2019      0        1
award      year  2025      0        1
project    dates 2023      0        1
```

(occurrences in the generated `.tex`)

The shape it leaves:

```latex
\resumeSubheading
  {Corp}{}          % 2024 should be here
```

…while the builder reports `"valid": true` and exits 0. So a LaTeX CV ships without employment dates, education dates, project dates or award years, and nothing says so — the same failure #2641 describes, on the other builder.

These two have needed to move together before: **#2588 fixed the `$`-pattern replacement in both builders.**

## Fix

Mirror #2641's rule exactly — blank only `null`/`undefined`/objects, coerce scalars with `String()`.

## Two things I checked rather than assumed

**`sanitizeUrl()` in the same file keeps its string guard, deliberately.** A URL is inherently a string; coercing an object would produce `"[object Object]"` and then run it through scheme-matching, which is worse than dropping it.

**The two builders read different field names in places** — LaTeX education uses `dates` where HTML uses `year`. My first repro used the HTML names and showed the education year "missing" for the wrong reason. I re-ran against the fields *this* builder actually reads before claiming anything, and the test uses those. Whether that schema divergence is itself a problem is a separate question I haven't touched.

## Tests

`tests/cv-latex-numeric-scalars.test.mjs`, mirroring `tests/cv-numeric-scalars.test.mjs`. Both assertions fail on `main`:

```
❌ numeric scalars dropped from the .tex: experience dates (2024), education dates (2019), award year (2025), project dates (2023)
❌ experience subheading lost its date: {Corp}{}
```

`node test-all.mjs --quick` → **3937 passed, 0 failed** · `validate-system-paths-coverage` → OK.

2 commits (fix + test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Numeric and other scalar values now render correctly in generated LaTeX.
  * URL and text output handle scalar values consistently.
  * Empty values and objects continue to produce blank output where appropriate.

* **Tests**
  * Added coverage for numeric dates and years across experience, education, awards, and projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->