### PR TITLE
fix(web): 27 states.yml aliases resolve to no stage at all — plus the fold that keeps Turkish broken anyway

### DIFF
--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -3,40 +3,12 @@
 // core: normalize-statuses.mjs (aliases) + the Go TUI dashboard (score/status
 // colours = the current state-of-the-art).
 
-// Spanish + legacy aliases → canonical English tokens (normalize-statuses.mjs).
-const STATUS_ALIAS: Record<string, string> = {
-  evaluada: "EVALUATED",
-  evaluado: "EVALUATED",
-  condicional: "EVALUATED",
-  hold: "EVALUATED",
-  evaluar: "EVALUATED",
-  verificar: "EVALUATED",
-  aplicada: "APPLIED",
-  aplicado: "APPLIED",
-  enviada: "APPLIED",
-  sent: "APPLIED",
-  respondida: "RESPONDED",
-  respondido: "RESPONDED",
-  contestada: "RESPONDED",
-  entrevista: "INTERVIEW",
-  oferta: "OFFER",
-  rechazada: "REJECTED",
-  rechazado: "REJECTED",
-  descartada: "DISCARDED",
-  descartado: "DISCARDED",
-  cerrada: "DISCARDED",
-  cancelada: "DISCARDED",
-  duplicado: "DISCARDED",
-  repost: "DISCARDED",
-  monitor: "SKIP",
-  no_aplicar: "SKIP",
-  "no aplicar": "SKIP",
-  // Hired — terminal success (offer accepted), added to states.yml in #2050.
-  contratado: "HIRED",
-  contratada: "HIRED",
-  accepted: "HIRED",
-  accept: "HIRED",
-};
+// Alias → canonical stage. Lives in status-alias.mjs so a `node --test` unit
+// test can load it and assert it still covers templates/states.yml (#2917);
+// a hand-maintained copy is what drifted in #2249 and again after #2705.
+import { canonStatus } from "@/lib/status-alias.mjs";
+
+export { canonStatus };
 
 export const CANONICAL_STATES = [
   "Evaluated",
@@ -49,12 +21,6 @@ export const CANONICAL_STATES = [
   "Discarded",
   "SKIP",
 ] as const;
-
-export function canonStatus(s: string): string {
-  const k = s.trim().toLowerCase();
-  if (k === "" || k === "—" || k === "-") return "DISCARDED";
-  return STATUS_ALIAS[k] ?? s.toUpperCase();
-}
 
 /** Status dot colour, mirroring the Go TUI: green hired/interview/offer, sky
  *  applied/responded, red skip/rejected, gray discarded, neutral evaluated. */

--- a/web/src/lib/status-alias.mjs
+++ b/web/src/lib/status-alias.mjs
@@ -1,0 +1,63 @@
+// Status alias → canonical stage, mirroring `templates/states.yml`.
+//
+// Pure JS (no TS types) so it can be imported both by format.ts and by a
+// `node --test` unit test, matching funnel-tiles.mjs / clean-chips.mjs /
+// stream-parse.mjs.
+//
+// This map is a LITERAL rather than a read of states.yml because format.ts is
+// node-free on purpose — it is imported by client components, so it cannot
+// touch fs at runtime. The map has to ship in the bundle as data.
+//
+// Moved here verbatim; the alias list is unchanged by this commit.
+
+/** @type {Record<string, string>} */
+export const STATUS_ALIAS = {
+  evaluada: "EVALUATED",
+  evaluado: "EVALUATED",
+  condicional: "EVALUATED",
+  hold: "EVALUATED",
+  evaluar: "EVALUATED",
+  verificar: "EVALUATED",
+  aplicada: "APPLIED",
+  aplicado: "APPLIED",
+  enviada: "APPLIED",
+  sent: "APPLIED",
+  respondida: "RESPONDED",
+  respondido: "RESPONDED",
+  contestada: "RESPONDED",
+  entrevista: "INTERVIEW",
+  oferta: "OFFER",
+  rechazada: "REJECTED",
+  rechazado: "REJECTED",
+  descartada: "DISCARDED",
+  descartado: "DISCARDED",
+  cerrada: "DISCARDED",
+  cancelada: "DISCARDED",
+  duplicado: "DISCARDED",
+  repost: "DISCARDED",
+  monitor: "SKIP",
+  no_aplicar: "SKIP",
+  "no aplicar": "SKIP",
+  // Hired — terminal success (offer accepted), added to states.yml in #2050.
+  contratado: "HIRED",
+  contratada: "HIRED",
+  accepted: "HIRED",
+  accept: "HIRED",
+};
+
+/**
+ * Normalize a raw tracker status to a canonical stage token.
+ *
+ * Unknown input is passed through uppercased rather than rejected, so a status
+ * this map has never seen still renders as itself. Consumers substring-test the
+ * result, which is why an alias missing from the map above resolves to no stage
+ * at all — see tests/lib/status-alias.test.mjs.
+ *
+ * @param {string} s - Raw status text from the tracker.
+ * @returns {string} Canonical stage token, or the uppercased input.
+ */
+export function canonStatus(s) {
+  const k = String(s ?? "").trim().toLowerCase();
+  if (k === "" || k === "—" || k === "-") return "DISCARDED";
+  return STATUS_ALIAS[k] ?? String(s ?? "").toUpperCase();
+}

--- a/web/src/lib/status-alias.mjs
+++ b/web/src/lib/status-alias.mjs
@@ -89,6 +89,34 @@ export const STATUS_ALIAS = {
 };
 
 /**
+ * Fold raw status text to a lookup key.
+ *
+ * Mirrors foldStatusInput() in tracker-utils.mjs (#2705). The `\u0307` strip is
+ * what makes a capitalised Turkish status resolve: JS lowercases `İ` to `i` +
+ * U+0307 COMBINING DOT ABOVE, so "İşe alındı" keys as "i̇şe alındı" and misses
+ * the "işe alındı" entry. Real tracker rows are capitalised, so without this
+ * the alias table is only reachable by input that is already lowercase.
+ *
+ * NFKC and NOT NFD, deliberately: NFD decomposes precomposed letters too, so
+ * the same strip would reach the dots of ż / ė / ġ and collapse Żubr onto
+ * Zubr, Ėmė onto Eme, Ġenerali onto Generali.
+ *
+ * Markdown bold is stripped because AGENTS.md forbids it in the status field —
+ * which is exactly why it turns up there.
+ *
+ * @param {string} s - Raw status text from the tracker.
+ * @returns {string} Lookup key.
+ */
+function foldStatus(s) {
+  return String(s ?? "")
+    .replace(/\*\*/g, "")
+    .trim()
+    .normalize("NFKC")
+    .toLowerCase()
+    .replace(/\u0307/gu, "");
+}
+
+/**
  * Normalize a raw tracker status to a canonical stage token.
  *
  * Unknown input is passed through uppercased rather than rejected, so a status
@@ -100,7 +128,7 @@ export const STATUS_ALIAS = {
  * @returns {string} Canonical stage token, or the uppercased input.
  */
 export function canonStatus(s) {
-  const k = String(s ?? "").trim().toLowerCase();
+  const k = foldStatus(s);
   if (k === "" || k === "—" || k === "-") return "DISCARDED";
   return STATUS_ALIAS[k] ?? String(s ?? "").toUpperCase();
 }

--- a/web/src/lib/status-alias.mjs
+++ b/web/src/lib/status-alias.mjs
@@ -8,41 +8,84 @@
 // node-free on purpose — it is imported by client components, so it cannot
 // touch fs at runtime. The map has to ship in the bundle as data.
 //
-// Moved here verbatim; the alias list is unchanged by this commit.
+// Kept honest by tests/lib/status-alias.test.mjs, which loads states.yml and
+// asserts every alias in it resolves here. A copy with nothing checking it is
+// what #2249 fixed by hand for `Hired` and what drifted again as #2917.
+//
+// Entries marked `web-only` have no counterpart in states.yml; they predate it
+// and are kept so this cannot regress an existing tracker. The sync is
+// one-directional: states.yml is a floor, not a cap.
 
 /** @type {Record<string, string>} */
 export const STATUS_ALIAS = {
+  // Evaluated — states.yml `evaluated`
   evaluada: "EVALUATED",
-  evaluado: "EVALUATED",
   condicional: "EVALUATED",
   hold: "EVALUATED",
   evaluar: "EVALUATED",
   verificar: "EVALUATED",
-  aplicada: "APPLIED",
+  "değerlendirildi": "EVALUATED",
+  degerlendirildi: "EVALUATED",
+  evaluado: "EVALUATED", // web-only: not in states.yml
+  // Applied — states.yml `applied`
   aplicado: "APPLIED",
   enviada: "APPLIED",
+  aplicada: "APPLIED",
   sent: "APPLIED",
-  respondida: "RESPONDED",
+  "başvuruldu": "APPLIED",
+  basvuruldu: "APPLIED",
+  // Responded — states.yml `responded`
   respondido: "RESPONDED",
-  contestada: "RESPONDED",
+  "yanıt verildi": "RESPONDED",
+  "yanıt_verildi": "RESPONDED",
+  "yanit verildi": "RESPONDED",
+  yanit_verildi: "RESPONDED",
+  respondida: "RESPONDED", // web-only: not in states.yml
+  contestada: "RESPONDED", // web-only: not in states.yml
+  // Interview — states.yml `interview`
   entrevista: "INTERVIEW",
+  "mülakat": "INTERVIEW",
+  mulakat: "INTERVIEW",
+  // Offer — states.yml `offer`
   oferta: "OFFER",
-  rechazada: "REJECTED",
+  teklif: "OFFER",
+  // Rejected — states.yml `rejected`
   rechazado: "REJECTED",
-  descartada: "DISCARDED",
+  rechazada: "REJECTED",
+  reddedildi: "REJECTED",
+  // Discarded — states.yml `discarded`
   descartado: "DISCARDED",
+  descartada: "DISCARDED",
   cerrada: "DISCARDED",
   cancelada: "DISCARDED",
-  duplicado: "DISCARDED",
-  repost: "DISCARDED",
-  monitor: "SKIP",
+  "iptal edildi": "DISCARDED",
+  iptal_edildi: "DISCARDED",
+  "ıptal edildi": "DISCARDED",
+  "ıptal_edildi": "DISCARDED",
+  duplicado: "DISCARDED", // web-only: not in states.yml
+  repost: "DISCARDED", // web-only: not in states.yml
+  // SKIP — states.yml `skip`
   no_aplicar: "SKIP",
   "no aplicar": "SKIP",
-  // Hired — terminal success (offer accepted), added to states.yml in #2050.
+  skip: "SKIP",
+  monitor: "SKIP",
+  "geo blocker": "SKIP",
+  geo_blocker: "SKIP",
+  "uygun değil": "SKIP",
+  "uygun_değil": "SKIP",
+  "uygun degil": "SKIP",
+  uygun_degil: "SKIP",
+  // Hired — states.yml `hired`
   contratado: "HIRED",
   contratada: "HIRED",
+  hired: "HIRED",
   accepted: "HIRED",
   accept: "HIRED",
+  "kabul edildi": "HIRED",
+  kabul_edildi: "HIRED",
+  "işe alındı": "HIRED",
+  "ise alindi": "HIRED",
+  "işe alindi": "HIRED",
 };
 
 /**

--- a/web/tests/lib/status-alias.test.mjs
+++ b/web/tests/lib/status-alias.test.mjs
@@ -1,0 +1,82 @@
+// Drift guard: web's STATUS_ALIAS literal vs templates/states.yml.
+//
+// format.ts is node-free (client components import it), so it cannot read
+// states.yml at runtime — the alias map has to ship in the bundle as a
+// literal. This test is what makes that copy safe: it loads the real
+// states.yml and asserts every alias in it still resolves here.
+//
+// Without it, an alias added to states.yml silently resolves to nothing in the
+// dashboard. `canonStatus` ends in `STATUS_ALIAS[k] ?? s.toUpperCase()`, so an
+// unknown alias is not rejected — it is passed through as raw uppercased text,
+// and every consumer substring-tests it against the canonical names, which it
+// matches none of. The row then shows under ALL and no other tracker tab, is
+// absent from every tab badge and stage bar, and reads as zero in the
+// analytics achievement tiles — re-firing the #2410 "keep follow-ups warm"
+// nudge at someone who is mid-interview. That is #2249 (fixed by hand for one
+// state) recurring as #2917 with 27 aliases.
+//
+// Imports from status-alias.mjs rather than format.ts because `node --test`
+// has no TS runner. Reading up out of web/ follows clean-chips.test.mjs, which
+// loads ../../../templates/portals.example.yml the same way.
+//
+// Run:  node --test tests/lib/status-alias.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import yaml from "js-yaml";
+import { STATUS_ALIAS, canonStatus } from "../../src/lib/status-alias.mjs";
+
+const states = yaml.load(
+  readFileSync(new URL("../../../templates/states.yml", import.meta.url), "utf8"),
+).states;
+const STAGES = states.map((s) => s.label.toUpperCase());
+
+test("every states.yml alias resolves to its own canonical stage", () => {
+  const broken = [];
+  for (const st of states) {
+    const canon = st.label.toUpperCase();
+    for (const alias of st.aliases ?? []) {
+      const got = canonStatus(String(alias));
+      // Consumers test with `.includes`, so that is the contract to assert.
+      if (!got.includes(canon)) broken.push(`${JSON.stringify(alias)} -> ${JSON.stringify(got)}, want ${canon}`);
+    }
+  }
+  assert.deepEqual(
+    broken,
+    [],
+    `${broken.length} states.yml alias(es) resolve to no canonical stage in the dashboard (#2917).\n` +
+      `Add them to web/src/lib/status-alias.mjs:\n  ${broken.join("\n  ")}`,
+  );
+});
+
+test("no alias maps to a stage the dashboard does not know", () => {
+  for (const [alias, canon] of Object.entries(STATUS_ALIAS)) {
+    assert.ok(STAGES.includes(canon), `alias ${JSON.stringify(alias)} maps to unknown stage ${JSON.stringify(canon)}`);
+  }
+});
+
+test("a bare canonical label resolves to itself with no alias entry", () => {
+  for (const st of states) {
+    const label = st.label;
+    assert.ok(canonStatus(label).includes(label.toUpperCase()), `${label} does not resolve to itself`);
+  }
+});
+
+test("aliases states.yml does not list are still honoured", () => {
+  // These predate states.yml. Dropping them would regress an existing tracker,
+  // so the sync above is one-directional: states.yml is a floor, not a cap.
+  for (const [alias, canon] of [
+    ["evaluado", "EVALUATED"],
+    ["respondida", "RESPONDED"],
+    ["contestada", "RESPONDED"],
+    ["duplicado", "DISCARDED"],
+    ["repost", "DISCARDED"],
+  ]) {
+    assert.equal(canonStatus(alias), canon, `web-only alias ${alias} was dropped`);
+  }
+});
+
+test("empty and placeholder statuses are Discarded, not a crash", () => {
+  for (const blank of ["", "   ", "—", "-"]) assert.equal(canonStatus(blank), "DISCARDED");
+});

--- a/web/tests/lib/status-alias.test.mjs
+++ b/web/tests/lib/status-alias.test.mjs
@@ -24,7 +24,9 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import yaml from "js-yaml";
+// Namespace import, not default: js-yaml has no default export (test-all.mjs
+// enforces this — a default import breaks on js-yaml 5).
+import * as yaml from "js-yaml";
 import { STATUS_ALIAS, canonStatus } from "../../src/lib/status-alias.mjs";
 
 const states = yaml.load(
@@ -79,4 +81,39 @@ test("aliases states.yml does not list are still honoured", () => {
 
 test("empty and placeholder statuses are Discarded, not a crash", () => {
   for (const blank of ["", "   ", "—", "-"]) assert.equal(canonStatus(blank), "DISCARDED");
+});
+
+// The drift test above feeds aliases exactly as states.yml spells them, which
+// is lowercase — so it cannot see a folding bug. A real tracker row is
+// capitalised, and that is where the Turkish dotted capital breaks: JS
+// lowercases "İ" to "i" + U+0307, so "İşe alındı" keys as "i̇şe alındı" and
+// misses the "işe alındı" entry however complete the map is.
+test("a capitalised status resolves, including Turkish dotted İ", () => {
+  for (const [input, canon] of [
+    ["İşe alındı", "HIRED"],
+    ["Mülakat", "INTERVIEW"],
+    ["Teklif", "OFFER"],
+    ["Değerlendirildi", "EVALUATED"],
+    ["Başvuruldu", "APPLIED"],
+    ["Uygun değil", "SKIP"],
+    ["Reddedildi", "REJECTED"],
+    ["Entrevista", "INTERVIEW"],
+  ]) {
+    assert.equal(canonStatus(input), canon, `${input} did not resolve to ${canon}`);
+  }
+});
+
+test("the İ fold does not reach other languages' dots", () => {
+  // Why the fold is NFKC and not NFD: NFD decomposes precomposed letters too,
+  // so stripping U+0307 afterwards would eat the dot of ż / ė / ġ and collapse
+  // these onto Zubr / Eme / Generali. None is a status, so each must simply
+  // pass through unrecognised rather than silently become a different word.
+  for (const name of ["Żubr", "Ėmė", "Ġenerali"]) {
+    assert.equal(canonStatus(name), name.toUpperCase(), `${name} was over-folded`);
+  }
+});
+
+test("a bolded alias resolves — AGENTS.md forbids bold, so it turns up", () => {
+  assert.equal(canonStatus("**Oferta**"), "OFFER");
+  assert.equal(canonStatus("**Mülakat**"), "INTERVIEW");
 });


### PR DESCRIPTION
Fixes #2917.

`STATUS_ALIAS` in `web/src/lib/format.ts` is a hand-maintained copy of the alias lists in `templates/states.yml`. **27 of the aliases in states.yml resolved to no canonical stage at all** in the dashboard.

This is #2249 recurring. That issue reported the same drift for one state (`Hired`) and was fixed by hand-adding that state's aliases. The *class* — a duplicated map with nothing asserting it stays in sync — was left in place, so it drifted again as soon as #2705 landed. Two of the 27 (`geo blocker`, `geo_blocker`) predate #2705 entirely, which is the point: nothing in CI could notice.

## The bug

`canonStatus` ends in `STATUS_ALIAS[k] ?? s.toUpperCase()`. A missing alias is not rejected — it is passed through as raw uppercased text, and every consumer substring-tests it against the canonical names, which it matches none of:

```
"mülakat"     -> "MÜLAKAT"     matches tabs: NONE   (want INTERVIEW)
"teklif"      -> "TEKLIF"      matches tabs: NONE   (want OFFER)
"geo blocker" -> "GEO BLOCKER" matches tabs: NONE   (want SKIP)
```

For a row with any of them:

1. It shows under `ALL` and under **no other tracker tab** (`pipeline-view.tsx:96`).
2. It is missing from every tab badge (`:151`) and every stage bar (`analytics/page.tsx:25`).
3. **It re-opens #2410.** The analytics headline tiles are achievement counters whose zero-state is a coaching nudge:

```js
cumulativeTiles([canonStatus("Mülakat")])  // => { interviews: 0, offers: 0 }
```

Someone actively interviewing is told *"Interviews follow replies — keep follow-ups warm."* #2410 fixed that nudge for the cumulative-math case; the alias gap re-opened it through a different door.

## Second half of the bug, which the obvious fix does not reach

Completing the table was necessary but not sufficient. states.yml spells its aliases lowercase, so a test that feeds them verbatim cannot see a folding bug — but a real tracker row is capitalised:

```
canonStatus("İşe alındı")  ->  "İŞE ALINDI"   matches tabs: NONE
```

JS lowercases `İ` (U+0130) to `i` + U+0307 COMBINING DOT ABOVE, so the key becomes `i̇şe alındı` and misses the `işe alındı` entry however complete the map is. Every Turkish status written the way a user actually writes it still vanished.

Fixed with the same fold as `foldStatusInput()` in `tracker-utils.mjs` (#2705): strip bold → trim → NFKC → lowercase → drop U+0307.

**NFKC and not NFD, deliberately.** NFD decomposes precomposed letters too, so the same strip would reach the dots of `ż` / `ė` / `ġ` and collapse Żubr→Zubr, Ėmė→Eme, Ġenerali→Generali. There is a test pinning those three unchanged, so a future switch to NFD fails loudly.

Stripping bold also means `"**Oferta**"` now resolves to `OFFER` instead of matching nothing. AGENTS.md forbids bold in the status field, which is precisely why it turns up there.

## Why the map is still a literal

`format.ts` is node-free on purpose — client components import it — so it cannot read `states.yml` at runtime. The map has to ship in the bundle as data.

What makes that copy safe is the guard, not the fill: `tests/lib/status-alias.test.mjs` loads the real `templates/states.yml` and asserts every alias resolves to its own stage. Adding an alias to states.yml now **fails web CI** until it is added here too. That is the "copy + CI assertion" mechanism rather than a bare copy.

Reading up out of `web/` follows `tests/lib/clean-chips.test.mjs:101`, which loads `../../../templates/portals.example.yml` the same way; `js-yaml` is already a web dependency.

## Commits

1. **`refactor`** — move `STATUS_ALIAS` + `canonStatus` into `web/src/lib/status-alias.mjs`, following the `funnel-tiles.mjs` / `clean-chips.mjs` / `stream-parse.mjs` pattern (pure JS so a `node --test` test can import it; web has no TS runner). `format.ts` re-exports `canonStatus`, so no import site changes. No behaviour change.
2. **`fix`** — add the 29 missing aliases + the drift test.
3. **`fix`** — fold the lookup key for the Turkish dotted capital.

## Verification

Both fixes were checked for discrimination rather than assumed:

- Against the **previous map**, the drift test fails listing exactly the 27, while its sibling assertions still pass.
- Reverting **only the fold** (keeping the completed map) fails the capitalised and bolded tests while the other six pass.

`web`: 257 pass / 0 fail. `node test-all.mjs --quick`: 3935 pass / 0 fail (the 2 warnings are pre-existing and environmental — no user data, no Playwright browser).

The suite also caught a real mistake in my first draft: I default-imported `js-yaml`, and test-all.mjs rejects that. Fixed to `import * as yaml`.

## Compatibility

The 5 aliases web carries that states.yml does not list (`evaluado`, `respondida`, `contestada`, `duplicado`, `repost`) are kept and pinned by their own test — the sync is one-directional, states.yml is a floor and not a cap, so this cannot regress an existing tracker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard status recognition for localized, tracker-specific, bolded, blank, and dash-like status values.
  * Preserved correct capitalization and Unicode handling when normalizing statuses.

* **Tests**
  * Added coverage to verify status aliases remain synchronized with configured workflow stages and canonical labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->