### PR TITLE
fix(cli): a one-letter typo returned a false all-clear at exit 0 in 4 reporting CLIs

### DIFF
--- a/detect-reposts.mjs
+++ b/detect-reposts.mjs
@@ -28,13 +28,16 @@ import { fileURLToPath, pathToFileURL } from 'url';
 
 import { roleFuzzyMatch, roleTokens, BASELINE_TOKENS } from './role-matcher.mjs';
 import { normalizeCompanyName } from './invite-match.mjs';
-import { flagValue } from './lib/cli-flags.mjs';
+import { flagValue, validateFlags } from './lib/cli-flags.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const SCAN_HISTORY_PATH = join(CAREER_OPS, 'data/scan-history.tsv');
 const DEFAULT_WINDOW_DAYS = 90;
 
 // --- CLI args ---
+
+const KNOWN_FLAGS = ['--window', '--summary', '--self-test', '--help', '-h'];
+const VALUE_FLAGS = ['--window'];
 
 const USAGE = `Usage:
   node detect-reposts.mjs                       # full JSON repost clusters to stdout
@@ -490,10 +493,16 @@ function runSelfTest() {
 
 // --- Run (CLI only; guarded so the module is safely importable for tests) ---
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  if (args.includes('--help') || args.includes('-h')) {
-    console.log(USAGE);
-    process.exit(0);
-  }
+  // Replaces a bare --help check that never looked at the other flags, so a
+  // mistyped --window was ignored and the scan silently used the 90-day
+  // default instead of the window that was asked for (#2919). validateFlags
+  // also runs the unrecognized-flag check BEFORE --help, so `--help --bogus`
+  // errors rather than exiting 0 unread.
+  //
+  // Inside the main-module guard, not at import time: company-history.mjs
+  // imports detectReposts/parseScanHistory from here, so a top-level check
+  // would judge the IMPORTER's argv.
+  validateFlags(args, KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS });
 
   if (selfTestMode) {
     runSelfTest();

--- a/process-quality.mjs
+++ b/process-quality.mjs
@@ -36,7 +36,7 @@
 import { readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
-import { flagValue } from './lib/cli-flags.mjs';
+import { flagValue, validateFlags } from './lib/cli-flags.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_ACTIVE_INTERVIEWS_PATH = existsSync(join(CAREER_OPS, 'data/active-interviews.md'))
@@ -316,7 +316,26 @@ function runSelfTest() {
 }
 
 // --- Run (CLI only; guarded so the module is safely importable for tests) ---
+const KNOWN_FLAGS = ['--file', '--min-threshold', '--summary', '--self-test', '--help', '-h'];
+const VALUE_FLAGS = ['--file', '--min-threshold'];
+
+const USAGE = `Usage:
+  node process-quality.mjs                        # JSON report
+  node process-quality.mjs --summary              # human-readable table
+  node process-quality.mjs --file <path>          # a different active-interviews.md
+  node process-quality.mjs --min-threshold <N>    # minimum rounds before a company is reported (default 1)
+  node process-quality.mjs --self-test            # run the built-in fixtures
+  node process-quality.mjs --help                 # show this message`;
+
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  // Inside the main-module guard, not at import time: rejection-latency.mjs
+  // imports parseActiveInterviews from here, so a top-level check would judge
+  // the IMPORTER's argv and reject its flags as unrecognized (#2919).
+  //
+  // A mistyped --file was previously ignored, so the script silently reported
+  // on data/active-interviews.md instead of the path that was asked for.
+  validateFlags(args, KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS });
+
   if (selfTestMode) {
     runSelfTest();
   }

--- a/rejection-latency.mjs
+++ b/rejection-latency.mjs
@@ -53,6 +53,7 @@ import * as yaml from 'js-yaml';
 import { parseActiveInterviews } from './process-quality.mjs';
 import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 import { roleFuzzyMatch } from './role-matcher.mjs';
+import { flagValue, hasFlag, validateFlags } from './lib/cli-flags.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_ACTIVE_INTERVIEWS_PATH = existsSync(join(CAREER_OPS, 'data/active-interviews.md'))
@@ -71,19 +72,54 @@ export const DISCLAIMER =
 
 // --- CLI args ---
 const args = process.argv.slice(2);
+
+const KNOWN_FLAGS = [
+  '--file', '--tracker', '--courtesy-days', '--today',
+  '--summary', '--self-test', '--help', '-h',
+];
+const VALUE_FLAGS = ['--file', '--tracker', '--courtesy-days', '--today'];
+
+const USAGE = `Usage:
+  node rejection-latency.mjs                        # JSON report
+  node rejection-latency.mjs --summary              # human-readable table
+  node rejection-latency.mjs --file <path>          # a different active-interviews.md
+  node rejection-latency.mjs --tracker <path>       # a different applications.md
+  node rejection-latency.mjs --courtesy-days <N>    # override the courtesy threshold (default ${DEFAULT_COURTESY_DAYS})
+  node rejection-latency.mjs --today <YYYY-MM-DD>   # evaluate as of a fixed date
+  node rejection-latency.mjs --self-test            # run the built-in fixtures
+  node rejection-latency.mjs --help                 # show this message
+
+Suggestion-only: nothing is ever written to data/blacklist.md for you.
+${DISCLAIMER}`;
+
+// A mistyped flag used to be ignored, so --traker fell back to
+// DEFAULT_TRACKER_PATH and the tool reported "no post-interview silence
+// exceeded the configured thresholds" at exit 0 — a false all-clear computed
+// from a tracker the caller never named (#2919). Same shape as doctor.mjs's
+// --targe (#2874). Runs before --help so `--help --bogus` still errors.
+validateFlags(args, KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS });
+
 const summaryMode = args.includes('--summary');
 const selfTestMode = args.includes('--self-test');
-// A flag's value must be present and must not itself look like another flag
-// (e.g. `--today --summary` must not silently set cliToday to '--summary').
+// Shared flagValue so `--tracker=path` is honoured too: the previous
+// indexOf-only lookup returned -1 for the `=` form and silently discarded the
+// value, the defect lib/cli-flags.mjs documents as #2401/#2402.
+//
+// The "value must not itself look like another flag" check is kept — it is
+// stricter than the shared helper, and it is what stops `--today --summary`
+// from setting cliToday to '--summary'.
 const argValue = (flag) => {
-  const idx = args.indexOf(flag);
-  if (idx === -1) return null;
-  const next = args[idx + 1];
-  if (next === undefined || next.startsWith('--')) {
+  // hasFlag before flagValue: flagValue returns undefined for BOTH an absent
+  // flag and one supplied with no value, so testing it alone would turn a
+  // trailing `--tracker` from a usage error into a silent fall back to the
+  // default path. lib/cli-flags.mjs documents pairing the two for exactly this.
+  if (!hasFlag(args, flag)) return null;
+  const value = flagValue(args, flag);
+  if (value === undefined || value === '' || value.startsWith('--')) {
     console.error(`${flag} requires a value.`);
     process.exit(2);
   }
-  return next;
+  return value;
 };
 const ACTIVE_INTERVIEWS_PATH = argValue('--file') || DEFAULT_ACTIVE_INTERVIEWS_PATH;
 const TRACKER_PATH = argValue('--tracker') || DEFAULT_TRACKER_PATH;

--- a/tests/cli-flag-validation.test.mjs
+++ b/tests/cli-flag-validation.test.mjs
@@ -1,0 +1,165 @@
+// tests/cli-flag-validation.test.mjs — four reporting CLIs must reject a
+// mistyped flag instead of answering from their defaults (#2919).
+//
+// The failure class lib/cli-flags.mjs exists to end: an unrecognized flag is
+// ignored, the value flag it was meant to be falls back to its default, and
+// the script reports a result for inputs nobody asked for at exit 0. Already
+// fixed in scan-ats-full.mjs (#1633/#1635), reply-watch.mjs (#2743/#2745),
+// dedup-tracker.mjs (#2744/#2746), scan.mjs (#2270), doctor.mjs (#2874),
+// check-table-freshness.mjs (#2873) and plugin-audit.mjs (#2813).
+//
+// rejection-latency.mjs is the sharpest case and gets its own fixture: its
+// output is a blacklist suggestion, so the silent failure is a FALSE ALL-CLEAR
+// the user then acts on. The fixture below has one company 217 days past the
+// 30-day courtesy threshold, so "no post-interview silence exceeded" is proof
+// the flag was dropped and a different tracker was read.
+//
+// HERMETIC: every path is a tmpdir fixture; nothing reads or writes the real
+// data/ directory. Each run asserts the subprocess actually ran (no spawn
+// error, no signal), so a timeout cannot pass as a silent success.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function runScript(script, ...args) {
+  const r = spawnSync(process.execPath, [join(ROOT, script), ...args], {
+    cwd: ROOT,
+    encoding: 'utf-8',
+    timeout: 30_000,
+  });
+  assert.equal(r.error, undefined, `${script} failed to spawn: ${r.error?.message}`);
+  assert.equal(r.signal, null, `${script} was killed by ${r.signal} (timeout?)`);
+  return { ...r, all: `${r.stdout ?? ''}${r.stderr ?? ''}` };
+}
+
+// Each script paired with a realistic typo of one of ITS OWN value flags —
+// the transposition a user actually makes, not an obviously bogus token.
+const SCRIPTS = [
+  ['rejection-latency.mjs', '--traker'],
+  ['process-quality.mjs', '--fiel'],
+  ['detect-reposts.mjs', '--windo'],
+  ['weekly-digest.mjs', '--dri'],
+];
+
+for (const [script, typo] of SCRIPTS) {
+  test(`${script} rejects ${typo} instead of falling back to its default`, () => {
+    const r = runScript(script, typo, 'some-value');
+    assert.equal(r.status, 1, `${script} ${typo} exited ${r.status}, want 1`);
+    assert.match(r.all, /unrecognized flag/i, `${script} did not name the unrecognized flag`);
+    assert.match(r.all, new RegExp(typo.replace(/^--/, '--')), `${script} did not echo ${typo} back`);
+  });
+
+  test(`${script} --help exits 0 and prints usage`, () => {
+    const r = runScript(script, '--help');
+    assert.equal(r.status, 0, `${script} --help exited ${r.status}, want 0`);
+    assert.match(r.all, /Usage:/i, `${script} --help printed no usage block`);
+  });
+
+  // CodeRabbit caught the reverse ordering as a bug on #2745 and #2746: the
+  // unrecognized-flag check must run BEFORE --help, or `--help --bogus` exits
+  // 0 having never looked at --bogus.
+  test(`${script} --help --bogus still errors`, () => {
+    const r = runScript(script, '--help', '--bogus');
+    assert.equal(r.status, 1, `${script} --help --bogus exited ${r.status}, want 1`);
+    assert.match(r.all, /unrecognized flag/i);
+  });
+}
+
+// --- rejection-latency: the false all-clear, and the `=` form (#2401) -------
+
+function withFixture(fn) {
+  const dir = mkdtempSync(join(tmpdir(), 'career-ops-flagval-'));
+  try {
+    mkdirSync(join(dir, 'data'), { recursive: true });
+    const tracker = join(dir, 'data', 'applications.md');
+    const active = join(dir, 'data', 'active-interviews.md');
+    writeFileSync(
+      tracker,
+      '# Applications Tracker\n\n' +
+        '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+        '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
+        '| 1 | 2026-01-05 | SandboxCo | Staff Eng | 4.5/5 | Interview | ✅ | [1](reports/001-sandboxco-2026-01-05.md) | — |\n',
+    );
+    writeFileSync(
+      active,
+      '# Active Interviews\n\n' +
+        '| Company | Role | Round | Date/Time | Interviewer | Status | Notes |\n' +
+        '|---------|------|-------|-----------|-------------|--------|-------|\n' +
+        '| SandboxCo | Staff Eng | Round 3 | 2026-01-10 | Panel | Done | #1 in tracker |\n',
+    );
+    return fn({ tracker, active });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const FLAGGED = /SandboxCo/;
+const ALL_CLEAR = /No post-interview silence exceeded/i;
+
+test('rejection-latency finds the 217-day row with space-separated flags', () => {
+  withFixture(({ tracker, active }) => {
+    const r = runScript(
+      'rejection-latency.mjs',
+      '--tracker', tracker, '--file', active, '--today', '2026-08-15', '--summary',
+    );
+    assert.equal(r.status, 0);
+    assert.match(r.all, FLAGGED, 'the flagged company is missing — fixture or join broke');
+    assert.doesNotMatch(r.all, ALL_CLEAR);
+  });
+});
+
+test('rejection-latency honours the --flag=value form (#2401)', () => {
+  withFixture(({ tracker, active }) => {
+    const r = runScript(
+      'rejection-latency.mjs',
+      `--tracker=${tracker}`, `--file=${active}`, '--today=2026-08-15', '--summary',
+    );
+    assert.equal(r.status, 0);
+    // Before the fix this printed the all-clear: indexOf() cannot see the `=`
+    // form, so both paths silently fell back to the real data/ directory.
+    assert.match(r.all, FLAGGED, 'the `=` form was silently discarded');
+    assert.doesNotMatch(r.all, ALL_CLEAR);
+  });
+});
+
+test('rejection-latency: a trailing value flag is a usage error, not a default', () => {
+  // hasFlag is paired with flagValue precisely so this stays an error —
+  // flagValue alone returns undefined for both "absent" and "no value given",
+  // which would silently reinstate the default tracker.
+  const r = runScript('rejection-latency.mjs', '--summary', '--tracker');
+  assert.equal(r.status, 2, `want exit 2, got ${r.status}`);
+  assert.match(r.all, /--tracker requires a value/);
+});
+
+test('rejection-latency: --today --summary does not set the date to "--summary"', () => {
+  const r = runScript('rejection-latency.mjs', '--today', '--summary');
+  assert.equal(r.status, 2);
+  assert.match(r.all, /--today requires a value/);
+});
+
+// --- the importer hazard ---------------------------------------------------
+
+// process-quality.mjs and detect-reposts.mjs are imported by other CLIs, so
+// their validateFlags call must sit inside the main-module guard. At top level
+// it would judge the IMPORTER's argv and reject its valid flags.
+test('validating importable modules does not break their importers', () => {
+  withFixture(({ tracker, active }) => {
+    // rejection-latency imports parseActiveInterviews from process-quality
+    const r1 = runScript(
+      'rejection-latency.mjs',
+      '--tracker', tracker, '--file', active, '--today', '2026-08-15', '--summary',
+    );
+    assert.equal(r1.status, 0, 'process-quality rejected its importer\'s flags');
+    assert.doesNotMatch(r1.all, /unrecognized flag/i);
+  });
+  // company-history imports detectReposts/parseScanHistory from detect-reposts
+  const r2 = runScript('company-history.mjs', '--help');
+  assert.equal(r2.status, 0, 'detect-reposts rejected its importer\'s flags');
+  assert.doesNotMatch(r2.all, /unrecognized flag/i);
+});

--- a/weekly-digest.mjs
+++ b/weekly-digest.mjs
@@ -42,6 +42,10 @@ import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import * as yaml from 'js-yaml';
 
+// Only validateFlags: this module keeps its own flagValue (see below), so
+// importing the shared one too would shadow it.
+import { validateFlags } from './lib/cli-flags.mjs';
+
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_SESSIONS_DIR = join(CAREER_OPS, 'interview-prep', 'sessions');
 const DEFAULT_QUESTION_BANK_PATH = join(CAREER_OPS, 'interview-prep', 'question-bank.md');
@@ -650,8 +654,31 @@ async function runSelfTest() {
 
 // ── CLI ──────────────────────────────────────────────────────────────
 
+const KNOWN_FLAGS = ['--from', '--to', '--dir', '--summary', '--self-test', '--help', '-h'];
+const VALUE_FLAGS = ['--from', '--to', '--dir'];
+
+const USAGE = `Usage:
+  node weekly-digest.mjs                        # JSON digest for the current ISO week
+  node weekly-digest.mjs --summary              # human-readable roll-up
+  node weekly-digest.mjs --from <YYYY-MM-DD>    # start of the window
+  node weekly-digest.mjs --to <YYYY-MM-DD>      # end of the window
+  node weekly-digest.mjs --dir <path>           # a different interview-prep/sessions dir
+  node weekly-digest.mjs --self-test            # run the built-in fixtures
+  node weekly-digest.mjs --help                 # show this message
+
+Both bounds are optional; supplying one without the other is rejected rather
+than silently widened.`;
+
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const args = process.argv.slice(2);
+
+  // The script had no --help and no unrecognized-flag check at all, so a
+  // mistyped --dir was ignored and the digest silently rolled up
+  // interview-prep/sessions instead of the directory that was asked for —
+  // the same silent discard #2402 already fixed here for the `--from=` form
+  // (#2919). Inside the main-module guard so importers are unaffected.
+  validateFlags(args, KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS });
+
   if (args.includes('--self-test')) {
     await runSelfTest();
   }


### PR DESCRIPTION
Fixes #2919.

Four reporting CLIs swallowed a mistyped flag and reported a result computed from inputs nobody asked for, at exit 0.

## The sharpest case

`rejection-latency.mjs` had **both** defects `lib/cli-flags.mjs` exists to end, on a script whose output is a blacklist suggestion — so its silent failure mode is a false negative the user then acts on.

Fixture: one company 217 days past the 30-day courtesy threshold.

```
$ node rejection-latency.mjs --tracker sb/applications.md --file sb/ai.md --today 2026-08-15 --summary
  SandboxCo               2026-01-10      217    courtesy   30d
  Suggested data/blacklist.md rows (copy manually — nothing is written for you):
```

One transposed letter:

```
$ node rejection-latency.mjs --traker sb/applications.md --file sb/ai.md --today 2026-08-15 --summary
  No post-interview silence exceeded the configured thresholds.
$ echo $?
0
```

Same exit code, opposite conclusion — `--tracker` fell back to `DEFAULT_TRACKER_PATH` and the tool answered from a file the caller never named. That is `doctor.mjs`'s `--targe` (#2874) with a worse payload.

The `=` form failed identically: `argValue` was `args.indexOf(flag)`-based, which returns -1 for `--tracker=path` and silently discards the value — defect #2401/#2402, in a script that never got the fix.

## Scope

| script | `--flag=value` | mistyped flag | fix |
|---|---|---|---|
| `rejection-latency.mjs` | ❌ own `indexOf` helper | ❌ ignored, exit 0 | `flagValue` + `hasFlag` + `validateFlags` |
| `weekly-digest.mjs` | ✅ own local copy | ❌ ignored, exit 0 | `validateFlags` + a `USAGE` block (it had neither) |
| `process-quality.mjs` | ✅ imports the helper | ❌ ignored, exit 0 | `validateFlags` |
| `detect-reposts.mjs` | ✅ imports the helper | ❌ ignored, exit 0 | `validateFlags` replacing a bare `--help` check |

Every value flag involved either redirects the script to a different data file or moves the threshold that decides what gets reported, so a dropped value changes the answer rather than producing an obvious error.

## Two things worth reviewing

**`hasFlag` is paired with `flagValue` on purpose.** `flagValue` returns `undefined` for *both* an absent flag and one supplied without a value, so testing it alone would have turned a trailing `--tracker` from a usage error into a silent fall back to the default path — trading one silent default for another. `lib/cli-flags.mjs` documents pairing them for exactly this case. There is a test pinning it at exit 2.

**Two calls sit inside the main-module guard, not at top level.** `rejection-latency.mjs` imports `parseActiveInterviews` from `process-quality.mjs`, and `company-history.mjs` imports `detectReposts`/`parseScanHistory` from `detect-reposts.mjs`. A top-level `validateFlags` there would judge the **importer's** argv and reject its perfectly valid flags. There is a test covering that too.

I kept `rejection-latency`'s local "value must not itself look like another flag" check rather than dropping it for the shared helper — it is stricter, and it is what stops `--today --summary` from setting the evaluation date to `'--summary'`.

## Commits

1. `rejection-latency.mjs` — both defects.
2. `process-quality.mjs` + `detect-reposts.mjs` — flag-name validation, inside the guard.
3. `weekly-digest.mjs` — validation plus the missing usage block.
4. `tests/cli-flag-validation.test.mjs` — the regression suite.

## Verification

The test suite was checked for discrimination rather than assumed: **with all four source fixes reverted, 12 of the 17 tests fail**, and the 5 survivors are exactly the assertions that pin behaviour which must *not* change (space-separated form, trailing-flag usage error, `--today --summary`, the importer check, and detect-reposts' pre-existing `--help`).

Self-tests all still pass: rejection-latency 34/34, process-quality 21/21, detect-reposts 8/8, weekly-digest 52/52. `node test-all.mjs --quick`: 3936 pass / 0 fail (the 2 warnings are pre-existing and environmental — no user data, no Playwright browser). The new fixtures are tmpdir-only; nothing reads or writes the real `data/`.

## Deliberately out of scope

`upskill.mjs`, `salary-gap.mjs`, `tracker-sync-check.mjs` and `stats.mjs` also exit 0 on a bogus flag, but carry boolean flags only — a dropped `--summary` prints JSON instead of a table, which is visible immediately. Worth sweeping, not the same severity.

`weekly-digest.mjs` also carries its own local `flagValue` duplicating the shared one (its docstring notes `company-history.mjs` carries "this same note and the same fix"). It is exported, so folding it into `lib/cli-flags.mjs` touches importers — a refactor better done on its own than mixed into this fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved command-line argument validation across reporting and analysis tools.
  - Unknown, misspelled, or malformed options are now rejected with clear usage guidance.
  - Required option values are validated, including support for both `--option value` and `--option=value` formats.
  - Invalid arguments are detected before help or processing begins, preventing unintended execution.

- **Tests**
  - Added comprehensive coverage for invalid flags, missing values, supported formats, help handling, and command-line compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->