### PR TITLE
fix(providers): undecoded &amp; in titles silently drops matching jobs and bypasses negative filters

### DIFF
--- a/providers/beesite.mjs
+++ b/providers/beesite.mjs
@@ -30,6 +30,13 @@
 //     searchCriteria:
 //       - { CriterionName: PositionLocation.Country, CriterionValue: [329] }
 
+// Titles arrive HTML-escaped, so the tag strip below is not enough on its own:
+// an undecoded "R&amp;D Engineer" fails the user's own title_filter positive
+// "r&d" and is silently dropped, and a negative like "sales & marketing" never
+// vetoes "Sales &amp; Marketing Lead". Shared decoder, same as softgarden and
+// radancy (#2487, #2921).
+import { decodeEntities } from './_html-entities.mjs';
+
 const PAGE_SIZE = 100; // verified: the endpoint happily serves 100+/page
 const MAX_PAGES = 40; // safety cap on request count (40*100 = 4000 postings)
 const MAX_JOBS = 1000; // cap total postings pulled (newest-first sort)
@@ -104,7 +111,7 @@ export function parseSearchResult(json) {
     const d = item?.MatchedObjectDescriptor;
     if (!d) continue;
     const id = item.MatchedObjectId != null ? String(item.MatchedObjectId) : String(d.PositionID || '');
-    const title = String(d.PositionTitle || '').replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+    const title = decodeEntities(String(d.PositionTitle || '').replace(/<[^>]*>/g, ' ')).replace(/\s+/g, ' ').trim();
     const url = String(d.PositionURI || '').trim();
     if (!id || !title || !/^https?:\/\//i.test(url)) continue;
     const locs = Array.isArray(d.PositionLocation) ? d.PositionLocation : [];

--- a/providers/csod.mjs
+++ b/providers/csod.mjs
@@ -27,6 +27,13 @@
 // shape; the branded corporate page goes in careers_url and the csod.com URL in
 // `api:` (same convention as workday/successfactors).
 
+// Titles arrive HTML-escaped, so the tag strip below is not enough on its own:
+// an undecoded "R&amp;D Engineer" fails the user's own title_filter positive
+// "r&d" and is silently dropped, and a negative like "sales & marketing" never
+// vetoes "Sales &amp; Marketing Lead". Shared decoder, same as softgarden and
+// radancy (#2487, #2921).
+import { decodeEntities } from './_html-entities.mjs';
+
 const PAGE_SIZE = 25; // server default; verified OHB serves exactly 25/page
 const MAX_PAGES = 40; // safety cap on request count (40*25 = 1000 postings)
 const MAX_JOBS = 1000; // cap total postings pulled per site
@@ -137,7 +144,7 @@ export function parseRequisitions(json, cfg) {
   for (const r of list) {
     if (!r || typeof r !== 'object') continue;
     const id = r.requisitionId != null ? String(r.requisitionId) : '';
-    const title = String(r.displayJobTitle || '').replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+    const title = decodeEntities(String(r.displayJobTitle || '').replace(/<[^>]*>/g, ' ')).replace(/\s+/g, ' ').trim();
     if (!id || !title) continue;
     out.push({
       id,

--- a/providers/hackernews.mjs
+++ b/providers/hackernews.mjs
@@ -43,18 +43,12 @@ function extractUrl(text) {
   return m ? m[0].replace(/[.,;!?)]+$/, '') : '';
 }
 
-// Named HTML entities we decode in comment bodies. Kept in single map
-/** @type {Record<string, string>} */
-const ENTITY_MAP = {
-  '&amp;': '&',
-  '&lt;': '<',
-  '&gt;': '>',
-  '&quot;': '"',
-  '&#x27;': "'",
-  '&#39;': "'",
-  '&nbsp;': ' ',
-};
-const ENTITY_RE = /&amp;|&lt;|&gt;|&quot;|&#x27;|&#39;|&nbsp;/g;
+// Shared decoder instead of a local map (#2487, #2921). The local ENTITY_RE
+// was a literal alternation of seven forms, so it decoded &#39; but left every
+// OTHER numeric entity (&#8211;, &#232;, &#x2013;) and every other named one
+// (&uuml;, &eacute;) sitting in the title — where an undecoded entity does not
+// just look wrong, it fails the user's title_filter and the posting is dropped.
+import { decodeEntities } from './_html-entities.mjs';
 
 /**
  * Parse a single HN comment text into a normalized job object.
@@ -76,11 +70,10 @@ export function parseHnComment(text, threadUrl = '') {
   // Strip HTML. Anchors: keep the href value in place so URL extraction works.
   // Block-level tags (<p>, <br>, <div>, <li>, headings) become newlines so that
   // body paragraphs never bleed into the first header line after the join.
-  const plain = text
+  const plain = decodeEntities(text
     .replace(/<a\s[^>]*href="([^"]+)"[^>]*>.*?<\/a>/gi, (_, href) => href)
     .replace(/<\/?(?:p|br|div|li|h[1-6])\b[^>]*>/gi, '\n')
-    .replace(/<[^>]+>/g, ' ')
-    .replace(ENTITY_RE, (m) => ENTITY_MAP[m])
+    .replace(/<[^>]+>/g, ' '))
     .replace(/\r\n/g, '\n')
     .replace(/\r/g, '\n');
 

--- a/providers/phenom.mjs
+++ b/providers/phenom.mjs
@@ -2,6 +2,12 @@
 /** @typedef {import('./_types.js').Provider} Provider */
 
 import { fetchJsonWithRetry } from './_http.mjs';
+// Titles arrive HTML-escaped, so the tag strip below is not enough on its own:
+// an undecoded "R&amp;D Engineer" fails the user's own title_filter positive
+// "r&d" and is silently dropped, and a negative like "sales & marketing" never
+// vetoes "Sales &amp; Marketing Lead". Shared decoder, same as softgarden and
+// radancy (#2487, #2921).
+import { decodeEntities } from './_html-entities.mjs';
 
 // Phenom People provider — the "CareerConnect" career sites many large
 // enterprises run (branded domains like careers.exampleco.com). The search
@@ -110,7 +116,7 @@ export function parsePhenomDate(raw) {
 // and collapses whitespace.
 /** @param {any} job @returns {string} */
 export function jobLocation(job) {
-  const direct = String(job?.location || job?.cityStateCountry || job?.cityState || '').replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+  const direct = decodeEntities(String(job?.location || job?.cityStateCountry || job?.cityState || '').replace(/<[^>]*>/g, ' ')).replace(/\s+/g, ' ').trim();
   if (direct) return direct;
   const parts = [job?.city, job?.state, job?.country].map((p) => String(p || '').trim()).filter(Boolean);
   return [...new Set(parts)].join(', ');
@@ -129,7 +135,7 @@ export function parseRefineSearch(json, cfg) {
   for (const job of list) {
     if (!job || typeof job !== 'object') continue;
     const id = job.jobId != null ? String(job.jobId) : '';
-    const title = String(job.title || '').replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+    const title = decodeEntities(String(job.title || '').replace(/<[^>]*>/g, ' ')).replace(/\s+/g, ' ').trim();
     if (!id || !title) continue;
     rows.push({
       id,

--- a/providers/tkms.mjs
+++ b/providers/tkms.mjs
@@ -21,6 +21,13 @@
 // Detection: jobs.tkmsgroup.com is the only known host, and it carries no
 // generic platform token, so detect() claims that host explicitly.
 
+// Titles arrive HTML-escaped, so the tag strip below is not enough on its own:
+// an undecoded "R&amp;D Engineer" fails the user's own title_filter positive
+// "r&d" and is silently dropped, and a negative like "sales & marketing" never
+// vetoes "Sales &amp; Marketing Lead". Shared decoder, same as softgarden and
+// radancy (#2487, #2921).
+import { decodeEntities } from './_html-entities.mjs';
+
 const MAX_PAGES = 60; // safety cap on request count (60*20 = 1200 postings)
 const MAX_JOBS = 1000; // cap total postings pulled
 const PAGE_DELAY_MS = 150; // polite pacing between page requests
@@ -102,7 +109,7 @@ export function parseQuery(json, cfg) {
     const d = item?.data;
     if (!d) continue;
     const id = d.id != null ? String(d.id) : '';
-    const title = String(d.title || '').replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+    const title = decodeEntities(String(d.title || '').replace(/<[^>]*>/g, ' ')).replace(/\s+/g, ' ').trim();
     if (!id || !title) continue;
     rows.push({
       id,

--- a/tests/providers/title-entity-decode.test.mjs
+++ b/tests/providers/title-entity-decode.test.mjs
@@ -1,0 +1,107 @@
+// tests/providers/title-entity-decode.test.mjs — titles must be entity-decoded
+// before they reach title_filter (#2921).
+//
+// Not cosmetic. scan.mjs's buildTitleFilter lowercases and substring-matches,
+// so an undecoded "R&amp;D Engineer" fails a positive keyword "r&d" and the
+// posting is silently dropped — it never reaches pipeline.md and the user
+// never learns it existed. A negative keyword fails the opposite way: the veto
+// never fires. Zero-token scanning is what makes this invisible; there is no
+// LLM pass downstream that would notice the mangled title.
+//
+// #2487 fixed this shape in softgarden and radancy; these five were the
+// remainder. Numeric entities matter as much as &amp; here: beesite and tkms
+// point at DACH postings where "Syst&#232;mes" and "&#8211;" are routine.
+import { pass, fail, ROOT } from '../helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+const load = (f) => import(pathToFileURL(join(ROOT, `providers/${f}`)).href);
+
+console.log('\nProviders — title entity decoding (#2921)');
+try {
+  const { buildTitleFilter } = await load('../scan.mjs');
+
+  // The end-to-end claim: the decoded title survives the user's own filter.
+  const keepsRnD = buildTitleFilter({ positive: ['r&d'], negative: [] });
+  const vetoesSales = buildTitleFilter({ positive: [], negative: ['sales & marketing'] });
+
+  const check = (name, title) => {
+    if (title === 'R&D Engineer') pass(`${name} decodes &amp; in the title`);
+    else fail(`${name} title is ${JSON.stringify(title)}, want "R&D Engineer"`);
+    if (keepsRnD(title)) pass(`${name} title survives a positive "r&d" filter`);
+    else fail(`${name} title ${JSON.stringify(title)} was dropped by positive "r&d"`);
+  };
+
+  // ── beesite ── (parseSearchResult -> { jobs })
+  {
+    const { parseSearchResult } = await load('beesite.mjs');
+    const json = { SearchResult: { SearchResultCount: 1, SearchResultCountAll: 1, SearchResultItems: [{
+      MatchedObjectId: '1',
+      MatchedObjectDescriptor: {
+        PositionID: 'x1', PositionTitle: 'R&amp;D Engineer',
+        PositionURI: 'https://jobs.example.com/a-1',
+        PositionLocation: [{ CityName: 'Bremen' }], PublicationStartDate: '2026-07-04',
+      },
+    }] } };
+    const out = parseSearchResult(json);
+    check('beesite', (out.jobs ?? out.rows ?? out)[0].title);
+  }
+
+  // ── csod ── (parseRequisitions -> array)
+  {
+    const { parseRequisitions } = await load('csod.mjs');
+    const json = { data: { totalCount: 1, requisitions: [
+      { requisitionId: 8410, postingEffectiveDate: '7/3/2026', displayJobTitle: 'R&amp;D Engineer', locations: [{ city: 'Bremen', country: 'DE' }] },
+    ] } };
+    const reqs = parseRequisitions(json, { origin: 'https://career-ohb.csod.com', siteId: 4, corpName: 'career-ohb' });
+    check('csod', reqs[0].title);
+  }
+
+  // ── tkms ── (parseQuery -> { rows })
+  {
+    const { parseQuery } = await load('tkms.mjs');
+    const json = { totalHits: 1, nextPage: null, jobs: [
+      { data: { id: '964694', title: 'R&amp;D Engineer', city: 'Kiel', country: 'Germany' } },
+    ] };
+    const { rows } = parseQuery(json, { origin: 'https://jobs.tkmsgroup.com', locale: 'en' });
+    check('tkms', rows[0].title);
+  }
+
+  // ── phenom ── (parseRefineSearch -> { rows }); title AND location
+  {
+    const { parseRefineSearch, jobLocation } = await load('phenom.mjs');
+    const json = { refineSearch: { status: 200, totalHits: 1, data: { jobs: [
+      { jobId: '98098', title: 'R&amp;D Engineer', location: 'M&#252;nchen', postedDate: '2026-05-07T18:25:30.000+0000' },
+    ] } } };
+    const { rows } = parseRefineSearch(json, { origin: 'https://careers.exampleco.com', urlPrefix: 'global/en' });
+    check('phenom', rows[0].title);
+    const loc = jobLocation({ location: 'M&#252;nchen' });
+    if (loc === 'München') pass('phenom decodes a numeric entity in the location');
+    else fail(`phenom location is ${JSON.stringify(loc)}, want "München"`);
+  }
+
+  // ── the negative side: an undecoded title bypasses the user's veto ──
+  if (vetoesSales('Sales & Marketing Lead') === false && vetoesSales('Sales &amp; Marketing Lead') === true) {
+    pass('an UNDECODED title bypasses a negative filter (why decoding is a filter fix)');
+  } else {
+    fail('negative-filter premise no longer holds — buildTitleFilter changed?');
+  }
+
+  // ── hackernews: the local map decoded &#39; but no other numeric entity ──
+  {
+    const hn = await load('hackernews.mjs');
+    const out = hn.parseHnComment(
+      '<p>Acme GmbH | Softwareentwickler &#8211; R&amp;D | M&#252;nchen | https://acme.example/jobs</p>',
+      'https://news.ycombinator.com/item?id=1',
+    );
+    if (out && out.title.includes('–') && out.title.includes('R&D')) {
+      pass('hackernews decodes numeric entities its local 7-form map missed');
+    } else {
+      fail(`hackernews title is ${JSON.stringify(out && out.title)}`);
+    }
+    if (out && out.location === 'München') pass('hackernews decodes &#252; in the location');
+    else fail(`hackernews location is ${JSON.stringify(out && out.location)}, want "München"`);
+  }
+} catch (err) {
+  fail(`title entity decode suite threw: ${err.message}`);
+}


### PR DESCRIPTION
Fixes #2921.

Four providers stripped HTML tags out of the title but never decoded the entities in it, so `R&amp;D Engineer` reached the pipeline verbatim. The `replace(/<[^>]*>/g, …)` is itself the evidence the field carries HTML — #2487 fixed this exact shape in `softgarden.mjs` and `radancy.mjs`, and `beesite`, `csod`, `phenom` and `tkms` were not swept.

## It changes which jobs the scan keeps

`buildTitleFilter` in `scan.mjs` lowercases and substring/word-matches, so an undecoded ampersand moves the filter boundary — in **both** directions:

```
POSITIVE ["r&d", "research & development"]
  "R&amp;D Engineer"                 undecoded kept:false    decoded kept:true
  "Research &amp; Development Lead"  undecoded kept:false    decoded kept:true

NEGATIVE ["sales & marketing"]
  "Sales &amp; Marketing Lead"       undecoded kept:true   <- veto never fires
                                     decoded   kept:false
```

A role the user's own `title_filter.positive` asks for is **silently dropped** — it never reaches `pipeline.md` and the user never learns it existed. A veto they wrote is silently bypassed. Zero-token scanning is what makes this invisible: there is no LLM pass downstream that would notice the mangled title.

Ampersands are ordinary in job titles (R&D, Sales & Marketing, Health & Safety, Mergers & Acquisitions), and numeric entities are just as common in the DACH/FR postings `beesite` and `tkms` actually point at:

```
"Softwareentwickler (m/w/d) &#8211; Backend"  ->  "Softwareentwickler (m/w/d) – Backend"
"Ingénieur Syst&#232;mes"                    ->  "Ingénieur Systèmes"
```

`phenom` gets both of its sites: the title and the location fallback chain, which strips tags the same way.

## hackernews carried a 7-form local decoder

`providers/hackernews.mjs` had its own `ENTITY_MAP` + `ENTITY_RE`, the same duplication #2487 removed — but this copy was a strict subset. `ENTITY_RE` was a literal alternation of seven forms, so it decoded `&#39;` and left every other numeric entity and every other named one in place. Measured on the reverted code:

```
"Acme GmbH | Softwareentwickler &#8211; R&D | M&#252;nchen |"
```

The `&amp;` decoded; the en dash and the umlaut did not. Now `"Softwareentwickler – R&D"`, location `"München"`. Decoding still happens **after** tag stripping, exactly as the local map did, so href extraction and the `<p>`/`<br>` → newline pass are unaffected.

## Commits

1. `beesite`, `csod`, `phenom`, `tkms` — route through `providers/_html-entities.mjs`.
2. `hackernews` — replace the partial local map with the shared decoder.
3. `tests/providers/title-entity-decode.test.mjs`.

## Verification

The test asserts the end-to-end claim rather than the string transform alone: each provider's own parse function is fed an entity-bearing fixture, and the resulting title is then run through the **real** `buildTitleFilter` with a positive `"r&d"`. That is what makes it a filter test rather than a cosmetics test.

One assertion deliberately pins the *premise* instead of the fix — an undecoded `"Sales &amp; Marketing Lead"` must still slip past a negative `"sales & marketing"`. If `buildTitleFilter` ever normalizes entities itself, that assertion fails and tells the next reader the provider-side decode became redundant, rather than leaving a silently pointless test behind.

Checked for discrimination: **with all five provider fixes reverted, 11 of the 12 assertions fail**, and the survivor is exactly that premise test.

`node test-all.mjs --quick`: 3947 pass / 0 fail (the 2 warnings are pre-existing and environmental — no user data, no Playwright browser). Existing per-provider suites still pass unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decoding of HTML-encoded characters in job titles and locations.
  * Expanded entity handling in comment content, including numeric entities.
  * Filters and displayed listings now use correctly decoded text.

* **Tests**
  * Added coverage for encoded titles, locations, comments, and title-filter behavior across supported providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->