### PR TITLE
fix(merge-tracker): match inline `**URL:**` headers so URL dedup activates

### DIFF
--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -228,8 +228,19 @@ function resolveReportUrl(reportField) {
   // [ \t]* NOT \s*: \s matches newlines, so an empty `**URL:**` header swallowed
   // the line break and captured the NEXT header's text. Every such report then
   // minted the same bogus key (`**Legitimacy:**`), and the backfill counted it
-  // as a successful fill.
-  const m = readFileSync(reportPath, 'utf-8').match(/^\*\*URL:\*\*[ \t]*(\S+)/m);
+  // as a successful fill. `\S+` cannot cross a newline, so an empty header now
+  // just fails to match at that position instead of reaching into the next line.
+  //
+  // Deliberately NOT anchored to line start. AGENTS.md requires `**URL:**` "in
+  // the header (between Score and PDF)" — that is, INLINE:
+  //   **Score:** 4.1/5 | **URL:** https://… | **Legitimacy:** High | **PDF:** …
+  // which a `^`-anchored pattern cannot see. Every report written in the
+  // documented format reported "no **URL:** header" and silently fell back to
+  // fuzzy company+role dedup — the exact matching that let a new Google req
+  // overwrite a different, concurrently-live one. Checked against all 399
+  // reports: 376 match both ways and agree on the URL 376/376, so dropping the
+  // anchor cannot change a URL that already resolved.
+  const m = readFileSync(reportPath, 'utf-8').match(/\*\*URL:\*\*[ \t]*(\S+)/);
   if (!m) return { url: '', reason: 'no-url' };
   // Strip a markdown autolink wrapper and trailing punctuation, then require a
   // real http(s) URL. `**URL:** N/A` is legitimate for recruiter-sourced roles,


### PR DESCRIPTION
Fixes #2925.

## Problem

`resolveReportUrl` matched `/^\*\*URL:\*\*[ \t]*(\S+)/m`, requiring the header to start a line. `AGENTS.md` requires the opposite placement — `**URL:**` "in the header (between Score and PDF)", i.e. inline, which is what `modes/oferta.md` emits:

```
**Score:** 4.1/5 | **URL:** https://… | **Legitimacy:** High Confidence | **PDF:** …
```

So a report written exactly as documented resolved to `reason: 'no-url'`.

## Why it matters beyond the backfill

The derivation is deliberately shared with the merge loop — per the existing comment, the key "has to be written on the way IN, not only by a migration … A dedup key that only exists after a manual step is a dedup key that is usually absent."

Because the regex missed the documented format, that intent was defeated in both directions: the backfill skipped those rows *and* new rows never got a URL on ingest. Pass 0 had no key and fell back to fuzzy company+role — which is exactly the matching that lets two sibling requisitions (a leveled variant and its bare title) collide, overwriting a live row's date, PDF flag and report link with a different opening's data.

## Change

Drop the `^` anchor and the now-redundant `/m`. One logic line; the rest is comment explaining the constraint so it is not re-anchored later.

## Safety

- The `[ \t]*` guard from the empty-header fix is retained and is what makes this safe: `\S+` cannot cross a newline, so an empty `**URL:**` fails to match at that position rather than capturing the next line's `**Legitimacy:**`. I added a note to that effect next to the original comment.
- `normalizeUrl` still gates the result, so `**URL:** N/A` continues to yield no key.

Verified against a 399-report corpus:

| | Count |
|---|---|
| Match both anchored and unanchored | 376 — captured URL identical in **376 of 376** |
| Match unanchored only (documented inline form) | 22 — recovered |
| No `**URL:**` at all | 1 |

Zero disagreements, so this cannot change a URL that already resolved.

## Tests

`node test-all.mjs` → **3938 passed, 0 failed**, 1 pre-existing warning (`cv-sync-check.mjs exited with error (expected without user data)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved report link detection for inline `**URL:**` headers.
  - Prevented empty URL fields from incorrectly consuming content from the next header.
  - Improved handling of spaces and tabs when parsing report URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->