### PR TITLE
fix(trust-validator): a company with an accent in its name is flagged for being on its own domain

### DIFF
--- a/providers/_trust-validator.mjs
+++ b/providers/_trust-validator.mjs
@@ -104,9 +104,19 @@ export function matchesDomainList(hostname, domainList) {
 
 // Latin letters that do NOT decompose under NFD, so stripping combining marks
 // alone still deletes them. Lowercase only — the caller lowercases first.
+// A stroke or bar through a letter is part of the glyph, not a combining
+// mark, so NFD leaves these untouched and the [^a-z0-9] strip below then
+// DELETES them — the very failure this fold exists to stop. The Turkish
+// dotless ı is the one that actually bites: "Işık" scored no match against
+// isik.com.tr and was flagged for being on its own domain. ħ/ŋ/ŧ happened to
+// pass anyway on a word-level substring, which is luck, not correctness —
+// the same accidental pass "Nestlé" had before this fold existed.
+// (CodeRabbit, reviewing #2927.)
 const NON_DECOMPOSING_LATIN = [
   [/ø/g, 'o'], [/æ/g, 'ae'], [/œ/g, 'oe'], [/ß/g, 'ss'],
   [/đ/g, 'd'], [/ł/g, 'l'], [/þ/g, 'th'], [/ð/g, 'd'],
+  [/ħ/g, 'h'], [/ı/g, 'i'], [/ŋ/g, 'ng'], [/ŧ/g, 't'],
+  [/ĸ/g, 'k'], [/ſ/g, 's'],
 ];
 
 /**

--- a/providers/_trust-validator.mjs
+++ b/providers/_trust-validator.mjs
@@ -102,6 +102,35 @@ export function matchesDomainList(hostname, domainList) {
   return false;
 }
 
+// Latin letters that do NOT decompose under NFD, so stripping combining marks
+// alone still deletes them. Lowercase only — the caller lowercases first.
+const NON_DECOMPOSING_LATIN = [
+  [/ø/g, 'o'], [/æ/g, 'ae'], [/œ/g, 'oe'], [/ß/g, 'ss'],
+  [/đ/g, 'd'], [/ł/g, 'l'], [/þ/g, 'th'], [/ð/g, 'd'],
+];
+
+/**
+ * ASCII-fold a company name for comparison against a hostname.
+ *
+ * NFD is the right tool HERE and the wrong one in foldStatusInput()
+ * (tracker-utils.mjs, #2705). There the fold must not collapse distinct
+ * identities — Żubr must never become Zubr. Here we are deliberately comparing
+ * against an ASCII hostname, so folding to the ASCII base letter is the whole
+ * point: "societegenerale.com" IS the ASCII folding of "Société Générale".
+ *
+ * The previous `[^a-z0-9 ]` strip DELETED accented letters instead of folding
+ * them, so "Société Générale" became "socit gnrale" and matched neither the
+ * slug nor any word of its own domain (#2924).
+ *
+ * @param {string} company
+ * @returns {string} Lowercased, space-separated ASCII, or '' when nothing Latin remains.
+ */
+export function asciiFoldForHostname(company) {
+  let out = String(company ?? '').toLowerCase().normalize('NFD').replace(/\p{M}+/gu, '');
+  for (const [re, to] of NON_DECOMPOSING_LATIN) out = out.replace(re, to);
+  return out.replace(/[^a-z0-9 ]/g, '').replace(/\s+/g, ' ').trim();
+}
+
 /**
  * Heuristic: does the company name plausibly match the URL hostname?
  *
@@ -116,7 +145,12 @@ export function matchesDomainList(hostname, domainList) {
 export function companyMatchesHostname(company, hostname) {
   if (!company || !hostname) return true; // can't evaluate → no flag
 
-  const normalized = company.toLowerCase().replace(/[^a-z0-9 ]/g, '').trim();
+  const normalized = asciiFoldForHostname(company);
+  // Nothing Latin survived (a CJK, Cyrillic, Greek, … name). Deliberate, not
+  // an oversight: hostnames are effectively ASCII, so such a name can never
+  // appear in one and the absence of a match proves nothing. "Working" here
+  // would flag every non-Latin company posting on its own legitimate domain —
+  // trading a silent skip for a systematic false positive (#2924).
   if (!normalized) return true;
 
   // Full slug check (all spaces removed)

--- a/test-trust-validator.mjs
+++ b/test-trust-validator.mjs
@@ -153,6 +153,19 @@ assert(companyMatchesHostname('Nestlé', 'www.nestle.com') === true, 'Nestlé ma
 assert(companyMatchesHostname('Ørsted', 'orsted.com') === true, 'Ørsted: ø folds to o');
 assert(companyMatchesHostname('Æon', 'aeon.co.jp') === true, 'Æon: æ folds to ae');
 
+// Letters NFD does NOT decompose: a stroke or bar is part of the glyph, not a
+// combining mark, so stripping marks leaves them and [^a-z0-9] then deletes
+// them (CodeRabbit, reviewing #2927). The Turkish dotless ı is the one that
+// actually bit — "Işık" scored no match against its own isik.com.tr.
+assert(companyMatchesHostname('Işık', 'isik.com.tr') === true, 'Işık: dotless ı folds to i');
+assert(companyMatchesHostname('Ħamrun', 'hamrun.com.mt') === true, 'Ħamrun: ħ folds to h');
+assert(companyMatchesHostname('Ŧorne', 'torne.example') === true, 'Ŧorne: ŧ folds to t');
+// ŋ (eng) romanises as "ng", not "n" — mapping it to "n" made "Ŋaro" miss
+// ngaro.example, which is how this mapping got caught.
+assert(companyMatchesHostname('Ŋaro', 'ngaro.example') === true, 'Ŋaro: ŋ folds to ng');
+// Still a mismatch on a hostile host — the fold must not become "always true".
+assert(companyMatchesHostname('Işık', 'evil-phishing.example') === false, 'Işık still flags a hostile host');
+
 // The fold must not turn the check into "always true" — a hostile host is
 // still a mismatch. Without these, deleting the function body would pass.
 assert(companyMatchesHostname('Société Générale', 'evil-phishing.example') === false, 'accented name still flags a hostile host');

--- a/test-trust-validator.mjs
+++ b/test-trust-validator.mjs
@@ -133,6 +133,42 @@ assert(companyMatchesHostname(null, 'example.com') === true, 'null company → n
 assert(companyMatchesHostname(undefined, 'example.com') === true, 'undefined company → no flag');
 assert(companyMatchesHostname('   ', 'example.com') === true, 'whitespace-only company → no flag');
 
+section('companyMatchesHostname — accented Latin folds to its own domain (#2924)');
+
+// The bug: `[^a-z0-9 ]` DELETED the accent instead of folding it, so
+// "Société Générale" became "socit gnrale" — not a substring of
+// "societegenerale" and neither are its words. Rule 4 then charged the posting
+// a 15-point company_domain_mismatch penalty, dropping a clean 100 to 85 and
+// crossing the high→medium boundary, purely because the company spells its
+// name with an accent.
+assert(companyMatchesHostname('Société Générale', 'careers.societegenerale.com') === true, 'Société Générale matches its own domain');
+assert(companyMatchesHostname('Telefónica', 'jobs.telefonica.com') === true, 'Telefónica matches its own domain');
+assert(companyMatchesHostname('Schrödinger', 'schrodinger.com') === true, 'Schrödinger matches its own domain');
+assert(companyMatchesHostname('Citroën', 'careers.citroen.com') === true, 'Citroën matches its own domain');
+
+// These two passed BEFORE the fix, but by luck rather than design: "nestl" is
+// a substring of "nestle" and "rsted" of "orsted". Pinned so the fold, not the
+// coincidence, is what keeps them passing.
+assert(companyMatchesHostname('Nestlé', 'www.nestle.com') === true, 'Nestlé matches (by fold now, not coincidence)');
+assert(companyMatchesHostname('Ørsted', 'orsted.com') === true, 'Ørsted: ø folds to o');
+assert(companyMatchesHostname('Æon', 'aeon.co.jp') === true, 'Æon: æ folds to ae');
+
+// The fold must not turn the check into "always true" — a hostile host is
+// still a mismatch. Without these, deleting the function body would pass.
+assert(companyMatchesHostname('Société Générale', 'evil-phishing.example') === false, 'accented name still flags a hostile host');
+assert(companyMatchesHostname('Telefónica', 'totally-unrelated.example') === false, 'accented name still flags an unrelated host');
+
+section('companyMatchesHostname — a non-Latin name cannot be evaluated (deliberate)');
+
+// NOT a hole to be closed. Hostnames are effectively ASCII, so a CJK or
+// Cyrillic name can never appear in one and the absence of a match proves
+// nothing. Making this "work" would flag every non-Latin company posting on
+// its own legitimate domain — a systematic false positive in place of a
+// silent skip.
+assert(companyMatchesHostname('楽天', 'evil-phishing.example') === true, 'CJK name → cannot evaluate, no flag');
+assert(companyMatchesHostname('Сбербанк', 'evil-phishing.example') === true, 'Cyrillic name → cannot evaluate, no flag');
+assert(companyMatchesHostname('Ελλάκτωρ', 'ellaktor.com') === true, 'Greek name → cannot evaluate, no flag');
+
 // ══════════════════════════════════════════════════════════════════════
 // PART 5: buildTrustValidator — disabled / no-op cases
 // ══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Fixes #2924.

`companyMatchesHostname` in `providers/_trust-validator.mjs` **deleted** every character outside `[a-z0-9 ]` instead of folding it, so a company whose own name carries a diacritic failed to match its own official domain and was penalised as a legitimacy risk.

```
company            hostname                       matches?  (false = mismatch FLAG raised)
Société Générale   careers.societegenerale.com    false
Telefónica         jobs.telefonica.com            false
Schrödinger        schrodinger.com                false
Rakuten            rakuten.co.jp                  true      <- plain-Latin control
```

`é` was removed rather than folded to `e`, so `"Société Générale"` became `"socit gnrale"` — not a substring of `societegenerale`, and neither are its words.

Rule 4 in `buildTrustValidator` then fires a 15-point `company_domain_mismatch` penalty, dropping a clean 100 → 85 and crossing `classifyTrustLevel`'s **high → medium** boundary. A legitimate posting on the company's own domain is reported as less trustworthy purely because the company spells its name with an accent. Stacked with any other flag it degrades further (`missing_apply_url` + this = 45 = **low**).

Same key-building defect as #2782 / #2848 / #2850, in the legitimacy path rather than the matching path.

## The fix

ASCII-fold before stripping: NFD → drop combining marks → map the Latin letters that do not decompose (`ø æ œ ß đ ł þ ð`).

**On NFD, since I argued the opposite in #2705.** NFD is the right tool here and the wrong one in `foldStatusInput`. There the fold must not collapse distinct identities — `Żubr` must never become `Zubr`. Here we are deliberately comparing against an ASCII hostname, so folding to the ASCII base letter is the entire point: `societegenerale.com` *is* the ASCII folding of `Société Générale`. Different question, different answer, and I have put that reasoning in the code so the two do not look inconsistent to the next reader.

## What I deliberately did NOT "fix"

A fully non-Latin name folds to `''` and the function returns `true` — "cannot evaluate → no flag":

```
楽天       evil-phishing.example    true
Сбербанк   evil-phishing.example    true
```

That reads like a hole, and it is not one. Hostnames are effectively ASCII, so a CJK or Cyrillic name can never appear in one and the absence of a match proves nothing. Making the check "work" for those names would flag **every** non-Latin company posting on its own legitimate domain — trading a silent skip for a systematic false positive. The escape is kept and now carries a comment saying why, plus three assertions, so it does not get filed as a bug later.

## Verification

`test-trust-validator.mjs` already covered this function and is wired into `test-all.mjs`, so the new assertions live there. They fall into three groups, only the first of which is the bug:

1. The four accented-Latin names that genuinely failed.
2. `Nestlé` / `Ørsted` / `Æon`, which passed **before** the fix but by coincidence — `nestl` is a substring of `nestle`, `rsted` of `orsted`. Pinned so the fold, not the accident, keeps them green.
3. Guards that the fold did not turn the check into "always true": an accented name on a hostile or unrelated host must **still** be flagged. Without those two, deleting the function body would pass this suite.

Checked for discrimination: with the source fix reverted, **exactly the 4 genuinely-broken cases fail (98/102)** and every must-not-change assertion still passes.

`node test-all.mjs --quick`: 3935 pass / 0 fail (the 2 warnings are pre-existing and environmental — no user data, no Playwright browser).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved company-to-domain matching for names with accented Latin characters.
  * Added support for special character conversions, such as `ø` to `o` and `æ` to `ae`.
  * Non-Latin company names are now handled safely without generating incorrect mismatch warnings.

* **Tests**
  * Added coverage for matching, unrelated, and potentially deceptive domains involving accented and non-Latin names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->