### PR TITLE
fix(ci): install root deps so the web job can import the core tracker lock

### DIFF
--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -30,6 +30,13 @@ jobs:
           node-version: 24
           cache: npm
           cache-dependency-path: web/package-lock.json
+      # web/tests/lib/tracker-lock.test.mjs imports the core tracker lock from
+      # the repo root to assert the real primitive rather than a copy of it —
+      # which is what lets that test survive a change of caller. The root module
+      # pulls in js-yaml, so the root install has to happen or the dynamic
+      # import throws and every web PR shows a failure that is not its own.
+      - run: npm ci --ignore-scripts
+        working-directory: .
       - run: npm ci
       - run: npm test
       - run: npx tsc --noEmit


### PR DESCRIPTION
## What does this PR do?

Installs the root dependencies in the `web typecheck + build` job, so `web/tests/lib/tracker-lock.test.mjs` can import the core tracker lock. Web CI has been red on `main` since #2903 added that test.

## Related issue

Closes #2922

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---

## The failure

`Web CI` flipped to red exactly at `d9c4fd0` (#2903) and has stayed there:

```
2026-08-14T22:13:09  failure  d9c4fd0   <- #2903
2026-08-14T19:58:34  success  6eece73
2026-08-14T14:29:38  success  be62e3e
```

`web/tests/lib/tracker-lock.test.mjs` reaches out of `web/` to exercise the real primitive:

```js
const { acquireTrackerLock, trackerLockDirFor } = await import(pathToFileURL(coreLock).href);
```

`tracker-utils.mjs:15` imports `js-yaml`, and the job installs only the web workspace (`working-directory: web`, one `npm ci`), so the import throws `ERR_MODULE_NOT_FOUND`.

## Why install rather than skip

The obvious alternative is to guard the dynamic import and skip when the root module is unresolvable. I think that is the weaker option: this test was written to guard a **lost update on `data/applications.md`**, and a test that silently does not run in CI is not guarding anything. Installing the root deps keeps it asserting the real primitive — which is also what lets it survive a change of caller, the property #2904 depends on.

`--ignore-scripts` on the root install because the job only needs the module graph resolvable; the root `postinstall` downloads a Playwright browser this job never uses.

## Why it is worth landing promptly

While this sat as an issue, @abankar1 hit the same red check on #2918 and [wrote](https://github.com/santifer/career-ops/pull/2918#issuecomment-5301543337): *"Not rebasing onto a fix for #2922, since that is @rubicon's to land — happy to rebase once it does."* That is the real cost of an ambient failure: every `web/` PR now shows a failing check for a reason that is not its own, and contributors either wait or learn to ignore it.

Their own new test is unaffected — it imports `js-yaml` directly, which resolves inside `web/node_modules` because it is a declared web dependency. Only the reach into the root module is affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved web project CI setup by installing required root-level dependencies before running installation and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->