### PR TITLE
test(web): resolve the core import in the tracker-lock guard instead of stat-ing the path

### DIFF
--- a/web/tests/lib/tracker-lock.test.mjs
+++ b/web/tests/lib/tracker-lock.test.mjs
@@ -17,11 +17,34 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
-const CORE = process.env.CAREER_OPS_ROOT || path.join(process.cwd(), "..");
+// Resolved from this file, not from the cwd: test-all.mjs runs these suites from
+// the repo root, where `cwd/..` points outside the checkout and every core case
+// skipped as "not resolvable" while reporting green.
+const CORE =
+  process.env.CAREER_OPS_ROOT ||
+  path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 const coreLock = path.join(CORE, "tracker-utils.mjs");
-const HAS_CORE = fs.existsSync(coreLock);
+
+// The guard has to answer "can this be imported", not "is the file there".
+// tracker-utils.mjs imports js-yaml, so a web-only install (web-ci.yml runs
+// `npm ci` in web/ alone) has the file and not its dependencies, and existsSync
+// called that runnable: the cases failed on ERR_MODULE_NOT_FOUND instead of
+// skipping (#2922).
+let core = null;
+let skipCore = false;
+try {
+  core = await import(pathToFileURL(coreLock).href);
+} catch (err) {
+  // Skipping is only correct where the core genuinely is not installed. If the
+  // root deps ARE there and the import still fails, that is a real break, and
+  // swallowing it here would hide it exactly as the old guard hid this one.
+  if (err.code !== "ERR_MODULE_NOT_FOUND" || fs.existsSync(path.join(CORE, "node_modules"))) throw err;
+  skipCore = fs.existsSync(coreLock)
+    ? `core dependencies are not installed at ${CORE} (web-only checkout)`
+    : `no core checkout at ${CORE}`;
+}
 
 function makeTracker() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "trklock-"));
@@ -68,8 +91,8 @@ test("WITHOUT a lock, two concurrent writers lose one update silently", async ()
   }
 });
 
-test("WITH the core lock, both updates survive", { skip: HAS_CORE ? false : "core checkout not resolvable" }, async () => {
-  const { acquireTrackerLock, trackerLockDirFor } = await import(pathToFileURL(coreLock).href);
+test("WITH the core lock, both updates survive", { skip: skipCore }, async () => {
+  const { acquireTrackerLock, trackerLockDirFor } = core;
   const { root, file } = makeTracker();
   const guarded = async (rowNum, status, pauseMs) => {
     const lock = await acquireTrackerLock(trackerLockDirFor(file), { timeoutMs: 5_000, retryMs: 25, tracker: file });
@@ -88,10 +111,10 @@ test("WITH the core lock, both updates survive", { skip: HAS_CORE ? false : "cor
   }
 });
 
-test("the lock is released on a throwing path, not just the happy one", { skip: HAS_CORE ? false : "core checkout not resolvable" }, async () => {
+test("the lock is released on a throwing path, not just the happy one", { skip: skipCore }, async () => {
   // A leaked lock on a long-lived server is worse than the bug: the holder's pid
   // stays alive, so the core's stale-recovery will not reclaim it.
-  const { acquireTrackerLock, trackerLockDirFor } = await import(pathToFileURL(coreLock).href);
+  const { acquireTrackerLock, trackerLockDirFor } = core;
   const { root, file } = makeTracker();
   try {
     const lock = await acquireTrackerLock(trackerLockDirFor(file), { timeoutMs: 5_000, retryMs: 25, tracker: file });

--- a/web/tests/lib/tracker-lock.test.mjs
+++ b/web/tests/lib/tracker-lock.test.mjs
@@ -37,13 +37,25 @@ let skipCore = false;
 try {
   core = await import(pathToFileURL(coreLock).href);
 } catch (err) {
-  // Skipping is only correct where the core genuinely is not installed. If the
-  // root deps ARE there and the import still fails, that is a real break, and
-  // swallowing it here would hide it exactly as the old guard hid this one.
-  if (err.code !== "ERR_MODULE_NOT_FOUND" || fs.existsSync(path.join(CORE, "node_modules"))) throw err;
-  skipCore = fs.existsSync(coreLock)
-    ? `core dependencies are not installed at ${CORE} (web-only checkout)`
-    : `no core checkout at ${CORE}`;
+  // Skipping is only correct where the core genuinely is not installed: no core
+  // file here at all, or an unresolvable package in a checkout whose root deps
+  // were never installed, which is what a web-only install looks like.
+  //
+  // Node names the missing path in err.url when a FILE is unresolvable and
+  // leaves it unset when a bare package is, which separates "js-yaml was never
+  // installed" from "tracker-parse.mjs is missing from this core". The second is
+  // a broken checkout, and skipping it would report a real break as an
+  // uninstalled dependency, which is the failure this guard exists to stop.
+  // Anything unrecognized rethrows for the same reason: a loud failure here is
+  // recoverable, a silent skip is not.
+  const coreAbsent = !fs.existsSync(coreLock);
+  const packageUnresolvable = err.url == null;
+  const depsAbsent = !fs.existsSync(path.join(CORE, "node_modules"));
+
+  if (err.code !== "ERR_MODULE_NOT_FOUND") throw err;
+  if (coreAbsent) skipCore = `no core checkout at ${CORE}`;
+  else if (packageUnresolvable && depsAbsent) skipCore = `core dependencies are not installed at ${CORE} (web-only checkout)`;
+  else throw err;
 }
 
 function makeTracker() {


### PR DESCRIPTION
## What does this PR do?

`web/tests/lib/tracker-lock.test.mjs` guards its two core cases with `existsSync` on `tracker-utils.mjs`, which answers whether the file is there rather than whether it can be imported. This resolves the core path from the test file instead of the cwd, and attempts the import, so the full-repo run actually executes the cases and a web-only install skips them with the reason stated.

While tracing the CI failure I found the guard was wrong in both directions, not one. `web-ci.yml` runs `npm ci` in `web/` alone, so the file is present and js-yaml is not: the guard reported it runnable and the two cases failed on `ERR_MODULE_NOT_FOUND`, which is the red on `main` since d9c4fd0. `test-all.mjs` discovers `web/tests/lib/*.test.mjs` and runs them from the repo root, where `cwd/..` resolves to the parent of the checkout: the file is not there, so both cases skipped and the required check stayed green.

So the two cases that prove the lock works, which are the guarantee #2903 added, have not run in any CI job since they were written. That is why I went with the guard rather than a root install in `web-ci.yml`, which is the opposite of what I suggested when I filed the issue: making the resolution file-relative puts the coverage in the required `Tests` job on all three platforms, where the root dependencies are installed, and leaves `web/` self-contained in the informative web job.

The guard is written so it cannot hide the next problem the way it hid this one. It skips only where the core genuinely is not installed: no core file here at all, or a package that will not resolve in a checkout whose root dependencies were never installed. Anything else rethrows, including a missing local module inside the core, which Node reports with the same error code and which would otherwise skip while claiming the dependency was uninstalled.

## Related issue

Closes #2922

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## How I verified

Four environments, reproduced against the current `main` first and then re-run with the change:

| Environment | Before | After |
|---|---|---|
| Full repo, run from repo root (how `test-all.mjs` invokes it) | 1 pass, 2 silent skips | 3 pass |
| Full repo, run from `web/` (the documented command) | 3 pass | 3 pass |
| Web-only install, run from `web/` (the `web-ci.yml` shape) | 1 pass, 2 fail on `ERR_MODULE_NOT_FOUND` | 1 pass, 2 skip, "core dependencies are not installed" |
| Standalone `web/` copy with no core alongside it | 1 pass, 2 skip | 1 pass, 2 skip, "no core checkout" |

The web-only cases were reproduced in a tree outside any parent `node_modules`, since Node walks up and would otherwise resolve js-yaml from an ancestor and hide the failure.

I also checked the guard is not vacuous, in the two shapes where a skip would be wrong:

| Environment | Result |
|---|---|
| Root `node_modules` present, js-yaml absent from it | fails, naming the package |
| Core missing `tracker-parse.mjs`, js-yaml resolving from an ancestor `node_modules` | fails, naming the file |

The second is the case CodeRabbit raised, fixed in 4586e3a. Note it does not reproduce by deleting `tracker-parse.mjs` from a core that also lacks `node_modules`: js-yaml is imported first, so that is the error Node reports and the skip is correct there.

`cd web && npm test` is 249 passing, 0 skipped. `npx tsc --noEmit` is clean. `node test-all.mjs` is 3938 passed, 0 failed, with the one pre-existing `cv-sync-check.mjs` warning that comes from having no user data.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved tracker lock test setup across different checkout locations.
  * Tests now distinguish between genuinely missing dependencies and actual import failures.
  * Lock-dependent tests consistently reuse the shared module setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->