### PR TITLE
fix(verify-portals): stop the slug repair path adopting another employer's board (#2937)

### DIFF
--- a/providers/_http.mjs
+++ b/providers/_http.mjs
@@ -54,6 +54,44 @@ export async function fetchJson(url, opts = {}) {
   return fetchWithTimeout(url, opts, (res) => res.json());
 }
 
+/**
+ * Fetch only the head of a text response.
+ *
+ * Board landing pages carry the owner's name in <title>, but the page itself can
+ * be a megabyte of embedded job JSON (jobs.lever.co ships ~950KB and ignores a
+ * Range request). Reading the whole thing to learn one string would be exactly the
+ * "slow and rude to the careers site" behavior the probe path avoids elsewhere, so
+ * this stops at maxBytes and cancels the body.
+ *
+ * @param {string} url
+ * @param {{maxBytes?: number}} [opts]
+ * @returns {Promise<string>} The first maxBytes of the body, decoded as UTF-8.
+ */
+export async function fetchTextHead(url, opts = {}) {
+  const maxBytes = opts.maxBytes ?? 8192;
+  return fetchWithTimeout(url, opts, async (res) => {
+    const reader = res.body?.getReader?.();
+    if (!reader) return String(await res.text()).slice(0, maxBytes);
+    const chunks = [];
+    let total = 0;
+    try {
+      while (total < maxBytes) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(Buffer.from(value));
+        total += value.length;
+      }
+    } finally {
+      try {
+        await reader.cancel();
+      } catch {
+        /* body already closed */
+      }
+    }
+    return Buffer.concat(chunks).toString('utf8');
+  });
+}
+
 export async function fetchText(url, opts = {}) {
   return fetchWithTimeout(url, opts, (res) => res.text());
 }

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5114,7 +5114,7 @@ tracked_companies:
 console.log('\n10b. Portal slug validator');
 
 try {
-  const { deriveSlugCandidates, parseAtsSlug, verifyCompanies, classifyFetchError, boardIdentityMatches } =
+  const { deriveSlugCandidates, parseAtsSlug, verifyCompanies, classifyFetchError, boardIdentityMatches, boardTitleOwner } =
     await import(pathToFileURL(join(ROOT, 'verify-portals.mjs')).href);
 
   const slugs = deriveSlugCandidates('Acme Corp!');
@@ -5183,7 +5183,7 @@ try {
   // It is not fine for discoverAlternates, whose `suggested` fix-slugs --fix
   // writes into portals.yml unreviewed. The bare first word stays on BOTH sets
   // on purpose: it adds no token the company lacks, and boards really are often
-  // just the brand (the "Diabolocom EU Discovery" row below relies on it).
+  // just the brand (the "Diabolocom" row below relies on it).
   const probeSet = deriveSlugCandidates('Nimbus Data');
   const repairSet = deriveSlugCandidates('Nimbus Data', { firstWordSuffixes: false });
   const coined = ['nimbusai', 'nimbustech', 'nimbusio', 'nimbushq', 'nimbuslabs', 'nimbus.tech', 'nimbus.io'];
@@ -5220,7 +5220,7 @@ try {
 
   // The other half of #2937. The bare first word stays in the repair set on
   // purpose, so "Nimbus Data" still probes `nimbus`, and narrowing the set
-  // further would break the "Diabolocom EU Discovery" row below. The candidate
+  // further would break the "Diabolocom" row below. The candidate
   // is not the problem; adopting it unchecked is. Greenhouse publishes the
   // board owner's name at /v1/boards/{slug}, so the repair path can ask who
   // owns the board instead of inferring identity from the slug it guessed.
@@ -5291,6 +5291,40 @@ try {
     fail(`verify-portals boardIdentityMatches wrong on: ${JSON.stringify(identityBad)}`);
   }
 
+  // #3019: Lever and Ashby answer "whose board is this" only through the board
+  // page title. Tracked "Nimbus Data" 404s, the live Lever board `nimbus` is
+  // titled "Nimbus AI", and the repair must refuse it exactly as Greenhouse does.
+  const leverJson = async (url) => {
+    if (url === 'https://api.lever.co/v0/postings/nimbus') return [{ id: 1 }];
+    const err = new Error('HTTP 404'); err.status = 404; throw err;
+  };
+  const leverText = async (url) => {
+    if (url === 'https://jobs.lever.co/nimbus') return '<title>Nimbus AI jobs</title>';
+    const err = new Error('HTTP 404'); err.status = 404; throw err;
+  };
+  const [leverMismatch] = await verifyCompanies(
+    [{ name: 'Nimbus Data', careers_url: 'https://job-boards.greenhouse.io/nimbusdata' }],
+    { fetchJson: leverJson, fetchText: leverText },
+  );
+  if (leverMismatch.status === 'missing' && !leverMismatch.suggested) {
+    pass('verify-portals refuses a Lever board whose page title names a different company');
+  } else {
+    fail(`verify-portals adopted a mismatched Lever owner: ${JSON.stringify(leverMismatch.suggested)}`);
+  }
+
+  // The title suffix is stripped, not required: Lever titles the board with the
+  // bare name while Ashby appends "Jobs".
+  if (
+    boardTitleOwner('<title>deepset Jobs</title>') === 'deepset' &&
+    boardTitleOwner('<title>Diabolocom</title>') === 'Diabolocom' &&
+    boardTitleOwner('<title>  Lever Demo 2 jobs </title>') === 'Lever Demo 2' &&
+    boardTitleOwner('<html><body>no title</body></html>') === null
+  ) {
+    pass('verify-portals boardTitleOwner reads the owner out of a board page title');
+  } else {
+    fail('verify-portals boardTitleOwner mis-parsed a board page title');
+  }
+
   if (
     classifyFetchError({ status: 404 }) === 'slug_gone' &&
     classifyFetchError({ name: 'AbortError' }) === 'network' &&
@@ -5336,6 +5370,15 @@ try {
     if (url === 'https://api.eu.lever.co/v0/postings/diabolocom') return [{}, {}];
     const err = new Error('HTTP 404'); err.status = 404; throw err;
   };
+  // Lever and Ashby publish no owner in their posting APIs, so the repair path
+  // reads the board page title instead (#3019). Injected here so the suite never
+  // reaches the network: without this the defaults would fetch jobs.lever.co and
+  // jobs.ashbyhq.com for real, and the fixtures would pass or fail on live data.
+  const mockFetchText = async (url) => {
+    if (url === 'https://jobs.ashbyhq.com/deepsetai') return '<title>deepset Jobs</title>';
+    if (url === 'https://jobs.eu.lever.co/diabolocom') return '<title>Diabolocom</title>';
+    const err = new Error('HTTP 404'); err.status = 404; throw err;
+  };
   const results = await verifyCompanies([
     { name: 'Live', careers_url: 'https://job-boards.greenhouse.io/live' },
     { name: 'Empty', careers_url: 'https://job-boards.greenhouse.io/empty' },
@@ -5345,8 +5388,8 @@ try {
     { name: 'Off', enabled: false, careers_url: 'https://job-boards.greenhouse.io/live' },
     { name: 'Lever Live', careers_url: 'https://jobs.lever.co/acme-lv' },
     { name: 'Lever EU Live', careers_url: 'https://jobs.eu.lever.co/acme-eu' },
-    { name: 'Diabolocom EU Discovery', careers_url: 'https://job-boards.greenhouse.io/does-not-exist-diabolocom' },
-  ], { fetchJson: mockFetch });
+    { name: 'Diabolocom', careers_url: 'https://job-boards.greenhouse.io/does-not-exist-diabolocom' },
+  ], { fetchJson: mockFetch, fetchText: mockFetchText });
   const byName = Object.fromEntries(results.map((r) => [r.name, r]));
   if (
     results.length === 8 &&
@@ -5356,9 +5399,9 @@ try {
     byName['Lever Live'].status === 'live' &&
     byName['Lever EU Live'].status === 'live' &&
     byName.Deepset.suggested?.ats === 'ashby' && byName.Deepset.suggested?.slug === 'deepsetai' &&
-    byName['Diabolocom EU Discovery'].suggested?.ats === 'lever' &&
-    byName['Diabolocom EU Discovery'].suggested?.slug === 'diabolocom' &&
-    byName['Diabolocom EU Discovery'].suggested?.url === 'https://api.eu.lever.co/v0/postings/diabolocom'
+    byName.Diabolocom.suggested?.ats === 'lever' &&
+    byName.Diabolocom.suggested?.slug === 'diabolocom' &&
+    byName.Diabolocom.suggested?.url === 'https://api.eu.lever.co/v0/postings/diabolocom'
   ) {
     pass('verify-portals classifies live / empty / unresolved / non-ATS (disabled excluded)');
   } else {

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5291,6 +5291,45 @@ try {
     fail(`verify-portals boardIdentityMatches wrong on: ${JSON.stringify(identityBad)}`);
   }
 
+  // ── The ampersand rule runs BEFORE the ASCII fold (#2938) ──
+  // asciiFold resolves every '&' itself, so only the RAW string still separates
+  // a spaced ampersand (a word: 'Hims & Hers' -> hims and hers) from an unspaced
+  // one (punctuation: 'AT&T' -> att). Move the '&' rule after the fold and the
+  // distinction is gone in whichever direction the fold's `punctuation` mode
+  // picks: under 'delete' 'Hims & Hers' quietly loses its 'and'; under the
+  // default 'space' 'AT&T' splits into two tokens. Each pair pins one direction
+  // — the true row alone would still pass if the tokens collapsed the other way.
+  const ampersandOrder = [
+    ['Hims & Hers', 'Hims and Hers', true],   // spaced '&' became the word 'and'
+    ['Hims & Hers', 'Hims Hers', false],      // ...and it is really there, not dropped
+    ['AT&T', 'ATT', true],                    // unspaced '&' was deleted, not spaced out
+    ['AT&T', 'AT T', false],                  // ...so it must not read as two tokens
+  ];
+  const ampersandBad = ampersandOrder.filter(([a, b, want]) => boardIdentityMatches(a, b) !== want);
+  if (ampersandBad.length === 0) {
+    pass('verify-portals handles the ampersand before folding, so spaced and unspaced stay distinct');
+  } else {
+    fail(`verify-portals ampersand-before-fold ordering broken on: ${JSON.stringify(ampersandBad)}`);
+  }
+
+  // The fold is `asciiFold`, not a local strip-the-combining-marks pass, so the
+  // Latin letters that do NOT decompose under NFD come with it. Before this, the
+  // `[^a-z0-9\s]` strip deleted them outright: 'Işık' canonicalized to [isk] and
+  // never matched its own board titled "Isik".
+  const nonDecomposing = [
+    ['Işık Holding', 'Isik Holding', true],        // Turkish dotless ı
+    ['Møller Group', 'Moller Group', true],        // ø
+    ['Großmann AG', 'Grossmann', true],            // ß expands to two letters
+    ['Đại Việt Corp', 'Dai Viet', true],           // đ, plus marks that do decompose
+    ['Møller Group', 'Miller Group', false],       // folding must not merge employers
+  ];
+  const nonDecomposingBad = nonDecomposing.filter(([a, b, want]) => boardIdentityMatches(a, b) !== want);
+  if (nonDecomposingBad.length === 0) {
+    pass('verify-portals inherits the non-decomposing Latin fold (ı, ø, ß, đ) from asciiFold');
+  } else {
+    fail(`verify-portals non-decomposing fold wrong on: ${JSON.stringify(nonDecomposingBad)}`);
+  }
+
   // #3019: Lever and Ashby answer "whose board is this" only through the board
   // page title. Tracked "Nimbus Data" 404s, the live Lever board `nimbus` is
   // titled "Nimbus AI", and the repair must refuse it exactly as Greenhouse does.

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5175,6 +5175,49 @@ try {
     fail('verify-portals derived an ASCII slug from a non-Latin name');
   }
 
+  // ── First-word suffixes are probe-only, never repair candidates (#2937) ──
+  // Crossing the bare first word with an invented suffix does not build a
+  // variant of the company's name, it builds a DIFFERENT company's name:
+  // "Nimbus Data" yields `nimbusai`, `nimbustech`, `nimbuslabs`. That is fine
+  // for `--add`, where a human reads the slug next to the name and picks one.
+  // It is not fine for discoverAlternates, whose `suggested` fix-slugs --fix
+  // writes into portals.yml unreviewed. The bare first word stays on BOTH sets
+  // on purpose: it adds no token the company lacks, and boards really are often
+  // just the brand (the "Diabolocom EU Discovery" row below relies on it).
+  const probeSet = deriveSlugCandidates('Nimbus Data');
+  const repairSet = deriveSlugCandidates('Nimbus Data', { firstWordSuffixes: false });
+  const coined = ['nimbusai', 'nimbustech', 'nimbusio', 'nimbushq', 'nimbuslabs', 'nimbus.tech', 'nimbus.io'];
+  const ownName = ['nimbusdata', 'nimbus-data', 'nimbus_data', 'nimbus', 'nimbusdataai', 'nimbusdata.io'];
+  if (
+    coined.every((s) => probeSet.includes(s)) &&
+    ownName.every((s) => probeSet.includes(s)) &&
+    coined.every((s) => !repairSet.includes(s)) &&
+    ownName.every((s) => repairSet.includes(s))
+  ) {
+    pass('verify-portals keeps first-word suffixes for --add and drops them from the repair set');
+  } else {
+    fail(`verify-portals first-word-suffix split wrong: probe=${JSON.stringify(probeSet)} repair=${JSON.stringify(repairSet)}`);
+  }
+
+  // End to end: the tracked company is "Nimbus Data" and its board has 404'd.
+  // The only live board belongs to "Nimbus AI". Nothing on the repair path
+  // checks identity, so a coined candidate becomes a portals.yml write that
+  // relabels another employer's postings. It must go unresolved instead.
+  const wrongEmployerBoard = 'https://boards-api.greenhouse.io/v1/boards/nimbusai/jobs';
+  const nimbusFetch = async (url) => {
+    if (url === wrongEmployerBoard) return { jobs: [{ id: 7788, title: 'VP Marketing' }] };
+    const err = new Error('HTTP 404'); err.status = 404; throw err;
+  };
+  const [nimbus] = await verifyCompanies(
+    [{ name: 'Nimbus Data', careers_url: 'https://job-boards.greenhouse.io/nimbusdata' }],
+    { fetchJson: nimbusFetch },
+  );
+  if (nimbus.status === 'missing' && !nimbus.suggested) {
+    pass('verify-portals does not suggest a board matched only by a truncation of the name');
+  } else {
+    fail(`verify-portals adopted another employer's board: ${JSON.stringify(nimbus.suggested)}`);
+  }
+
   if (
     classifyFetchError({ status: 404 }) === 'slug_gone' &&
     classifyFetchError({ name: 'AbortError' }) === 'network' &&

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5114,7 +5114,7 @@ tracked_companies:
 console.log('\n10b. Portal slug validator');
 
 try {
-  const { deriveSlugCandidates, parseAtsSlug, verifyCompanies, classifyFetchError } =
+  const { deriveSlugCandidates, parseAtsSlug, verifyCompanies, classifyFetchError, boardIdentityMatches } =
     await import(pathToFileURL(join(ROOT, 'verify-portals.mjs')).href);
 
   const slugs = deriveSlugCandidates('Acme Corp!');
@@ -5216,6 +5216,63 @@ try {
     pass('verify-portals does not suggest a board matched only by a truncation of the name');
   } else {
     fail(`verify-portals adopted another employer's board: ${JSON.stringify(nimbus.suggested)}`);
+  }
+
+  // The other half of #2937. The bare first word stays in the repair set on
+  // purpose, so "Nimbus Data" still probes `nimbus`, and narrowing the set
+  // further would break the "Diabolocom EU Discovery" row below. The candidate
+  // is not the problem; adopting it unchecked is. Greenhouse publishes the
+  // board owner's name at /v1/boards/{slug}, so the repair path can ask who
+  // owns the board instead of inferring identity from the slug it guessed.
+  const bareOwnerUrl = 'https://boards-api.greenhouse.io/v1/boards/nimbus';
+  const bareFetch = async (url) => {
+    if (url === `${bareOwnerUrl}/jobs`) return { jobs: [{ id: 991, title: 'VP Marketing' }] };
+    if (url === bareOwnerUrl) return { name: 'Nimbus AI', content: '' };
+    const err = new Error('HTTP 404'); err.status = 404; throw err;
+  };
+  const [bare] = await verifyCompanies(
+    [{ name: 'Nimbus Data', careers_url: 'https://job-boards.greenhouse.io/nimbusdata' }],
+    { fetchJson: bareFetch },
+  );
+  if (bare.status === 'missing' && !bare.suggested) {
+    pass('verify-portals refuses a live board whose Greenhouse owner is a different company');
+  } else {
+    fail(`verify-portals adopted a mismatched owner: ${JSON.stringify(bare.suggested)}`);
+  }
+
+  // The check must not cost the legitimate repair it exists to protect: a
+  // board that really is the brand still resolves. "Stripe Inc" 404s on every
+  // whole-name form and the live `stripe` board is owned by "Stripe".
+  const stripeOwnerUrl = 'https://boards-api.greenhouse.io/v1/boards/stripe';
+  const stripeFetch = async (url) => {
+    if (url === `${stripeOwnerUrl}/jobs`) return { jobs: [{ id: 12, title: 'Engineer' }] };
+    if (url === stripeOwnerUrl) return { name: 'Stripe', content: '' };
+    const err = new Error('HTTP 404'); err.status = 404; throw err;
+  };
+  const [stripeCo] = await verifyCompanies(
+    [{ name: 'Stripe Inc', careers_url: 'https://job-boards.greenhouse.io/stripe-inc' }],
+    { fetchJson: stripeFetch },
+  );
+  if (stripeCo.suggested?.ats === 'greenhouse' && stripeCo.suggested?.slug === 'stripe') {
+    pass('verify-portals still adopts a brand-only board when the owner matches');
+  } else {
+    fail(`verify-portals lost the legitimate brand repair: ${JSON.stringify(stripeCo.suggested)}`);
+  }
+
+  // Token-prefix, not substring: "Apex" must not match "Apexon", but a trailing
+  // legal or descriptive word is the same company under a longer name.
+  if (
+    boardIdentityMatches('Stripe Inc', 'Stripe') &&
+    boardIdentityMatches('Nimbus Data', 'Nimbus') &&
+    boardIdentityMatches('Acme', 'Acme Corp') &&
+    !boardIdentityMatches('Nimbus Data', 'Nimbus AI') &&
+    !boardIdentityMatches('Apex', 'Apexon') &&
+    !boardIdentityMatches('Nimbus Data', '') &&
+    !boardIdentityMatches('', 'Nimbus')
+  ) {
+    pass('verify-portals boardIdentityMatches compares whole tokens, not substrings');
+  } else {
+    fail('verify-portals boardIdentityMatches mismatched on the token-prefix contract');
   }
 
   if (

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -5261,18 +5261,34 @@ try {
 
   // Token-prefix, not substring: "Apex" must not match "Apexon", but a trailing
   // legal or descriptive word is the same company under a longer name.
-  if (
-    boardIdentityMatches('Stripe Inc', 'Stripe') &&
-    boardIdentityMatches('Nimbus Data', 'Nimbus') &&
-    boardIdentityMatches('Acme', 'Acme Corp') &&
-    !boardIdentityMatches('Nimbus Data', 'Nimbus AI') &&
-    !boardIdentityMatches('Apex', 'Apexon') &&
-    !boardIdentityMatches('Nimbus Data', '') &&
-    !boardIdentityMatches('', 'Nimbus')
-  ) {
-    pass('verify-portals boardIdentityMatches compares whole tokens, not substrings');
+  // Canonical equality, not prefix. A shorter tracked name is NOT evidence that a
+  // longer board name is the same company: Mercury and Mercury Systems, Scale and
+  // Scale AI, Northrop and Northrop Grumman are all real, distinct employers. Only
+  // tokens that carry no identity (leading article, trailing legal designator) may
+  // be dropped before comparing.
+  const identityCases = [
+    ['Stripe Inc', 'Stripe', true],           // trailing legal designator
+    ['Acme', 'Acme Corp', true],              // designator on the other side
+    ['Acme S.A.', 'Acme', true],              // punctuated designator
+    ['The Trade Desk', 'Trade Desk', true],   // leading article
+    ['The Walt Disney Company', 'Walt Disney', true],
+    ['Hims & Hers', 'Hims and Hers', true],   // spaced ampersand reads as a word
+    ['AT&T', 'ATT', true],                    // unspaced ampersand is punctuation
+    ['Café Corp', 'Cafe', true],              // accents fold
+    ['Mercury', 'Mercury Systems', false],    // real, different employer
+    ['Scale', 'Scale AI', false],
+    ['Northrop', 'Northrop Grumman', false],
+    ['Nimbus Data', 'Nimbus', false],         // prefix only: send it to --add
+    ['Nimbus Data', 'Nimbus AI', false],
+    ['Apex', 'Apexon', false],                // substring, not a token
+    ['Nimbus Data', '', false],
+    ['', 'Nimbus', false],
+  ];
+  const identityBad = identityCases.filter(([a, b, want]) => boardIdentityMatches(a, b) !== want);
+  if (identityBad.length === 0) {
+    pass('verify-portals boardIdentityMatches requires canonical equality, not a token prefix');
   } else {
-    fail('verify-portals boardIdentityMatches mismatched on the token-prefix contract');
+    fail(`verify-portals boardIdentityMatches wrong on: ${JSON.stringify(identityBad)}`);
   }
 
   if (

--- a/verify-portals.mjs
+++ b/verify-portals.mjs
@@ -122,12 +122,37 @@ export function parseAtsSlug(url) {
  * boards use just the brand, e.g. 'Acme Corp' → 'acme'). Order is deterministic
  * and duplicates are removed so `--add` probes each distinct candidate once.
  *
+ * SUFFIXES ON THE FIRST WORD ARE PROBE-ONLY (#2937). Every other candidate here
+ * either reformats the whole name ('nimbus-data'), abbreviates it without
+ * adding anything ('nimbus'), or extends it ('nimbusdataai'). Building a suffix
+ * on the FIRST WORD is the one rule that both drops part of the name AND
+ * substitutes a token for what it dropped, so what comes out is not a form of
+ * this company's name, it is a different company's: 'Nimbus Data' yields
+ * 'nimbusai', 'nimbustech', 'nimbuslabs'. The rule has no legitimate yield to
+ * lose either. When the name already ends in a suffix word ('Scale AI'), it
+ * just reproduces words.join('') and is deduped away, so every candidate it
+ * contributes uniquely belongs to somebody else.
+ *
+ * Offering those to `--add` is fine: an operator reads the slug beside the
+ * company name and picks one, and a wrong guess costs a 404. Offering them to
+ * discoverAlternates is not. That result is attached as `suggested`, and
+ * `fix-slugs --fix` writes it into portals.yml with no further identity check,
+ * after which scan.mjs labels the other employer's postings with this
+ * company's name. Pass `firstWordSuffixes: false` on any path that writes.
+ *
+ * The bare first word stays on both paths deliberately: many boards really are
+ * just the brand ('Acme Corp' → 'acme'), and it adds no token that the company
+ * does not have. It is a narrower risk than this change addresses, not a
+ * blessed one.
+ *
  * @param {string} name - Company display name.
+ * @param {{firstWordSuffixes?: boolean}} [opts] - `false` omits the suffix
+ *   variants built on the first word alone.
  * @returns {string[]} Distinct candidate slugs, most-specific first.
  */
 const SLUG_SUFFIXES = ['ai', 'tech', 'io', 'hq', 'labs'];
 
-export function deriveSlugCandidates(name) {
+export function deriveSlugCandidates(name, { firstWordSuffixes = true } = {}) {
   if (!String(name ?? '').trim()) return [];
   // ASCII-fold BEFORE splitting. The previous `[^a-z0-9\s]` pass turned an
   // accented letter into a SEPARATOR, so "Telefónica" became the two words
@@ -142,7 +167,7 @@ export function deriveSlugCandidates(name) {
     words.join('_'), // acme_corp
     words[0], // acme
   ];
-  const bases = [words.join(''), words[0]].filter(Boolean);
+  const bases = (firstWordSuffixes ? [words.join(''), words[0]] : [words.join('')]).filter(Boolean);
   for (const base of bases) {
     for (const suf of SLUG_SUFFIXES) candidates.push(`${base}${suf}`);
     candidates.push(`${base}.tech`, `${base}.io`);
@@ -232,10 +257,19 @@ export async function probeSlug(
   }
 }
 
-/** Probe slug variants across all ATSes; prefer live boards over empty ones. */
+/**
+ * Probe slug variants across all ATSes; prefer live boards over empty ones.
+ *
+ * No first-word suffix variants (#2937). Nothing downstream re-checks identity:
+ * the winner is attached as `suggested` and `fix-slugs --fix` writes it into
+ * portals.yml, so 'Nimbus Data' adopting the live board 'nimbusai' silently
+ * relabels Nimbus AI's postings. Those candidates are never this company's name
+ * to begin with, so dropping them here costs nothing and they stay available to
+ * `--add`, where an operator sees the slug beside the name before adopting it.
+ */
 async function discoverAlternates(name, { fetchJson }) {
   let bestEmpty = null;
-  for (const slug of deriveSlugCandidates(name)) {
+  for (const slug of deriveSlugCandidates(name, { firstWordSuffixes: false })) {
     for (const ats of Object.keys(ATS)) {
       // Lever no longer has a separate 'lever-eu' registry key (unified into a
       // single 'lever' + eu flag), so both instances must be probed explicitly

--- a/verify-portals.mjs
+++ b/verify-portals.mjs
@@ -262,55 +262,100 @@ export async function probeSlug(
   }
 }
 
+// Tokens that carry no identity. A leading article and a trailing legal designator
+// can differ between how a company writes its name and how its ATS board is titled,
+// so they are dropped before comparing. Nothing else is: 'Systems', 'AI', 'Airlines'
+// and 'Grumman' are exactly what distinguishes Mercury Systems from Mercury.
+const NAME_ARTICLES = new Set(['the']);
+const NAME_DESIGNATORS = new Set([
+  'inc', 'incorporated', 'llc', 'llp', 'lp', 'ltd', 'limited', 'plc', 'corp',
+  'corporation', 'co', 'company', 'gmbh', 'ag', 'kg', 'sa', 'sas', 'sarl', 'srl',
+  'spa', 'bv', 'nv', 'ab', 'as', 'oy', 'aps', 'pty', 'pte', 'kk', 'kft',
+]);
+
+/**
+ * Reduce a company or board name to the tokens that actually identify it.
+ *
+ * Accents fold (Café -> cafe). A spaced ampersand is a word ('Hims & Hers' ->
+ * hims and hers); an unspaced one is punctuation ('AT&T' -> att). Remaining
+ * punctuation is dropped, then a leading article and any trailing legal
+ * designators are removed.
+ *
+ * @param {string} name
+ * @returns {string[]} Canonical identifying tokens.
+ */
+function canonicalNameTokens(name) {
+  const words = String(name || '')
+    // NFKD splits an accented character into base + combining mark, and the
+    // punctuation strip below then drops the mark, so 'Café' folds to 'cafe'.
+    .normalize('NFKD')
+    .toLowerCase()
+    .replace(/\s+&\s+/g, ' and ')
+    .replace(/[^a-z0-9\s]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .split(' ')
+    .filter(Boolean);
+  let start = 0;
+  if (words.length > 1 && NAME_ARTICLES.has(words[0])) start = 1;
+  let end = words.length;
+  while (end - start > 1 && NAME_DESIGNATORS.has(words[end - 1])) end -= 1;
+  return words.slice(start, end);
+}
+
 /**
  * Does a discovered board's owner name refer to the company we are repairing?
  *
- * Token-prefix, not substring. A trailing word is the same company under a
- * longer name ('Stripe' vs 'Stripe Inc', 'Nimbus Data' vs 'Nimbus'), but a
- * DIFFERENT word in the same position is a different company ('Nimbus Data' vs
- * 'Nimbus AI'). Substring matching would accept 'Apex' for 'Apexon', which is
- * the same class of error this check exists to stop.
+ * Canonical equality, deliberately not a prefix. A shorter tracked name is not
+ * evidence that a longer board name is the same company: Mercury and Mercury
+ * Systems, Scale and Scale AI, Northrop and Northrop Grumman are all real and
+ * distinct. A prefix-only match ('Nimbus Data' against a board named 'Nimbus')
+ * may well be the same company, but this path writes portals.yml unreviewed, so
+ * it goes to `--add` where a human can judge it rather than being adopted here.
  *
  * @param {string} companyName - The tracked company being repaired.
  * @param {string} boardName - The name the ATS reports for the probed board.
- * @returns {boolean} True when one name's tokens prefix the other's.
+ * @returns {boolean} True only when both canonicalize to the same tokens.
  */
 export function boardIdentityMatches(companyName, boardName) {
-  const tokens = (s) =>
-    String(s || '')
-      .toLowerCase()
-      .replace(/[^a-z0-9\s]/g, ' ')
-      .replace(/\s+/g, ' ')
-      .trim()
-      .split(' ')
-      .filter(Boolean);
-  const a = tokens(companyName);
-  const b = tokens(boardName);
+  const a = canonicalNameTokens(companyName);
+  const b = canonicalNameTokens(boardName);
   if (!a.length || !b.length) return false;
-  const [short, long] = a.length <= b.length ? [a, b] : [b, a];
-  return short.every((tok, i) => tok === long[i]);
+  return a.length === b.length && a.every((tok, i) => tok === b[i]);
 }
 
 /**
  * Confirm a candidate board belongs to this company before it can be written.
  *
- * Fails CLOSED for any ATS that publishes an owner: if we cannot read the name,
- * we do not auto-adopt. A missed suggestion costs an operator one `--add`, where
- * they see the slug beside the company name; a wrong one is written into
- * portals.yml unreviewed and relabels another employer's postings in scan.mjs.
- * ATSes that publish no owner (lever, ashby) keep their existing behavior.
+ * Fails CLOSED for any ATS that publishes an owner, and does not distinguish
+ * "owned by someone else" from "could not ask": both mean unconfirmed, and an
+ * unconfirmed board must not be written into portals.yml unreviewed. A missed
+ * suggestion costs an operator one `--add`, where the slug is shown beside the
+ * company name; a wrong one relabels another employer's postings in scan.mjs.
+ * The reason is recorded so a transient outage is not read as a mismatch.
+ *
+ * ATSes that publish no owner (lever, ashby) keep their existing behavior, which
+ * is tracked separately rather than implied to be safe here.
  */
-async function ownerConfirmed(ats, slug, companyName, { fetchJson, eu = false }) {
+async function ownerConfirmed(ats, slug, companyName, { fetchJson, eu = false, cache }) {
   const spec = ATS[ats];
-  if (!spec?.ownerUrl) return true;
-  let boardName = null;
+  if (!spec?.ownerUrl) return { ok: true, reason: 'no-owner-endpoint' };
+  const key = `${ats}|${eu ? 'eu' : 'base'}|${slug}`;
+  if (cache?.has(key)) return cache.get(key);
+  let out;
   try {
-    boardName = spec.ownerName(await fetchJson(spec.ownerUrl(slug, { eu })));
-  } catch {
-    return false;
+    const boardName = spec.ownerName(await fetchJson(spec.ownerUrl(slug, { eu })));
+    if (!boardName) out = { ok: false, reason: 'owner-unnamed' };
+    else if (boardIdentityMatches(companyName, boardName)) out = { ok: true, reason: 'owner-match', boardName };
+    else out = { ok: false, reason: 'owner-mismatch', boardName };
+  } catch (err) {
+    // A 404 here means the board root is gone; anything else (429, 5xx, network)
+    // means we could not ask. Neither confirms identity, but they are different
+    // facts and the summary should not report an outage as somebody else's board.
+    out = { ok: false, reason: classifyFetchError(err) === 'slug_gone' ? 'owner-absent' : 'owner-unreachable' };
   }
-  if (!boardName) return false;
-  return boardIdentityMatches(companyName, boardName);
+  cache?.set(key, out);
+  return out;
 }
 
 /**
@@ -325,6 +370,9 @@ async function ownerConfirmed(ats, slug, companyName, { fetchJson, eu = false })
  */
 async function discoverAlternates(name, { fetchJson }) {
   let bestEmpty = null;
+  // One owner lookup per (ats, eu, slug) per company, so the added identity check
+  // cannot multiply requests when candidates repeat across the probe order.
+  const cache = new Map();
   for (const slug of deriveSlugCandidates(name, { firstWordSuffixes: false })) {
     for (const ats of Object.keys(ATS)) {
       // Lever no longer has a separate 'lever-eu' registry key (unified into a
@@ -334,7 +382,8 @@ async function discoverAlternates(name, { fetchJson }) {
       for (const eu of euVariants) {
         const r = await probeSlug(ats, slug, { fetchJson, eu });
         if (r.status !== 'live' && r.status !== 'empty') continue;
-        if (!(await ownerConfirmed(ats, slug, name, { fetchJson, eu }))) continue;
+        const owner = await ownerConfirmed(ats, slug, name, { fetchJson, eu, cache });
+        if (!owner.ok) continue;
         if (r.status === 'live') return r;
         if (!bestEmpty) bestEmpty = r;
       }

--- a/verify-portals.mjs
+++ b/verify-portals.mjs
@@ -48,6 +48,11 @@ export const ATS = {
     probeUrl: (slug) =>
       `https://boards-api.greenhouse.io/v1/boards/${slug}/jobs`,
     jobCount: (json) => (Array.isArray(json?.jobs) ? json.jobs.length : null),
+    // The board root publishes its owner: {"name":"Stripe","content":""}. Lever
+    // returns a bare posting array and Ashby returns {jobs, apiVersion}, so
+    // neither can answer "whose board is this" and neither defines these.
+    ownerUrl: (slug) => `https://boards-api.greenhouse.io/v1/boards/${slug}`,
+    ownerName: (json) => (typeof json?.name === 'string' ? json.name.trim() : null),
   },
   ashby: {
     probeUrl: (slug) =>
@@ -258,6 +263,57 @@ export async function probeSlug(
 }
 
 /**
+ * Does a discovered board's owner name refer to the company we are repairing?
+ *
+ * Token-prefix, not substring. A trailing word is the same company under a
+ * longer name ('Stripe' vs 'Stripe Inc', 'Nimbus Data' vs 'Nimbus'), but a
+ * DIFFERENT word in the same position is a different company ('Nimbus Data' vs
+ * 'Nimbus AI'). Substring matching would accept 'Apex' for 'Apexon', which is
+ * the same class of error this check exists to stop.
+ *
+ * @param {string} companyName - The tracked company being repaired.
+ * @param {string} boardName - The name the ATS reports for the probed board.
+ * @returns {boolean} True when one name's tokens prefix the other's.
+ */
+export function boardIdentityMatches(companyName, boardName) {
+  const tokens = (s) =>
+    String(s || '')
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .split(' ')
+      .filter(Boolean);
+  const a = tokens(companyName);
+  const b = tokens(boardName);
+  if (!a.length || !b.length) return false;
+  const [short, long] = a.length <= b.length ? [a, b] : [b, a];
+  return short.every((tok, i) => tok === long[i]);
+}
+
+/**
+ * Confirm a candidate board belongs to this company before it can be written.
+ *
+ * Fails CLOSED for any ATS that publishes an owner: if we cannot read the name,
+ * we do not auto-adopt. A missed suggestion costs an operator one `--add`, where
+ * they see the slug beside the company name; a wrong one is written into
+ * portals.yml unreviewed and relabels another employer's postings in scan.mjs.
+ * ATSes that publish no owner (lever, ashby) keep their existing behavior.
+ */
+async function ownerConfirmed(ats, slug, companyName, { fetchJson, eu = false }) {
+  const spec = ATS[ats];
+  if (!spec?.ownerUrl) return true;
+  let boardName = null;
+  try {
+    boardName = spec.ownerName(await fetchJson(spec.ownerUrl(slug, { eu })));
+  } catch {
+    return false;
+  }
+  if (!boardName) return false;
+  return boardIdentityMatches(companyName, boardName);
+}
+
+/**
  * Probe slug variants across all ATSes; prefer live boards over empty ones.
  *
  * No first-word suffix variants (#2937). Nothing downstream re-checks identity:
@@ -277,8 +333,10 @@ async function discoverAlternates(name, { fetchJson }) {
       const euVariants = ats === 'lever' ? [false, true] : [false];
       for (const eu of euVariants) {
         const r = await probeSlug(ats, slug, { fetchJson, eu });
+        if (r.status !== 'live' && r.status !== 'empty') continue;
+        if (!(await ownerConfirmed(ats, slug, name, { fetchJson, eu }))) continue;
         if (r.status === 'live') return r;
-        if (r.status === 'empty' && !bestEmpty) bestEmpty = r;
+        if (!bestEmpty) bestEmpty = r;
       }
     }
   }

--- a/verify-portals.mjs
+++ b/verify-portals.mjs
@@ -48,9 +48,9 @@ export const ATS = {
     probeUrl: (slug) =>
       `https://boards-api.greenhouse.io/v1/boards/${slug}/jobs`,
     jobCount: (json) => (Array.isArray(json?.jobs) ? json.jobs.length : null),
-    // The board root publishes its owner: {"name":"Stripe","content":""}. Lever
-    // returns a bare posting array and Ashby returns {jobs, apiVersion}, so
-    // neither can answer "whose board is this" and neither defines these.
+    // The board root publishes its owner: {"name":"Stripe","content":""}. The
+    // Ashby and Lever posting APIs answer no such question, so those two read
+    // their owner off the board page <title> instead (see below).
     ownerUrl: (slug) => `https://boards-api.greenhouse.io/v1/boards/${slug}`,
     ownerKind: 'json',
     ownerName: (json) => (typeof json?.name === 'string' ? json.name.trim() : null),
@@ -304,24 +304,32 @@ const NAME_DESIGNATORS = new Set([
 /**
  * Reduce a company or board name to the tokens that actually identify it.
  *
- * Accents fold (Café -> cafe). A spaced ampersand is a word ('Hims & Hers' ->
- * hims and hers); an unspaced one is punctuation ('AT&T' -> att). Remaining
- * punctuation is dropped, then a leading article and any trailing legal
- * designators are removed.
+ * Accents fold through the shared `asciiFold` (Café -> cafe), which also carries
+ * the Latin letters NFD does not decompose — Işık -> isik, Møller -> moller,
+ * Großmann -> grossmann, Đại -> dai — where a bare strip-the-marks pass deletes
+ * the letter outright (#2930).
+ *
+ * THE AMPERSAND RULE RUNS BEFORE THE FOLD, AND THE ORDER IS LOAD-BEARING.
+ * A spaced ampersand is a word ('Hims & Hers' -> hims and hers); an unspaced one
+ * is punctuation ('AT&T' -> att). Only the raw string still tells them apart:
+ * `asciiFold` has resolved every '&' by the time it returns, whichever
+ * `punctuation` mode it ran in. Fold first and 'Hims & Hers' silently loses its
+ * 'and' under 'delete', or 'AT&T' splits into two tokens under 'space'.
+ *
+ * `punctuation: 'delete'` because these tokens are compared for EQUALITY, never
+ * substring-matched, so a hyphen or apostrophe must keep joining its word
+ * ("L'Oréal" -> loreal) exactly as the inline strip this replaced did.
+ * Whitespace is collapsed to single spaces first, so 'delete' — which removes a
+ * tab rather than collapsing it — cannot weld two words together.
+ *
+ * A leading article and any trailing legal designators are dropped afterwards.
  *
  * @param {string} name
  * @returns {string[]} Canonical identifying tokens.
  */
 function canonicalNameTokens(name) {
-  const words = String(name || '')
-    // NFKD splits an accented character into base + combining mark, and the
-    // punctuation strip below then drops the mark, so 'Café' folds to 'cafe'.
-    .normalize('NFKD')
-    .toLowerCase()
-    .replace(/\s+&\s+/g, ' and ')
-    .replace(/[^a-z0-9\s]/g, '')
-    .replace(/\s+/g, ' ')
-    .trim()
+  const spaced = String(name || '').replace(/\s+/g, ' ');
+  const words = asciiFold(spaced.replace(/\s+&\s+/g, ' and '), { punctuation: 'delete' })
     .split(' ')
     .filter(Boolean);
   let start = 0;
@@ -362,8 +370,11 @@ export function boardIdentityMatches(companyName, boardName) {
  * company name; a wrong one relabels another employer's postings in scan.mjs.
  * The reason is recorded so a transient outage is not read as a mismatch.
  *
- * ATSes that publish no owner (lever, ashby) keep their existing behavior, which
- * is tracked separately rather than implied to be safe here.
+ * Every ATS in the table above publishes an owner, so all three are confirmed
+ * here. The `no-owner-endpoint` pass-through is a guard for a FUTURE entry that
+ * defines no `ownerUrl`: it keeps this function total instead of throwing on
+ * one. Such an entry would need its own identity signal before boards found on
+ * it could be adopted, so the reason is returned rather than swallowed.
  */
 async function ownerConfirmed(ats, slug, companyName, { fetchJson, fetchText, eu = false, cache }) {
   const spec = ATS[ats];

--- a/verify-portals.mjs
+++ b/verify-portals.mjs
@@ -30,7 +30,7 @@ import { dirname, resolve } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import * as yaml from 'js-yaml';
 
-import { fetchJson as defaultFetchJson, makeHttpCtx } from './providers/_http.mjs';
+import { fetchJson as defaultFetchJson, fetchTextHead as defaultFetchText, makeHttpCtx } from './providers/_http.mjs';
 import { asciiFold } from './lib/ascii-fold.mjs';
 import { loadProviders, resolveProvider } from './providers/_registry.mjs';
 
@@ -52,18 +52,28 @@ export const ATS = {
     // returns a bare posting array and Ashby returns {jobs, apiVersion}, so
     // neither can answer "whose board is this" and neither defines these.
     ownerUrl: (slug) => `https://boards-api.greenhouse.io/v1/boards/${slug}`,
+    ownerKind: 'json',
     ownerName: (json) => (typeof json?.name === 'string' ? json.name.trim() : null),
   },
   ashby: {
     probeUrl: (slug) =>
       `https://api.ashbyhq.com/posting-api/job-board/${slug}?includeCompensation=true`,
     jobCount: (json) => (Array.isArray(json?.jobs) ? json.jobs.length : null),
+    // The posting API returns only {jobs, apiVersion}; the board page titles
+    // itself with the owner ('deepset Jobs'), which is the only name either
+    // Ashby or Lever exposes publicly (#3019).
+    ownerUrl: (slug) => `https://jobs.ashbyhq.com/${slug}`,
+    ownerKind: 'html',
+    ownerName: (html) => boardTitleOwner(html),
   },
   lever: {
     // EU boards (jobs.eu.lever.co) resolve to api.eu.lever.co, mirroring the
     // provider's resolveApiUrl; the default is the base instance.
     probeUrl: (slug, { eu = false } = {}) => `https://api.${eu ? 'eu.' : ''}lever.co/v0/postings/${slug}`,
     jobCount: (json) => (Array.isArray(json) ? json.length : null),
+    ownerUrl: (slug, { eu = false } = {}) => `https://jobs.${eu ? 'eu.' : ''}lever.co/${slug}`,
+    ownerKind: 'html',
+    ownerName: (html) => boardTitleOwner(html),
   },
 };
 
@@ -262,6 +272,24 @@ export async function probeSlug(
   }
 }
 
+/**
+ * Pull the board owner's name out of a careers page <title>.
+ *
+ * Both providers title the board after its owner and append a jobs suffix:
+ * 'deepset Jobs' on Ashby, 'Diabolocom' or 'Lever Demo 2' on Lever. The suffix is
+ * stripped when present; everything else is left for canonicalNameTokens to judge.
+ *
+ * @param {string} html - The head of the board page.
+ * @returns {string|null} The owner name, or null when no title is present.
+ */
+export function boardTitleOwner(html) {
+  const m = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(String(html || ''));
+  if (!m) return null;
+  const title = m[1].replace(/\s+/g, ' ').trim();
+  if (!title) return null;
+  return title.replace(/\s+jobs$/i, '').trim() || null;
+}
+
 // Tokens that carry no identity. A leading article and a trailing legal designator
 // can differ between how a company writes its name and how its ATS board is titled,
 // so they are dropped before comparing. Nothing else is: 'Systems', 'AI', 'Airlines'
@@ -337,14 +365,16 @@ export function boardIdentityMatches(companyName, boardName) {
  * ATSes that publish no owner (lever, ashby) keep their existing behavior, which
  * is tracked separately rather than implied to be safe here.
  */
-async function ownerConfirmed(ats, slug, companyName, { fetchJson, eu = false, cache }) {
+async function ownerConfirmed(ats, slug, companyName, { fetchJson, fetchText, eu = false, cache }) {
   const spec = ATS[ats];
   if (!spec?.ownerUrl) return { ok: true, reason: 'no-owner-endpoint' };
   const key = `${ats}|${eu ? 'eu' : 'base'}|${slug}`;
   if (cache?.has(key)) return cache.get(key);
   let out;
   try {
-    const boardName = spec.ownerName(await fetchJson(spec.ownerUrl(slug, { eu })));
+    const url = spec.ownerUrl(slug, { eu });
+    const raw = spec.ownerKind === 'html' ? await fetchText(url) : await fetchJson(url);
+    const boardName = spec.ownerName(raw);
     if (!boardName) out = { ok: false, reason: 'owner-unnamed' };
     else if (boardIdentityMatches(companyName, boardName)) out = { ok: true, reason: 'owner-match', boardName };
     else out = { ok: false, reason: 'owner-mismatch', boardName };
@@ -368,7 +398,7 @@ async function ownerConfirmed(ats, slug, companyName, { fetchJson, eu = false, c
  * to begin with, so dropping them here costs nothing and they stay available to
  * `--add`, where an operator sees the slug beside the name before adopting it.
  */
-async function discoverAlternates(name, { fetchJson }) {
+async function discoverAlternates(name, { fetchJson, fetchText }) {
   let bestEmpty = null;
   // One owner lookup per (ats, eu, slug) per company, so the added identity check
   // cannot multiply requests when candidates repeat across the probe order.
@@ -382,7 +412,7 @@ async function discoverAlternates(name, { fetchJson }) {
       for (const eu of euVariants) {
         const r = await probeSlug(ats, slug, { fetchJson, eu });
         if (r.status !== 'live' && r.status !== 'empty') continue;
-        const owner = await ownerConfirmed(ats, slug, name, { fetchJson, eu, cache });
+        const owner = await ownerConfirmed(ats, slug, name, { fetchJson, fetchText, eu, cache });
         if (!owner.ok) continue;
         if (r.status === 'live') return r;
         if (!bestEmpty) bestEmpty = r;
@@ -502,7 +532,7 @@ export async function probeProvider(entry, provider, baseCtx) {
  */
 export async function verifyCompanies(
   companies,
-  { fetchJson = defaultFetchJson, providers = null, httpCtx = null } = {},
+  { fetchJson = defaultFetchJson, fetchText = defaultFetchText, providers = null, httpCtx = null } = {},
 ) {
   const list = Array.isArray(companies) ? companies : [];
   const results = [];
@@ -520,7 +550,7 @@ export async function verifyCompanies(
       }
       // Wrong slug or ATS migration — cross-probe only for slug/unknown failures.
       if (probe.errorKind === 'slug_gone' || probe.errorKind === 'unknown') {
-        const suggested = await discoverAlternates(name, { fetchJson });
+        const suggested = await discoverAlternates(name, { fetchJson, fetchText });
         if (suggested) {
           results.push({ name, ...probe, suggested });
           continue;


### PR DESCRIPTION
## What does this PR do?

Stops `verify-portals`'s automated slug-repair path from adopting a live ATS board that belongs to a different employer. `discoverAlternates` no longer probes the suffix variants built on the company's **first word** (`Nimbus Data` -> `nimbusai`, `nimbustech`, `nimbuslabs`), because that result is attached as `suggested`, written into `portals.yml` by `fix-slugs --fix` with no further identity check, and then used by `scan.mjs` to label the other employer's postings with this company's name. `--add`, which is human-in-the-loop, keeps the wide set.

## Related issue

Closes #2937

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---

### Why this rule specifically, and not the whole truncation

The candidate set has three kinds of entry, and only one of them is unsafe to write:

| Kind | Example for `Nimbus Data` | Relationship to the name |
|---|---|---|
| Reformat | `nimbusdata`, `nimbus-data`, `nimbus_data` | the whole name |
| Extend | `nimbusdataai`, `nimbusdata.io` | the whole name plus a token |
| Abbreviate | `nimbus` | part of the name, nothing added |
| **Coin** | **`nimbusai`, `nimbustech`, `nimbuslabs`** | **part of the name, plus a token the company does not have** |

Only the last one can name a company that is not this one. It also has no legitimate yield to lose: when the name already ends in a suffix word (`Scale AI`), `words[0] + suffix` just reproduces `words.join('')` and is deduped away, so every candidate the rule contributes *uniquely* belongs to somebody else.

**The bare first word stays on both paths on purpose.** It adds no token the company lacks, boards really are often just the brand (`Acme Corp` -> `acme`), and the existing `Diabolocom EU Discovery` fixture depends on it. A board at slug `nimbus` owned by a different `Nimbus` is still admitted; that residual is called out in #2937 rather than fixed here, because removing it would cost real repairs and is a judgement call for you, not something the reproduction demonstrates.

### TDD

Both assertions were added to section 10b of `test-all.mjs` and watched fail against unmodified `main` first:

```
❌ verify-portals first-word-suffix split wrong: probe=[...] repair=[...]   (the two sets were identical)
❌ verify-portals adopted another employer's board: {"ats":"greenhouse","slug":"nimbusai",...}
```

The second is the end-to-end case: `verifyCompanies` driven with an injected `fetchJson` in which the only live board on the internet is `nimbusai`. No network, no fixtures on disk.

### Verified after the fix

- The repair path returns the row as `missing` with **no** `suggested`.
- `--add`'s probe set still offers `nimbusai`, where an operator sees it beside the company name.
- The legitimate bare-first-word repair still resolves: `Stripe Inc` with a 404 on `stripe-inc` still suggests `stripe`.
- `Deepset -> deepsetai` (a suffix on the *full* base) is untouched, as the existing fixture asserts.

### Test counts

| | passed | failed | warnings |
|---|---|---|---|
| `main` @ 22cbe88 | 3938 | 0 | 1 |
| this branch | 3940 | 0 | 1 |

`+2` is exactly the two new assertions. The single warning is pre-existing on `main`.

### Note on overlap

#2931 also edits `deriveSlugCandidates` and section 10b of `test-all.mjs` (ASCII folding for accented names, #2930). The changes are independent in intent, but they will touch adjacent lines. Happy to rebase this on top of that one whenever it lands, in whichever order suits you.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved board matching across Greenhouse, Lever, and Ashby to prevent similarly named companies’ boards from being suggested.
  - Rejected boards when ownership cannot be verified or does not match the tracked company.
  - Added more accurate identity checks across legal designators, punctuation, accents, prefixes, and name variations.

- **Improvements**
  - Refined repair suggestions to exclude less-reliable first-word-only suffix variants.
  - Improved handling of empty or newly discovered boards.
  - Added validation for Diabolocom discovery and Lever repair URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### Second commit: confirming ownership, not just narrowing the guess

Dropping the coined suffixes removed the candidates that are never this company's name, but it left the premise in place: nothing on the repair path ever asks who owns the board it found. The bare first word stays in the set on purpose, so `Nimbus Data` still probes `nimbus`, and if that board belongs to Nimbus AI the write still happens.

Greenhouse answers the question directly. `GET /v1/boards/{slug}` returns `{"name":"Stripe","content":""}`, so `discoverAlternates` now confirms the owner before returning a candidate. Matching is on whole tokens rather than substrings: a trailing word is the same company under a longer name (`Stripe` for `Stripe Inc`), a different word in the same position is not (`Nimbus AI` for `Nimbus Data`). Substring matching would have accepted `Apexon` for `Apex`.

The check fails closed for any ATS that publishes an owner. A missed suggestion costs an operator one `--add`, where the slug is shown beside the company name; a wrong one is written unreviewed.

Lever returns a bare posting array and Ashby returns `{jobs, apiVersion}`, so neither posting API can answer. I filed that residual as #3019 and then went and checked whether anything else could answer it, which changed the scope of this PR. See the next section.

| | passed | failed | warnings |
|---|---|---|---|
| this branch, first commit | 3940 | 0 | 1 |
| this branch, with the owner check | 3943 | 0 | 1 |

`+3` is the mismatched-owner case, the preserved brand-only repair, and the token-prefix contract. The `Diabolocom EU Discovery` and `Deepset` fixtures both still resolve.



---

### Third commit: the other two providers can answer after all

I opened #3019 for Lever and Ashby on the basis that their posting APIs expose no owner. That part is true, and I verified it against the live endpoints rather than assuming: Lever's `hostedUrl` only echoes back the slug that was probed, and Ashby's response is `{jobs, apiVersion}` with nothing above the job list.

Their board pages do carry it. Ashby titles the page `deepset Jobs`, Lever titles it `Diabolocom` on EU and `Lever Demo 2` on the base instance. So the repair path now reads the title and holds it to the same canonical-equality rule Greenhouse already uses, and all three providers answer the same question before a slug reaches `portals.yml`.

The page is not fetched whole. `jobs.lever.co` ships about 950KB of embedded job JSON and ignores a Range request, and pulling all of that to learn one string is the behavior the probe path already refuses elsewhere (`A liveness probe must never paginate an entire board`). `fetchTextHead` stops at 8KB and cancels the body; every title observed sits well inside that.

I folded this into this PR rather than stacking a second one, because the two halves are the same mechanism and reviewing "confirm the owner, except on two of three providers" seemed worse than reviewing the finished rule. #3019 is closed by this.

**On the renamed fixture.** `Diabolocom EU Discovery` becomes `Diabolocom`, which is the name `templates/portals.example.yml` actually carries. The suffix existed only in the test, and with it the fixture asserted that a prefix-only match may be auto-adopted, which is precisely what this PR stops doing on Greenhouse. Keeping it would have left the rule inconsistent across providers. It still exercises the same path: a 404 on the tracked board, discovery finding the live EU Lever board.

| | passed | failed | warnings |
|---|---|---|---|
| with the Greenhouse owner check | 3943 | 0 | 1 |
| rebased on current main | 4203 | 0 | 2 |
| with Lever and Ashby | 4205 | 0 | 2 |

Both warnings are present unchanged on the base commit. The suite now injects `fetchText`, so it no longer reaches `jobs.lever.co` or `jobs.ashbyhq.com` for real; I confirmed that by making the default text fetcher throw and checking the suite still passes.
