### PR TITLE
fix(scan): add block_hard tier so always_allow cannot discard an explicit block

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -203,6 +203,8 @@ export function matchedTitleKeywords(title, titleFilter) {
 // Semantics (case-insensitive substring, in this order):
 //   - Empty / whitespace-only / non-string location → pass (don't penalize
 //     missing or malformed provider data)
+//   - `block_hard` matches → reject (the only tier `always_allow` cannot
+//     override; for country-level terms that are never a false rejection)
 //   - `always_allow` matches → pass (takes precedence over `block` — lets a
 //     multi-location string like "Remote, Belgium or France" through because
 //     the home region is an option, even though "france" is blocked)
@@ -340,6 +342,7 @@ export function buildLocationFilter(locationFilter) {
   const alwaysAllow = compileLocationKeywordList(locationFilter.always_allow);
   const allow = compileLocationKeywordList(locationFilter.allow);
   const block = compileLocationKeywordList(locationFilter.block);
+  const blockHard = compileLocationKeywordList(locationFilter.block_hard);
 
   return (location, url, title) => {
     const lower = typeof location === 'string' ? location.trim().toLowerCase() : '';
@@ -347,6 +350,21 @@ export function buildLocationFilter(locationFilter) {
     // Nothing to judge on either field → pass (don't penalize missing data).
     if (lower === '' && hint === '') return true;
     const matches = (m) => (lower !== '' && m(lower)) || (hint !== '' && m(hint));
+    // `block_hard` is the ONE tier always_allow cannot override. It exists because
+    // a European city name can be a whole word inside a non-European location, so
+    // word-boundary matching (#2087) does not catch it and always_allow's
+    // unconditional win silently discards the user's own block entry:
+    //
+    //   "Porto Alegre, Rio Grande do Sul, Brazil"  always_allow "Porto" beats block "Brazil"
+    //   "USA - New York - Malta"                   always_allow "Malta" beats block "USA"
+    //
+    // Both configs already listed the country under `block`. Plain `block` cannot
+    // be promoted wholesale — always_allow was added in #650 precisely so a
+    // multi-location posting survives one blocked city ("Stockholm · London ·
+    // Madrid" must not die on a London entry) — so the user marks the entries
+    // that are country-level and therefore never a false rejection. Opt-in and
+    // additive: a config without `block_hard` behaves exactly as before.
+    if (blockHard.length > 0 && blockHard.some(matches)) return false;
     // always_allow still wins over block, and may be satisfied by either field:
     // a genuinely US role whose display string says "United States" is never
     // rejected because of what its URL happens to contain.

--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -55,6 +55,7 @@
 #
 # Semantics (case-insensitive substring, in this order):
 #   - Empty location string on a job → pass (don't penalize missing data)
+#   - Any `block_hard` keyword present → reject (always_allow cannot override it)
 #   - Any `always_allow` keyword present → pass (takes precedence over `block`)
 #   - Any `block` keyword present → reject
 #   - `allow` empty → pass (already cleared block)
@@ -64,6 +65,16 @@
 # home region: with always_allow ["New York"] and block ["India"], a job listed
 # "Remote, New York or India" passes (New York wins), while "Remote, India" is
 # still rejected. Omit always_allow entirely and the filter behaves as before.
+#
+# `block_hard` is optional too, and is the one tier always_allow cannot override.
+# Use it for country-level terms that are never a false rejection for you. It
+# exists because a city name can be a whole word inside a location on another
+# continent: with always_allow ["Porto"], the string "Porto Alegre, Brazil"
+# passes and your own block ["Brazil"] is never consulted. Word-boundary
+# matching does not help — both are genuine whole words. Putting "Brazil" in
+# block_hard fixes that without touching the multi-location rescue above.
+# Do NOT copy your whole `block` list here: a city in block_hard would kill
+# "Stockholm or London" postings, which is exactly what always_allow prevents.
 #
 # Example below targets US-based remote + a couple of US metros, blocking
 # common foreign hubs. Customize to your geography.

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -6214,6 +6214,49 @@ try {
     fail('mixed-type keyword lists should not crash and should still match string entries');
   }
 
+  // Case 9b: block_hard beats always_allow — a European city name that is a whole
+  // word inside a non-European location. Word-boundary matching (#2087) cannot
+  // catch these because both sides are genuine whole words, and the pre-existing
+  // `always_allow`-wins rule discarded the user's own country-level block entry.
+  const hardFilter = buildLocationFilter({
+    always_allow: ['porto', 'malta', 'amsterdam'],
+    allow: ['europe', 'remote'],
+    block: ['brazil', 'usa'],
+    block_hard: ['brazil', 'usa'],
+  });
+  const homonyms = [
+    ['Porto Alegre, Rio Grande do Sul, Brazil', 'city name shared with a Portuguese city'],
+    ['USA - Example State - Malta', 'city name shared with a European country'],
+  ];
+  const leaks = homonyms.filter(([loc]) => hardFilter(loc) !== false);
+  if (leaks.length === 0) {
+    pass('block_hard rejects a non-European location whose city name matches always_allow');
+  } else {
+    fail(`block_hard failed to reject: ${leaks.map(([l]) => l).join('; ')}`);
+  }
+
+  // Case 9c: block_hard does NOT widen rejection — a genuine multi-location
+  // posting must still survive a plain `block` entry, which is the whole reason
+  // always_allow exists (#650). This is the regression guard for that feature.
+  if (hardFilter('Amsterdam, Netherlands') === true) {
+    pass('block_hard leaves a genuine always_allow hit untouched');
+  } else {
+    fail('block_hard must not reject a location that only matches always_allow');
+  }
+
+  // Case 9d: additive and backward compatible — the same config with no
+  // block_hard key behaves exactly as it did before this tier existed.
+  const noHardFilter = buildLocationFilter({
+    always_allow: ['porto', 'malta', 'amsterdam'],
+    allow: ['europe', 'remote'],
+    block: ['brazil', 'usa'],
+  });
+  if (noHardFilter('Porto Alegre, Rio Grande do Sul, Brazil') === true) {
+    pass('without block_hard, always_allow still wins over block (unchanged semantics)');
+  } else {
+    fail('omitting block_hard must preserve the pre-existing always_allow-wins behaviour');
+  }
+
   // Case 10: all-null/non-string list → empty after normalization (no false rejects)
   const allBadFilter = buildLocationFilter({ block: [null, 42, undefined], allow: ['remote'] });
   if (allBadFilter('Remote') === true) {

--- a/validate-portals.mjs
+++ b/validate-portals.mjs
@@ -142,6 +142,7 @@ export async function validatePortalsConfig(config, { providerIds = new Set() } 
       validateKeywordList(config.location_filter.always_allow, 'location_filter.always_allow', errors);
       validateKeywordList(config.location_filter.allow, 'location_filter.allow', errors);
       validateKeywordList(config.location_filter.block, 'location_filter.block', errors);
+      validateKeywordList(config.location_filter.block_hard, 'location_filter.block_hard', errors);
     }
   }
 


### PR DESCRIPTION
## What does this PR do?

`buildLocationFilter()` returns `true` on the first `always_allow` hit, before `block` is consulted. When a location matches **both** lists, the user's own `block` entry is silently discarded — and for a whole-word homonym that is always the wrong call.

Measured on a real reverse-ATS corpus (~1,650 rows, Greenhouse/Lever/Ashby/Workday/iCIMS). Both configs below **already listed the country under `block`**:

| Location string | `always_allow` hit | `block` hit | Today | Expected |
|---|---|---|---|---|
| `Porto Alegre, Rio Grande do Sul, Brazil` | `Porto` | `Brazil` | passes | reject |
| `USA - <state> - Malta` | `Malta` | `USA`, `New York` | passes | reject |

This is not a re-report of #2087. Word-boundary matching landed there and is active — I verified it on this checkout (`buildLocationFilter({always_allow:['PA'],allow:['x']})('Tokyo, Japan') === false`). It cannot catch this class, because both sides are genuine whole words.

The pattern is systematic rather than anecdotal: New York State alone contains Amsterdam, Malta, Rome, Athens, Berlin and Utrecht; California has Dublin. Two of the three above turned up in a single nine-row sample from one sweep.

## Why not simply let `block` win

`always_allow` exists (#650/#652) precisely so a multi-location posting survives one blocked city — `Stockholm · London · Madrid` must not die on a `London` entry. Promoting `block` wholesale reverts that.

The difference is what kind of term matched. In the legitimate case both hits are **cities**. In the defect the block hit is **country-level** while the allow hit is a city homonym.

I considered deriving that distinction automatically (a block hit on a country name outranks a city-level allow hit). I did not implement it, because it requires shipping a country list inside the system layer, and a shipped list that must track an external world goes stale silently. `block_hard` ships no data — it tracks the user's own intent, so it cannot fall behind.

## Behaviour

One new optional tier, evaluated first:

```yaml
location_filter:
  block_hard: ["Brazil", "USA"]   # always_allow can never override these
  always_allow: ["Porto", "Malta"]
  block: ["London"]                # unchanged: always_allow still wins here
```

Additive and backward compatible — a config without `block_hard` behaves exactly as before, and that is asserted by its own test rather than assumed.

## Prior art checked

- **#2087** (merged) — word-boundary keywords + URL fallback. Present here; different class.
- **#1479** (closed) — earlier word-boundary attempt, superseded by #2087.
- **#1478** (closed, unmerged, no review comment) — nearest prior attempt at US city/state false positives.
- **#650 / #652** — the `always_allow` tier this preserves.
- No open issue covers this; searched `location_filter`, `always_allow`, `substring`, location false positives, and PRs on `buildLocationFilter`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Test plan

- `node test-all.mjs` → **3931 passed, 0 failed**, 3 pre-existing warnings.
- **Verified in both directions:** with `scan.mjs` reverted to `origin/main` the new assertion fails (`block_hard failed to reject: Porto Alegre…; USA - <state> - Malta`) and the suite reports 1 failure; with the change it passes. The two companion assertions pass either way by design — they guard against the fix *widening* rejection.
- Fixtures are synthesized. No real employer names or requisition URLs in the diff.

## Scope

One machine, one config, one corpus. I make no claim about how many other users have a `block` entry being overridden this way — only that when they do, the config says one thing and the code does another.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for `block_hard` location-filter keywords that always reject matching locations, even when `always_allow` matches.
  - Existing filtering behavior remains unchanged when `block_hard` is not configured.
- **Documentation**
  - Documented the distinction between hard-block and standard block keywords.
- **Bug Fixes**
  - Improved validation for `block_hard` keyword lists.
- **Tests**
  - Added coverage for hard-block precedence and backward-compatible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->