### PR TITLE
fix(batch-tailor): --min-score 4.5 was silently ignored, and the worker's pdf mode path was cwd-relative

### DIFF
--- a/batch-tailor.mjs
+++ b/batch-tailor.mjs
@@ -37,7 +37,12 @@ validateFlags(args, ['--min-score', '--help', '-h'], USAGE, { valueFlags: ['--mi
 let minScore = 4.0;
 if (hasFlag(args, '--min-score')) {
   const raw = flagValue(args, '--min-score');
-  minScore = Number.parseFloat(raw);
+  // Number(), not parseFloat(): parseFloat stops at the first invalid character,
+  // so "4.5abc" silently became 4.5 and the run proceeded on a threshold the
+  // caller never wrote. The empty/whitespace guard must come FIRST — Number('')
+  // is 0, which is finite, and a 0 threshold tailors every completed job.
+  const trimmed = typeof raw === 'string' ? raw.trim() : '';
+  minScore = trimmed === '' ? NaN : Number(trimmed);
   // A NaN threshold compares false against every score, so the old code printed
   // "no roles found with score >= NaN" and exited 0 — indistinguishable from a
   // genuinely empty batch. Fail loudly instead.
@@ -52,7 +57,19 @@ if (!existsSync(batchStateFile)) {
   process.exit(1);
 }
 
-const lines = readFileSync(batchStateFile, 'utf-8').split('\n');
+// existsSync() is true for a directory and says nothing about permissions, so
+// reading can still throw (EISDIR, EACCES) — an uncaught stack trace where a
+// usage error belongs. Name the RESOLVED path: with CAREER_OPS_BATCH_STATE set,
+// the value that failed is not the one written in the source.
+let stateContent;
+try {
+  stateContent = readFileSync(batchStateFile, 'utf-8');
+} catch (err) {
+  console.error(`ERROR: cannot read batch state file at ${batchStateFile}: ${err.message}`);
+  process.exit(1);
+}
+
+const lines = stateContent.split('\n');
 const toProcess = [];
 
 for (const line of lines) {

--- a/batch-tailor.mjs
+++ b/batch-tailor.mjs
@@ -6,7 +6,12 @@ import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
-const batchStateFile = join(__dirname, 'batch', 'batch-state.tsv');
+// CAREER_OPS_BATCH_STATE overrides the batch-state.tsv path — the same override
+// merge-tracker.mjs already honours, so tests can drive this script against a
+// sandbox instead of the developer's real batch run.
+const batchStateFile = process.env.CAREER_OPS_BATCH_STATE
+  ? resolve(process.env.CAREER_OPS_BATCH_STATE)
+  : join(__dirname, 'batch', 'batch-state.tsv');
 const reportsDir = join(__dirname, 'reports');
 
 function usage() {

--- a/batch-tailor.mjs
+++ b/batch-tailor.mjs
@@ -32,7 +32,11 @@ const args = process.argv.slice(2);
 // typo fell through — both silently ran at the 4.0 default and spawned worker
 // runs the caller never asked for. That is the #2459 class lib/cli-flags.mjs
 // exists to end.
-validateFlags(args, ['--min-score', '--help', '-h'], USAGE, { valueFlags: ['--min-score'] });
+// requireOperand: `--min-score --help` would otherwise print usage and exit 0,
+// so the malformed flag is never reported and the numeric check below never
+// runs. This script has nothing more specific to say about a missing operand
+// than the shared message, which is exactly when opting in is right.
+validateFlags(args, ['--min-score', '--help', '-h'], USAGE, { valueFlags: ['--min-score'], requireOperand: true });
 
 let minScore = 4.0;
 if (hasFlag(args, '--min-score')) {

--- a/batch-tailor.mjs
+++ b/batch-tailor.mjs
@@ -2,6 +2,7 @@
 
 import { readFileSync, existsSync, readdirSync } from 'fs';
 import { resolve, join } from 'path';
+import { flagValue, hasFlag, validateFlags } from './lib/cli-flags.mjs';
 import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 
@@ -14,27 +15,35 @@ const batchStateFile = process.env.CAREER_OPS_BATCH_STATE
   : join(__dirname, 'batch', 'batch-state.tsv');
 const reportsDir = join(__dirname, 'reports');
 
-function usage() {
-  console.log(`career-ops batch tailor — bulk generate tailored CVs for high-scoring batch jobs
+const USAGE = `career-ops batch tailor — bulk generate tailored CVs for high-scoring batch jobs
 
 Usage:
-  node batch-tailor.mjs [--min-score=4.0]
+  node batch-tailor.mjs [--min-score N]
 
 Options:
-  --min-score=N   Minimum score to tailor (default: 4.0)
-`);
-  process.exit(0);
-}
+  --min-score N   Minimum score to tailor (default: 4.0). The --min-score=N form works too.
+  --help, -h      Show this help
+`;
 
 const args = process.argv.slice(2);
-if (args.includes('-h') || args.includes('--help')) {
-  usage();
-}
+
+// Route through the shared parser instead of hand-rolling it: this script used
+// to read only the `--min-score=N` form, so `--min-score 4.5` was dropped and a
+// typo fell through — both silently ran at the 4.0 default and spawned worker
+// runs the caller never asked for. That is the #2459 class lib/cli-flags.mjs
+// exists to end.
+validateFlags(args, ['--min-score', '--help', '-h'], USAGE, { valueFlags: ['--min-score'] });
 
 let minScore = 4.0;
-for (const arg of args) {
-  if (arg.startsWith('--min-score=')) {
-    minScore = parseFloat(arg.split('=')[1]);
+if (hasFlag(args, '--min-score')) {
+  const raw = flagValue(args, '--min-score');
+  minScore = Number.parseFloat(raw);
+  // A NaN threshold compares false against every score, so the old code printed
+  // "no roles found with score >= NaN" and exited 0 — indistinguishable from a
+  // genuinely empty batch. Fail loudly instead.
+  if (!Number.isFinite(minScore)) {
+    console.error(`ERROR: --min-score expects a number, got ${raw === undefined ? '(no value)' : `"${raw}"`}`);
+    process.exit(1);
   }
 }
 
@@ -88,7 +97,12 @@ for (let i = 0; i < toProcess.length; i++) {
     '-p',
     '--dangerously-skip-permissions',
     '--append-system-prompt-file',
-    'modes/pdf.md',
+    // Absolute: the state file already resolves through __dirname, so passing
+    // this one bare handed the worker a cwd-relative path that only exists when
+    // the script happens to run from the project root. modes/pdf.md is where
+    // the CV fact gate (verify-cv-facts.mjs, step 19) is instructed, so losing
+    // it silently drops the anti-fabrication check from a bulk CV run.
+    join(__dirname, 'modes', 'pdf.md'),
     prompt
   ];
   

--- a/lib/cli-flags.mjs
+++ b/lib/cli-flags.mjs
@@ -86,7 +86,7 @@ export function hasFlag(args, flag) {
  * @returns {void} Returns normally when every flag is recognized and --help
  *   was not requested; otherwise prints and calls `process.exit()`.
  */
-export function validateFlags(args, knownFlags, usage, { valueFlags = [] } = {}) {
+export function validateFlags(args, knownFlags, usage, { valueFlags = [], requireOperand = false } = {}) {
   if (!Array.isArray(args)) return;
 
   // A value-taking flag's space-separated value (e.g. the `-5` in
@@ -109,6 +109,35 @@ export function validateFlags(args, knownFlags, usage, { valueFlags = [] } = {})
   });
   if (unknownFlags.length > 0) {
     console.error(`Error: unrecognized flag(s): ${unknownFlags.join(', ')}. Valid flags: ${knownFlags.join(', ')}`);
+    process.exit(1);
+  }
+
+  // OPT-IN (`requireOperand`): a value-taking flag whose operand is MISSING is a
+  // usage error, caught BEFORE --help — otherwise `--min-score --help` prints
+  // usage and exits 0, the malformed flag is never reported, and the caller's
+  // own value validation never runs (#2961). Same ordering argument as the
+  // unrecognized-flag check above.
+  //
+  // Opt-in rather than automatic because several callers already validate this
+  // themselves and say more than a generic message can. scan.mjs's requireValue()
+  // distinguishes "no value" from a zero, a negative, a non-finite, an
+  // out-of-range cutoff and a repeated flag; firing here first would replace all
+  // five diagnostics with one line. Callers with nothing better to say opt in.
+  //
+  // Missing means: nothing follows, or what follows is another `--flag`. A token
+  // starting with a single `-` is left alone — that is the negative-number shape
+  // the adjacency rule above exists for (`--since -5`). The `--flag=value` form
+  // carries its own operand and is never considered here.
+  const missingOperand = requireOperand ? args.filter((a, idx) => {
+    if (typeof a !== 'string' || !valueFlags.includes(a)) return false;
+    const next = args[idx + 1];
+    return next === undefined || (typeof next === 'string' && next.startsWith('--'));
+  }) : [];
+  if (missingOperand.length > 0) {
+    // Wording matches scan.mjs's own hand-rolled requireValue() (scan.mjs:2345),
+    // which already reports exactly this condition, so a caller that later
+    // switches to this path keeps the message its tests assert on.
+    console.error(`Error: ${missingOperand[0]} requires a value`);
     process.exit(1);
   }
 

--- a/tests/batch-tailor-flags.test.mjs
+++ b/tests/batch-tailor-flags.test.mjs
@@ -99,6 +99,44 @@ try {
     }
   }
 
+  // ── 3b. A numeric prefix with trailing garbage is not a number ──
+  // parseFloat stops at the first invalid character, so "4.5abc" was read as
+  // 4.5 and the run proceeded on a value the caller never wrote (CodeRabbit).
+  // Number() rejects it — but only paired with the empty-string guard below,
+  // because Number('') is 0, which is finite and would tailor everything.
+  {
+    const r = runTailor(['--min-score=4.5abc'], sandbox.file);
+    if (r.code !== 0 && !/NaN/.test(r.out)) {
+      pass('--min-score=4.5abc is rejected, not silently truncated to 4.5');
+    } else {
+      fail(`trailing garbage accepted: code=${r.code} out=${r.out.trim().slice(0, 160)}`);
+    }
+  }
+
+  // Guard: an empty or whitespace value must stay an error, not become 0.
+  {
+    const empty = runTailor(['--min-score='], sandbox.file);
+    const blank = runTailor(['--min-score= '], sandbox.file);
+    if (empty.code !== 0 && blank.code !== 0) {
+      pass('an empty or blank --min-score is an error, never a 0 threshold');
+    } else {
+      fail(`empty/blank accepted: empty=${empty.code} blank=${blank.code} ${empty.out}${blank.out}`.slice(0, 200));
+    }
+  }
+
+  // ── 3c. An unreadable state-file path is a usage error, not a stack trace ──
+  // existsSync() is true for a DIRECTORY, so readFileSync threw an uncaught
+  // EISDIR. The message must name the resolved path so an operator can see
+  // which value CAREER_OPS_BATCH_STATE actually resolved to.
+  {
+    const r = runTailor([], tmpdir());
+    if (r.code === 1 && !/at Object\.|node:fs/.test(r.out) && r.out.includes(tmpdir())) {
+      pass('an unreadable state-file path fails cleanly and names the path');
+    } else {
+      fail(`state-file failure not handled: code=${r.code} out=${r.out.trim().slice(0, 200)}`);
+    }
+  }
+
   // ── 4. --help still works ──
   {
     const r = runTailor(['--help'], sandbox.file);

--- a/tests/batch-tailor-flags.test.mjs
+++ b/tests/batch-tailor-flags.test.mjs
@@ -1,0 +1,130 @@
+// tests/batch-tailor-flags.test.mjs — batch-tailor.mjs's CLI contract and the
+// paths it hands to the worker.
+//
+// batch-tailor.mjs spawns one agent run per matching job, so a mis-parsed
+// threshold is not a cosmetic problem: it decides how many paid runs happen and
+// on which roles. It predates lib/cli-flags.mjs and hand-rolled its own
+// parsing, which left three silent failures:
+//
+//   --min-score 4.5   (space form)  → ignored, ran at the 4.0 default
+//   --min-score=abc   (bad value)   → NaN, matched nothing, exited 0
+//   --min-scor=4.5    (typo)        → ignored, ran at the 4.0 default
+//
+// All three are the #2459 class that lib/cli-flags.mjs exists to end.
+//
+// The state-file path is env-overridable (CAREER_OPS_BATCH_STATE, the same
+// override merge-tracker.mjs already honours) so these cases run against a
+// sandbox instead of the developer's real batch run. Every case below picks a
+// threshold that matches NO job, so the script always exits before spawning a
+// worker.
+import { pass, fail, ROOT } from './helpers.mjs';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, writeFileSync, rmSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+console.log('\nbatch-tailor.mjs — flag parsing and worker paths');
+
+const NODE = process.execPath;
+const SCRIPT = join(ROOT, 'batch-tailor.mjs');
+
+function makeStateFile() {
+  const dir = mkdtempSync(join(tmpdir(), 'co-batch-tailor-'));
+  const file = join(dir, 'batch-state.tsv');
+  writeFileSync(file,
+    'id\turl\tstatus\tstarted_at\tcompleted_at\treport_num\tscore\terror\tretries\n' +
+    '1\thttps://example.com/job\tcompleted\t-\t-\t001\t4.5\t-\t0\n');
+  return { dir, file };
+}
+
+// Run batch-tailor and return { code, out }. cwd defaults to a directory that
+// is NOT the project root, which is what exposes a cwd-relative path.
+function runTailor(args, stateFile, cwd) {
+  const env = { ...process.env, CAREER_OPS_BATCH_STATE: stateFile };
+  try {
+    const out = execFileSync(NODE, [SCRIPT, ...args], { cwd: cwd || tmpdir(), env, encoding: 'utf-8', timeout: 30000 });
+    return { code: 0, out };
+  } catch (e) {
+    return { code: e.status ?? 1, out: `${e.stdout || ''}${e.stderr || ''}` };
+  }
+}
+
+const sandbox = makeStateFile();
+try {
+  // ── 1. The space-separated form must be honoured ──
+  // The job scores 4.5, so a 9.9 threshold must match nothing. Reading the
+  // default 4.0 instead would tailor it — a paid run the caller excluded.
+  {
+    const r = runTailor(['--min-score', '9.9'], sandbox.file);
+    if (r.code === 0 && /No completed roles/.test(r.out)) {
+      pass('--min-score 9.9 (space form) is honoured, not silently defaulted');
+    } else {
+      fail(`space form ignored: code=${r.code} out=${r.out.trim().slice(0, 160)}`);
+    }
+  }
+
+  // Guard: the equals form keeps working, and a threshold BELOW the job's score
+  // still selects it — otherwise case 1 could pass by rejecting everything.
+  {
+    const r = runTailor(['--min-score=9.9'], sandbox.file);
+    if (r.code === 0 && /No completed roles/.test(r.out)) {
+      pass('--min-score=9.9 (equals form) still filters everything out');
+    } else {
+      fail(`equals form: code=${r.code} out=${r.out.trim().slice(0, 160)}`);
+    }
+  }
+
+  // ── 2. A non-numeric threshold is a usage error, not a silent no-op ──
+  // Before: parseFloat('abc') → NaN, every comparison false, "No completed
+  // roles found with score >= NaN", exit 0. The caller cannot tell that from a
+  // genuinely empty batch.
+  {
+    const r = runTailor(['--min-score=abc'], sandbox.file);
+    if (r.code !== 0 && !/NaN/.test(r.out)) {
+      pass('a non-numeric --min-score is rejected instead of matching nothing');
+    } else {
+      fail(`bad value not rejected: code=${r.code} out=${r.out.trim().slice(0, 160)}`);
+    }
+  }
+
+  // ── 3. An unrecognized flag is refused ──
+  // A typo used to fall through to the 4.0 default and spawn worker runs the
+  // caller never asked for.
+  {
+    const r = runTailor(['--min-scor=9.9'], sandbox.file);
+    if (r.code !== 0) {
+      pass('an unrecognized flag is refused instead of running at the default');
+    } else {
+      fail(`typo accepted: code=${r.code} out=${r.out.trim().slice(0, 160)}`);
+    }
+  }
+
+  // ── 4. --help still works ──
+  {
+    const r = runTailor(['--help'], sandbox.file);
+    if (r.code === 0 && /min-score/.test(r.out)) {
+      pass('--help prints the usage block and exits 0');
+    } else {
+      fail(`--help: code=${r.code} out=${r.out.trim().slice(0, 160)}`);
+    }
+  }
+
+  // ── 5. The worker's mode file must not be a cwd-relative path ──
+  // The state file resolved through __dirname while `modes/pdf.md` was passed
+  // bare, so running the script from anywhere else handed the worker a path
+  // that does not exist — and modes/pdf.md is where the CV fact gate
+  // (verify-cv-facts.mjs, step 19) is instructed. Asserted at source level, the
+  // same shape as test-all's provider-pacing guard, because observing the
+  // spawn argument would mean actually launching a worker.
+  {
+    const src = readFileSync(SCRIPT, 'utf-8');
+    const bareRelative = /(['"`])modes\/pdf\.md\1/.test(src);
+    if (!bareRelative) {
+      pass('the pdf mode file is not passed as a bare cwd-relative path');
+    } else {
+      fail('batch-tailor.mjs still passes a bare "modes/pdf.md" — breaks from any other cwd');
+    }
+  }
+} finally {
+  rmSync(sandbox.dir, { recursive: true, force: true });
+}

--- a/tests/batch-tailor-flags.test.mjs
+++ b/tests/batch-tailor-flags.test.mjs
@@ -147,6 +147,20 @@ try {
     }
   }
 
+  // ── 4b. --min-score with no operand must not be swallowed by --help ──
+  // flagValue() does not consume `--help` as a value, and validateFlags handled
+  // --help before any value check — so this printed usage, exited 0, and the
+  // malformed flag was never reported (CodeRabbit on #2961). The shared helper's
+  // opt-in `requireOperand` closes it.
+  {
+    const r = runTailor(['--min-score', '--help'], sandbox.file);
+    if (r.code === 1 && /--min-score requires a value/.test(r.out)) {
+      pass('--min-score --help reports the missing operand instead of showing help');
+    } else {
+      fail(`min-score-then-help: code=${r.code} out=${r.out.trim().slice(0, 160)}`);
+    }
+  }
+
   // ── 5. The worker's mode file must not be a cwd-relative path ──
   // The state file resolved through __dirname while `modes/pdf.md` was passed
   // bare, so running the script from anywhere else handed the worker a path

--- a/tests/cli-flags.test.mjs
+++ b/tests/cli-flags.test.mjs
@@ -168,6 +168,76 @@ try {
       fail(`--since=-5 case => status=${r.status} stdout=${r.stdout} stderr=${r.stderr}`);
     }
   }
+  {
+    // CodeRabbit (#2961): with requireOperand, a value-taking flag whose operand
+    // is MISSING is reported instead of --help silently winning. Without it,
+    // `--since --help` prints usage and exits 0.
+    const opts = { valueFlags: ['--since'], requireOperand: true };
+    const r = runValidate(['--since', '--help'], ['--since', '--help', '-h'], 'USAGE-TEXT', opts);
+    if (r.status === 1 && /--since requires a value/.test(r.stderr || '') && !/USAGE-TEXT/.test(r.stdout || '')) {
+      pass('requireOperand: --since --help is a missing operand, not a help request (#2961)');
+    } else {
+      fail(`requireOperand before-help case => status=${r.status} stdout=${r.stdout} stderr=${r.stderr}`);
+    }
+  }
+
+  {
+    const opts = { valueFlags: ['--since'], requireOperand: true };
+    const r = runValidate(['--since'], ['--since', '--help', '-h'], 'USAGE-TEXT', opts);
+    if (r.status === 1 && /--since requires a value/.test(r.stderr || '')) {
+      pass('requireOperand: a value-taking flag ending argv reports its missing operand');
+    } else {
+      fail(`requireOperand end-of-argv case => status=${r.status} stdout=${r.stdout} stderr=${r.stderr}`);
+    }
+  }
+
+  {
+    // The guard that keeps this OPT-IN: without requireOperand the behaviour is
+    // unchanged, so callers with richer validation of their own (scan.mjs tells
+    // a missing value from a zero, a negative, a non-finite and a repeat) keep
+    // reaching it.
+    const r = runValidate(['--since'], ['--since', '--help', '-h'], 'USAGE-TEXT', { valueFlags: ['--since'] });
+    if (r.status === 0 && /REACHED-END/.test(r.stdout || '')) {
+      pass('without requireOperand a missing operand still falls through to the caller');
+    } else {
+      fail(`opt-in guard case => status=${r.status} stdout=${r.stdout} stderr=${r.stderr}`);
+    }
+  }
+
+  {
+    // Guard: plain --help still works when nothing is dangling.
+    const opts = { valueFlags: ['--since'], requireOperand: true };
+    const r = runValidate(['--help'], ['--since', '--help', '-h'], 'USAGE-TEXT', opts);
+    if (r.status === 0 && /USAGE-TEXT/.test(r.stdout || '')) {
+      pass('requireOperand: --help alone still prints usage and exits 0');
+    } else {
+      fail(`requireOperand help-alone case => status=${r.status} stdout=${r.stdout} stderr=${r.stderr}`);
+    }
+  }
+
+  {
+    // Guard: a negative-number operand is an operand, not a missing one — the
+    // shape the adjacency rule exists for.
+    const opts = { valueFlags: ['--since'], requireOperand: true };
+    const r = runValidate(['--since', '-5'], ['--since', '--help', '-h'], 'USAGE-TEXT', opts);
+    if (r.status === 0 && /REACHED-END/.test(r.stdout || '')) {
+      pass('requireOperand: --since -5 passes through, a negative value is an operand');
+    } else {
+      fail(`requireOperand negative case => status=${r.status} stdout=${r.stdout} stderr=${r.stderr}`);
+    }
+  }
+
+  {
+    // Guard: the equals form carries its own operand, even before --help.
+    const opts = { valueFlags: ['--since'], requireOperand: true };
+    const r = runValidate(['--since=7', '--help'], ['--since', '--help', '-h'], 'USAGE-TEXT', opts);
+    if (r.status === 0 && /USAGE-TEXT/.test(r.stdout || '')) {
+      pass('requireOperand: --since=7 --help shows help, the equals form is complete');
+    } else {
+      fail(`requireOperand equals-then-help case => status=${r.status} stdout=${r.stdout} stderr=${r.stderr}`);
+    }
+  }
+
 } catch (e) {
   fail(`cli-flags tests crashed: ${e.message}`);
 }


### PR DESCRIPTION
No issue — found while auditing `batch-tailor.mjs`, one of the few core scripts with no test file. `CONTRIBUTING.md:22` welcomes a direct PR for a bug fix.

`batch-tailor.mjs` spawns one agent run per matching job, so a mis-parsed threshold is not cosmetic: it decides how many paid runs happen and on which roles. It hand-rolled its own flag parsing and predates `lib/cli-flags.mjs`, so it carries three of the exact failures that helper exists to end.

## Measured on `main`

Sandbox `batch-state.tsv` with one `completed` job scoring **4.5**:

| Command | `main` | Should be |
|---|---|---|
| `--min-score 9.9` | `Found 1 roles scoring >= 4. Beginning bulk tailoring...` | match nothing |
| `--min-score=abc` | `No completed roles found with score >= NaN.` (exit 0) | usage error |
| `--min-scor=9.9` (typo) | `Found 1 roles scoring >= 4. Beginning bulk tailoring...` | usage error |

The first is the costly one: the caller asked for a stricter threshold, the script read only the `--min-score=N` form, dropped the value, and went on to tailor at the 4.0 default — spawning worker runs on roles that were explicitly excluded.

The second is silent: a `NaN` threshold compares false against every score, so the output is indistinguishable from a genuinely empty batch.

## The worker's mode file was cwd-relative

```js
const batchStateFile = join(__dirname, 'batch', 'batch-state.tsv');  // absolute
...
'--append-system-prompt-file',
'modes/pdf.md',                                                       // cwd-relative
```

Within one script, the state file resolves through `__dirname` while the mode file does not, so running it from anywhere but the project root hands the worker a path that does not exist. `resolve` was imported and never used, which reads like the intent was there.

This one matters beyond tidiness: `modes/pdf.md:44` is where the CV fact gate is instructed (`node verify-cv-facts.mjs {html-path}`). Losing that system prompt drops the anti-fabrication check from a **bulk** CV run — the run where nobody is reading each output.

## The fix

- Route parsing through `lib/cli-flags.mjs` (`validateFlags` / `hasFlag` / `flagValue`) instead of a fourth hand-rolled copy. Both flag forms work, unknown flags fail fast, `--help` is handled by the shared path.
- A non-numeric `--min-score` exits 1 with the value quoted back, rather than matching nothing.
- `modes/pdf.md` resolves through `__dirname`, like the state file next to it.
- `CAREER_OPS_BATCH_STATE` overrides the state-file path — the same override `merge-tracker.mjs` already honours, and what makes the script testable without touching a real batch run.

## Test plan

New `tests/batch-tailor-flags.test.mjs`, picked up by `test-all.mjs` auto-discovery. Every case picks a threshold that matches **no** job, so the script always exits before spawning a worker.

Two notes on making the cases honest:

- The env override had to land first. Without it the script exits 1 on the missing state file, and the "bad value" and "typo" cases went green **before** the fix — passing for the wrong reason. They only became genuinely red once the script could reach its own parsing.
- The mode-path fix is asserted at source level (the script must not pass a bare `'modes/pdf.md'`), the same shape as `test-all`'s provider-pacing guard, because observing the real spawn argument would mean launching a paid worker.

- [x] 4 of the 6 cases verified red after the override landed; the equals-form and `--help` cases pass before and after, which is what makes them guards.
- [x] `node test-all.mjs` — 3944 passed, 0 failed (the single warning is the pre-existing `Dashboard build skipped — go compiler not in env`).

## Noted, not changed

`spawnSync('claude', ...)` hardcodes one CLI in a project that ships a per-CLI headless command table for nine of them (`AGENTS.md`). On any other CLI the loop prints an ENOENT per job and keeps going. That is a design decision rather than a defect, so it is not in this PR — happy to open it separately if you want it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added flexible `--min-score` options in separated and equals formats.
  * Added support for overriding the batch state file location through an environment setting.
  * Added help flag handling and clearer score threshold validation.

* **Bug Fixes**
  * Invalid or missing values, unknown options, and unreadable state files now return clear errors and nonzero exit codes.
  * PDF processing reliably loads its configured instructions regardless of the launch directory.

* **Tests**
  * Added coverage for command-line parsing, validation, state overrides, error handling, and PDF processing paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->