### PR TITLE
fix(discover-ats): a definitive 404 was reported as a transient error with re-run advice (#2883)

### DIFF
--- a/discover-ats.mjs
+++ b/discover-ats.mjs
@@ -428,8 +428,29 @@ export async function probeVendor(company, candidate, ctx) {
     const jobCount = Array.isArray(jobs) ? jobs.length : 0;
     return { status: jobCount > 0 ? 'match' : 'empty', jobCount };
   } catch (err) {
-    return { status: 'error', jobCount: 0, error: err?.message || String(err) };
+    /** @type {any} */
+    const out = { status: 'error', jobCount: 0, error: err?.message || String(err) };
+    // _http.mjs attaches the numeric status to the thrown error; keeping it is
+    // what lets the caller tell a definitive 404 from a transient 5xx instead of
+    // re-parsing the message text (#2883).
+    if (Number.isInteger(err?.status)) out.httpStatus = err.status;
+    return out;
   }
+}
+
+/**
+ * Whether a probe failure ESTABLISHES that no board exists.
+ *
+ * 404 and 410 are answers: the vendor was reached and said the board is not
+ * there. Everything else — 5xx, a timeout, DNS, a rejected redirect, or a
+ * candidate whose API URL could not even be derived — leaves the question open,
+ * because nothing ever answered it.
+ *
+ * @param {{httpStatus?: number}} probeError
+ * @returns {boolean}
+ */
+export function isDefinitiveAbsence(probeError) {
+  return probeError?.httpStatus === 404 || probeError?.httpStatus === 410;
 }
 
 /**
@@ -509,7 +530,11 @@ export async function resolveCompany(company, { vendors = VENDOR_ORDER, ctx, inc
     if (result.status === 'empty') {
       emptyBoards.push({ vendor: candidate.vendor, careers_url: candidate.careers_url });
     } else {
-      errors.push({ vendor: candidate.vendor, error: result.error });
+      /** @type {any} */
+      const entry = { vendor: candidate.vendor, error: result.error };
+      if (Number.isInteger(result.httpStatus)) entry.httpStatus = result.httpStatus;
+      if (isDefinitiveAbsence(result)) entry.definitive = true;
+      errors.push(entry);
     }
   }
 
@@ -538,9 +563,17 @@ export async function resolveCompany(company, { vendors = VENDOR_ORDER, ctx, inc
       : (company.workday && typeof company.workday === 'object'));
   const reason = emptyBoards.length
     ? 'board(s) found but currently list 0 jobs — re-run later or force-add manually'
-    // Every probe errored (transient network/HTTP), and nothing was confirmed
-    // absent or empty — don't claim "no board found", the status is unknown.
-    : (errors.length && !coords)
+    // Every probe errored and nothing was confirmed absent or empty — don't
+    // claim "no board found", the status is unknown.
+    //
+    // Unless every failure was DEFINITIVE. A 404 from Greenhouse/Ashby/Lever is
+    // an answer, not a hiccup: the board is not there and re-running will say so
+    // again. Advising a retry in that case erased the difference between "this
+    // company has no board" and "the network hiccuped", which is exactly the
+    // pair a user pruning portals.yml has to tell apart (#2883). One transient
+    // failure among them is enough to leave the question open — that vendor
+    // never answered, so absence is not established.
+    : (errors.length && !coords && !errors.every(isDefinitiveAbsence))
       ? 'probe error(s) occurred — board status unknown, see errors[] and re-run'
       // A hint was given but rejected by parseWorkdayHint (bad chars, missing
       // tenant/site): tell the user to fix it, not to add one.

--- a/discover-ats.test.mjs
+++ b/discover-ats.test.mjs
@@ -284,6 +284,53 @@ const badHint = await resolveCompany({ name: 'BadHint', workday: { tenant: 'a/b'
 ok('rejected hint → "given but rejected" reason', /rejected/i.test(badHint.unresolved.reason));
 ok('rejected hint → NOT the "add a hint" message', !/add a hint/i.test(badHint.unresolved.reason));
 
+// ── #2883: a definitive 404 must not be reported as a transient error ──
+// Greenhouse/Ashby/Lever answering 404 means the board does not exist. Reporting
+// that as "board status unknown ... re-run" advises a retry guaranteed to give
+// the same answer, and erases the difference between "no board" and "the network
+// hiccuped" — the two states a user pruning portals.yml has to tell apart.
+const httpErrorCtx = (statusByVendor) => ({
+  fetchJson: async (url) => {
+    const vendor = /greenhouse/.test(url) ? 'gh' : /ashby/.test(url) ? 'ashby' : 'lever';
+    const status = statusByVendor[vendor] ?? 404;
+    const err = new Error(`HTTP ${status}${status === 404 ? ' Not Found' : ''}`);
+    err.status = status;
+    throw err;
+  },
+  fetchText: async () => { throw new Error('unused'); },
+});
+const SLUG_VENDORS = ['gh', 'ashby', 'lever'];
+
+const all404 = await resolveCompany({ name: 'Mercado Libre' },
+  { vendors: SLUG_VENDORS, includeWorkday: false, ctx: httpErrorCtx({ gh: 404, ashby: 404, lever: 404 }) });
+ok('all-404 → not reported as unknown', !/status unknown/i.test(all404.unresolved.reason));
+// Precisely: no advice to re-run THE SAME PROBE. The fallback message does say
+// "add a Workday hint and re-run", which is a different and actionable
+// instruction — the user changes their input first. What must not survive is
+// the unconditional retry attached to an unknown status.
+ok('all-404 → no advice to re-run the same probe', !/errors\[\] and re-run/i.test(all404.unresolved.reason));
+ok('all-404 → says no board was found', /no .*board found/i.test(all404.unresolved.reason));
+ok('all-404 → each error is marked definitive',
+  all404.unresolved.errors.length === 3 && all404.unresolved.errors.every(e => e.definitive === true));
+
+// A 410 Gone is equally definitive.
+const all410 = await resolveCompany({ name: 'Gone Co' },
+  { vendors: SLUG_VENDORS, includeWorkday: false, ctx: httpErrorCtx({ gh: 410, ashby: 410, lever: 410 }) });
+ok('all-410 → treated as definitive too', !/status unknown/i.test(all410.unresolved.reason));
+
+// Guard: a genuinely transient failure must KEEP the unknown/re-run wording.
+const all503 = await resolveCompany({ name: 'Flaky Co' },
+  { vendors: SLUG_VENDORS, includeWorkday: false, ctx: httpErrorCtx({ gh: 503, ashby: 503, lever: 503 }) });
+ok('all-503 → still reported as unknown', /status unknown/i.test(all503.unresolved.reason));
+ok('all-503 → still advises a re-run', /re-run/i.test(all503.unresolved.reason));
+ok('all-503 → errors are not marked definitive', all503.unresolved.errors.every(e => e.definitive !== true));
+
+// Guard: ONE transient failure among 404s leaves the outcome unknown — that
+// vendor was never actually answered, so absence is not established.
+const mixed = await resolveCompany({ name: 'Mixed Co' },
+  { vendors: SLUG_VENDORS, includeWorkday: false, ctx: httpErrorCtx({ gh: 404, ashby: 503, lever: 404 }) });
+ok('mixed 404/503 → still unknown, absence not established', /status unknown/i.test(mixed.unresolved.reason));
+
 // parseCompanyInput warns on a present-but-wrong-typed workday field (e.g. a number).
 const wrongType = parseCompanyInput('companies:\n  - name: X\n    workday: 42\n', []);
 ok('wrong-typed workday hint → warning emitted', wrongType.warnings.some(w => /workday/i.test(w)));


### PR DESCRIPTION
Addresses the **second half** of #2883 only — the part you said is "independently useful, smaller, and I'd merge it on its own".

Half 1 (vendor coverage: 4 of 74) is deliberately left alone. You raised two design questions on it — which vendors are meaningfully slug-resolvable, and how to bound the extra requests — and said you'd rather hear @hernanflores's view than decide alone. That conversation shouldn't be pre-empted by a PR.

## The defect

`discover-ats.mjs` reported every probe failure as transient:

```
: (errors.length && !coords)
  ? 'probe error(s) occurred — board status unknown, see errors[] and re-run'
```

But an HTTP 404 from Greenhouse/Ashby/Lever is an **answer**: the vendor was reached and said the board is not there. Re-running produces the same result, forever.

Measured on the reporter's case, before:

```
Mercado Libre: probe error(s) occurred — board status unknown, see errors[] and re-run
  err: {vendor: gh,    error: HTTP 404 Not Found}
  err: {vendor: ashby, error: HTTP 404 Not Found}
  err: {vendor: lever, error: HTTP 404 Not Found}
```

After:

```
no Greenhouse/Ashby/Lever board found. If this company uses Workday, add a hint — …
  errors: [{vendor: gh,    error: HTTP 404 Not Found, httpStatus: 404, definitive: true},
           {vendor: ashby, error: HTTP 404 Not Found, httpStatus: 404, definitive: true},
           {vendor: lever, error: HTTP 404 Not Found, httpStatus: 404, definitive: true}]
```

## The fix

`_http.mjs` already attaches the numeric status to the thrown error; `probeVendor` was discarding it. Keeping it is what lets the caller classify without re-parsing message text.

- `isDefinitiveAbsence()` — 404 and 410 establish absence. Everything else (5xx, timeout, DNS, a rejected redirect, or a candidate whose API URL could not be derived) leaves the question open, because nothing answered it.
- The unknown/re-run branch now requires that **not every** failure was definitive. One transient failure among 404s is enough to keep the outcome unknown: that vendor never answered, so absence is not established.
- Each error entry carries `httpStatus` and, when definitive, `definitive: true` — so the JSON says which of the three states the user is in rather than collapsing them.

## A judgement call worth flagging

The fallback message still ends with "add a Workday hint **and re-run**". I left that: it is a different instruction — the user changes their input first, so the retry can genuinely produce a different answer. What this PR removes is the unconditional retry attached to a status that will not change.

My first test asserted the reason contained no `re-run` at all, and it failed on that legitimate sentence. The assertion was too blunt, not the code; it now pins the exact string that had to go (`errors[] and re-run`).

## Test plan

Six cases in `discover-ats.test.mjs`, driven through the real `resolveCompany` with an injected `ctx` whose probes throw `err.status`.

- [x] 5 of the 6 verified red before the fix.
- [x] The guards pass before and after, which is what makes them guards: all-503 keeps the unknown wording, keeps the re-run advice, and is not marked definitive — and a **mixed** 404/503 run stays unknown, because one unanswered vendor is enough to leave absence unestablished.
- [x] 410 is covered alongside 404.
- [x] `node discover-ats.test.mjs` — 115 passed, 0 failed.
- [x] `node test-all.mjs` — 3967 passed, 0 failed (the single warning is the pre-existing `Dashboard build skipped — go compiler not in env`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved board availability detection for HTTP 404 and 410 responses.
  * Transient or mixed failures now remain marked as unresolved instead of being incorrectly reported as missing.
  * Error details now retain relevant HTTP status information and provide clearer retry guidance.

* **Tests**
  * Added coverage for confirmed missing boards, temporary service failures, and mixed failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->