### PR TITLE
fix(pipeline-lock): the refused removal path was never covered — a rmSync EPERM still kills a writer (#2777)

### DIFF
--- a/pipeline-lock.mjs
+++ b/pipeline-lock.mjs
@@ -311,7 +311,19 @@ export async function acquirePipelineLock(pipelinePath, options = {}) {
       }
       // Best-effort: a contended rm here must not mask ownerErr, and an
       // orphaned owner-less lock ages out via lockCanRecover anyway.
-      rmLockArtifactSync(lockDir);
+      //
+      // The try/catch is what makes that sentence true for EVERY failure, not
+      // just a contended one. rmLockArtifactSync deliberately rethrows the
+      // non-contention class (EROFS/ENOSPC), so without this an unwritable
+      // filesystem would propagate from the CLEANUP and the `throw ownerErr`
+      // below would never run — the caller would be told the lock could not be
+      // removed, and never learn why the owner stamp could not be written.
+      // A leftover lock ages out; a swallowed cause is recovered by nothing.
+      try {
+        rmLockArtifactSync(lockDir);
+      } catch {
+        /* cleanup must never outrank the reason we are here */
+      }
       throw ownerErr;
     }
 


### PR DESCRIPTION
Another angle on #2777. Not claiming it closes the issue — you've been wrong about that twice and I'd rather not add a third. But this is a **crash path that has never been covered**, and it produces the exact signature.

## The evidence

`test (windows-latest)` on my PR #2975 — run `32046172901`, on a branch touching only `discover-ats.mjs`:

```
❌ every concurrent add exited cleanly — 1 non-zero exits
   ↳ item-18 exited 1: Error: EPERM, Permission denied:
        \\?\C:\...\inbox-concurrent-W0D8bw\agent-inbox.md.lock.recover
❌ all 30 concurrently queued items survive — kept=29 of 30
```

**That message shape is `rmSync`'s, not `mkdirSync`'s.** mkdir reports `EPERM: operation not permitted, mkdir '…'`; `fs.rmSync` reports `EPERM, Permission denied: <path>`. So the reclassification in `tests/pipeline-lock-mkdir-eperm.test.mjs` could not have covered this one — it is a *removal*.

For the record, an earlier run of mine on #2962 produced the other signature, `ENOENT … owner.json`. You noted the signature had changed; it looks like there is more than one.

## The defect

`acquirePipelineLock` had three `rmSync(..., { recursive: true, force: true })` calls in its retry loop. `force: true` suppresses **ENOENT and nothing else**, so any refusal throws straight at the caller — and in `agent-inbox add` that kills the process before its line is appended.

Windows refuses a removal whenever another process still holds a handle on the directory, which under a burst of 30 concurrent writers is ordinary contention, not a fault. The module already argues this at length for `mkdir`:

> Treating it as fatal is how an item gets LOST.

The removals never got that treatment. One of them sits in a `finally`, so it can also replace the outcome of the block it is unwinding.

## The fix

`removeContended()` — `rmSync` with Node's own `maxRetries`/`retryDelay` (its Windows accommodation for a handle that is still closing), then swallowing a residual EPERM/EACCES/EBUSY/ENOTEMPTY and reporting whether the directory actually went away.

Failing to delete either directory is **recoverable**: both the lock and the recover guard are judged by the stale rules, so a leftover ages out. Throwing is not recoverable — it loses the caller's item. Same trade this module already made for mkdir.

Two details worth reviewing:

- The lock-reclaim site now only `continue`s when the directory *actually* went away. Claiming a reclaim that did not happen would spin hot on a lock that is still there; it now falls through to the jittered wait.
- The owner-stamp cleanup (`pipeline-lock.mjs:308`) uses it too, for a different reason: a refused cleanup there replaced `ownerErr` with an errno about the cleanup, so the caller never learned why the stamp could not be written.

## Test plan

`tests/pipeline-lock-remove-refusal.test.mjs`, mirroring the mkdir case's shape including its root/win32 skips and the reasoning for them.

The refusal is **real, not stubbed**: a guard directory holding a child, with its own write bit cleared, cannot be emptied, so `rmSync(recursive)` answers ENOTEMPTY — the same unprotected call Windows refuses with EPERM.

- [x] Verified red before the fix: the raw `ENOTEMPTY` escaped to the caller.
- [x] Verified the test discriminates: restoring the rethrow turns it red again.
- [x] A second assertion pins that the un-removable guard is **left in place** — swallowing the refusal must not be mistaken for having deleted it, since recovery depends on the stale rules ageing it out.
- [x] `node agent-inbox-tests.mjs` — 19 passed, 0 failed, three consecutive runs (macOS; the failure is Windows-only, so this shows no regression rather than a fix).
- [x] `node test-all.mjs` — 3969 passed, 0 failed (the single warning is the pre-existing `Dashboard build skipped — go compiler not in env`).

## What this does not prove

I cannot reproduce the Windows EPERM locally. What I have is: the signature is a removal, the removals were unprotected, and they now behave like the mkdir path that was already fixed for the same reason. Whether it removes the last `kept=29 of 30` is something only repeated Windows CI can answer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when owner metadata cannot be written.
  * Preserved the original write failure while safely suppressing any cleanup errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->