### PR TITLE
fix(locks): treat Windows rm contention as contention, not death

### DIFF
--- a/pipeline-lock.mjs
+++ b/pipeline-lock.mjs
@@ -148,8 +148,14 @@ function lockCanRecover(lockDir, staleMs) {
   if (owner?.pid) return !processIsAlive(owner.pid);
   try {
     return Date.now() - statSync(lockDir).mtimeMs > Math.max(staleMs, OWNERLESS_GRACE_MS);
-  } catch {
-    return true; // vanished — nothing to recover, retry acquisition
+  } catch (err) {
+    // Only a genuinely vanished directory is "nothing to recover". Any other
+    // stat failure — Windows EPERM/EBUSY while the directory is mid-flight —
+    // is "could not look", and answering "recoverable" to that hands the
+    // caller an rmSync of a LIVE lock created microseconds ago: its winner
+    // then dies with ENOENT writing owner.json (#2777, third face — measured
+    // after the rm-contention fix exposed it).
+    return err?.code === 'ENOENT';
   }
 }
 
@@ -295,6 +301,14 @@ export async function acquirePipelineLock(pipelinePath, options = {}) {
         pipeline: pipelinePath,
       }, null, 2));
     } catch (ownerErr) {
+      // ENOENT writing owner.json means the just-won lock directory is gone:
+      // another caller (mis)judged it reclaimable and deleted it. That is a
+      // lost race, not a failure — re-enter the loop and compete again.
+      // Dying here loses the caller's queued write (#2777, third face).
+      if (ownerErr?.code === 'ENOENT') {
+        if (Date.now() > deadline) throw buildTimeoutError();
+        continue;
+      }
       // Best-effort: a contended rm here must not mask ownerErr, and an
       // orphaned owner-less lock ages out via lockCanRecover anyway.
       rmLockArtifactSync(lockDir);

--- a/pipeline-lock.mjs
+++ b/pipeline-lock.mjs
@@ -87,8 +87,37 @@ function sameLockDirectory(left, right) {
 // A genuine permissions problem still surfaces: it simply stops being an
 // instant throw and becomes a timeout that names the last error it saw, which
 // is the correct trade when the alternative is silent data loss.
-function isMkdirContention(err) {
+export function isMkdirContention(err) {
   return err?.code === 'EEXIST' || err?.code === 'EPERM' || err?.code === 'EACCES';
+}
+
+// rm's Windows answer under contention mirrors mkdir's. Removing a directory
+// another process is inside of — mid-mkdir, mid-scan (antivirus, indexer), or
+// mid-rm — fails with EPERM/EACCES/EBUSY/ENOTEMPTY, and `force: true` only
+// silences ENOENT. Measured on windows-latest (#2777, run 32044401225): two of
+// 30 concurrent `agent-inbox add` processes died on
+// `EPERM … agent-inbox.md.lock.recover` thrown by a bare rmSync of the recover
+// guard, and their items were never appended — the same loss the mkdir half of
+// this handling removed, resurfacing one call later.
+export function isRmContention(err) {
+  return err?.code === 'EPERM' || err?.code === 'EACCES' || err?.code === 'EBUSY' || err?.code === 'ENOTEMPTY';
+}
+
+// Best-effort removal of a lock artifact (the lock dir or the recover guard).
+// Contention is swallowed and reported via the return value; anything else
+// (EROFS/ENOSPC-class breakage) still throws. Never fatal on contention
+// because every lock artifact ages out: an abandoned guard or lock is
+// reclaimed by lockCanRecover on a later attempt, so the worst case of
+// leaving one behind is one extra retry for some caller. Killing the writer
+// loses its item; waiting does not.
+export function rmLockArtifactSync(dir) {
+  try {
+    rmSync(dir, { recursive: true, force: true });
+    return true;
+  } catch (err) {
+    if (isRmContention(err)) return false;
+    throw err;
+  }
 }
 
 function processIsAlive(pid) {
@@ -211,18 +240,22 @@ export async function acquirePipelineLock(pipelinePath, options = {}) {
         // otherwise disable stale recovery forever. The guard normally lives
         // for milliseconds, so an old one is judged by the same age rule.
         if (lockCanRecover(recoverGuardDir, staleMs)) {
-          rmSync(recoverGuardDir, { recursive: true, force: true });
+          rmLockArtifactSync(recoverGuardDir);
         }
       }
 
       if (hasRecoverGuard) {
         try {
           if (lockCanRecover(lockDir, staleMs)) {
-            rmSync(lockDir, { recursive: true, force: true });
-            continue; // retry acquisition immediately, still holding the guard's decision
+            if (rmLockArtifactSync(lockDir)) {
+              continue; // retry acquisition immediately, still holding the guard's decision
+            }
+            // rm hit contention: another process is touching the stale lock at
+            // this instant, so fall through to the normal backoff instead of
+            // treating the collision as fatal.
           }
         } finally {
-          rmSync(recoverGuardDir, { recursive: true, force: true });
+          rmLockArtifactSync(recoverGuardDir);
         }
       }
 
@@ -262,7 +295,9 @@ export async function acquirePipelineLock(pipelinePath, options = {}) {
         pipeline: pipelinePath,
       }, null, 2));
     } catch (ownerErr) {
-      rmSync(lockDir, { recursive: true, force: true });
+      // Best-effort: a contended rm here must not mask ownerErr, and an
+      // orphaned owner-less lock ages out via lockCanRecover anyway.
+      rmLockArtifactSync(lockDir);
       throw ownerErr;
     }
 

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -7550,6 +7550,9 @@ try {
       // via tracker-utils, so the fixture has to carry both — same reason
       // tracker-aliases.json is copied for tracker-parse.mjs (#2704).
       copyFileSync(join(ROOT, 'tracker-utils.mjs'), join(e2eTmp, 'tracker-utils.mjs'));
+      // ...and tracker-utils imports the shared lock-contention helpers
+      // (#2777 fix), so the fixture carries that import too.
+      copyFileSync(join(ROOT, 'pipeline-lock.mjs'), join(e2eTmp, 'pipeline-lock.mjs'));
       mkdirSync(join(e2eTmp, 'templates'), { recursive: true });
       copyFileSync(join(ROOT, 'templates', 'states.yml'), join(e2eTmp, 'templates', 'states.yml'));
       // 'junction' on Windows, not 'dir': a directory symlink needs

--- a/tests/lock-rm-contention.test.mjs
+++ b/tests/lock-rm-contention.test.mjs
@@ -70,6 +70,26 @@ const mkErr = (code) => Object.assign(new Error(code), { code });
   );
 }
 
+// ── 3b. "Could not look" is never "recoverable" ──────────────────────
+// The third face of #2777: lockCanRecover's stat catch answered `true`
+// (recoverable) to EVERY stat failure, so a Windows EPERM on a mid-flight
+// directory let a caller delete a live lock created microseconds ago — its
+// winner then died with ENOENT writing owner.json. Only ENOENT (genuinely
+// vanished) may answer "nothing to recover"; both locks must carry the guard.
+{
+  for (const file of ['pipeline-lock.mjs', 'tracker-utils.mjs']) {
+    const src = readFileSync(join(ROOT, file), 'utf-8');
+    ok(
+      /return err\?\.code === 'ENOENT';/.test(src),
+      `${file}: lockCanRecover's stat catch answers recoverable ONLY on ENOENT`,
+    );
+    ok(
+      !/catch\s*\{\s*\n\s*return true;/.test(src),
+      `${file}: no bare catch{return true} remains in a recovery judgment`,
+    );
+  }
+}
+
 // ── 4. No bare rmSync of a lock artifact in either acquisition path ──
 // The helper is the only code allowed to rmSync the recover guard, and the
 // only permitted direct rmSync(lockDir) is pipeline-lock's release(), which

--- a/tests/lock-rm-contention.test.mjs
+++ b/tests/lock-rm-contention.test.mjs
@@ -1,0 +1,91 @@
+// tests/lock-rm-contention.test.mjs
+//
+// #2777, the EPERM half. The mkdir side of both locks already treated
+// Windows' EPERM/EACCES answers as contention, but every rmSync of a lock
+// artifact (the lock dir, the recover guard) was bare — and on windows-latest
+// removing a directory another process is touching fails with
+// EPERM/EBUSY/ENOTEMPTY, killing the writer and losing its queued item
+// (run 32044401225: 2 of 30 concurrent adds died exactly there).
+//
+// These tests pin three things:
+//   1. the contention classifiers agree on the measured Windows codes,
+//   2. both locks share ONE definition (the drift between the two parallel
+//      lock implementations is how this class survived two earlier fixes),
+//   3. no bare rmSync of a lock artifact remains in either acquisition path.
+
+import { readFileSync, mkdirSync, existsSync, rmSync, mkdtempSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { pass, fail, ROOT } from './helpers.mjs';
+import { isMkdirContention, isRmContention, rmLockArtifactSync } from '../pipeline-lock.mjs';
+
+console.log('\n🔒 lock artifacts: rm contention is contention, not death (#2777)');
+
+const ok = (cond, msg) => (cond ? pass(msg) : fail(msg));
+const mkErr = (code) => Object.assign(new Error(code), { code });
+
+// ── 1. Classifier tables ─────────────────────────────────────────────
+// The codes come from measured windows-latest failures, not speculation:
+// EPERM (#2777 both halves), EACCES (mkdir mid-flight), EBUSY/ENOTEMPTY
+// (rm of a directory with an open handle inside).
+{
+  for (const code of ['EPERM', 'EACCES', 'EBUSY', 'ENOTEMPTY']) {
+    ok(isRmContention(mkErr(code)), `rm ${code} is contention`);
+  }
+  for (const code of ['EROFS', 'ENOSPC', 'ENOENT']) {
+    ok(!isRmContention(mkErr(code)), `rm ${code} is NOT contention (real breakage must still throw)`);
+  }
+  for (const code of ['EEXIST', 'EPERM', 'EACCES']) {
+    ok(isMkdirContention(mkErr(code)), `mkdir ${code} is contention`);
+  }
+  ok(!isMkdirContention(mkErr('EROFS')), 'mkdir EROFS is NOT contention');
+  ok(!isRmContention(undefined) && !isRmContention(null), 'no error object is not contention');
+}
+
+// ── 2. rmLockArtifactSync on a real directory ────────────────────────
+{
+  const dir = mkdtempSync(join(tmpdir(), 'lockrm-'));
+  const artifact = join(dir, 'x.lock');
+  mkdirSync(artifact);
+  ok(rmLockArtifactSync(artifact) === true, 'removing an existing artifact returns true');
+  ok(!existsSync(artifact), 'and the artifact is gone');
+  ok(rmLockArtifactSync(artifact) === true, 'removing a missing artifact is a quiet success (force semantics)');
+  rmSync(dir, { recursive: true, force: true });
+}
+
+// ── 3. One definition, two locks ─────────────────────────────────────
+// tracker-utils.mjs must IMPORT the classifiers from pipeline-lock.mjs, not
+// carry its own copy. Two parallel implementations of the same protocol is
+// exactly how the EEXIST-only check survived in one file after the other
+// learned better.
+{
+  const tracker = readFileSync(join(ROOT, 'tracker-utils.mjs'), 'utf-8');
+  ok(
+    /import\s*\{[^}]*isMkdirContention[^}]*\}\s*from\s*'\.\/pipeline-lock\.mjs'/.test(tracker),
+    'tracker-utils imports the contention classifiers from pipeline-lock',
+  );
+  ok(
+    !/function isMkdirContention/.test(tracker) && !/function isRmContention/.test(tracker),
+    'tracker-utils defines no second copy of the classifiers',
+  );
+}
+
+// ── 4. No bare rmSync of a lock artifact in either acquisition path ──
+// The helper is the only code allowed to rmSync the recover guard, and the
+// only permitted direct rmSync(lockDir) is pipeline-lock's release(), which
+// wraps it in its own deliberate swallow-everything catch (work is already
+// done by then). A bare call anywhere else reintroduces the crash one
+// refactor from now.
+{
+  for (const file of ['pipeline-lock.mjs', 'tracker-utils.mjs']) {
+    const src = readFileSync(join(ROOT, file), 'utf-8');
+    const guardCalls = [...src.matchAll(/rmSync\(\s*recoverGuardDir\b/g)].length;
+    ok(guardCalls === 0, `${file}: no bare rmSync(recoverGuardDir) remains (found ${guardCalls})`);
+  }
+  const trackerLockCalls = [...readFileSync(join(ROOT, 'tracker-utils.mjs'), 'utf-8')
+    .matchAll(/rmSync\(\s*lockDir\b/g)].length;
+  ok(trackerLockCalls === 0, `tracker-utils.mjs: no bare rmSync(lockDir) remains (found ${trackerLockCalls})`);
+  const pipelineLockCalls = [...readFileSync(join(ROOT, 'pipeline-lock.mjs'), 'utf-8')
+    .matchAll(/rmSync\(\s*lockDir\b/g)].length;
+  ok(pipelineLockCalls <= 1, `pipeline-lock.mjs: at most release()'s guarded rmSync(lockDir) remains (found ${pipelineLockCalls})`);
+}

--- a/tests/ollama-profile-context.test.mjs
+++ b/tests/ollama-profile-context.test.mjs
@@ -27,6 +27,9 @@ for (const relativePath of [
   'tracker-aliases.json',
   'tracker-parse.mjs',
   'tracker-utils.mjs',
+  // tracker-utils imports the shared lock-contention helpers (#2777 fix):
+  // a fixture that carries tracker-utils has to carry its import too.
+  'pipeline-lock.mjs',
   'lib/context-budget.mjs',
   'utils/token-tracker.mjs',
 ]) {

--- a/tracker-utils.mjs
+++ b/tracker-utils.mjs
@@ -13,6 +13,12 @@ import { join, dirname, basename, resolve, relative, isAbsolute, sep } from 'pat
 import { createHash, randomUUID } from 'crypto';
 import { tmpdir } from 'os';
 import * as yaml from 'js-yaml';
+// One definition for both locks: this module and pipeline-lock.mjs implement
+// the same directory-lock protocol on purpose, and #2777 showed how the two
+// copies drift — pipeline-lock learned that Windows answers mkdir/rm with
+// EPERM/EACCES/EBUSY under contention while this file still treated anything
+// but EEXIST as fatal, killing a writer and losing its item.
+import { isMkdirContention, isRmContention, rmLockArtifactSync } from './pipeline-lock.mjs';
 import { normalizeTextKey } from './tracker-parse.mjs';
 
 /**
@@ -343,9 +349,10 @@ export async function acquireTrackerLock(lockDir, options = {}) {
         // We created the dir but could not record ownership. An empty,
         // owner-less lock dir would block every future locker until the
         // staleMs age-out — remove what we just created before rethrowing.
-        // Scoped to the owner write only: the mkdir EEXIST contention path
-        // is still handled by the outer catch.
-        rmSync(lockDir, { recursive: true, force: true });
+        // Scoped to the owner write only: the mkdir contention path is still
+        // handled by the outer catch. Best-effort removal: a contended rm
+        // must not mask ownerErr, and the orphan ages out regardless.
+        rmLockArtifactSync(lockDir);
         throw ownerErr;
       }
 
@@ -409,39 +416,60 @@ export async function acquireTrackerLock(lockDir, options = {}) {
             ownerVerified = true;
             verifiedDir = afterRead;
           }
-          removeLock(lockDir);
+          // Best-effort, mirroring pipeline-lock's release: ownership was
+          // verified above, so a contended rm (Windows EPERM/EBUSY while
+          // another process stats the directory) must not kill a caller whose
+          // work already succeeded — the orphaned lock ages out via
+          // lockCanRecover. Injected removeLock hooks (fault tests) keep
+          // their errors: only the known contention codes are swallowed.
+          try {
+            removeLock(lockDir);
+          } catch (rmErr) {
+            if (!isRmContention(rmErr)) throw rmErr;
+          }
           released = true;
         },
       };
     } catch (err) {
-      if (err?.code !== 'EEXIST') throw err;
+      // Not just EEXIST: Windows reports a lock directory that is mid-create
+      // or mid-remove by another process as EPERM/EACCES. That is contention,
+      // not failure — treating it as fatal is how a concurrent writer dies and
+      // its write is lost (#2777, measured on windows-latest).
+      if (!isMkdirContention(err)) throw err;
 
       let hasRecoverGuard = false;
       try {
         mkdirSync(recoverGuardDir);
         hasRecoverGuard = true;
       } catch (guardErr) {
-        if (guardErr?.code !== 'EEXIST') throw guardErr;
+        if (!isMkdirContention(guardErr)) throw guardErr;
         // A process killed between creating the guard and its cleanup leaves
         // the guard behind forever, permanently disabling stale-lock recovery
         // for every future writer. The guard normally lives for milliseconds,
         // so an old one is judged stale by the same age rule as a
         // metadata-free lock and removed; the next loop iteration can then
         // take the guard and run recovery.
-        if (lockCanRecover(recoverGuardDir, staleMs)) {
-          rmSync(recoverGuardDir, { recursive: true, force: true });
+        //
+        // Only an EEXIST guard is judged by age: an EPERM/EACCES answer means
+        // the guard is mid-flight right now, and reasoning about the age of a
+        // directory we cannot even stat reliably would evict a live guard.
+        if (guardErr.code === 'EEXIST' && lockCanRecover(recoverGuardDir, staleMs)) {
+          rmLockArtifactSync(recoverGuardDir);
         }
       }
 
       if (hasRecoverGuard) {
         try {
           if (lockCanRecover(lockDir, staleMs)) {
-            rmSync(lockDir, { recursive: true, force: true });
-            staleRecovered = true;
-            continue;
+            if (rmLockArtifactSync(lockDir)) {
+              staleRecovered = true;
+              continue;
+            }
+            // rm hit contention: another process is touching the stale lock at
+            // this instant — back off instead of treating the collision as fatal.
           }
         } finally {
-          rmSync(recoverGuardDir, { recursive: true, force: true });
+          rmLockArtifactSync(recoverGuardDir);
         }
       }
 

--- a/tracker-utils.mjs
+++ b/tracker-utils.mjs
@@ -299,8 +299,12 @@ function lockCanRecover(lockDir, staleMs) {
 
   try {
     return Date.now() - statSync(lockDir).mtimeMs > Math.max(staleMs, OWNERLESS_GRACE_MS);
-  } catch {
-    return true;
+  } catch (err) {
+    // Mirrors pipeline-lock: only ENOENT means "vanished, nothing to
+    // recover". A Windows EPERM/EBUSY mid-flight stat is "could not look",
+    // and treating it as recoverable lets a caller delete a live lock
+    // created microseconds ago (#2777, third face).
+    return err?.code === 'ENOENT';
   }
 }
 
@@ -346,6 +350,11 @@ export async function acquireTrackerLock(lockDir, options = {}) {
           tracker: options.tracker ?? '',
         }, null, 2));
       } catch (ownerErr) {
+        // ENOENT writing owner.json means the just-won lock directory is
+        // gone: another caller (mis)judged it reclaimable and deleted it.
+        // A lost race, not a failure — re-enter the loop and compete again
+        // (mirrors pipeline-lock; dying here loses the caller's write).
+        if (ownerErr?.code === 'ENOENT') continue;
         // We created the dir but could not record ownership. An empty,
         // owner-less lock dir would block every future locker until the
         // staleMs age-out — remove what we just created before rethrowing.


### PR DESCRIPTION
## What does this PR do?

Fixes the remaining half of #2777: the EPERM crash. The mkdir side of both locks already treated Windows' EPERM/EACCES answers as contention, but every `rmSync` of a lock artifact (the recover guard, a stale lock dir) was bare — and on Windows, removing a directory another process is touching fails with EPERM/EBUSY/ENOTEMPTY (`force: true` only silences ENOENT). The writer dies and its queued item is lost.

Measured today on `windows-latest` (run 32044401225, an unrelated PR's CI): 2 of 30 concurrent `agent-inbox add` processes died on `EPERM … agent-inbox.md.lock.recover`, `kept=28 of 30`. This is the red that has been randomly failing the Windows leg for open PRs.

## Changes

- **pipeline-lock.mjs**: `isRmContention()` + `rmLockArtifactSync()` (swallows only the measured contention codes; EROFS/ENOSPC-class breakage still throws). All acquisition-path removals routed through it.
- **tracker-utils.mjs**: imports the classifiers from pipeline-lock (one definition — the drift between the two parallel lock implementations is how this class survived #2506 and #2825), stops treating non-EEXIST mkdir answers as fatal, and `release()` no longer dies on a contended rm after the work already succeeded. Injected `removeLock` fault hooks keep their errors.
- **tests/lock-rm-contention.test.mjs**: pins the classifier table, the shared single definition, and that no bare artifact `rmSync` remains in either file.
- Fixture lists that copy `tracker-utils.mjs` standalone now carry `pipeline-lock.mjs` too.

Safety: a failed removal is never fatal because every lock artifact ages out via `lockCanRecover` — worst case is one extra retry for some caller. Killing the writer loses its item; waiting does not.

## Related issue

Closes #2777

## Type of change

- [x] Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved lock recovery during concurrent filesystem operations.
  - Lock acquisition and release now better tolerate Windows file contention.
  - Prevented recovery from proceeding when unexpected filesystem errors occur.
  - Added safer cleanup and retry behavior for stale or partially removed lock artifacts.
- **Tests**
  - Added coverage for Windows contention scenarios, recovery safeguards, cleanup behavior, and forced removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->