### PR TITLE
fix(portals): block German student and support postings in the example title filter

### DIFF
--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -349,6 +349,29 @@ title_filter:
     - "Oracle EBS"
     - "Mainframe"
     - "COBOL"
+    # -- German student / apprenticeship postings (DACH market) --
+    # Large DACH employers publish these in volume, and the German AI keywords
+    # in title_filter.positive ("KI", "Künstliche Intelligenz") match them, so
+    # without these a scan of one big employer returns mostly student ads.
+    - "Werkstudent"
+    - "Praktikant"
+    - "Praktikum"
+    - "Masterarbeit"
+    - "Bachelorarbeit"
+    - "Abschlussarbeit"
+    - "PreMaster"
+    - "Duales Studium"
+    - "Ausbildung"
+    # Qualified rather than a bare "Thesis": keywords longer than three
+    # characters match as plain substrings, so "Thesis" would also reject
+    # "Speech Synthesis Engineer" — and "Speech" is a positive keyword above.
+    - "Master Thesis"
+    - "Bachelor Thesis"
+    # -- Support roles that match on "Agent" --
+    # "Customer Care Agent" and its German equivalent otherwise pass the
+    # "AI Agent" / "Agent" side of the positive list.
+    - "Customer Care"
+    - "Kundenbetreuung"
   seniority_boost:
     # These prefixes add relevance but are not required
     - "Senior"


### PR DESCRIPTION
## What does this PR do?

The example `title_filter.negative` excludes `Junior` and `Intern` but not their German
equivalents, while `title_filter.positive` already carries German AI keywords (`KI`,
`Künstliche Intelligenz`). A scan of one large DACH employer therefore returns mostly
student postings.

Verified against the shipped template with `buildTitleFilter`. These all PASS today and
REJECT after the change:

- `Werkstudent AI (m/w/d)`
- `Praktikum Künstliche Intelligenz`
- `Masterarbeit: KI-Agenten`
- `Abschlussarbeit KI`
- `PreMaster Programm KI`
- `Master Thesis LLM Agents`
- `Bachelor Thesis AI`
- `Customer Care Agent`
- `Kundenbetreuung KI`

Nothing wanted is lost — `Speech Synthesis Engineer`, `Applied AI Architect`,
`Forward Deployed Engineer`, `Senior AI Engineer`, `Conversational AI Engineer` and
`KI Engineer` all still pass, before and after.

One deliberate choice, documented in a comment next to the entries: `"Master Thesis"` /
`"Bachelor Thesis"` rather than a bare `"Thesis"`. Keywords longer than three characters
match as plain substrings, so `"Thesis"` would also reject `"Speech Synthesis Engineer"` —
and `"Speech"` is a positive keyword in the same file. I checked both variants before
picking.

A companion PR adds SAP, Bosch and Delivery Hero to the same file; those are the employers
where these titles arrive in volume, which is what surfaced this.

## Related issue

None — bug fix, which CONTRIBUTING.md exempts from issue-first.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass (4053 passed, 0 failed)
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added German title filters to exclude irrelevant student, apprenticeship, thesis, and customer-support postings from search results.
  * Improved matching accuracy for roles using the “Agent” keyword.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->