### PR TITLE
feat(portals): an Africa section — the regional gap #2962 exposed, closed without new code

### DIFF
--- a/templates/portals.example.yml
+++ b/templates/portals.example.yml
@@ -1939,6 +1939,37 @@ tracked_companies:
     notes: "Istanbul. E-commerce marketplace (Doğuş Group)."
     enabled: false
 
+  # -- Africa (employers on already-supported ATS) --
+  #
+  # The scanner ships 74 providers and a regional section for the UK, the
+  # Nordics, Iberia, Türkiye and Indonesia — and none for Africa. That gap is
+  # not a missing provider: these employers already publish through Greenhouse
+  # and Ashby, whose public zero-auth APIs the scanner has always read.
+  #
+  # Every entry below was verified live on 2026-08-17: the API answered 200 and
+  # the posting locations were checked, because an African-founded company is
+  # not the same thing as a company hiring in Africa. The note on each says what
+  # it actually posts, so nobody enables one expecting a market it does not
+  # serve. Left `enabled: false` like every other example.
+
+  - name: Moniepoint
+    careers_url: https://job-boards.greenhouse.io/moniepoint
+    api: https://boards-api.greenhouse.io/v1/boards/moniepoint/jobs
+    notes: "Lagos. Fintech (business banking, payments). Verified 2026-08-17: 120 postings, the largest group in Lagos and Remote-Nigeria; also hires Remote in Bangalore, Poland and Spain."
+    enabled: false
+
+  - name: Jumia
+    careers_url: https://job-boards.greenhouse.io/jumia
+    api: https://boards-api.greenhouse.io/v1/boards/jumia/jobs
+    notes: "Pan-African e-commerce. Verified 2026-08-17: 25 postings across Nigeria, Ghana, Uganda, Egypt and Kenya — the widest continental spread of the three."
+    enabled: false
+
+  - name: Andela
+    careers_url: https://jobs.ashbyhq.com/andela
+    api: https://api.ashbyhq.com/posting-api/job-board/andela
+    notes: "African-founded talent marketplace. Verified 2026-08-17: 19 postings, but mostly North America and the UK with a single Kenya role — enable it for the company, not for African coverage."
+    enabled: false
+
 # ── Job Boards ────────────────────────────────────────────────────────
 # Multi-employer aggregators. Unlike tracked_companies (one entry = one employer),
 # job boards return offers from many companies in a single API call.


### PR DESCRIPTION
Follow-up to #2962. That PR gave the scanner its first African *source*; this one gives it African *employers* — and it needs no new code at all.

`templates/portals.example.yml` ships regional sections for the UK & Ireland, the Nordics, Denmark, Iberia, Türkiye and Indonesia. There is none for Africa. That gap is not a missing provider: these companies already publish through Greenhouse and Ashby, whose public zero-auth APIs the scanner has read since the beginning.

## What I looked for first, and did not ship

The obvious move after #2962 was a second African board. I probed nine across five markets on 2026-08-17, and **none of them can be shipped responsibly**:

| Board | Market | Result |
|---|---|---|
| Jobberman | Nigeria | Cloudflare on data paths; no API, no RSS, no reachable sitemap |
| BrighterMonday | Kenya | same platform, same result |
| MyJobMag | Nigeria | listing path 404s behind Cloudflare |
| Fuzu | Kenya | 403 |
| Wuzzuf | Egypt | Cloudflare |
| TanitJobs | Tunisia | 403 |
| emploi.ma | Morocco | 403 |
| **Rekrute** | **Morocco** | **reachable, and explicitly off-limits — see below** |

Rekrute was the promising one: Apache, no interstitial, a parseable listing carrying title, company, city and publication window — strictly better data than senjob. Its `robots.txt` stopped it:

```
User-agent: JobBot/2.0
Disallow: /

User-agent: Jooblebot/2.0
Disallow: /
```

496 lines, **no `User-agent: *` group at all**, and job aggregators banned from the whole site by name. `ClaudeBot`, `GPTBot` and `OAI-SearchBot` are each allowed for search but disallowed on the offers pages. A career-ops provider is precisely what `Jooblebot` denotes; arguing we are a different kind of aggregator would be reasoning around an answer the owner already gave.

So this PR takes the sanctioned path instead.

## What is here

Three employers, each verified live on 2026-08-17 — the API answered 200 **and** the posting locations were checked, because an African-founded company is not the same thing as a company hiring in Africa:

| Company | ATS | Postings | Where they actually hire |
|---|---|---|---|
| Moniepoint | Greenhouse | 120 | Lagos (18) and Remote-Nigeria (13) lead; also Bangalore, Poland, Spain |
| Jumia | Greenhouse | 25 | Nigeria (16), Ghana (3), Uganda, Egypt, Kenya — the widest spread |
| Andela | Ashby | 19 | mostly North America and the UK, **one** Kenya role |

Andela is included with that caveat written into its note. It is African-founded and legitimately of interest, but enabling it expecting African coverage would disappoint — the note says so rather than letting the name imply it.

All three ship `enabled: false`, like every other example in the file.

## Test plan

- [x] Each `api:` URL fetched live: 200, and the payload parsed to the posting count above.
- [x] Locations tabulated per company rather than assumed from the company's origin.
- [x] `node -e` YAML load of the edited template — parses, 120 companies, the three present.
- [x] `node test-all.mjs` — 4080 passed, 0 failed.

No provider code, no scraping, no robots.txt question to weigh: these are the same public ATS endpoints the scanner already consumes for every other region in the file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a disabled Africa region configuration with career tracking entries for Moniepoint, Jumia, and Andela.
  * Included regional hiring notes, careers links, API endpoints, and verification details for each company.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->