### PR TITLE
fix(cv): an empty Skills section no longer deletes the sections after it

### DIFF
--- a/cv-sections-core.mjs
+++ b/cv-sections-core.mjs
@@ -23,26 +23,31 @@
 // ── The Skills sentinel: part of the template contract ───────────────────────
 //
 // Skills is the LAST section in every shipped template, which makes it the one
-// optional section with no following section marker to stop at. Given the
-// shared `…|$` boundary the others use, stripping an empty Skills section
-// falls through to true end-of-file and takes the closing
+// optional section that may have no following section marker to stop at. Given
+// the shared `…|$` boundary the others use, stripping an empty trailing Skills
+// section falls through to true end-of-file and takes the closing
 // `</div></body></html>` (`\end{document}` in LaTeX) with it — a truncated,
 // unopenable document, which is far worse than the bare header this module
 // exists to remove.
 //
 // So the Skills patterns below deliberately do NOT use the shared boundary.
-// They match only up to an explicit `<!-- END -->` (`%%%% END %%%%` in LaTeX)
-// sentinel, with no end-of-input alternative. Two consequences, both
-// intentional:
+// They use the same marker shapes with the `|$` branch removed, so they stop at
+// the next marker and never at end-of-input. Because `END` is itself a marker,
+// that is the `<!-- END -->` (`%%%% END %%%%` in LaTeX) sentinel when Skills is
+// last, and the following section's marker when a custom template puts Skills
+// somewhere else. Matching the sentinel *only* would be wrong for that second
+// case: the lazy body would run past every section between Skills and the
+// sentinel and delete them along with the empty header, which is silent data
+// loss in a populated CV. Two consequences, both intentional:
 //
-//   1. **The sentinel is part of the template contract.** A template that
-//      renders a Skills section must place `<!-- END -->` / `%%%% END %%%%`
+//   1. **The sentinel is part of the template contract.** A template that ends
+//      on its Skills section must place `<!-- END -->` / `%%%% END %%%%`
 //      immediately after it. All four shipped templates do; do not remove it
 //      when editing a template's tail. This is documented for custom-template
 //      authors in templates/README.md.
-//   2. **A template without the sentinel FAILS SAFE.** The pattern simply
-//      does not match, `String.replace` is a no-op, and the template comes
-//      out untouched — the Skills section renders as a bare header. That is
+//   2. **A template with no marker after Skills FAILS SAFE.** The pattern
+//      simply does not match, `String.replace` is a no-op, and the template
+//      comes out untouched — the Skills section renders as a bare header. That is
 //      the original cosmetic bug, and it is the deliberate choice: a bare
 //      header beats a truncated CV by a wide margin, and the person it lands
 //      on (a third-party template pack with no sentinel and no skills listed)
@@ -74,11 +79,23 @@
 const HTML_BOUNDARY = String.raw`(?=<!--\s+[A-Z][A-Z ]*-->|$)`;
 const TEX_BOUNDARY = String.raw`(?=%{4,}\s|$)`;
 
-// Sentinel-only boundaries for Skills — no end-of-input alternative, so a
-// template lacking the sentinel is left untouched rather than truncated. See
-// "The Skills sentinel" above before changing these.
-const HTML_END_SENTINEL = String.raw`(?=<!--\s+END\s+-->)`;
-const TEX_END_SENTINEL = String.raw`(?=%{4,}\s+END\s+%{4,})`;
+// Marker-only boundaries for Skills — the same marker shapes as the shared
+// boundaries above, but with NO end-of-input alternative, so a template lacking
+// any following marker is left untouched rather than truncated. `END` is itself
+// a marker, so these stop at the `<!-- END -->` / `%%%% END %%%%` sentinel when
+// Skills is last and at the next section's marker when it is not. See "The
+// Skills sentinel" above before changing these, and never add an `|$` branch.
+//
+// The LaTeX one anchors the banner to the start of a line (hence the `m` flag on
+// the pattern that uses it). Without `^`, dropping the `|$` branch lets the
+// engine backtrack the opening banner's own greedy trailing `%{4,}`: with no
+// following banner to stop at it gives back `%` until the leftovers themselves
+// satisfy the lookahead, matching half the banner and leaving a stray `%%%%`
+// behind instead of no-opping. Only banners wider than 8 `%` can backtrack that
+// far, so a narrow fixture will not catch a regression here — the fixtures in
+// tests/cv-optional-sections.test.mjs use the shipped 28-wide banner on purpose.
+const HTML_END_SENTINEL = String.raw`(?=<!--\s+[A-Z][A-Z ]*-->)`;
+const TEX_END_SENTINEL = String.raw`(?=^%{4,}\s)`;
 
 const PATTERNS = {
   html: {
@@ -93,7 +110,7 @@ const PATTERNS = {
     projects: new RegExp(String.raw`%{4,}\s+PROJECTS\s+%{4,}[\s\S]*?` + TEX_BOUNDARY),
     education: new RegExp(String.raw`%{4,}\s+Education\s+%{4,}[\s\S]*?` + TEX_BOUNDARY),
     awards: new RegExp(String.raw`%{4,}\s+AWARDS\s+%{4,}[\s\S]*?` + TEX_BOUNDARY),
-    skills: new RegExp(String.raw`%{4,}\s+Technical Skills\s+%{4,}[\s\S]*?` + TEX_END_SENTINEL),
+    skills: new RegExp(String.raw`%{4,}\s+Technical Skills\s+%{4,}[\s\S]*?` + TEX_END_SENTINEL, 'm'),
   },
 };
 

--- a/tests/cv-optional-sections.test.mjs
+++ b/tests/cv-optional-sections.test.mjs
@@ -19,12 +19,13 @@
 // cv-sections-core.mjs for the failure modes exercised here.
 //
 // Skills carries one extra burden the other five do not. It is the LAST
-// section in every shipped template, so it has no following section marker to
-// stop at; with the shared `…|$` boundary, stripping it would run to
-// end-of-file and swallow the closing document skeleton. Its patterns
-// therefore match only up to an explicit `<!-- END -->` / `%%%% END %%%%`
-// sentinel, with NO end-of-input alternative, which produces two behaviours
-// this suite pins down:
+// section in every shipped template, so it may have no following section marker
+// to stop at; with the shared `…|$` boundary, stripping it would run to
+// end-of-file and swallow the closing document skeleton. Its patterns therefore
+// use the same marker shapes with NO end-of-input alternative — stopping at the
+// `<!-- END -->` / `%%%% END %%%%` sentinel when Skills is last, and at the next
+// section's marker when a custom template puts Skills higher up. That produces
+// two behaviours this suite pins down:
 //
 //   - with the sentinel: the section is stripped and the closing skeleton
 //     survives ("keeps the closing document skeleton" checks);
@@ -238,8 +239,15 @@ check('html: with no sentinel, empty skills is a no-op (fail-safe, bare header b
   withoutSentinel, SKILLS_NO_SENTINEL);
 check('html: with no sentinel, the closing skeleton survives', withoutSentinel.includes('</body></html>'), true);
 
-const TEX_WITH_SENTINEL = '%%%%  Technical Skills  %%%%\nskills\n%%%%  END  %%%%\n\\end{document}';
-const TEX_NO_SENTINEL = '%%%%  Technical Skills  %%%%\nskills\n\\end{document}';
+// Banners are the shipped 28-wide, NOT a minimal `%%%%`. Width matters: the
+// Skills lookahead has no end-of-input branch, so on a template with no
+// following banner the engine backtracks the opening banner's own greedy
+// trailing `%{4,}`. It can only give back enough `%` to fake a boundary when the
+// banner is wider than 8, so a narrow fixture passes while the real template
+// gets a stray `%%%%` left behind. See TEX_END_SENTINEL in cv-sections-core.mjs.
+const TEX_BANNER = '%'.repeat(28);
+const TEX_WITH_SENTINEL = `${TEX_BANNER}  Technical Skills  ${TEX_BANNER}\nskills\n${TEX_BANNER}  END  ${TEX_BANNER}\n\\end{document}`;
+const TEX_NO_SENTINEL = `${TEX_BANNER}  Technical Skills  ${TEX_BANNER}\nskills\n\\end{document}`;
 
 const texWith = stripEmptySections(TEX_WITH_SENTINEL, EMPTY, 'tex');
 check('tex: with the sentinel, empty skills is stripped', texWith.includes('Technical Skills'), false);
@@ -248,6 +256,55 @@ check('tex: with the sentinel, \\end{document} survives', texWith.includes('\\en
 const texWithout = stripEmptySections(TEX_NO_SENTINEL, EMPTY, 'tex');
 check('tex: with no sentinel, empty skills is a no-op (fail-safe)', texWithout, TEX_NO_SENTINEL);
 check('tex: with no sentinel, \\end{document} survives', texWithout.includes('\\end{document}'), true);
+check('tex: with no sentinel, no half-eaten banner is left behind',
+  texWithout.includes('Technical Skills'), true);
+
+// --- Skills is not always the last section ---------------------------------
+// A custom template may put Skills above Education. The Skills boundary must
+// then stop at the NEXT section's marker, not run all the way to the trailing
+// sentinel: matching the sentinel only would delete every populated section in
+// between along with the empty Skills header — silent data loss in a CV that
+// still has an education block to show. Both formats, because both boundaries
+// have the same shape.
+
+const SKILLS_NOT_LAST_HTML = [
+  '<html><body><div>',
+  '<!-- SKILLS -->',
+  '<div>{{SKILLS}}</div>',
+  '<!-- EDUCATION -->',
+  '<div>keep my degree</div>',
+  '<!-- END -->',
+  '</div></body></html>',
+].join('\n');
+
+const skillsNotLast = stripEmptySections(
+  SKILLS_NOT_LAST_HTML, { ...FULL, skills: [] }, 'html');
+check('html: skills above education — the empty skills block goes',
+  skillsNotLast.includes('<!-- SKILLS -->'), false);
+check('html: skills above education — the populated education block survives',
+  skillsNotLast.includes('keep my degree'), true);
+check('html: skills above education — the sentinel survives',
+  skillsNotLast.includes('<!-- END -->'), true);
+check('html: skills above education — the closing skeleton survives',
+  skillsNotLast.trimEnd().endsWith('</div></body></html>'), true);
+
+const SKILLS_NOT_LAST_TEX = [
+  `${TEX_BANNER}  Technical Skills  ${TEX_BANNER}`,
+  '{{SKILLS}}',
+  `${TEX_BANNER}  Education  ${TEX_BANNER}`,
+  'keep my degree',
+  `${TEX_BANNER}  END  ${TEX_BANNER}`,
+  '\\end{document}',
+].join('\n');
+
+const texSkillsNotLast = stripEmptySections(
+  SKILLS_NOT_LAST_TEX, { ...FULL, skills: [] }, 'tex');
+check('tex: skills above education — the empty skills block goes',
+  texSkillsNotLast.includes('Technical Skills'), false);
+check('tex: skills above education — the populated education block survives',
+  texSkillsNotLast.includes('keep my degree'), true);
+check('tex: skills above education — \\end{document} survives',
+  texSkillsNotLast.includes('\\end{document}'), true);
 
 // Stripping one section must not depend on the other still being present: a
 // lookahead naming `<!-- EDUCATION -->` breaks once education is removed.

--- a/tests/cv-optional-sections.test.mjs
+++ b/tests/cv-optional-sections.test.mjs
@@ -256,6 +256,15 @@ check('tex: with the sentinel, \\end{document} survives', texWith.includes('\\en
 const texWithout = stripEmptySections(TEX_NO_SENTINEL, EMPTY, 'tex');
 check('tex: with no sentinel, empty skills is a no-op (fail-safe)', texWithout, TEX_NO_SENTINEL);
 check('tex: with no sentinel, \\end{document} survives', texWithout.includes('\\end{document}'), true);
+// The two checks above are narrowing diagnostics under the exact-equality check
+// on the previous line, not independent coverage: that one already pins the
+// whole template byte for byte, so anything these catch it catches too. They
+// earn their place by naming WHICH half of the fail-safe broke, so a regression
+// reports "half-eaten banner" instead of only a full-template diff.
+// The substring is the right probe for that: when the boundary loses its `^`
+// anchor the engine backtracks the opening banner's own greedy trailing `%{4,}`
+// and consumes the heading with it, leaving `%%%%\nskills\n\end{document}`. The
+// heading text is gone in that state, so this assertion goes red.
 check('tex: with no sentinel, no half-eaten banner is left behind',
   texWithout.includes('Technical Skills'), true);
 


### PR DESCRIPTION
## What does this PR do?

Fixes a silent data-loss bug in `cv-sections-core.mjs`: when a template puts Skills anywhere other than last, stripping an empty Skills section also deletes every populated section between it and the trailing `<!-- END -->` / `%%%% END %%%%` sentinel. Both HTML and LaTeX.

## Related issue

None - bug fix, sent straight in per CONTRIBUTING.

## The bug

The Skills boundary matched up to the sentinel and nothing else, which is correct only while Skills is genuinely the last section. In a custom template that puts Skills higher up (above Education, to match `cv.md`'s own order), the lazy body runs straight past everything in between.

Reproduced on `main`, `skills: []` and every other section populated:

```
input                        output
<!-- SKILLS -->
<div>{{SKILLS}}</div>
<!-- EDUCATION -->      ->   <!-- END -->
<div>my degree</div>
<!-- END -->
```

The education block is gone, no error, no warning. Same for LaTeX.

## The fix

The Skills patterns now use the same marker shapes as the other five sections, still with **no** end-of-input branch. `END` is itself a marker, so they stop at the sentinel when Skills is last (unchanged behaviour for all four shipped templates) and at the following section's marker when it is not.

This also lines up with a rule this file already documents: naming an expected successor couples a strip to template ordering.

**The fail-safe is intact.** A template with no marker after Skills still does not match, the strip is a no-op, and the closing document skeleton survives. A bare header still beats a truncated CV, and `|$` is still never an option.

## One subtlety worth reviewing

The LaTeX lookahead is line-anchored (`(?=^%{4,}\s)`, `m` flag) rather than the obvious `(?=%{4,}\s)`. Without `^`, dropping the `|$` branch lets the engine backtrack the opening banner's *own* greedy trailing `%{4,}`: with no following banner it gives back `%` until the leftovers themselves satisfy the lookahead, matching half the banner and leaving a stray `%%%%` behind where the fail-safe should have changed nothing.

It only reaches that far on banners wider than 8 `%`, so the existing 4-wide fixture could not have caught it. The LaTeX fixtures now use the shipped 28-wide banner, plus an explicit "no half-eaten banner is left behind" assertion.

## Tests

New "skills above education" cases for both formats. Both fail on `main`:

```
❌ html: skills above education — the populated education block survives — expected true, got false
❌ tex: skills above education — the populated education block survives — expected true, got false
```

- `node tests/cv-optional-sections.test.mjs` -> 134 passed, 0 failed
- `node test-all.mjs` -> 4088 passed, 0 failed (2 pre-existing warnings, unrelated: missing local user data and a `santifer.io` string in `dashboard/`)

No template changes. Shipped templates keep Skills last and their rendered output is byte-identical.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes exempt)
- [x] My PR does not include personal data
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the Data Contract (system-layer files only)
- [x] My changes align with the project roadmap


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved removal of empty Skills sections in CVs.
  * Sections now stop cleanly at subsequent section markers, including the end marker.
  * Preserved templates without a following section marker.
  * Prevented partial LaTeX banner matching and removal.

* **Tests**
  * Expanded HTML and LaTeX coverage for Skills and Education section handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->