### PR TITLE
feat(discover-ats): probe the long-tail ATS vendors, not just the big three

### DIFF
--- a/discover-ats.mjs
+++ b/discover-ats.mjs
@@ -41,6 +41,14 @@ import greenhouse from './providers/greenhouse.mjs';
 import ashby from './providers/ashby.mjs';
 import lever from './providers/lever.mjs';
 import workday from './providers/workday.mjs';
+import workable from './providers/workable.mjs';
+import smartrecruiters from './providers/smartrecruiters.mjs';
+import recruitee from './providers/recruitee.mjs';
+import breezy from './providers/breezy.mjs';
+import bamboohr from './providers/bamboohr.mjs';
+import pinpoint from './providers/pinpoint.mjs';
+import rippling from './providers/rippling.mjs';
+import joinProvider from './providers/join.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const PORTALS_PATH = process.env.CAREER_OPS_PORTALS || join(CAREER_OPS, 'portals.yml');
@@ -67,13 +75,38 @@ const DEFAULT_CONCURRENCY = 8;
 // resolves from a Workday hint instead (see resolveWorkday): a full careers URL,
 // or an explicit {tenant, site[, instance]} block — with a bounded instance
 // auto-probe when the instance is the only missing coordinate.
+// `host` pins the hostname buildCandidateUrls asserts against. Vendors that put
+// the company in a SUBDOMAIN have a slug-dependent host, so they supply
+// `hostFor(slug)` instead of a constant; `buildCandidateUrls` prefers it when
+// present. Those hosts are matched lowercase-only by their providers, so their
+// buildUrl lowercases the slug rather than emitting a URL the provider would
+// then reject (Ashby is the reason slugs are not lowercased globally: its boards
+// are case-sensitive).
+const lower = (s) => String(s).toLowerCase();
+
 const VENDORS = {
   gh:    { id: 'greenhouse', provider: greenhouse, host: 'job-boards.greenhouse.io', buildUrl: (s) => `https://job-boards.greenhouse.io/${s}`, api: (s) => `https://boards-api.greenhouse.io/v1/boards/${s}/jobs` },
   ashby: { id: 'ashby',      provider: ashby,      host: 'jobs.ashbyhq.com',        buildUrl: (s) => `https://jobs.ashbyhq.com/${s}` },
   lever: { id: 'lever',      provider: lever,      host: 'jobs.lever.co',           buildUrl: (s) => `https://jobs.lever.co/${s}` },
+
+  // Long tail, probed only after the three above miss (see VENDOR_ORDER).
+  workable:        { id: 'workable',        provider: workable,        host: 'apply.workable.com',          buildUrl: (s) => `https://apply.workable.com/${s}` },
+  smartrecruiters: { id: 'smartrecruiters', provider: smartrecruiters, host: 'careers.smartrecruiters.com', buildUrl: (s) => `https://careers.smartrecruiters.com/${s}` },
+  rippling:        { id: 'rippling',        provider: rippling,        host: 'ats.rippling.com',            buildUrl: (s) => `https://ats.rippling.com/${s}/jobs` },
+  join:            { id: 'join',            provider: joinProvider,            host: 'join.com',                    buildUrl: (s) => `https://join.com/companies/${s}` },
+  recruitee:       { id: 'recruitee',       provider: recruitee,       hostFor: (s) => `${lower(s)}.recruitee.com`,  buildUrl: (s) => `https://${lower(s)}.recruitee.com` },
+  breezy:          { id: 'breezy',          provider: breezy,          hostFor: (s) => `${lower(s)}.breezy.hr`,      buildUrl: (s) => `https://${lower(s)}.breezy.hr` },
+  bamboohr:        { id: 'bamboohr',        provider: bamboohr,        hostFor: (s) => `${lower(s)}.bamboohr.com`,   buildUrl: (s) => `https://${lower(s)}.bamboohr.com` },
+  pinpoint:        { id: 'pinpoint',        provider: pinpoint,        hostFor: (s) => `${lower(s)}.pinpointhq.com`, buildUrl: (s) => `https://${lower(s)}.pinpointhq.com` },
 };
 // Slug-resolvable vendors, probed in order for each company (first match wins).
-const VENDOR_ORDER = ['gh', 'ashby', 'lever'];
+// Probe order is also a cost decision. resolveCompany returns on the FIRST match,
+// so keeping the three highest-hit-rate vendors first means the common case still
+// costs the same three requests it always did, and the long tail is only paid for
+// by a company none of them could resolve. A company on no supported board now
+// costs one request per vendor before giving up, which is the honest price of the
+// extra coverage.
+const VENDOR_ORDER = ['gh', 'ashby', 'lever', 'workable', 'smartrecruiters', 'recruitee', 'bamboohr', 'breezy', 'pinpoint', 'rippling', 'join'];
 
 // Workday instance subdomains, most common first. Used only when the user gives
 // a tenant + site but no instance: we try each `<tenant>.<inst>.myworkdayjobs.com`
@@ -223,7 +256,11 @@ export function buildCandidateUrls(company, vendors = VENDOR_ORDER) {
     // new URL(...).hostname allowlist check.)
     let host;
     try { host = new URL(careers_url).hostname; } catch { host = null; }
-    if (host !== cfg.host) {
+    // Subdomain vendors derive their host from the slug, so the expected value is
+    // computed the same way rather than being a constant. The assertion itself is
+    // unchanged: whatever we are about to probe must be EXACTLY the host we meant.
+    const expected = cfg.hostFor ? cfg.hostFor(slug) : cfg.host;
+    if (host !== expected) {
       skipped.push(vendor);
       continue;
     }
@@ -647,10 +684,41 @@ function runSelfTest() {
 
   // buildCandidateUrls
   const b1 = buildCandidateUrls({ name: 'Adyen' });
-  check(b1.candidates.length === 3, 'buildCandidateUrls emits 3 candidates in vendor order');
+  // Counted off VENDOR_ORDER rather than a literal, so adding a vendor does not
+  // require editing an unrelated assertion.
+  check(b1.candidates.length === VENDOR_ORDER.length, 'buildCandidateUrls emits one candidate per vendor');
   check(b1.candidates[0].vendor === 'gh' && b1.candidates[0].careers_url === 'https://job-boards.greenhouse.io/adyen', 'buildCandidateUrls GH url');
+  // The three highest-hit-rate vendors stay first: resolveCompany returns on the
+  // first match, so this ordering is what keeps the common case at three requests.
+  check(b1.candidates.slice(0, 3).map((c) => c.vendor).join(',') === 'gh,ashby,lever', 'buildCandidateUrls probes the common vendors first');
   const b2 = buildCandidateUrls({ name: 'X', slug: 'bad/slug' });
-  check(b2.candidates.length === 0 && b2.skipped.length === 3, 'buildCandidateUrls SLUG_RE rejects unsafe slug (no URL built)');
+  check(b2.candidates.length === 0 && b2.skipped.length === VENDOR_ORDER.length, 'buildCandidateUrls SLUG_RE rejects unsafe slug (no URL built)');
+
+  // Long-tail vendors: path-style hosts are constant, subdomain-style hosts are
+  // derived from the slug, and every built URL must survive its own host assertion.
+  const byVendor = Object.fromEntries(b1.candidates.map((c) => [c.vendor, c.careers_url]));
+  check(byVendor.workable === 'https://apply.workable.com/adyen', 'buildCandidateUrls workable url');
+  check(byVendor.smartrecruiters === 'https://careers.smartrecruiters.com/adyen', 'buildCandidateUrls smartrecruiters url');
+  check(byVendor.rippling === 'https://ats.rippling.com/adyen/jobs', 'buildCandidateUrls rippling url');
+  check(byVendor.join === 'https://join.com/companies/adyen', 'buildCandidateUrls join url');
+  check(byVendor.recruitee === 'https://adyen.recruitee.com', 'buildCandidateUrls recruitee subdomain url');
+  check(byVendor.breezy === 'https://adyen.breezy.hr', 'buildCandidateUrls breezy subdomain url');
+  check(byVendor.bamboohr === 'https://adyen.bamboohr.com', 'buildCandidateUrls bamboohr subdomain url');
+  check(byVendor.pinpoint === 'https://adyen.pinpointhq.com', 'buildCandidateUrls pinpoint subdomain url');
+  // Every candidate must be accepted by its own provider's detect(), or the probe
+  // would report "no API URL derivable" instead of actually checking the board.
+  check(
+    b1.candidates.every((c) => !!VENDORS[c.vendor].provider.detect({ name: 'Adyen', careers_url: c.careers_url })),
+    'every built candidate URL is recognized by its provider detect()',
+  );
+  // Ashby boards are case-sensitive so slugs are not lowercased globally, but the
+  // subdomain vendors only match lowercase hosts. A mixed-case slug must still
+  // produce a probeable URL for them rather than being silently skipped.
+  const bMixed = buildCandidateUrls({ name: 'DeepL', slug: 'DeepL' });
+  const mixed = Object.fromEntries(bMixed.candidates.map((c) => [c.vendor, c.careers_url]));
+  check(mixed.ashby === 'https://jobs.ashbyhq.com/DeepL', 'buildCandidateUrls preserves slug case for Ashby');
+  check(mixed.recruitee === 'https://deepl.recruitee.com', 'buildCandidateUrls lowercases a subdomain host');
+  check(bMixed.skipped.length === 0, 'a mixed-case slug is not skipped by the host assertion');
   const b3 = buildCandidateUrls({ name: 'Adyen' }, ['ashby']);
   check(b3.candidates.length === 1 && b3.candidates[0].vendor === 'ashby', 'buildCandidateUrls honors vendor subset');
 

--- a/discover-ats.mjs
+++ b/discover-ats.mjs
@@ -100,12 +100,15 @@ const VENDORS = {
   pinpoint:        { id: 'pinpoint',        provider: pinpoint,        hostFor: (s) => `${lower(s)}.pinpointhq.com`, buildUrl: (s) => `https://${lower(s)}.pinpointhq.com` },
 };
 // Slug-resolvable vendors, probed in order for each company (first match wins).
-// Probe order is also a cost decision. resolveCompany returns on the FIRST match,
-// so keeping the three highest-hit-rate vendors first means the common case still
-// costs the same three requests it always did, and the long tail is only paid for
-// by a company none of them could resolve. A company on no supported board now
-// costs one request per vendor before giving up, which is the honest price of the
-// extra coverage.
+// Probe order is also a cost decision. resolveCompany probes candidates in this
+// order and returns on the FIRST match, so a resolvable company pays only for the
+// vendors ahead of its own: one probe on Greenhouse, two on Ashby, three on
+// Lever. Keeping the three highest-hit-rate vendors first therefore leaves every
+// company they can resolve costing exactly what it did before this list grew, and
+// the long tail is paid for only by a company none of the three could resolve.
+// A company on no supported board is the case that got more expensive: it now
+// probes every vendor before giving up, which is the honest price of the extra
+// coverage.
 const VENDOR_ORDER = ['gh', 'ashby', 'lever', 'workable', 'smartrecruiters', 'recruitee', 'bamboohr', 'breezy', 'pinpoint', 'rippling', 'join'];
 
 // Workday instance subdomains, most common first. Used only when the user gives
@@ -726,7 +729,8 @@ function runSelfTest() {
   check(b1.candidates.length === VENDOR_ORDER.length, 'buildCandidateUrls emits one candidate per vendor');
   check(b1.candidates[0].vendor === 'gh' && b1.candidates[0].careers_url === 'https://job-boards.greenhouse.io/adyen', 'buildCandidateUrls GH url');
   // The three highest-hit-rate vendors stay first: resolveCompany returns on the
-  // first match, so this ordering is what keeps the common case at three requests.
+  // first match, so this ordering is what caps a company they can resolve at
+  // three probes (one on gh, two on ashby, three on lever) rather than eleven.
   check(b1.candidates.slice(0, 3).map((c) => c.vendor).join(',') === 'gh,ashby,lever', 'buildCandidateUrls probes the common vendors first');
   const b2 = buildCandidateUrls({ name: 'X', slug: 'bad/slug' });
   check(b2.candidates.length === 0 && b2.skipped.length === VENDOR_ORDER.length, 'buildCandidateUrls SLUG_RE rejects unsafe slug (no URL built)');

--- a/discover-ats.mjs
+++ b/discover-ats.mjs
@@ -3,9 +3,9 @@
  * discover-ats.mjs — Company-list → scannable ATS board resolver for career-ops
  *
  * Takes a list of companies and resolves each to a scannable ATS board by
- * probing the public JSON APIs career-ops already supports (Greenhouse, Ashby,
- * Lever) via the existing providers/ layer — zero LLM tokens, zero auth. A
- * company "resolves" when a vendor's board exists AND currently lists ≥1 job.
+ * probing the public JSON APIs career-ops already supports (see VENDOR_ORDER)
+ * via the existing providers/ layer — zero LLM tokens, zero auth. A company
+ * "resolves" when a vendor's board exists AND currently lists ≥1 job.
  *
  * portals.yml is a USER-LAYER file, so by DEFAULT this command is preview-only:
  * it prints the entries it WOULD add (pendingEntries) and writes nothing. Pass
@@ -127,8 +127,10 @@ const USAGE = `Usage:
 portals.yml is a user-layer file: this command NEVER writes it unless you pass
 --write. The default previews the entries it would add (see pendingEntries).
 
-Vendors: gh, ashby, lever (resolve from a name/slug) and workday (resolves from
-a coordinate hint — a name alone can't locate a Workday site). Default: all four.
+Vendors: gh, ashby, lever, workable, smartrecruiters, recruitee, bamboohr,
+breezy, pinpoint, rippling, join (all resolve from a name/slug) and workday
+(resolves from a coordinate hint — a name alone can't locate a Workday site).
+Default: all of them, probed in that order, first match wins.
 
 Input YAML shape:
   companies:
@@ -231,15 +233,19 @@ export function parseCompanyInput(rawYaml, cliNames = []) {
  * Build the candidate {vendor, slug, careers_url} probes for one company.
  * SLUG_RE is enforced before every interpolation — the SSRF choke point.
  * A vendor whose slug fails the guard is skipped (recorded in `skipped`).
+ * A vendor that CAN'T represent this slug at all — the URL is well-formed and
+ * on the right host, but the provider's own contract rejects its shape — is
+ * recorded in `unsupported` and never becomes a candidate (see below).
  *
  * @param {{name:string, slug?:string}} company
  * @param {string[]} [vendors]  Subset of VENDOR_ORDER.
- * @returns {{candidates: {vendor:string, slug:string, careers_url:string}[], skipped: string[]}}
+ * @returns {{candidates: {vendor:string, slug:string, careers_url:string}[], skipped: string[], unsupported: string[]}}
  */
 export function buildCandidateUrls(company, vendors = VENDOR_ORDER) {
   const slug = company.slug || deriveSlug(company.name);
   const candidates = [];
   const skipped = [];
+  const unsupported = [];
   for (const vendor of vendors) {
     const cfg = VENDORS[vendor];
     if (!cfg) continue;
@@ -264,9 +270,30 @@ export function buildCandidateUrls(company, vendors = VENDOR_ORDER) {
       skipped.push(vendor);
       continue;
     }
+    // Last gate, and the only one that knows each vendor's REAL slug contract:
+    // ask the provider itself whether it can derive an API URL from this URL.
+    // detect() is pure and local (a URL parse, no network, no side effects).
+    //
+    // The host assertion above can't catch this: `expected` is built by the same
+    // concatenation as the URL, so for a subdomain vendor a dotted slug like
+    // `foo.bar` yields host === expected === `foo.bar.bamboohr.com` and sails
+    // through — the suffix is always appended, so nothing escapes the vendor
+    // domain (no SSRF), but that host cannot exist. Every subdomain provider
+    // pins a SINGLE tenant label (`^[a-z0-9][a-z0-9-]*\.bamboohr\.com$`), and
+    // several path vendors have their own slug shape too, so their detect()
+    // returns null. Left in, such a candidate is recorded as a probe ERROR
+    // ("no API URL derivable") indistinguishable from a transient network
+    // failure, which drags resolveCompany's reason to "board status unknown —
+    // re-run" and invites a retry that can never succeed. Deriving the rule from
+    // the provider rather than re-declaring a slug regex here means the
+    // discovery guard and the provider contract cannot drift apart.
+    if (!cfg.provider.detect({ name: company.name, careers_url })) {
+      unsupported.push(vendor);
+      continue;
+    }
     candidates.push({ vendor, slug, careers_url });
   }
-  return { candidates, skipped };
+  return { candidates, skipped, unsupported };
 }
 
 // Coordinate token guard — tenant/instance/site segments interpolated into a
@@ -522,7 +549,7 @@ export async function resolveWorkday(company, coords, ctx) {
  * probe Workday. Returns either a resolved record or an unresolved record.
  */
 export async function resolveCompany(company, { vendors = VENDOR_ORDER, ctx, includeWorkday = true } = {}) {
-  const { candidates, skipped } = buildCandidateUrls(company, vendors);
+  const { candidates, skipped, unsupported } = buildCandidateUrls(company, vendors);
   const triedVendors = [];
   const emptyBoards = [];
   const errors = [];
@@ -585,13 +612,23 @@ export async function resolveCompany(company, { vendors = VENDOR_ORDER, ctx, inc
         ? 'Workday hint given but rejected (invalid/missing tenant or site) — check the `workday` field and re-run'
         : coords
           ? 'Workday coordinates given but no live board with open jobs found at the probed host(s).'
-          : 'no Greenhouse/Ashby/Lever board found. If this company uses Workday, add a hint — '
-            + 'a full careers URL (workday: https://<tenant>.wd<N>.myworkdayjobs.com/<site>) or '
-            + 'workday: {tenant, site} — and re-run; discover-ats will confirm and add it.';
+          // Nothing was probeable: every vendor's own contract rejected this
+          // slug's shape, so no board was ruled out — say that, rather than
+          // implying we looked and found nothing.
+          : (!candidates.length && unsupported.length)
+            ? `slug "${company.slug || deriveSlug(company.name)}" is not a valid board slug for any probed vendor `
+              + `(${unsupported.join(', ')}) — nothing was probed; fix the \`slug\` field and re-run.`
+            // VENDOR_ORDER covers eleven vendors now, so name none of them here.
+            : 'no supported ATS board found. If this company uses Workday, add a hint — '
+              + 'a full careers URL (workday: https://<tenant>.wd<N>.myworkdayjobs.com/<site>) or '
+              + 'workday: {tenant, site} — and re-run; discover-ats will confirm and add it.';
 
   /** @type {any} */
   const unresolved = { name: company.name, triedVendors, reason };
   if (skipped.length) unresolved.skippedUnsafeSlug = skipped;
+  // Well-formed URL on the right host, but the vendor's own slug contract
+  // rejects its shape — reported separately so it isn't read as a probe failure.
+  if (unsupported.length) unresolved.unsupportedSlugShape = unsupported;
   if (emptyBoards.length) unresolved.emptyBoards = emptyBoards;
   if (errors.length) unresolved.errors = errors;
   if (company.website) unresolved.website = company.website;
@@ -719,6 +756,39 @@ function runSelfTest() {
   check(mixed.ashby === 'https://jobs.ashbyhq.com/DeepL', 'buildCandidateUrls preserves slug case for Ashby');
   check(mixed.recruitee === 'https://deepl.recruitee.com', 'buildCandidateUrls lowercases a subdomain host');
   check(bMixed.skipped.length === 0, 'a mixed-case slug is not skipped by the host assertion');
+
+  // Dotted slug. SLUG_RE allows dots (path vendors accept them), but a subdomain
+  // vendor turns `foo.bar` into `foo.bar.bamboohr.com` — two tenant labels, which
+  // every subdomain provider's `<tenant>.<vendor>` regex rejects. The host
+  // assertion can't catch it (expected is built by the same concatenation), so
+  // the provider-contract gate is what keeps it out of the probe loop.
+  const SUBDOMAIN_VENDORS = ['recruitee', 'breezy', 'bamboohr', 'pinpoint'];
+  const bDot = buildCandidateUrls({ name: 'X', slug: 'foo.bar' });
+  const dotCandidates = new Set(bDot.candidates.map((c) => c.vendor));
+  check(
+    SUBDOMAIN_VENDORS.every((v) => !dotCandidates.has(v) && bDot.unsupported.includes(v)),
+    'a dotted slug is unsupported for every subdomain vendor, never a candidate',
+  );
+  check(bDot.skipped.length === 0, 'a dotted slug is an unsupported shape, not an unsafe-slug skip');
+  check(
+    bDot.candidates.length > 0
+      && bDot.candidates.every((c) => !!VENDORS[c.vendor].provider.detect({ name: 'X', careers_url: c.careers_url })),
+    'a dotted slug still probes the vendors whose contract accepts it',
+  );
+  // The security property, asserted rather than argued: buildUrl always appends
+  // the vendor suffix, so no slug can move the host off the vendor's own domain.
+  // A dotted slug is a wasted-probe/reporting problem, not an SSRF one.
+  const SUBDOMAIN_SUFFIX = {
+    recruitee: '.recruitee.com', breezy: '.breezy.hr', bamboohr: '.bamboohr.com', pinpoint: '.pinpointhq.com',
+  };
+  let offDomain = 0;
+  for (const s of ['foo.bar', 'evil.com', 'a.b.c.d', '..evil.com', 'x.bamboohr.com', '169.254.169.254']) {
+    for (const c of buildCandidateUrls({ name: 'X', slug: s }, SUBDOMAIN_VENDORS).candidates) {
+      if (!new URL(c.careers_url).hostname.endsWith(SUBDOMAIN_SUFFIX[c.vendor])) offDomain += 1;
+    }
+  }
+  check(offDomain === 0, 'no slug can move a subdomain-vendor host off the vendor domain');
+
   const b3 = buildCandidateUrls({ name: 'Adyen' }, ['ashby']);
   check(b3.candidates.length === 1 && b3.candidates[0].vendor === 'ashby', 'buildCandidateUrls honors vendor subset');
 

--- a/discover-ats.test.mjs
+++ b/discover-ats.test.mjs
@@ -111,14 +111,17 @@ ok('non-list doc → warning about companies key', p9.warnings.some(w => w.inclu
 console.log('\n--- 3. buildCandidateUrls ---');
 
 const b1 = buildCandidateUrls({ name: 'Adyen' });
-eq('3 candidates in vendor order', b1.candidates.map(c => c.vendor), ['gh', 'ashby', 'lever']);
+// The three highest-hit-rate vendors must stay FIRST: resolveCompany returns on
+// the first match, so this ordering is what keeps a common company at three
+// requests even though the long tail is now probed too.
+eq('common vendors probed first', b1.candidates.slice(0, 3).map(c => c.vendor), ['gh', 'ashby', 'lever']);
 eq('GH careers_url', b1.candidates[0].careers_url, 'https://job-boards.greenhouse.io/adyen');
 eq('Ashby careers_url', b1.candidates[1].careers_url, 'https://jobs.ashbyhq.com/adyen');
 eq('Lever careers_url', b1.candidates[2].careers_url, 'https://jobs.lever.co/adyen');
 
 const b2 = buildCandidateUrls({ name: 'X', slug: 'bad/slug' });
 eq('unsafe slug builds NO candidate URLs (SSRF guard)', b2.candidates.length, 0);
-eq('unsafe slug records all vendors as skipped', b2.skipped, ['gh', 'ashby', 'lever']);
+eq('unsafe slug records every vendor as skipped', b2.skipped.length, b1.candidates.length);
 
 const b2b = buildCandidateUrls({ name: 'X', slug: 'has space' });
 eq('slug with space rejected', b2b.candidates.length, 0);

--- a/discover-ats.test.mjs
+++ b/discover-ats.test.mjs
@@ -4,7 +4,8 @@
  * Tests the pure, network-free functions with inline fixtures:
  * - deriveSlug (lowercasing, punctuation, edge cases)
  * - parseCompanyInput (shape, bare-name merge, malformed YAML, dedup, drops)
- * - buildCandidateUrls (vendor order, subset, SLUG_RE rejection, explicit slug)
+ * - buildCandidateUrls (vendor order, subset, SLUG_RE rejection, explicit slug,
+ *   dotted slugs vs subdomain vendors, host-never-leaves-vendor-domain)
  * - yamlScalar / renderPortalEntry (GH api line, quoting)
  * - dedupeAgainstPortals (name/url/api hits, trailing-slash norm, self-dedup)
  * - insertIntoTrackedCompanies (splice correctness, byte-preservation, empty
@@ -131,6 +132,36 @@ eq('honors vendor subset', b3.candidates.map(c => c.vendor), ['ashby']);
 
 const b4 = buildCandidateUrls({ name: 'Some Co', slug: 'DeepL' });
 eq('explicit mixed-case slug preserved', b4.candidates[1].careers_url, 'https://jobs.ashbyhq.com/DeepL');
+
+// --- dotted slugs vs subdomain vendors -------------------------------------
+// SLUG_RE allows dots and path vendors accept them, but a subdomain vendor
+// interpolates the slug into the HOSTNAME: `foo.bar` → `foo.bar.bamboohr.com`,
+// two tenant labels, which every subdomain provider's `<tenant>.<vendor>` regex
+// rejects. The host assertion cannot catch this (the expected host is built by
+// the same concatenation), so buildCandidateUrls asks the provider itself.
+const SUBDOMAIN_VENDORS = ['recruitee', 'breezy', 'bamboohr', 'pinpoint'];
+const bDot = buildCandidateUrls({ name: 'X', slug: 'foo.bar' });
+const dotCandidates = bDot.candidates.map(c => c.vendor);
+for (const v of SUBDOMAIN_VENDORS) {
+  ok(`dotted slug is not a ${v} candidate`, !dotCandidates.includes(v));
+  ok(`dotted slug reported unsupported for ${v}`, bDot.unsupported.includes(v));
+}
+eq('dotted slug is an unsupported shape, not an unsafe-slug skip', bDot.skipped, []);
+ok('dotted slug still probes the vendors whose contract accepts it', bDot.candidates.length > 0);
+
+// The security property, asserted rather than argued: buildUrl always appends the
+// vendor suffix, so no slug can move the host off the vendor's own domain. A
+// dotted slug is a wasted-probe/reporting problem, not an SSRF one.
+const SUBDOMAIN_SUFFIX = {
+  recruitee: '.recruitee.com', breezy: '.breezy.hr', bamboohr: '.bamboohr.com', pinpoint: '.pinpointhq.com',
+};
+const offDomain = [];
+for (const s of ['foo.bar', 'evil.com', 'a.b.c.d', '..evil.com', 'x.bamboohr.com', '169.254.169.254', 'localhost']) {
+  for (const c of buildCandidateUrls({ name: 'X', slug: s }, SUBDOMAIN_VENDORS).candidates) {
+    if (!new URL(c.careers_url).hostname.endsWith(SUBDOMAIN_SUFFIX[c.vendor])) offDomain.push(c.careers_url);
+  }
+}
+eq('no slug moves a subdomain-vendor host off the vendor domain', offDomain, []);
 
 // ============================================================================
 // 4. yamlScalar / renderPortalEntry
@@ -280,6 +311,18 @@ ok('workday entry has no api line', !wdRender.includes('api:'));
 const noWd = await resolveCompany({ name: 'Whatever', slug: 'bad/slug' }, { vendors: [], includeWorkday: false });
 ok('resolveCompany no-vendor no-workday → unresolved', !!noWd.unresolved);
 ok('resolveCompany unresolved names workday hint path', /Workday/.test(noWd.unresolved.reason));
+// VENDOR_ORDER probes eleven vendors now, so the fallback must not name three of
+// them as if they were the whole list.
+ok('fallback reason is provider-neutral', !/Greenhouse|Ashby|Lever/i.test(noWd.unresolved.reason));
+
+// A slug no vendor's contract can represent must be reported as such — NOT as a
+// probe error, which would read as transient and invite a pointless re-run.
+// Subdomain vendors only → nothing is probeable → network-free.
+const dotResolve = await resolveCompany({ name: 'X', slug: 'foo.bar' }, { vendors: SUBDOMAIN_VENDORS, includeWorkday: false });
+eq('dotted slug → nothing tried', dotResolve.unresolved.triedVendors, []);
+eq('dotted slug → reported as unsupported shape', dotResolve.unresolved.unsupportedSlugShape, SUBDOMAIN_VENDORS);
+ok('dotted slug → no probe errors recorded', !dotResolve.unresolved.errors);
+ok('dotted slug → reason says the slug is invalid, not that a board is missing', /not a valid board slug/i.test(dotResolve.unresolved.reason));
 
 // A rejected Workday hint (bad tenant/site) must produce a "fix your hint" reason,
 // NOT the "add a hint" message. No slug vendors → network-free.

--- a/discover-ats.test.mjs
+++ b/discover-ats.test.mjs
@@ -113,8 +113,9 @@ console.log('\n--- 3. buildCandidateUrls ---');
 
 const b1 = buildCandidateUrls({ name: 'Adyen' });
 // The three highest-hit-rate vendors must stay FIRST: resolveCompany returns on
-// the first match, so this ordering is what keeps a common company at three
-// requests even though the long tail is now probed too.
+// the first match, so this ordering is what caps a company they can resolve at
+// three probes (one on gh, two on ashby, three on lever) even though the long
+// tail is now probed too.
 eq('common vendors probed first', b1.candidates.slice(0, 3).map(c => c.vendor), ['gh', 'ashby', 'lever']);
 eq('GH careers_url', b1.candidates[0].careers_url, 'https://job-boards.greenhouse.io/adyen');
 eq('Ashby careers_url', b1.candidates[1].careers_url, 'https://jobs.ashbyhq.com/adyen');

--- a/modes/discover.md
+++ b/modes/discover.md
@@ -72,7 +72,9 @@ Vendor keywords for `--vendors`: `gh`, `ashby`, `lever`, `workable`,
 `smartrecruiters`, `recruitee`, `bamboohr`, `breezy`, `pinpoint`, `rippling`,
 `join` (all slug-resolvable) and `workday` (fires only for companies carrying a
 hint). Default is all of them; `gh`, `ashby` and `lever` are probed first and the
-first match wins, so a common company still costs three requests.
+first match wins, so a company on one of them is resolved within at most three
+probes (one on `gh`, two on `ashby`, three on `lever`) before any long-tail
+vendor is tried. Only a company none of the three can resolve pays for the rest.
 
 Parse the JSON envelope:
 

--- a/modes/discover.md
+++ b/modes/discover.md
@@ -68,8 +68,11 @@ node discover-ats.mjs --in companies.yml --vendors gh,ashby  # restrict probes
 node discover-ats.mjs --in companies.yml --vendors workday   # Workday only
 ```
 
-Vendor keywords for `--vendors`: `gh`, `ashby`, `lever` (slug-resolvable) and
-`workday` (fires only for companies carrying a hint). Default is all four.
+Vendor keywords for `--vendors`: `gh`, `ashby`, `lever`, `workable`,
+`smartrecruiters`, `recruitee`, `bamboohr`, `breezy`, `pinpoint`, `rippling`,
+`join` (all slug-resolvable) and `workday` (fires only for companies carrying a
+hint). Default is all of them; `gh`, `ashby` and `lever` are probed first and the
+first match wins, so a common company still costs three requests.
 
 Parse the JSON envelope:
 
@@ -77,7 +80,7 @@ Parse the JSON envelope:
 |-----|----------|
 | `metadata` | Counts (`resolved`, `unresolved`, `duplicatesSkipped`, `fresh`, `freshWritten`), `written` flag, `previewOnly`, `portalsPath`, `warnings` |
 | `resolved` | Per company: `name`, `vendor`, `slug`, `careers_url`, `api` (Greenhouse only), `provider` (Workday only), `jobCount` |
-| `unresolved` | Per company: `name`, `triedVendors`, `reason`, and (when present) `emptyBoards`, `errors`, `skippedUnsafeSlug`, `website` |
+| `unresolved` | Per company: `name`, `triedVendors`, `reason`, and (when present) `emptyBoards`, `errors`, `skippedUnsafeSlug`, `unsupportedSlugShape`, `website` |
 | `pendingEntries` | The rendered YAML block — present whenever nothing was written (i.e. on a preview run, the default) so the user can paste it manually |
 
 **Default is preview.** Always show the user the `pendingEntries` / resolved
@@ -97,6 +100,11 @@ careers_url) and the unresolved list with reasons. Call out:
   a `workday:` hint, then re-run. discover-ats confirms it live and adds it — no
   manual portals.yml editing. If you have the tenant + site but not the instance,
   give `workday: {tenant, site}` and the instance is auto-probed.
+- **Unsupported slug shape** (`unsupportedSlugShape`): the slug is safe but the
+  listed vendors' own contracts can't represent it, so they were never probed.
+  Most often a dotted slug (`foo.bar`): the subdomain vendors (recruitee,
+  bamboohr, breezy, pinpoint) put the slug in the hostname and accept exactly one
+  tenant label. Fix the `slug:` field rather than re-running unchanged.
 - **camelCase Ashby slugs** (e.g. `DeepL`, `AlephAlpha`): if a company you know
   is on Ashby came back unresolved, its slug is likely mixed-case — re-run with
   an explicit `slug:` in the input file (derived slugs are lowercased).


### PR DESCRIPTION
## What does this PR do?

`discover-ats` only ever probed Greenhouse, Ashby and Lever, so a company on any other board came back unresolved even though the provider module for its board already ships in `providers/`. This wires eight of those existing providers into the vendor table: Workable, SmartRecruiters, Rippling, JOIN, Recruitee, Breezy, BambooHR and Pinpoint.

No new provider code, no new dependency, no new auth. Only `discover-ats.mjs` and its two test suites change.

## Related issue

None. This is provider coverage over modules already in the repo, which CONTRIBUTING lists as send-straight-in. Happy to open an issue first if you would rather route it that way.

## Two things the existing table could not express

**Subdomain vendors.** Recruitee, Breezy, BambooHR and Pinpoint put the company in the hostname, so the host `buildCandidateUrls` asserts against is slug-dependent. Those entries supply `hostFor(slug)` instead of a constant `host`; the assertion itself is unchanged, it just compares against a computed expectation rather than a literal. Their providers match lowercase hosts only, so their `buildUrl` lowercases the slug. Slugs are still not lowercased globally, because Ashby boards are case-sensitive.

**Probe order is a cost decision.** `resolveCompany` returns on the first match, so `VENDOR_ORDER` keeps `gh, ashby, lever` first: a company on one of them still costs the same three requests it always did. The long tail is paid for only by a company none of them could resolve, and a company on no supported board costs one request per vendor before giving up. That is the honest price of the extra coverage, and it is the case that was already failing.

## Tests

Both suites now assert the built URL per vendor, and:

- every candidate URL is accepted by its own provider's `detect()` - otherwise a probe reports "no API URL derivable" instead of actually checking the board, which would make this look like coverage without being coverage;
- a mixed-case slug still produces a probeable URL for the subdomain vendors while staying verbatim for Ashby;
- `gh, ashby, lever` are still probed first, so the ordering that keeps the common case cheap is pinned rather than assumed.

Candidate-count assertions now derive from `VENDOR_ORDER` instead of the literal `3`, so adding a vendor no longer means editing an unrelated assertion.

- `node discover-ats.mjs --self-test` -> 46 passed, 0 failed
- `node discover-ats.test.mjs` -> 106 passed, 0 failed

## Type of change

- [ ] Bug fix
- [x] New feature (provider coverage over existing modules)
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] Provider coverage - see the note under "Related issue"
- [x] My PR does not include personal data
- [x] I ran the affected suites and all tests pass
- [x] My changes respect the Data Contract (system-layer files only)
- [x] My changes align with the project roadmap


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded ATS detection from three to eleven slug-based providers.
  * Improved recognition of mixed-case identifiers and subdomain-based hosting.
  * Added clearer reporting for unsupported slug formats and unresolved results.
  * Enhanced candidate URL generation with consistent provider ordering and safer host handling.

* **Bug Fixes**
  * Improved validation for invalid, unsafe, and unsupported vendor identifiers.
  * Improved error messaging and documentation for vendor support and probe behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->