### PR TITLE
feat(web): choose which tab the Pipeline page opens on

### DIFF
--- a/config/profile.example.yml
+++ b/config/profile.example.yml
@@ -290,3 +290,15 @@ cover_letter:
 #     cross_role_bucket: "all_EM_roles"
 #     applied_to: ["Senior Software Engineer"]
 #     last_apply_date: "2026-01-01"
+
+# ---------------------------------------------------------------------------
+# WEB APP VIEW PREFERENCES (optional, set from Config in the web app)
+# ---------------------------------------------------------------------------
+#
+#   default_pipeline_tab: which tab the Pipeline page opens on when the URL
+#                         names none. One of INBOX, ALL, EVALUATED, APPLIED,
+#                         RESPONDED, INTERVIEW, OFFER, HIRED, REJECTED,
+#                         DISCARDED, SKIP. Default (key absent): INBOX.
+#
+# web:
+#   default_pipeline_tab: INBOX

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -13982,8 +13982,11 @@ try {
   const webStatusLists = [
     { file: 'web/src/lib/format.ts', re: /CANONICAL_STATES\s*=\s*\[([\s\S]*?)\]/, upper: false, exclude: [] },
     { file: 'web/src/app/actions/registry.ts', re: /CANON_STATUS\s*=\s*\[([\s\S]*?)\]/, upper: false, exclude: [] },
-    { file: 'web/src/app/actions/registry.ts', re: /TAB_VALUES\s*=\s*\[([\s\S]*?)\]/, upper: true, exclude: [] },
-    { file: 'web/src/components/pipeline-view.tsx', re: /TABS\s*=\s*\[([\s\S]*?)\]/, upper: true, exclude: [] },
+    // registry.ts's TAB_VALUES and pipeline-view.tsx's TABS used to be two
+    // literal copies checked separately. They now both alias PIPELINE_TABS, so
+    // the one shared list is what this has to read — checking the aliases would
+    // match an empty block and report every state as missing.
+    { file: 'web/src/lib/pipeline-tabs.mjs', re: /PIPELINE_TABS\s*=\s*\[([\s\S]*?)\]/, upper: true, exclude: [] },
     { file: 'web/src/app/analytics/page.tsx', re: /STAGES[^=]*=\s*\[([\s\S]*?)\];/, upper: true, exclude: ['SKIP'] },
     // The states ACL used to be checked here too. It moved to its own block
     // below, because it now has TWO valid shapes and this table only knows one.
@@ -14003,6 +14006,22 @@ try {
       pass('every web status list covers all canonical states from states.yml (#2249)');
     } else {
       fail(`web status list(s) missing canonical state(s) — dashboard can't set/count them (#2249): ${drift.join(' | ')}`);
+    }
+
+    // Reading the shared list only proves the dashboard's tabs when the tab
+    // consumers actually read it too. Without this, a re-added local literal
+    // would drop out of coverage silently and #2249 could recur unseen.
+    const tabConsumers = ['web/src/app/actions/registry.ts', 'web/src/components/pipeline-view.tsx'];
+    const detached = tabConsumers.filter((f) => {
+      const p = join(ROOT, f);
+      // \b both sides: a substring test would accept a PIPELINE_TABS_LEGACY
+      // local copy as if it were the shared import.
+      return existsSync(p) && !/\bPIPELINE_TABS\b/.test(readFileSync(p, 'utf-8'));
+    });
+    if (detached.length === 0) {
+      pass('both pipeline tab consumers read the shared PIPELINE_TABS list (#2249)');
+    } else {
+      fail(`pipeline tab consumer(s) no longer read PIPELINE_TABS — their tabs are unchecked: ${detached.join(', ')}`);
     }
 
     // 55.3b+ the degraded-path FALLBACK in the states ACL (career-ops-ui's

--- a/web/src/app/actions/registry.ts
+++ b/web/src/app/actions/registry.ts
@@ -11,6 +11,7 @@
 import type { Application, InboxJob } from "@/lib/career-ops";
 import type { Job } from "@/components/jobs/job-store";
 import { normalizeTextKey } from "@/lib/core/normalize-text-key.mjs";
+import { PIPELINE_TABS } from "@/lib/pipeline-tabs.mjs";
 
 export const AUTO_FIRE_MAX = 3; // fire ≤3 evaluations silently; confirm above that
 export const BATCH_CAP = 12; // hard ceiling on a single fan-out
@@ -18,9 +19,8 @@ export const BATCH_CAP = 12; // hard ceiling on a single fan-out
 // Canonical states (templates/states.yml) — the web validates against the same set.
 const CANON_STATUS = ["Evaluated", "Applied", "Responded", "Interview", "Offer", "Hired", "Rejected", "Discarded", "SKIP"];
 
-const TAB_VALUES = [
-  "INBOX", "ALL", "EVALUATED", "APPLIED", "RESPONDED", "INTERVIEW", "OFFER", "HIRED", "REJECTED", "DISCARDED", "SKIP",
-] as const;
+// Pipeline tabs: the same list the tab strip renders (lib/pipeline-tabs.mjs).
+const TAB_VALUES = PIPELINE_TABS;
 const SORT_VALUES = ["company", "role", "score", "status", "date"] as const;
 
 export type StartJobInput = {

--- a/web/src/app/api/pipeline/default-tab/route.ts
+++ b/web/src/app/api/pipeline/default-tab/route.ts
@@ -1,0 +1,31 @@
+import { normalizePipelineTab } from "@/lib/pipeline-tabs.mjs";
+import { readDefaultPipelineTab, writeDefaultPipelineTab } from "@/lib/web-prefs";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// The Pipeline page's default tab → config/profile.yml (`web.default_pipeline_tab`).
+// GET  → the current default (INBOX when unset)
+// POST {tab} → set it. Validated against the canonical tab list, so only a tab
+// that actually exists can ever be written.
+
+export async function GET() {
+  return Response.json({ tab: readDefaultPipelineTab() });
+}
+
+export async function POST(req: Request) {
+  let body: { tab?: unknown };
+  try {
+    body = (await req.json()) as { tab?: unknown };
+  } catch {
+    return Response.json({ error: "bad json" }, { status: 400 });
+  }
+  const tab = normalizePipelineTab(body.tab);
+  if (!tab) return Response.json({ error: "unknown tab" }, { status: 400 });
+  try {
+    writeDefaultPipelineTab(tab);
+  } catch (e) {
+    return Response.json({ error: e instanceof Error ? e.message : "write failed" }, { status: 500 });
+  }
+  return Response.json({ ok: true, tab });
+}

--- a/web/src/app/pipeline/page.tsx
+++ b/web/src/app/pipeline/page.tsx
@@ -1,14 +1,16 @@
 import { Suspense } from "react";
 import { pipelineSummary } from "@/lib/career-ops";
 import { PipelineView } from "@/components/pipeline-view";
+import { readDefaultPipelineTab } from "@/lib/web-prefs";
 
 export const dynamic = "force-dynamic"; // always read fresh local files
 
 export default function PipelinePage() {
   const { inbox, applications } = pipelineSummary();
+  // Read here (not in the client) so the landing tab is right on first paint.
   return (
     <Suspense>
-      <PipelineView applications={applications} inbox={inbox} />
+      <PipelineView applications={applications} inbox={inbox} defaultTab={readDefaultPipelineTab()} />
     </Suspense>
   );
 }

--- a/web/src/components/config-form.tsx
+++ b/web/src/components/config-form.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/cn";
 import { CadenceSettings } from "@/components/followups/cadence-settings";
+import { DefaultTabSetting } from "@/components/pipeline/default-tab-setting";
 
 type Cli = {
   id: string;
@@ -291,6 +292,8 @@ export function ConfigForm() {
           />
         </span>
       </button>
+
+      <DefaultTabSetting />
 
       <CadenceSettings />
 

--- a/web/src/components/pipeline-view.tsx
+++ b/web/src/components/pipeline-view.tsx
@@ -10,22 +10,18 @@ import { CompanyLogo } from "@/components/company-logo";
 import { canonStatus, scoreNum, scoreTone, statusDot } from "@/lib/format";
 import { InboxTriage } from "@/components/inbox/inbox-triage";
 import { cn } from "@/lib/cn";
+import {
+  FALLBACK_PIPELINE_TAB,
+  PIPELINE_TABS,
+  normalizePipelineTab,
+  type PipelineTab,
+} from "@/lib/pipeline-tabs.mjs";
 
-// INBOX (the triage queue) is the default tab; the rest filter the tracker.
-const TABS = [
-  "INBOX",
-  "ALL",
-  "EVALUATED",
-  "APPLIED",
-  "RESPONDED",
-  "INTERVIEW",
-  "OFFER",
-  "HIRED",
-  "REJECTED",
-  "DISCARDED",
-  "SKIP",
-] as const;
-type Tab = (typeof TABS)[number];
+// INBOX (the triage queue) through SKIP — the canonical list lives in
+// pipeline-tabs.mjs so the Config page's default-tab dropdown offers exactly the
+// tabs this strip renders.
+const TABS = PIPELINE_TABS;
+type Tab = PipelineTab;
 
 const SORT_KEYS = ["company", "role", "score", "status", "date"] as const;
 type SortKey = (typeof SORT_KEYS)[number];
@@ -33,9 +29,13 @@ type SortKey = (typeof SORT_KEYS)[number];
 export function PipelineView({
   applications,
   inbox,
+  defaultTab = FALLBACK_PIPELINE_TAB,
 }: {
   applications: Application[];
   inbox: InboxJob[];
+  /** The user's Config-page default, resolved on the server so the first paint
+   *  is already the right tab (no post-hydration swap). */
+  defaultTab?: Tab;
 }) {
   const params = useSearchParams();
   const router = useRouter();
@@ -44,8 +44,9 @@ export function PipelineView({
   // The URL is the SINGLE source of truth for tab/min/sort/dir, so the home stat
   // tiles' deep links AND the assistant's filterPipeline/navigate actions drive
   // the table identically (no useState mirror → no desync).
-  const pTab = (params.get("tab") ?? "").toUpperCase();
-  const tab: Tab = (TABS as readonly string[]).includes(pTab) ? (pTab as Tab) : "INBOX";
+  // No `tab` in the URL means "wherever the user chose to land" (Config →
+  // Pipeline → Default tab), not INBOX.
+  const tab: Tab = normalizePipelineTab(params.get("tab")) ?? defaultTab;
   const pMin = parseFloat(params.get("min") ?? "");
   const minFilter: number | null = Number.isFinite(pMin) ? pMin : null;
   const pSort = params.get("sort") ?? "";
@@ -140,7 +141,9 @@ export function PipelineView({
         )}
       </div>
 
-      {/* tabs */}
+      {/* tabs. The clicked tab is always written to the URL, INBOX included:
+          clearing the param would hand the choice back to the saved default, so
+          a user whose default is ALL could never click into INBOX. */}
       <div className="mt-6 flex flex-wrap gap-1 border-b border-border">
         {TABS.map((t) => {
           const count =
@@ -152,7 +155,7 @@ export function PipelineView({
           return (
             <button
               key={t}
-              onClick={() => setParams({ tab: t === "INBOX" ? null : t })}
+              onClick={() => setParams({ tab: t })}
               className={cn(
                 "-mb-px inline-flex items-center justify-center border-b-2 px-3 py-2 text-xs font-medium transition-colors max-sm:min-h-[44px]",
                 tab === t

--- a/web/src/components/pipeline/default-tab-setting.tsx
+++ b/web/src/components/pipeline/default-tab-setting.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Check, Loader2 } from "lucide-react";
+import { PIPELINE_TABS, type PipelineTab } from "@/lib/pipeline-tabs.mjs";
+import { cn } from "@/lib/cn";
+
+// Which Pipeline tab opens by default → config/profile.yml (web.default_pipeline_tab).
+// Server-persisted (unlike the localStorage engine prefs) because the Pipeline
+// page is server-rendered: reading it there is what keeps the first paint from
+// showing INBOX and then swapping tabs.
+
+const LABELS: Partial<Record<PipelineTab, string>> = {
+  INBOX: "Inbox (triage queue)",
+  ALL: "All (everything tracked)",
+};
+
+export function DefaultTabSetting() {
+  const [tab, setTab] = useState<PipelineTab | null>(null);
+  const [loadError, setLoadError] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // On a failed load do NOT preselect a value: a Save would then write a default
+  // the user never chose over the one they already have.
+  const load = useCallback(() => {
+    setLoadError(false);
+    fetch("/api/pipeline/default-tab")
+      .then((r) => {
+        if (!r.ok) throw new Error(String(r.status));
+        return r.json();
+      })
+      .then((d) => setTab(d?.tab as PipelineTab))
+      .catch(() => setLoadError(true));
+  }, []);
+  useEffect(load, [load]);
+
+  const save = async () => {
+    if (!tab) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/pipeline/default-tab", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ tab }),
+      });
+      const j = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(typeof j.error === "string" ? j.error : "Could not save.");
+      } else {
+        setSaved(true);
+        setTimeout(() => setSaved(false), 2000);
+      }
+    } catch {
+      setError("Could not save.");
+    }
+    setSaving(false);
+  };
+
+  return (
+    <div>
+      <label className="mt-8 mb-2 block text-xs font-semibold uppercase tracking-[0.18em] text-muted">
+        Pipeline
+      </label>
+      <div className="rounded-xl border border-border bg-surface/50 p-4">
+        <p className="text-sm font-medium text-foreground">Default tab</p>
+        <p className="mt-0.5 text-xs leading-relaxed text-faint">
+          Which tab the <span className="text-muted">Pipeline</span> page opens on. Saved to{" "}
+          <span className="font-mono text-muted">config/profile.yml</span>.
+        </p>
+        {loadError ? (
+          <div className="mt-3 text-sm text-muted">
+            <p className="text-red-500">Couldn&apos;t read your current default tab.</p>
+            <button
+              type="button"
+              onClick={load}
+              className="mt-2 rounded-md border border-border bg-surface px-3 py-1.5 text-xs font-medium transition-colors hover:bg-surface-hover"
+            >
+              Retry
+            </button>
+          </div>
+        ) : tab === null ? (
+          <div className="mt-3 flex items-center gap-2 text-sm text-muted">
+            <Loader2 className="size-4 animate-spin" /> Loading…
+          </div>
+        ) : (
+          <>
+            <select
+              aria-label="Default pipeline tab"
+              value={tab}
+              onChange={(e) => setTab(e.target.value as PipelineTab)}
+              className="mt-3 rounded-md border border-border bg-surface/60 px-3 py-1.5 text-sm outline-none transition-colors focus:border-brand/50 focus-visible:ring-2 focus-visible:ring-brand/40 max-sm:min-h-[44px]"
+            >
+              {PIPELINE_TABS.map((t) => (
+                <option key={t} value={t}>
+                  {LABELS[t] ?? t}
+                </option>
+              ))}
+            </select>
+            {error && <p className="mt-3 text-xs text-red-500">{error}</p>}
+            <div>
+              <button
+                type="button"
+                onClick={save}
+                disabled={saving}
+                className={cn(
+                  "mt-4 inline-flex items-center gap-2 rounded-md border border-border bg-surface px-3 py-1.5 text-xs font-medium transition-colors hover:bg-surface-hover",
+                  "disabled:pointer-events-none disabled:opacity-60",
+                )}
+              >
+                {saving ? <Loader2 className="size-3.5 animate-spin" /> : saved ? <Check className="size-3.5 text-emerald-400" /> : null}
+                {saved ? "Saved" : "Save default tab"}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/pipeline-tabs.mjs
+++ b/web/src/lib/pipeline-tabs.mjs
@@ -1,0 +1,50 @@
+/**
+ * pipeline-tabs.mjs — the canonical Pipeline tab list.
+ *
+ * The tab strip, the assistant's `filterPipeline` action and the Config page's
+ * "default tab" dropdown all read this one list, so a tab can never be offered
+ * in one of them and rejected by another.
+ *
+ * Plain .mjs, dependency-free (same pattern as job-url.mjs / pdf-paths.mjs) so
+ * the sibling test suite can import it under bare Node with no DOM.
+ */
+
+/**
+ * @typedef {"INBOX"|"ALL"|"EVALUATED"|"APPLIED"|"RESPONDED"|"INTERVIEW"|"OFFER"
+ *   |"HIRED"|"REJECTED"|"DISCARDED"|"SKIP"} PipelineTab
+ */
+
+/** INBOX is the triage queue; every other tab filters the tracker by status.
+ *  @type {readonly PipelineTab[]} */
+export const PIPELINE_TABS = [
+  "INBOX",
+  "ALL",
+  "EVALUATED",
+  "APPLIED",
+  "RESPONDED",
+  "INTERVIEW",
+  "OFFER",
+  "HIRED",
+  "REJECTED",
+  "DISCARDED",
+  "SKIP",
+];
+
+/** The tab to land on when the user has expressed no preference. */
+export const FALLBACK_PIPELINE_TAB = /** @type {PipelineTab} */ ("INBOX");
+
+/**
+ * A tab value from an untrusted source (URL query, profile.yml, an assistant
+ * intent) as a canonical tab, or null when it names no tab we have. Never
+ * throws and never guesses: an unknown value falls back at the call site.
+ *
+ * @param {unknown} value
+ * @returns {PipelineTab|null}
+ */
+export function normalizePipelineTab(value) {
+  if (typeof value !== "string") return null;
+  const upper = value.trim().toUpperCase();
+  return /** @type {readonly string[]} */ (PIPELINE_TABS).includes(upper)
+    ? /** @type {PipelineTab} */ (upper)
+    : null;
+}

--- a/web/src/lib/web-prefs.ts
+++ b/web/src/lib/web-prefs.ts
@@ -1,0 +1,79 @@
+import fs from "node:fs";
+import path from "node:path";
+import * as yaml from "js-yaml";
+import { careerOpsRoot } from "@/lib/career-ops";
+import { atomicWriteWithBackup } from "@/lib/core/safe-write";
+import { FALLBACK_PIPELINE_TAB, normalizePipelineTab, type PipelineTab } from "@/lib/pipeline-tabs.mjs";
+
+// Web-only view preferences, stored in config/profile.yml under `web:` — the
+// same USER-LAYER file every other persisted setting uses (apply.signed_in_profile,
+// followup_cadence). localStorage was the other candidate and is wrong here: the
+// Pipeline page is server-rendered, so a browser-only default would paint INBOX
+// first and swap tabs after hydration, and the preference would silently reset in
+// a different browser. Read on the server → the first paint is already correct.
+
+export type WebPrefs = { defaultPipelineTab: PipelineTab };
+
+function isObj(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === "object" && !Array.isArray(v);
+}
+
+function profilePath(): string {
+  return path.join(careerOpsRoot(), "config", "profile.yml");
+}
+
+/** The profile as an object — `{}` for absent/malformed (reads are best-effort). */
+function readProfile(): Record<string, unknown> {
+  try {
+    const parsed = yaml.load(fs.readFileSync(profilePath(), "utf8"));
+    return isObj(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * The tab the Pipeline page opens on: `web.default_pipeline_tab` from the
+ * profile, or INBOX. An unrecognized value (a hand-edited typo, a tab removed by
+ * a later version) degrades to the fallback rather than rendering an empty page.
+ */
+export function readDefaultPipelineTab(): PipelineTab {
+  const web = readProfile().web;
+  const stored = isObj(web) ? web.default_pipeline_tab : undefined;
+  return normalizePipelineTab(stored) ?? FALLBACK_PIPELINE_TAB;
+}
+
+/**
+ * Persist the default tab, merging into whatever else the profile holds.
+ *
+ * Same DATA-LOSS GUARD as /api/apply/profile and /api/followups/cadence: a
+ * profile.yml that EXISTS but does not parse is never overwritten — replacing a
+ * user's targeting, comp and narrative with a one-key file to store a tab name
+ * would be an absurd trade. Throws instead, and the route reports it.
+ */
+export function writeDefaultPipelineTab(tab: PipelineTab): void {
+  const file = profilePath();
+  let base: Record<string, unknown> = {};
+  let header = "";
+  if (fs.existsSync(file)) {
+    const raw = fs.readFileSync(file, "utf8");
+    let parsed: unknown;
+    try {
+      parsed = yaml.load(raw);
+    } catch {
+      throw new Error("config/profile.yml exists but could not be read as YAML, so it was left untouched.");
+    }
+    base = isObj(parsed) ? parsed : {};
+    // yaml.dump drops every comment; carrying the leading block across keeps the
+    // file's own title and explanation (mirrors the apply/profile writer).
+    const lead: string[] = [];
+    for (const line of raw.split("\n")) {
+      if (/^\s*#/.test(line) || line.trim() === "") lead.push(line);
+      else break;
+    }
+    if (lead.some((l) => l.trim())) header = `${lead.join("\n").replace(/\s+$/, "")}\n`;
+  }
+  const web = isObj(base.web) ? base.web : {};
+  const merged = { ...base, web: { ...web, default_pipeline_tab: tab } };
+  atomicWriteWithBackup(file, header + yaml.dump(merged, { lineWidth: 100, noRefs: true }));
+}

--- a/web/tests/lib/pipeline-tabs.test.mjs
+++ b/web/tests/lib/pipeline-tabs.test.mjs
@@ -1,0 +1,28 @@
+// pipeline-tabs — the canonical tab list shared by the tab strip, the assistant's
+// filterPipeline action and the Config page's default-tab dropdown.
+//
+// Run:  node --test tests/lib/pipeline-tabs.test.mjs
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { PIPELINE_TABS, FALLBACK_PIPELINE_TAB, normalizePipelineTab } from "../../src/lib/pipeline-tabs.mjs";
+
+test("the fallback is a real tab", () => {
+  assert.ok(PIPELINE_TABS.includes(FALLBACK_PIPELINE_TAB));
+  assert.equal(FALLBACK_PIPELINE_TAB, "INBOX");
+});
+
+test("every canonical tab normalizes to itself", () => {
+  for (const t of PIPELINE_TABS) assert.equal(normalizePipelineTab(t), t);
+});
+
+test("case and padding are forgiven (URL query, hand-edited profile.yml)", () => {
+  assert.equal(normalizePipelineTab("all"), "ALL");
+  assert.equal(normalizePipelineTab("  Interview "), "INTERVIEW");
+});
+
+test("anything that is not a tab is null, never a guess", () => {
+  for (const bad of ["", "NOPE", "IN BOX", null, undefined, 3, {}, ["ALL"]]) {
+    assert.equal(normalizePipelineTab(bad), null, `expected null for ${JSON.stringify(bad)}`);
+  }
+});


### PR DESCRIPTION
## Related issue

Addresses #2996.

## ⚠️ This is an example, not a proposal that the structure is right

**I am opening this as one worked example of how #2996 could be resolved, so the discussion has something concrete to react to. It is explicitly open to a better structure.** If you would rather this were shaped differently, split up, or replaced with another approach, say so and I will redo it. Question 1 in #2996 in particular (where a web view preference should live) would change this code's shape, and I am happy to redo it either way.

## What does this PR do?

Two things, one of which is worth keeping regardless of the other.

**The centralization.** `web/src/lib/pipeline-tabs.mjs` becomes the canonical tab list plus `normalizePipelineTab()` for untrusted values. The tab strip in `pipeline-view.tsx` and `TAB_VALUES` in `actions/registry.ts` now alias it instead of keeping their own copies, so `test-all.mjs` §55.3b reads the shared module rather than two literal arrays. **If the preference below is rejected, this half still stands on its own** and I would happily submit it alone.

**The preference.** A `web:` section in `config/profile.yml` holding `default_pipeline_tab`, set from Config in the web app, defaulting to INBOX when the key is absent. An explicit `?tab=` in the URL still wins, so a shared or bookmarked link keeps meaning what it says.

## The question I am least sure about

`config/profile.yml` is user-layer and mostly describes the person, not the UI. A `web:` block sits slightly oddly next to comp targets and archetypes. A separate web-prefs file (tracked or gitignored) may be the better answer, and that is question 1 in the issue. The read/write path is one small module, so moving it is cheap; I did not want to invent a new config file unilaterally.

`normalizePipelineTab()` treats the URL query, the `profile.yml` value and an assistant intent as untrusted in the same way, which is the property I would want preserved wherever the value ends up living.

## Tests

- `node test-all.mjs` → 4081 passed, 0 failed (2 pre-existing warnings, unrelated: missing local user data, and a `santifer.io` string in `dashboard/`)
- `node --test "tests/**/*.test.mjs"` in `web/` → 259 passed, 0 failed
- `tsc --noEmit` clean

Rebased onto current `main`; `web-prefs.ts` uses the `import * as yaml` namespace form per main's js-yaml guard.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] I opened an issue first (#2996)
- [x] My PR does not include personal data
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the Data Contract (system-layer files only)
- [x] My changes align with the project roadmap
