### PR TITLE
fix(reply-matcher): the '?' unknown-employer placeholder matched almost every reply, at high confidence

### DIFF
--- a/reply-matcher.mjs
+++ b/reply-matcher.mjs
@@ -21,8 +21,38 @@ export function normalizeChinese(s) {
     .trim();
 }
 
+// A company value that carries no letter and no digit is a PLACEHOLDER, not a
+// name: `?` is the documented marker for an unknown end employer (#1596), and a
+// hand-edited row can hold the tracker's other no-data sentinels (`—`, `-`).
+// Substring-matching those turns punctuation into a company signal — and since
+// replies ask questions, `?` matched almost every mail, scoring 2, corroborating
+// partial role matches, and reaching confidence `high` next to any
+// post-application keyword.
+function isPlaceholderCompany(company) {
+  return !/[\p{L}\p{N}]/u.test(company);
+}
+
+// Short names must land on a word boundary. The normalized check further down
+// has always required more than two characters, but the two substring checks
+// above it had no floor at all, so `HP` matched the word `PHP`. A boundary
+// keeps the short names that are real — HP, 3M, IBM — while refusing the ones
+// that merely occur inside a longer word.
+const SHORT_NAME_MAX = 3;
+
+function matchesOnWordBoundary(text, company) {
+  const escaped = company.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`(?<![\\p{L}\\p{N}])${escaped}(?![\\p{L}\\p{N}])`, 'iu').test(text);
+}
+
 export function checkCompanyMatch(text, company) {
   if (!company || !text) return false;
+  if (isPlaceholderCompany(company)) return false;
+
+  // A short name is decided by the boundary test alone: falling through to the
+  // substring checks below would reinstate the very match it just refused.
+  const alphanumeric = company.replace(/[^\p{L}\p{N}]/gu, '');
+  if (alphanumeric.length <= SHORT_NAME_MAX) return matchesOnWordBoundary(text, company);
+
   // Exact substring
   if (text.includes(company)) return true;
   

--- a/reply-matcher.mjs
+++ b/reply-matcher.mjs
@@ -39,12 +39,19 @@ function isPlaceholderCompany(company) {
 // that merely occur inside a longer word.
 const SHORT_NAME_MAX = 3;
 
-// ...but only where a word boundary can exist. CJK and Hangul run without
+// ...but only where a word boundary can exist. Chinese and Japanese run without
 // separators, so every neighbour of a name is itself a letter and the boundary
 // NEVER holds — requiring one would refuse `腾讯` inside `我们是腾讯的招聘团队`,
 // and two-character names are the norm in those scripts. They keep the
 // substring path and the normalizeChinese() handling written for them below.
-const NO_WORD_SEPARATOR_RE = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
+//
+// Hangul is deliberately NOT here. Korean orthography separates words with
+// spaces (띄어쓰기), so the boundary holds for it exactly as it does for Latin —
+// listing it would have waived the guard for no gain, letting a short Korean
+// name match inside a longer word, which is the very bug this rule exists to
+// stop. Found because the test asked for it never failed when Hangul was
+// removed (CodeRabbit, #3001).
+const NO_WORD_SEPARATOR_RE = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u;
 
 function matchesOnWordBoundary(text, company) {
   const escaped = company.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/reply-matcher.mjs
+++ b/reply-matcher.mjs
@@ -39,6 +39,13 @@ function isPlaceholderCompany(company) {
 // that merely occur inside a longer word.
 const SHORT_NAME_MAX = 3;
 
+// ...but only where a word boundary can exist. CJK and Hangul run without
+// separators, so every neighbour of a name is itself a letter and the boundary
+// NEVER holds — requiring one would refuse `腾讯` inside `我们是腾讯的招聘团队`,
+// and two-character names are the norm in those scripts. They keep the
+// substring path and the normalizeChinese() handling written for them below.
+const NO_WORD_SEPARATOR_RE = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
+
 function matchesOnWordBoundary(text, company) {
   const escaped = company.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   return new RegExp(`(?<![\\p{L}\\p{N}])${escaped}(?![\\p{L}\\p{N}])`, 'iu').test(text);
@@ -50,8 +57,14 @@ export function checkCompanyMatch(text, company) {
 
   // A short name is decided by the boundary test alone: falling through to the
   // substring checks below would reinstate the very match it just refused.
+  // Length is counted in CODE POINTS — `String.length` counts UTF-16 units, so a
+  // three-character supplementary-plane name reported 4 and slipped past the
+  // threshold into the substring path its BMP equivalent was refused.
   const alphanumeric = company.replace(/[^\p{L}\p{N}]/gu, '');
-  if (alphanumeric.length <= SHORT_NAME_MAX) return matchesOnWordBoundary(text, company);
+  const isShortName = Array.from(alphanumeric).length <= SHORT_NAME_MAX;
+  if (isShortName && !NO_WORD_SEPARATOR_RE.test(company)) {
+    return matchesOnWordBoundary(text, company);
+  }
 
   // Exact substring
   if (text.includes(company)) return true;

--- a/tests/reply-matcher-company-boundary.test.mjs
+++ b/tests/reply-matcher-company-boundary.test.mjs
@@ -1,0 +1,109 @@
+// tests/reply-matcher-company-boundary.test.mjs — what may count as a
+// company-name signal when matching a reply to an application.
+//
+// `reply-matcher.mjs` shipped with no test file at all, and the company check
+// is the load-bearing one: `isCompanyMatch` is worth 2 points, it is the
+// corroboration that lets a PARTIAL role match count (#2671), and paired with a
+// post-application keyword it raises the verdict to `high`. reply-watch then
+// proposes tracker updates from that verdict.
+//
+// Two ways it fired on text that names no company at all:
+//
+//   1. `?` is the DOCUMENTED placeholder for an unknown end employer (#1596,
+//      AGENTS.md). checkCompanyMatch opened with a bare `text.includes(company)`,
+//      so any reply containing a question mark "matched" it — and replies ask
+//      questions. Measured: a mail from an unrelated firm reading "Seriez-vous
+//      disponible pour un interview ?" attached itself to the `?` row with
+//      confidence `high`.
+//   2. The length floor (`cNorm.length > 2`) guarded only the third, normalized
+//      check. The two substring checks above it had none and no word boundary,
+//      so company `HP` matched the word `PHP`.
+//
+// The fix must not cost the short names that are real: HP, 3M and IBM all have
+// to keep matching when they appear as words.
+import { pass, fail, ROOT } from './helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nreply-matcher.mjs — a company signal must name a company');
+
+try {
+  const { checkCompanyMatch, matchCandidates } = await import(
+    pathToFileURL(join(ROOT, 'reply-matcher.mjs')).href
+  );
+
+  const check = (label, actual, expected) => {
+    if (actual === expected) pass(label);
+    else fail(`${label} => ${JSON.stringify(actual)}, expected ${JSON.stringify(expected)}`);
+  };
+
+  // ── 1. Placeholders are not names ──
+  check('"?" does not match a question mark',
+    checkCompanyMatch('Seriez-vous disponible pour un entretien ?', '?'), false);
+  check('"?" does not match text without one',
+    checkCompanyMatch('Merci de votre candidature.', '?'), false);
+  // The tracker uses these same sentinels for "no data" in other columns, and a
+  // hand-edited row can carry one in Company too.
+  check('an em-dash placeholder does not match',
+    checkCompanyMatch('Nous revenons vers vous — bonne journée', '—'), false);
+  check('a hyphen placeholder does not match',
+    checkCompanyMatch('Poste back-end senior', '-'), false);
+
+  // ── 2. A short name needs a word boundary ──
+  check('"HP" does not match inside "PHP"',
+    checkCompanyMatch('Nous recherchons un profil PHP senior', 'HP'), false);
+  check('"#" alone does not match "C#"',
+    checkCompanyMatch('Poste en C# et .NET', '#'), false);
+
+  // ── Guards: the short names that are real must keep working ──
+  check('"HP" still matches when it stands as a word',
+    checkCompanyMatch('Bonjour, HP Enterprise vous remercie', 'HP'), true);
+  check('"3M" still matches',
+    checkCompanyMatch('Votre candidature chez 3M a bien ete recue', '3M'), true);
+  check('"IBM" still matches',
+    checkCompanyMatch('IBM France — suite de votre candidature', 'IBM'), true);
+  check('a normal company name still matches',
+    checkCompanyMatch('Bonjour, suite a votre candidature chez Acme', 'Acme'), true);
+  check('a normal company name still fails when absent',
+    checkCompanyMatch('Rien a voir avec cette societe', 'Acme'), false);
+  check('case-insensitive matching survives',
+    checkCompanyMatch('bienvenue chez ACME corp', 'Acme'), true);
+
+  // ── 3. End to end: the reply must not land on the placeholder row ──
+  // Both applications exist; the mail belongs to neither. Before the fix it was
+  // attributed to #1 with confidence `high` on the strength of a "?".
+  const apps = [
+    { num: 1, company: '?', role: 'Developpeur Fullstack' },
+    { num: 2, company: 'Acme', role: 'Backend Engineer' },
+  ];
+  const candidates = [{
+    message_id: 'm1',
+    from: 'rh@societe-sans-rapport.com',
+    subject: 'Suite a votre candidature',
+    body_snippet: 'Seriez-vous disponible pour un interview la semaine prochaine ?',
+  }];
+  const matched = matchCandidates(candidates, apps, []);
+  const onPlaceholder = matched.filter((m) => m.application_num === 1);
+  if (onPlaceholder.length === 0) {
+    pass('an unrelated reply no longer attaches to the "?" application');
+  } else {
+    fail(`still attached to the placeholder row: ${JSON.stringify(onPlaceholder)}`);
+  }
+
+  // Guard: a reply that genuinely names a tracked company still matches, so the
+  // fix cannot be passing case 3 by matching nothing at all.
+  const realMatch = matchCandidates([{
+    message_id: 'm2',
+    from: 'talent@acme.com',
+    subject: 'Acme — Backend Engineer',
+    body_snippet: 'Nous aimerions vous proposer un interview.',
+  }], apps, []);
+  const onAcme = realMatch.filter((m) => m.application_num === 2);
+  if (onAcme.length === 1 && onAcme[0].confidence === 'high') {
+    pass('a reply naming the company and role still matches it with high confidence');
+  } else {
+    fail(`real match regressed: ${JSON.stringify(realMatch)}`);
+  }
+} catch (error) {
+  fail(`reply-matcher tests could not run: ${error.message}`);
+}

--- a/tests/reply-matcher-company-boundary.test.mjs
+++ b/tests/reply-matcher-company-boundary.test.mjs
@@ -69,6 +69,33 @@ try {
   check('case-insensitive matching survives',
     checkCompanyMatch('bienvenue chez ACME corp', 'Acme'), true);
 
+  // ── 2b. Scripts with no word separators keep the substring path ──
+  // A word boundary can never hold in CJK: every neighbouring character is a
+  // letter, so requiring one refuses names that are plainly present. Two-
+  // character company names are the norm there (腾讯 Tencent, 京東 JD), and this
+  // file already carries normalizeChinese() for exactly that case — a short-name
+  // early return must not skip it.
+  check('a two-character Chinese name matches inside running text',
+    checkCompanyMatch('我们是腾讯的招聘团队', '腾讯'), true);
+  check('a two-character Japanese name matches after 株式会社',
+    checkCompanyMatch('株式会社京東グループより', '京東'), true);
+  check('the Chinese suffix normalisation still works',
+    checkCompanyMatch('腾讯からのご連絡', '腾讯有限公司'), true);
+  // Guard: a CJK name genuinely absent still fails, so the cases above cannot
+  // be passing because CJK matches everything.
+  check('an absent Chinese name still fails',
+    checkCompanyMatch('我们是阿里巴巴的招聘团队', '腾讯'), false);
+
+  // ── 2c. Length is counted in CODE POINTS, not UTF-16 units ──
+  // `String.length` counts units, so a three-character name built from
+  // supplementary-plane characters reports 4 and slipped past SHORT_NAME_MAX
+  // into the substring path — the same name would be boundary-checked in the
+  // BMP (CodeRabbit, #3001).
+  check('a 3-code-point astral name is treated as short, not substring-matched',
+    checkCompanyMatch('prefix𐐀BCsuffix', '𐐀BC'), false);
+  check('...and still matches when it stands as a word',
+    checkCompanyMatch('bienvenue chez 𐐀BC', '𐐀BC'), true);
+
   // ── 3. End to end: the reply must not land on the placeholder row ──
   // Both applications exist; the mail belongs to neither. Before the fix it was
   // attributed to #1 with confidence `high` on the strength of a "?".

--- a/tests/reply-matcher-company-boundary.test.mjs
+++ b/tests/reply-matcher-company-boundary.test.mjs
@@ -85,6 +85,22 @@ try {
   // be passing because CJK matches everything.
   check('an absent Chinese name still fails',
     checkCompanyMatch('我们是阿里巴巴的招聘团队', '腾讯'), false);
+  // NO_WORD_SEPARATOR_RE lists four scripts, and 京東 above is Han despite its
+  // Japanese surroundings — so Hiragana, Katakana and Hangul were listed but
+  // never exercised, and dropping any of them would have failed no test
+  // (CodeRabbit, #3001). One short name per remaining script.
+  check('a short Hiragana name matches inside running text',
+    checkCompanyMatch('あおの採用チームです', 'あお'), true);
+  check('a short Katakana name matches inside running text',
+    checkCompanyMatch('テクの採用チームです', 'テク'), true);
+  // Korean is NOT on the substring path: 띄어쓰기 separates words, so the
+  // boundary rule applies to it as it does to Latin — it matches as a word, and
+  // is refused inside a longer one. Listing Hangul as separator-less would have
+  // waived the guard for no gain.
+  check('a Korean name matches when spaced as a word',
+    checkCompanyMatch('네이버 채용팀입니다', '네이버'), true);
+  check('...and is refused inside a longer Hangul word',
+    checkCompanyMatch('앞네이버뒤 채용팀입니다', '네이버'), false);
 
   // ── 2c. Length is counted in CODE POINTS, not UTF-16 units ──
   // `String.length` counts units, so a three-character name built from


### PR DESCRIPTION
No issue — found while auditing `reply-matcher.mjs`, which ships with **no test file and no self-test**, the least-covered substantive module left. `CONTRIBUTING.md:22` welcomes a direct PR for a bug fix.

## Why the company check is load-bearing

`isCompanyMatch` is worth 2 points, it is the corroboration that lets a **partial** role match count at all (#2671), and next to a post-application keyword it raises the verdict to `high`. `reply-watch` then proposes tracker updates from that verdict. A false company signal is therefore a wrong status on a real application.

## Defect 1 — `?` matched almost every reply

`?` is the **documented** placeholder for an unknown end employer (#1596, `AGENTS.md`). `checkCompanyMatch` opened with a bare `text.includes(company)`, so any text containing a question mark matched it. Replies ask questions.

Measured end to end on `main` — two applications, a mail belonging to neither:

```js
apps = [ {num: 1, company: '?',    role: 'Developpeur Fullstack'},
         {num: 2, company: 'Acme', role: 'Backend Engineer'} ]

from: rh@societe-sans-rapport.com
body: "Seriez-vous disponible pour un interview la semaine prochaine ?"
```

```json
{ "application_num": 1, "company_hint": "?", "confidence": "high",
  "signals": ["company-name", "post-application-keyword"] }
```

**High confidence, on the strength of a question mark.** The same applies to the tracker's other no-data sentinels (`—`, `-`) when one reaches the Company column.

## Defect 2 — a short name matched inside a longer word

The length floor (`cNorm.length > 2`) guarded only the third, normalized check. The two substring checks above it had no floor and no word boundary:

| Company | Text | `main` |
|---|---|---|
| `HP` | "un profil **PHP** senior" | matched |
| `#` | "Poste en C**#** et .NET" | matched |

## The fix

- **`isPlaceholderCompany`** — a value carrying no letter and no digit is a placeholder, not a name, and never matches.
- **Short names are decided by a word boundary.** Three alphanumeric characters or fewer go through `matchesOnWordBoundary` and return there, rather than falling through to the substring checks that would reinstate the match they just refused. The boundary is `\p{L}\p{N}`-aware, so it does not split on accents or CJK.

The names that are genuinely short had to keep working, and the tests pin them: **HP**, **3M** and **IBM** all still match when they appear as words.

## Test plan

New `tests/reply-matcher-company-boundary.test.mjs` (14 cases), picked up by `test-all.mjs` auto-discovery — the module's first tests.

- [x] 6 of the 14 verified red before the fix.
- [x] The 8 guards pass before **and** after, which is what makes them guards: HP/3M/IBM as words, a normal name matching and correctly failing, case-insensitivity, and an end-to-end reply that genuinely names company and role still landing on it with `high`. Without that last one, the end-to-end case could have passed by matching nothing at all.
- [x] Verified the placeholder guard discriminates: removing that single line turns 3 cases red again.
- [x] `node test-all.mjs` — 4094 passed, 0 failed (the two warnings are the pre-existing `Dashboard build skipped — go compiler not in env` and the `santifer.io` personal-data notice in `dashboard/`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved company matching to ignore punctuation-only or otherwise invalid placeholder values.
  * Prevented short company names from matching inside longer words.
  * Preserved valid matching for multilingual names, including CJK text, and high-confidence company replies.

* **Tests**
  * Added comprehensive coverage for placeholder values, word boundaries, Unicode names, valid short names, and end-to-end matching scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->