### PR TITLE
fix(process-quality): three undisclosed employers were reported as one company with an averaged friction rate

### DIFF
--- a/process-quality.mjs
+++ b/process-quality.mjs
@@ -149,6 +149,12 @@ export function extractFriction(row) {
   return { hasFriction: true, reason: (match[1] || '').trim() };
 }
 
+// A cell carrying no letter and no digit is a PLACEHOLDER, not a value: `?` for
+// an undisclosed employer (#1596), and the tracker's `—`/`-` no-data sentinels.
+function isPlaceholder(value) {
+  return !/[\p{L}\p{N}]/u.test(value);
+}
+
 // --- Core aggregation ---
 //
 // Groups rows by company (case-insensitive, trimmed), counts total
@@ -171,9 +177,26 @@ export function aggregateProcessQuality(rows, minThreshold = 1) {
     const company = companyKey(row);
     if (!company) continue;
 
-    const dedupeKey = company.toLowerCase();
+    // `?` is the documented marker for an undisclosed end employer (#1596), not
+    // a company name. Grouping on it merged every unrelated employer into ONE
+    // row and reported a friction rate averaged across all of them — the number
+    // a user acts on ("this company wastes my time") computed over companies
+    // they never dealt with. merge-tracker already refuses that merge; this
+    // aggregate has to refuse it too.
+    //
+    // The channel is what distinguishes those rows, so it becomes the bucket.
+    // A row naming neither employer nor channel supports no per-company claim
+    // at all and is dropped rather than given one.
+    let label = company;
+    if (isPlaceholder(company)) {
+      const via = findColumn(row, 'via').trim();
+      if (!via || isPlaceholder(via)) continue;
+      label = `${company} (via ${via})`;
+    }
+
+    const dedupeKey = label.toLowerCase();
     if (!byCompany.has(dedupeKey)) {
-      byCompany.set(dedupeKey, { company, total: 0, frictionCount: 0, reasons: [] });
+      byCompany.set(dedupeKey, { company: label, total: 0, frictionCount: 0, reasons: [] });
     }
     const entry = byCompany.get(dedupeKey);
     entry.total += 1;

--- a/process-quality.mjs
+++ b/process-quality.mjs
@@ -190,11 +190,12 @@ export function aggregateProcessQuality(rows, minThreshold = 1) {
     if (isPlaceholder(company)) {
       const via = findColumn(row, 'via').trim();
       if (!via || isPlaceholder(via)) continue;
-      // An EMPTY cell says the same thing as `?` — no employer named — so it
-      // takes the same route. The prefix is normalized to `?` rather than kept
-      // verbatim: composing it from an empty string would label the bucket
-      // " (via Hays)", and two spellings of "unknown" would key apart.
-      label = `${company || '?'} (via ${via})`;
+      // The prefix is ALWAYS `?`, never the cell's own spelling. isPlaceholder
+      // accepts `?`, `—`, `-` and an empty cell, and every one of them means the
+      // same thing — but keeping them verbatim keys `— (via Hays)` apart from
+      // `? (via Hays)`, splitting one channel's totals. That is this function's
+      // own bug in miniature, so it gets the same answer: normalize, then group.
+      label = `? (via ${via})`;
     }
 
     const dedupeKey = label.toLowerCase();

--- a/process-quality.mjs
+++ b/process-quality.mjs
@@ -175,7 +175,6 @@ export function aggregateProcessQuality(rows, minThreshold = 1) {
   for (const row of rows) {
     if (!row || typeof row !== 'object') continue;
     const company = companyKey(row);
-    if (!company) continue;
 
     // `?` is the documented marker for an undisclosed end employer (#1596), not
     // a company name. Grouping on it merged every unrelated employer into ONE
@@ -191,7 +190,11 @@ export function aggregateProcessQuality(rows, minThreshold = 1) {
     if (isPlaceholder(company)) {
       const via = findColumn(row, 'via').trim();
       if (!via || isPlaceholder(via)) continue;
-      label = `${company} (via ${via})`;
+      // An EMPTY cell says the same thing as `?` — no employer named — so it
+      // takes the same route. The prefix is normalized to `?` rather than kept
+      // verbatim: composing it from an empty string would label the bucket
+      // " (via Hays)", and two spellings of "unknown" would key apart.
+      label = `${company || '?'} (via ${via})`;
     }
 
     const dedupeKey = label.toLowerCase();

--- a/tests/process-quality-unknown-employer.test.mjs
+++ b/tests/process-quality-unknown-employer.test.mjs
@@ -1,0 +1,103 @@
+// tests/process-quality-unknown-employer.test.mjs — the `?` unknown-employer
+// placeholder must not become a company in the per-company friction report.
+//
+// `AGENTS.md` documents the convention: when the end employer is not disclosed,
+// the Company cell holds `?` and the agency goes in the tagged `via=` field
+// (#1596). merge-tracker already honours it — its dedup carries an explicit
+// cross-channel guard so `?` rows never fuzzy-merge across agencies.
+//
+// aggregateProcessQuality grouped on the Company cell alone, so every
+// undisclosed employer collapsed into ONE bucket. Measured before the fix, on
+// three unrelated employers reached through three different agencies:
+//
+//   { company: "?", totalInterviews: 3, frictionCount: 2, frictionRate: 0.67 }
+//
+// That row is not a company, it is three — and 0.67 is arithmetic across
+// unrelated employers. The number a user acts on ("this company wastes my
+// time") is precisely the one that cannot be computed here.
+import { pass, fail, ROOT } from './helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nprocess-quality.mjs — an undisclosed employer is not a company');
+
+try {
+  const { aggregateProcessQuality } = await import(
+    pathToFileURL(join(ROOT, 'process-quality.mjs')).href
+  );
+
+  const rows = [
+    { company: '?', via: 'Hays', role: 'Backend Engineer', notes: 'round 3 [process-friction] rescheduled twice' },
+    { company: '?', via: 'Michael Page', role: 'Data Engineer', notes: 'smooth process' },
+    { company: '?', via: 'Robert Half', role: 'Platform Eng', notes: '[process-friction] ghosted after onsite' },
+    { company: 'Acme', via: '—', role: 'Fullstack', notes: 'ok' },
+  ];
+  const out = aggregateProcessQuality(rows, 1);
+
+  // ── The three undisclosed employers must not merge ──
+  const bare = out.filter((r) => r.company.trim() === '?');
+  if (bare.length === 0) {
+    pass('no bucket is reported under the bare "?" placeholder');
+  } else {
+    fail(`three employers merged into one row: ${JSON.stringify(bare)}`);
+  }
+
+  const viaBuckets = out.filter((r) => /Hays|Michael Page|Robert Half/.test(r.company));
+  if (viaBuckets.length === 3 && viaBuckets.every((r) => r.totalInterviews === 1)) {
+    pass('each agency channel is its own bucket, one interview apiece');
+  } else {
+    fail(`channels not separated: ${JSON.stringify(out)}`);
+  }
+
+  // The friction must land on the channel that actually had it, not be averaged
+  // across all three.
+  const hays = out.find((r) => /Hays/.test(r.company));
+  const page = out.find((r) => /Michael Page/.test(r.company));
+  if (hays?.frictionRate === 1 && page?.frictionRate === 0) {
+    pass('friction is attributed to the channel that had it, not averaged');
+  } else {
+    fail(`friction misattributed: Hays=${JSON.stringify(hays)} Page=${JSON.stringify(page)}`);
+  }
+
+  // ── A row that names neither employer nor channel supports no claim ──
+  const unattributable = aggregateProcessQuality([
+    { company: '?', via: '', role: 'X', notes: '[process-friction] slow' },
+    { company: '?', via: '—', role: 'Y', notes: 'ok' },
+  ], 1);
+  if (unattributable.length === 0) {
+    pass('a row with no employer and no channel is dropped, not given a bucket');
+  } else {
+    fail(`unattributable rows produced buckets: ${JSON.stringify(unattributable)}`);
+  }
+
+  // ── Guards: ordinary companies are untouched ──
+  const acme = out.find((r) => r.company === 'Acme');
+  if (acme && acme.totalInterviews === 1 && acme.frictionCount === 0) {
+    pass('a named company is unaffected');
+  } else {
+    fail(`named company changed: ${JSON.stringify(acme)}`);
+  }
+
+  const plain = aggregateProcessQuality([
+    { company: 'Globex', role: 'A', notes: '[process-friction] rescheduled' },
+    { company: 'globex', role: 'B', notes: 'fine' },
+  ], 1);
+  if (plain.length === 1 && plain[0].totalInterviews === 2 && plain[0].frictionRate === 0.5) {
+    pass('case-insensitive grouping of a named company still merges');
+  } else {
+    fail(`named grouping regressed: ${JSON.stringify(plain)}`);
+  }
+
+  // A tracker with no Via column at all (the pre-#1596 layout) must not crash
+  // or invent channels.
+  const legacy = aggregateProcessQuality([
+    { company: 'Initech', role: 'A', notes: 'ok' },
+  ], 1);
+  if (legacy.length === 1 && legacy[0].company === 'Initech') {
+    pass('a tracker with no Via column still aggregates normally');
+  } else {
+    fail(`legacy layout broke: ${JSON.stringify(legacy)}`);
+  }
+} catch (error) {
+  fail(`process-quality tests could not run: ${error.message}`);
+}

--- a/tests/process-quality-unknown-employer.test.mjs
+++ b/tests/process-quality-unknown-employer.test.mjs
@@ -70,6 +70,27 @@ try {
     fail(`unattributable rows produced buckets: ${JSON.stringify(unattributable)}`);
   }
 
+  // An EMPTY company says the same thing as `?` — no employer named — so it must
+  // reach the same channel attribution instead of being dropped one line
+  // earlier (CodeRabbit, #3005). The label has to stay stable too: composing it
+  // from an empty prefix would yield " (via Hays)" with a leading space.
+  const blankCompany = aggregateProcessQuality([
+    { company: '', via: 'Hays', role: 'A', notes: '[process-friction] slow' },
+    { company: '', via: 'Hays', role: 'B', notes: 'fine' },
+    { company: '', via: 'Michael Page', role: 'C', notes: 'fine' },
+  ], 1);
+  const haysBlank = blankCompany.find((r) => /Hays/.test(r.company));
+  if (blankCompany.length === 2 && haysBlank?.totalInterviews === 2 && haysBlank?.frictionRate === 0.5) {
+    pass('an empty company with a via is attributed to its channel, not dropped');
+  } else {
+    fail(`blank company not attributed: ${JSON.stringify(blankCompany)}`);
+  }
+  if (haysBlank && haysBlank.company === '? (via Hays)') {
+    pass('an empty company gets the stable "?" label, with no leading space');
+  } else {
+    fail(`unstable label: ${JSON.stringify(haysBlank?.company)}`);
+  }
+
   // ── Guards: ordinary companies are untouched ──
   const acme = out.find((r) => r.company === 'Acme');
   if (acme && acme.totalInterviews === 1 && acme.frictionCount === 0) {

--- a/tests/process-quality-unknown-employer.test.mjs
+++ b/tests/process-quality-unknown-employer.test.mjs
@@ -91,6 +91,24 @@ try {
     fail(`unstable label: ${JSON.stringify(haysBlank?.company)}`);
   }
 
+  // EVERY placeholder spelling must collapse to the same bucket. isPlaceholder
+  // accepts `?`, `—`, `-` and an empty cell, so normalizing only the empty one
+  // left `— (via Hays)` keyed apart from `? (via Hays)` — splitting one
+  // channel's totals, which is this PR's own bug in miniature (CodeRabbit,
+  // #3005).
+  const mixedMarkers = aggregateProcessQuality([
+    { company: '?', via: 'Hays', role: 'A', notes: '[process-friction] slow' },
+    { company: '—', via: 'Hays', role: 'B', notes: 'fine' },
+    { company: '-', via: 'Hays', role: 'C', notes: 'fine' },
+    { company: '', via: 'Hays', role: 'D', notes: 'fine' },
+  ], 1);
+  if (mixedMarkers.length === 1 && mixedMarkers[0].company === '? (via Hays)'
+      && mixedMarkers[0].totalInterviews === 4 && mixedMarkers[0].frictionRate === 0.25) {
+    pass('every placeholder spelling collapses into one bucket per channel');
+  } else {
+    fail(`markers split the channel: ${JSON.stringify(mixedMarkers)}`);
+  }
+
   // ── Guards: ordinary companies are untouched ──
   const acme = out.find((r) => r.company === 'Acme');
   if (acme && acme.totalInterviews === 1 && acme.frictionCount === 0) {


### PR DESCRIPTION
No issue — found by following the `?` placeholder class out of #3001 into the analytics scripts. `CONTRIBUTING.md:22` welcomes a direct PR for a bug fix.

## The defect

`AGENTS.md` documents the convention: an undisclosed end employer is recorded as `?` in Company, with the agency in the tagged `via=` field (#1596). `merge-tracker` already honours it — its dedup carries an explicit cross-channel guard so `?` rows never fuzzy-merge across agencies (`tracker-columns-tests.mjs` case 12).

`aggregateProcessQuality` grouped on the Company cell alone. Every undisclosed employer therefore collapsed into one bucket. Measured on `main`, three unrelated employers reached through three different agencies:

```js
{ company: '?', via: 'Hays',         notes: '[process-friction] rescheduled twice' }
{ company: '?', via: 'Michael Page', notes: 'smooth process' }
{ company: '?', via: 'Robert Half',  notes: '[process-friction] ghosted after onsite' }
```

```json
{ "company": "?", "totalInterviews": 3, "frictionCount": 2, "frictionRate": 0.67 }
```

The script's own header calls this a "per-company recruiting-friction rate". That row is not a company, it is three — and `0.67` is arithmetic across employers the user never dealt with. The number they would act on ("this one wastes my time") is exactly the one that cannot be computed from these rows.

It also hides the real signal in the other direction: Michael Page had a clean process, and averaging buries that.

## The fix

- **`isPlaceholder`** — a cell with no letter and no digit is a marker, not a value. Covers `?` and the tracker's `—`/`-` no-data sentinels.
- **The channel becomes the bucket** for those rows: `? (via Hays)`. That is what actually distinguishes them, and it is the same axis merge-tracker already keys on.
- **A row naming neither employer nor channel is dropped.** It supports no per-company claim, so inventing a bucket for it would be the original bug in smaller form.

## Test plan

New `tests/process-quality-unknown-employer.test.mjs` (7 cases), the module's first dedicated tests.

- [x] 4 of the 7 verified red before the fix.
- [x] The 3 guards pass before **and** after: a named company unaffected, case-insensitive grouping of a named company still merging, and a pre-#1596 tracker with no Via column at all still aggregating normally.
- [x] One case pins the *direction* of the attribution, not just the split: Hays keeps `frictionRate: 1` and Michael Page `0`, so the friction lands on the channel that had it rather than being averaged.
- [x] Verified the guard discriminates: neutralising the `isPlaceholder` branch turns 4 cases red again.
- [x] `node process-quality.mjs --summary` still runs clean.
- [x] `node test-all.mjs` — 4087 passed, 0 failed (the two warnings are the pre-existing `Dashboard build skipped — go compiler not in env` and the `santifer.io` personal-data notice in `dashboard/`).

## Related

Same class as #3001, where `?` was matching almost every email reply because `checkCompanyMatch` treated it as a name. The convention is documented and one consumer honours it; the others were never audited against it. `analyze-patterns.mjs` and `company-history.mjs` group by company too — I have not measured them here and am not claiming they are affected, only that they are the next places I would look.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of undisclosed or placeholder employer information.
  * Separates unknown employers by available referral or agency channel.
  * Prevents records without usable employer or channel details from being incorrectly combined.
  * Preserves existing aggregation for named companies and older records without channel information.

* **Tests**
  * Added coverage for unknown-employer aggregation and channel attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->