### PR TITLE
fix(tracker): treat Windows rename contention as contention, not death (#2777)

### DIFF
--- a/tests/rename-contention.test.mjs
+++ b/tests/rename-contention.test.mjs
@@ -1,0 +1,170 @@
+// tests/rename-contention.test.mjs
+//
+// #2777's missing third syscall. The mkdir and rm sides of both locks now treat
+// Windows' EPERM/EACCES/EBUSY answers as contention, but `writeFileAtomic`'s
+// closing `renameSync` was still bare — and on Windows a rename whose
+// DESTINATION is open by anyone else at that instant fails with EPERM
+// (errno -4048), killing the writer and losing the tracker write.
+//
+// POSIX `rename(2)` replaces the destination atomically and cannot fail that
+// way, which is why this never reproduces on Linux/macOS CI. Measured on
+// Windows 11 / Node v24.18.0: `node test-all.mjs` failed 1-2 tests per run,
+// non-deterministically, in tracker-writer-lock-tests.mjs and
+// set-status-tests.mjs. Both suites pass in isolation; only the full run
+// manufactures enough concurrent readers to lose the race.
+//
+// The holder is usually not another writer of ours (the tracker lock serializes
+// those) but a transient reader: an antivirus scanner, the Search indexer, or a
+// concurrent readFileSync from a reporting script.
+//
+// These tests pin four things:
+//   1. the classifier agrees on the measured Windows codes and ONLY those,
+//   2. a contended rename is retried and the write completes,
+//   3. a non-contention errno still fails fast, with the temp file cleaned up,
+//   4. no bare renameSync remains in the tracker's atomic-write path.
+
+import { readFileSync, existsSync, mkdtempSync, writeFileSync, readdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { pass, fail, ROOT } from './helpers.mjs';
+import {
+  isRenameContention,
+  renameSyncWithRetry,
+  writeFileAtomic,
+  RENAME_RETRY_DELAYS_MS,
+} from '../tracker-utils.mjs';
+
+console.log('\n📝 atomic tracker writes: rename contention is contention, not death (#2777)');
+
+const ok = (cond, msg) => (cond ? pass(msg) : fail(msg));
+const mkErr = (code) => Object.assign(new Error(code), { code });
+
+// ── 1. Classifier table ──────────────────────────────────────────────────────
+// The codes come from measured Windows failures, not speculation. EPERM is the
+// one observed here; EACCES and EBUSY are the same family already recorded for
+// mkdir/rm in pipeline-lock.mjs.
+{
+  for (const code of ['EPERM', 'EACCES', 'EBUSY']) {
+    ok(isRenameContention(mkErr(code)) === true, `isRenameContention treats ${code} as contention`);
+  }
+  // A missing source or a cross-device move is a real failure, not a race.
+  // Retrying these would turn a clear error into a ~200ms stall and a stale message.
+  for (const code of ['ENOENT', 'EXDEV', 'EISDIR', 'ENOSPC']) {
+    ok(isRenameContention(mkErr(code)) === false, `isRenameContention does NOT retry ${code}`);
+  }
+  ok(isRenameContention(undefined) === false, 'isRenameContention tolerates a missing error');
+  ok(isRenameContention(new Error('no code')) === false, 'isRenameContention ignores an error with no code');
+}
+
+// ── 2. A contended rename is retried until it lands ──────────────────────────
+// Injecting the rename keeps this deterministic and cross-platform: CI on Linux
+// exercises the same retry loop that only Windows triggers in production.
+{
+  let attempts = 0;
+  const flakyRename = () => {
+    attempts++;
+    if (attempts <= 3) throw mkErr('EPERM');
+  };
+  let threw = null;
+  try {
+    renameSyncWithRetry('from.tmp', 'to.md', flakyRename);
+  } catch (err) {
+    threw = err;
+  }
+  ok(threw === null, 'renameSyncWithRetry survives 3 EPERM answers and returns');
+  ok(attempts === 4, `renameSyncWithRetry retried until success (${attempts} attempts)`);
+}
+
+// A rename that never recovers must still give up and rethrow the ORIGINAL
+// error, rather than looping forever or masking it.
+{
+  let attempts = 0;
+  const deadRename = () => {
+    attempts++;
+    throw mkErr('EPERM');
+  };
+  let code = null;
+  try {
+    renameSyncWithRetry('from.tmp', 'to.md', deadRename);
+  } catch (err) {
+    code = err.code;
+  }
+  ok(code === 'EPERM', 'a permanently contended rename rethrows the original EPERM');
+  ok(
+    attempts === RENAME_RETRY_DELAYS_MS.length + 1,
+    `retries are bounded at ${RENAME_RETRY_DELAYS_MS.length} (made ${attempts} attempts)`,
+  );
+}
+
+// ── 3. Non-contention errors fail fast, and the temp file never leaks ────────
+{
+  let attempts = 0;
+  const wrongDevice = () => {
+    attempts++;
+    throw mkErr('EXDEV');
+  };
+  let code = null;
+  try {
+    renameSyncWithRetry('from.tmp', 'to.md', wrongDevice);
+  } catch (err) {
+    code = err.code;
+  }
+  ok(code === 'EXDEV' && attempts === 1, 'a non-contention errno fails on the first attempt');
+}
+
+// writeFileAtomic's own contract: the destination is replaced, and on failure
+// no `.applications.md.<pid>.<ts>.<uuid>.tmp` is left behind.
+{
+  const dir = mkdtempSync(join(tmpdir(), 'career-ops-rename-'));
+  try {
+    const target = join(dir, 'applications.md');
+    writeFileSync(target, 'original\n');
+
+    writeFileAtomic(target, 'replaced\n');
+    ok(readFileSync(target, 'utf-8') === 'replaced\n', 'writeFileAtomic replaces the destination');
+    ok(
+      readdirSync(dir).filter((f) => f.endsWith('.tmp')).length === 0,
+      'writeFileAtomic leaves no .tmp behind on success',
+    );
+
+    // An unwritable destination (a directory) fails; the temp file must go too.
+    let failed = false;
+    try {
+      writeFileAtomic(join(dir), 'nope\n');
+    } catch {
+      failed = true;
+    }
+    ok(failed, 'writeFileAtomic still throws when the destination cannot be replaced');
+    ok(
+      readdirSync(dir).filter((f) => f.endsWith('.tmp')).length === 0,
+      'writeFileAtomic cleans up its .tmp on failure',
+    );
+    ok(existsSync(target), 'a failed write leaves the original file intact');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── 4. No bare renameSync in the atomic-write path ───────────────────────────
+// renameSyncWithRetry is the only code allowed to call renameSync in this file.
+// A bare call anywhere else reintroduces the lost write one refactor from now,
+// which is exactly how the mkdir/rm half of #2777 survived two earlier fixes.
+{
+  const src = readFileSync(join(ROOT, 'tracker-utils.mjs'), 'utf-8');
+
+  // renameSync must never be INVOKED directly. It may only appear as the
+  // imported name and as renameSyncWithRetry's default parameter, neither of
+  // which is a call, so the call-site count must be zero.
+  const directCalls = [...src.matchAll(/(?<![\w.])renameSync\s*\(/g)].length;
+  ok(
+    directCalls === 0,
+    `tracker-utils.mjs: no direct renameSync() call remains (found ${directCalls})`,
+  );
+
+  // And the atomic path routes through the injectable seam exactly once.
+  const seamCalls = [...src.matchAll(/^\s*rename\(tmpPath, path\);/gm)].length;
+  ok(
+    seamCalls === 1,
+    `the atomic write renames through the injectable helper exactly once (found ${seamCalls})`,
+  );
+}

--- a/tracker-utils.mjs
+++ b/tracker-utils.mjs
@@ -539,12 +539,81 @@ export async function openTrackerTransaction(appsFile, options = {}) {
 }
 
 /**
+ * Codes Windows raises when a rename-over-existing-file loses a race for the
+ * destination handle. Same portability gap this module already documents for
+ * mkdir/rm (#2777): POSIX `rename(2)` atomically replaces the destination and
+ * cannot fail this way, so these never fire on Linux/macOS.
+ */
+const RENAME_CONTENTION_CODES = new Set(['EPERM', 'EACCES', 'EBUSY']);
+
+/** Backoff schedule for a contended rename. Worst case ~193ms, then rethrow. */
+export const RENAME_RETRY_DELAYS_MS = [1, 2, 5, 10, 25, 50, 100];
+
+/**
+ * Is this error Windows saying "the destination is busy right now"?
+ *
+ * Exported for the same reason `pipeline-lock.mjs` exports `isMkdirContention`
+ * and `isRmContention`: one definition, testable, and no second copy to drift.
+ *
+ * @param {unknown} err - Error thrown by a rename attempt.
+ * @returns {boolean} True when the rename should be retried.
+ */
+export function isRenameContention(err) {
+  return RENAME_CONTENTION_CODES.has(err?.code);
+}
+
+/**
+ * Block the current thread for `ms` without an event-loop turn.
+ *
+ * `writeFileAtomic` is synchronous by contract (every tracker writer calls it
+ * inside a held lock), so the backoff cannot be a promise.
+ *
+ * @param {number} ms - Milliseconds to sleep.
+ * @returns {void}
+ */
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
+ * `renameSync` that survives Windows contention for the destination handle.
+ *
+ * Windows refuses a rename whose destination is open by anyone else at that
+ * instant, and answers EPERM/EACCES/EBUSY. The holder is usually not another
+ * writer of ours (they are serialized by the tracker lock) but a transient
+ * reader: an antivirus scanner, the Search indexer, or a concurrent
+ * `readFileSync` from a reporting script. The handle is released in
+ * milliseconds, so a short backoff converts a lost write into a completed one.
+ *
+ * This mirrors `isMkdirContention` / `isRmContention` in pipeline-lock.mjs.
+ * Same reasoning as #2777: treating portable-looking contention as fatal is how
+ * a write gets LOST, and the tracker is the canonical store.
+ *
+ * @param {string} tmpPath - Source path (the fully written temporary file).
+ * @param {string} path - Destination path to replace.
+ * @param {(from: string, to: string) => void} [rename] - Injectable rename, for tests.
+ * @returns {void}
+ */
+export function renameSyncWithRetry(tmpPath, path, rename = renameSync) {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      rename(tmpPath, path);
+      return;
+    } catch (err) {
+      if (!isRenameContention(err) || attempt >= RENAME_RETRY_DELAYS_MS.length) throw err;
+      sleepSync(RENAME_RETRY_DELAYS_MS[attempt]);
+    }
+  }
+}
+
+/**
  * Replace a tracker file atomically using a same-directory temporary file.
  *
- * Writing into the same directory keeps the final `renameSync` atomic on normal
+ * Writing into the same directory keeps the final rename atomic on normal
  * filesystems and avoids exposing a partially written `applications.md` to other
- * readers. If the write or rename fails, the temporary file is cleaned up before
- * the original error is rethrown.
+ * readers. The rename retries through short Windows contention (see
+ * `renameSyncWithRetry`). If the write or rename ultimately fails, the temporary
+ * file is cleaned up before the original error is rethrown.
  *
  * @param {string} path - Final file path to replace.
  * @param {string} content - Complete file content to write.
@@ -554,7 +623,7 @@ export function writeFileAtomic(path, content) {
   const tmpPath = join(dirname(path), `.${basename(path)}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`);
   try {
     writeFileSync(tmpPath, content);
-    renameSync(tmpPath, path);
+    renameSyncWithRetry(tmpPath, path);
   } catch (err) {
     rmSync(tmpPath, { force: true });
     throw err;


### PR DESCRIPTION
## The bug

`writeFileAtomic` in `tracker-utils.mjs` closes with a bare `renameSync`. On Windows, a rename whose **destination** is open by anyone else at that instant fails with `EPERM` (errno `-4048`). POSIX `rename(2)` replaces the destination atomically and cannot fail that way, which is why CI stays green and this only reproduces on Windows.

The handle holder is usually **not** another writer of ours, since the tracker lock serializes those. It is a transient reader: an antivirus scanner, the Windows Search indexer, or a concurrent `readFileSync` from a reporting script. The handle is released in milliseconds.

**This is a production bug, not only a test flake.** Any tracker write on Windows can fail with a raw stack trace and lose the write, and `data/applications.md` is the canonical store by the project's own doctrine ("Files are canonical, databases are derived").

## Why this is the same bug as #2777

`tracker-utils.mjs` already documents this exact portability gap, in its own header:

> pipeline-lock learned that Windows answers mkdir/rm with EPERM/EACCES/EBUSY under contention while this file still treated anything but EEXIST as fatal, killing a writer and losing its item.

`mkdir` was fixed, then `rm`/`stat` in `2743281`. `rename` is the third syscall in that family and the one still bare. I have followed the shape already established rather than inventing a new one.

## The fix

- **`isRenameContention(err)`** — one exported classifier, mirroring the exported `isMkdirContention` / `isRmContention`, so there is no second copy to drift.
- **`renameSyncWithRetry(tmp, path, rename = renameSync)`** — bounded backoff (`[1,2,5,10,25,50,100]`ms, ~193ms worst case, then rethrow the **original** error) on `EPERM`/`EACCES`/`EBUSY` only.
- Any other errno still fails on the first attempt. `writeFileAtomic` still cleans up its temp file on failure, and a failed write still leaves the original intact.
- The rename is injectable purely so the retry loop is testable off-Windows.

## Reproduction

Windows 11, Node v24.18.0:

| | Result |
|---|---|
| **Before** | `node test-all.mjs` failed **1-2 tests per run**, non-deterministically, in `tracker-writer-lock-tests.mjs` and `set-status-tests.mjs` |
| **After** | **4091 passed, 0 failed** |

Both suites pass in isolation (27/0 and 88/0, three runs each); only the full run manufactures enough concurrent readers to lose the race. Three consecutive clean full runs before the new test was added (4070/0), and green with it.

The actual failure:

```
Fatal: Error: EPERM: operation not permitted, rename
  'C:\...\Temp\career-ops-writer-lock-kJFY1z\.applications.md.15148.1786995213566.1a852d47-....tmp'
  -> 'C:\...\Temp\career-ops-writer-lock-kJFY1z\applications.md'
    at renameSync (node:fs:1013:11)
    at writeFileAtomic (tracker-utils.mjs:557:5)
    at Object.replace (tracker-utils.mjs:524:7)
    at updateTrackerStatuses (reply-watch.mjs:205:46)
  errno: -4048, code: 'EPERM', syscall: 'rename'
```

## Tests

`tests/rename-contention.test.mjs`, 21 assertions, glob-discovered so no registration needed. It pins:

1. The classifier agrees on the measured Windows codes **and only those** — `ENOENT`/`EXDEV`/`EISDIR`/`ENOSPC` still fail fast rather than stalling ~200ms behind a pointless retry loop.
2. A contended rename is retried until it lands; a permanently contended one gives up at the bound and rethrows the original `EPERM`.
3. `writeFileAtomic`'s contract holds: destination replaced, no `.tmp` left behind on success **or** failure, original intact after a failed write.
4. **No direct `renameSync()` call remains in the atomic path.** This is the guard that stops the bug being reintroduced one refactor from now, which is how the mkdir/rm half survived two earlier fixes. Same shape as the existing `no bare rmSync(lockDir) remains` guards in `tests/lock-rm-contention.test.mjs`.

## Deliberately left out

Six other bare `renameSync` atomic-replace sites carry the same latent bug. I have left them out rather than widening this PR:

- `discover-ats.mjs:852`
- `followup-seed.mjs:422`
- `paste-reply.mjs:134`
- `scan-ats-full.mjs:121`
- `merge-tracker.mjs:1228`
- `update-system.mjs:1296`

The last is the most consequential, since a failed rename there breaks an upgrade partway through. Happy to take them in a follow-up PR if you want them, either one-by-one or by exporting the helper for reuse.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of atomic tracker-file updates on Windows when files are temporarily locked or in use.
  * Automatically retries eligible rename conflicts before reporting an error.
  * Preserves original errors for persistent failures and immediately reports unrelated errors.
  * Ensures temporary files are cleaned up when an update cannot be completed.
  * Supports replacing existing destination files safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->