### PR TITLE
fix(providers): senjob was the fifth private entity decoder, and the weakest — it emitted C0 controls

### DIFF
--- a/providers/_html-entities.mjs
+++ b/providers/_html-entities.mjs
@@ -37,7 +37,40 @@
 // so a decimal entity can never absorb trailing hex letters — "&#1a2;" no
 // longer silently parses as codepoint 1 and drops "a2"; it just fails to
 // match and passes through untouched, same as any other malformed entity.
-const NAMED_ENTITIES = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ' };
+// The XML five plus nbsp, then the Latin-1 letter entities. The letters are not
+// decoration: a European board writes `D&eacute;veloppeur` and `Fran&ccedil;ais`
+// in its HTML, and leaving those literal puts `D&eacute;veloppeur` in a job
+// title, the tracker, and every document generated from it. Providers that
+// needed them grew private tables instead, which is the drift this module
+// exists to end — so they belong here rather than in the next scraper.
+//
+// Unknown names still pass through untouched (see decodeEntities), so this list
+// is a floor, not a closed set.
+const NAMED_ENTITIES = {
+  amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ',
+  // French / Portuguese / Spanish / German / Nordic letters, lower and upper.
+  agrave: 'à', aacute: 'á', acirc: 'â', atilde: 'ã', auml: 'ä', aring: 'å', aelig: 'æ',
+  ccedil: 'ç',
+  egrave: 'è', eacute: 'é', ecirc: 'ê', euml: 'ë',
+  igrave: 'ì', iacute: 'í', icirc: 'î', iuml: 'ï',
+  ntilde: 'ñ',
+  ograve: 'ò', oacute: 'ó', ocirc: 'ô', otilde: 'õ', ouml: 'ö', oslash: 'ø',
+  ugrave: 'ù', uacute: 'ú', ucirc: 'û', uuml: 'ü',
+  yacute: 'ý', yuml: 'ÿ', szlig: 'ß',
+  Agrave: 'À', Aacute: 'Á', Acirc: 'Â', Atilde: 'Ã', Auml: 'Ä', Aring: 'Å', AElig: 'Æ',
+  Ccedil: 'Ç',
+  Egrave: 'È', Eacute: 'É', Ecirc: 'Ê', Euml: 'Ë',
+  Igrave: 'Ì', Iacute: 'Í', Icirc: 'Î', Iuml: 'Ï',
+  Ntilde: 'Ñ',
+  Ograve: 'Ò', Oacute: 'Ó', Ocirc: 'Ô', Otilde: 'Õ', Ouml: 'Ö', Oslash: 'Ø',
+  Ugrave: 'Ù', Uacute: 'Ú', Ucirc: 'Û', Uuml: 'Ü',
+  Yacute: 'Ý',
+  // Punctuation these same pages emit around titles.
+  deg: '°', hellip: '…', laquo: '«', raquo: '»', ndash: '–', mdash: '—',
+  lsquo: '\u2018', rsquo: '\u2019', ldquo: '\u201C', rdquo: '\u201D', middot: '·', euro: '€',
+};
+
+const CASE_INSENSITIVE_NAMES = new Set(['amp', 'lt', 'gt', 'quot', 'apos', 'nbsp']);
 
 /**
  * Whether a numeric reference names a code point this decoder will emit.
@@ -88,6 +121,13 @@ export function decodeEntities(s) {
       // `&#0;` in a title is visible and inert; a decoded NUL is neither.
       return isEmittableCodePoint(code) ? String.fromCodePoint(code) : m;
     }
-    return NAMED_ENTITIES[body.toLowerCase()] ?? m;
+    // Letter entities are CASE-SENSITIVE: `&Eacute;` is É, not é. Looking the
+    // name up lowercased would make every uppercase entry unreachable and
+    // silently decode `&Eacute;` to the lowercase letter. Only the XML five and
+    // nbsp are matched case-insensitively, which is where legacy pages really do
+    // write `&AMP;`.
+    if (Object.hasOwn(NAMED_ENTITIES, body)) return NAMED_ENTITIES[body];
+    const lower = body.toLowerCase();
+    return CASE_INSENSITIVE_NAMES.has(lower) ? NAMED_ENTITIES[lower] : m;
   });
 }

--- a/providers/senjob.mjs
+++ b/providers/senjob.mjs
@@ -34,6 +34,7 @@
 // `assertParsedSomething` below.
 
 import { BROWSER_LIKE_USER_AGENT, fetchTextWithRetry } from './_http.mjs';
+import { decodeEntities } from './_html-entities.mjs';
 
 const TRUSTED_HOST = 'senjob.com';
 const LIST_URL = 'https://senjob.com/offres-d-emploi.php';
@@ -83,60 +84,6 @@ function assertSenjobUrl(url) {
 }
 
 /**
- * Named entities this board actually emits. A French-language listing carries
- * accented references freely, so they are decoded rather than left as noise in
- * a job title.
- */
-const NAMED_ENTITIES = new Map([
-  ['nbsp', ' '], ['amp', '&'], ['quot', '"'], ['apos', "'"], ['lt', '<'], ['gt', '>'],
-  ['eacute', 'é'], ['egrave', 'è'], ['ecirc', 'ê'], ['agrave', 'à'], ['acirc', 'â'],
-  ['ccedil', 'ç'], ['ocirc', 'ô'], ['ugrave', 'ù'], ['ucirc', 'û'], ['icirc', 'î'],
-  ['iuml', 'ï'], ['euml', 'ë'], ['ouml', 'ö'], ['deg', '°'], ['hellip', '…'],
-]);
-
-const ENTITY_RE = /&(#\d{1,7}|#x[0-9a-f]{1,6}|[a-z]+);/gi;
-
-/**
- * Whether a code point is a character worth emitting.
- *
- * `String.fromCodePoint()` does NOT reject surrogates: `&#55296;` builds a LONE
- * SURROGATE, which is not valid text and breaks strict serialization further
- * down the pipeline. Noncharacters are excluded for the same reason — a job
- * title is candidate-facing text, so an undecodable reference is better left
- * visible than turned into a broken glyph.
- * @param {number} code
- */
-function isValidScalar(code) {
-  if (!Number.isInteger(code) || code <= 0 || code > 0x10ffff) return false;
-  if (code >= 0xd800 && code <= 0xdfff) return false;          // surrogate halves
-  if (code >= 0xfdd0 && code <= 0xfdef) return false;          // noncharacter block
-  if ((code & 0xfffe) === 0xfffe) return false;                // U+xFFFE / U+xFFFF
-  return true;
-}
-
-/**
- * Decode ONE entity reference. Decoding must happen in a single pass: chained
- * `.replace()` calls decoded `&amp;` first, so `&amp;quot;` became `&quot;` and
- * then `"` — a double-unescape that rewrites text the board meant literally
- * (CodeQL flagged it on #2962). An unknown reference is returned untouched
- * rather than guessed at.
- * @param {string} match - The full entity reference, returned when it cannot be decoded.
- * @param {string} ref - The reference body: `#233`, `#xE9`, or a named entity.
- * @returns {string}
- */
-function decodeEntity(match, ref) {
-  if (ref[0] === '#') {
-    const code = ref[1] === 'x' || ref[1] === 'X'
-      ? Number.parseInt(ref.slice(2), 16)
-      : Number.parseInt(ref.slice(1), 10);
-    if (!isValidScalar(code)) return match;
-    return String.fromCodePoint(code);
-  }
-  const named = NAMED_ENTITIES.get(ref.toLowerCase());
-  return named === undefined ? match : named;
-}
-
-/**
  * Collapse a markup fragment to its visible text.
  * Comments are stripped FIRST: the anchor bodies carry `<!-- d ico postulez -->`
  * between the title and a spacer image, and a naive tag strip would leave the
@@ -145,10 +92,11 @@ function decodeEntity(match, ref) {
  * @returns {string}
  */
 export function visibleText(fragment) {
-  return String(fragment ?? '')
-    .replace(/<!--[\s\S]*?-->/g, ' ')
-    .replace(/<[^>]+>/g, ' ')
-    .replace(ENTITY_RE, decodeEntity)
+  return decodeEntities(
+    String(fragment ?? '')
+      .replace(/<!--[\s\S]*?-->/g, ' ')
+      .replace(/<[^>]+>/g, ' '),
+  )
     .replace(/\s+/g, ' ')
     .trim();
 }

--- a/tests/providers/senjob.test.mjs
+++ b/tests/providers/senjob.test.mjs
@@ -118,13 +118,22 @@ try {
   // block is INSIDE it and decodes — a deliberate consequence of naming that
   // standard, not an oversight here, so this pins the standard's actual edge
   // rather than a stricter rule this provider used to apply alone.
-  if (visibleText('&#55296;') === '&#55296;'
-      && visibleText('&#xD800;') === '&#xD800;'
-      && visibleText('&#65534;') === '&#65534;'
-      && visibleText('&#1;') === '&#1;') {
-    pass('visibleText() rejects surrogates, U+FFFE and the C0 controls');
+  const outsideXmlChar = ['&#55296;', '&#xD800;', '&#65534;', '&#65535;', '&#1;'];
+  const keptLiteral = outsideXmlChar.filter((ref) => visibleText(ref) === ref);
+  if (keptLiteral.length === outsideXmlChar.length) {
+    pass('visibleText() keeps surrogates, U+FFFE, U+FFFF and the C0 controls literal');
   } else {
-    fail(`invalid scalar decoded: ${JSON.stringify([visibleText('&#55296;'), visibleText('&#xD800;'), visibleText('&#65534;'), visibleText('&#1;')])}`);
+    fail(`decoded outside XML Char: ${JSON.stringify(outsideXmlChar.filter((r) => !keptLiteral.includes(r)).map((r) => [r, visibleText(r)]))}`);
+  }
+  // The other side of the same boundary, which the comment above claims and the
+  // assertion above cannot show: U+FDD0 is INSIDE XML Char and therefore
+  // decodes. Without this, a decoder that rejected the whole FDD0–FDEF block —
+  // the stricter rule senjob used to apply alone — would still pass (CodeRabbit,
+  // #3007).
+  if (visibleText('&#64976;') === '\uFDD0') {
+    pass('visibleText() decodes U+FDD0: inside XML Char, so inside the policy');
+  } else {
+    fail(`U+FDD0 not decoded: ${JSON.stringify(visibleText('&#64976;'))}`);
   }
   // Guard: valid references on both sides of the rejected ranges still decode.
   if (visibleText('&#233;') === 'é' && visibleText('&#xE9;') === 'é' && visibleText('&#128512;') === '\u{1F600}') {

--- a/tests/providers/senjob.test.mjs
+++ b/tests/providers/senjob.test.mjs
@@ -113,13 +113,18 @@ try {
   // A numeric reference outside the valid scalar range must stay literal.
   // String.fromCodePoint() happily builds a LONE SURROGATE, which is not valid
   // text and breaks strict serialization downstream (CodeRabbit, #2962).
+  // The policy is the shared decoder's: XML 1.0 §2.2 Char. Surrogates and
+  // U+FFFE/U+FFFF are outside it and stay literal. The FDD0–FDEF noncharacter
+  // block is INSIDE it and decodes — a deliberate consequence of naming that
+  // standard, not an oversight here, so this pins the standard's actual edge
+  // rather than a stricter rule this provider used to apply alone.
   if (visibleText('&#55296;') === '&#55296;'
       && visibleText('&#xD800;') === '&#xD800;'
       && visibleText('&#65534;') === '&#65534;'
-      && visibleText('&#xFDD0;') === '&#xFDD0;') {
-    pass('visibleText() rejects surrogates and noncharacters, leaving them literal');
+      && visibleText('&#1;') === '&#1;') {
+    pass('visibleText() rejects surrogates, U+FFFE and the C0 controls');
   } else {
-    fail(`invalid scalar decoded: ${JSON.stringify([visibleText('&#55296;'), visibleText('&#xD800;'), visibleText('&#65534;'), visibleText('&#xFDD0;')])}`);
+    fail(`invalid scalar decoded: ${JSON.stringify([visibleText('&#55296;'), visibleText('&#xD800;'), visibleText('&#65534;'), visibleText('&#1;')])}`);
   }
   // Guard: valid references on both sides of the rejected ranges still decode.
   if (visibleText('&#233;') === 'é' && visibleText('&#xE9;') === 'é' && visibleText('&#128512;') === '\u{1F600}') {
@@ -129,10 +134,12 @@ try {
   }
 
   // An entity the table does not know is left alone rather than mangled.
-  if (visibleText('100&euro; &unknown; net') === '100&euro; &unknown; net') {
+  // `&euro;` is now a KNOWN entity (the shared table carries it), so the guard
+  // uses names the table genuinely does not have.
+  if (visibleText('&unknown; &fakeent; net') === '&unknown; &fakeent; net') {
     pass('visibleText() leaves an unknown entity untouched');
   } else {
-    fail(`unknown entity mangled: ${JSON.stringify(visibleText('100&euro; &unknown; net'))}`);
+    fail(`unknown entity mangled: ${JSON.stringify(visibleText('&unknown; &fakeent; net'))}`);
   }
 
   // ── parseListingPage(): the shapes the board actually serves ──


### PR DESCRIPTION
Self-inflicted, and in the exact class this repo has spent four rounds consolidating. `providers/_html-entities.mjs` says it plainly:

> Each round has migrated whichever copies were in front of the contributor at the time, which is why there were four.

**#2962 added a fifth**, ten hours before #2902 landed the guard meant to stop them. `senjob.mjs` shipped with its own `NAMED_ENTITIES` table, its own `ENTITY_RE`, and its own `isValidScalar`.

## Why it matters: mine was weaker

My guard rejected surrogates and noncharacters. It did **not** reject the C0 controls:

```
visibleText('titre&#1;suite')  →  "titresuite"      ← before
                               →  "titre&#1;suite"        ← after (shared)
```

`_html-entities.mjs` explains exactly why that is not cosmetic: a decoded title is written to the scan history, the pipeline, the tracker, and every document generated downstream. A control character there produces ill-formed data that is tedious to trace back to one malformed entity weeks later. The shared decoder rejects it; my copy emitted it.

## Why the migration needed the shared table to grow

Swapping the decoder in wholesale would have **regressed** senjob: the shared `NAMED_ENTITIES` held only the XML five plus `nbsp`, so `Charg&eacute; de projet` came back literal. That is precisely the pressure that grows private tables in the first place, so the letters belong in the shared module rather than in the next European scraper:

- the Latin-1 letter entities (French, Portuguese, Spanish, German, Nordic), lower and upper case;
- the punctuation those same pages emit around titles (`&deg;`, `&hellip;`, `&laquo;`, `&ndash;`, `&euro;`, curly quotes).

Unknown names still pass through untouched, so the list is a floor, not a closed set.

## A bug found while adding them

The lookup was `NAMED_ENTITIES[body.toLowerCase()]`. That is right for the XML five — legacy pages really do write `&AMP;` — and **wrong for letters**, which are case-sensitive: `&Eacute;` is É, not é. Adding uppercase keys under a lowercasing lookup would have made every one of them unreachable *and* decoded `&Eacute;` to the lowercase letter.

Case-sensitive exact match first, with the case-insensitive fallback kept for the six names where it is correct. No existing behaviour changes: those six were the entire table before.

## One policy difference, stated rather than smoothed over

senjob's private guard rejected the U+FDD0–FDEF noncharacter block. The shared decoder admits it, because XML 1.0 §2.2 Char runs to U+FFFD and that block sits inside it. I did **not** change the shared policy: the module names a standard and implements it faithfully, and picking a different one is a design call, not a bug fix. The senjob test now pins the standard's real edge instead of a stricter rule one provider applied alone.

Worth a second opinion though: the range excludes U+FFFE and U+FFFF only as an accident of ending at FFFD, while admitting the other 32 noncharacters. If the intent is "safe to put in a job title" rather than "legal XML", those 32 are on the wrong side of the line.

## Test plan

- [x] `&#1;` verified emitted before the migration and literal after — the defect that motivated it.
- [x] Live re-parse of five real senjob listing pages: **208 postings**, identical to before.
- [x] `node test-all.mjs --only _html-entities` — 25 passed, the shared module's existing suite unaffected by the table growth.
- [x] `node test-all.mjs --only providers/senjob` — 27 passed. Two assertions were updated, both because the shared behaviour is now correct where mine was narrower, and both explain why in place.
- [x] `node test-all.mjs` — 4080 passed, 0 failed.

## Follow-up, deliberately not in this PR

The guard from #2902 could not have caught this, for two independent reasons: it skips any provider that does **not** import the shared module, and its name pattern looks for `decodeEntities`/`decodeXmlEntities`/`fromCodePoint` — senjob declared `decodeEntity`, singular. Widening it flags exactly one other file, `jobvite.mjs`, whose private copy the module's own header already describes as upstreamed. That is a separate change and I would rather send it separately than bundle a guard rewrite with a migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decoding of HTML and XML entities, including Latin-1 characters and common punctuation.
  * Preserved correct case handling for entity names and left unsupported entities unchanged.
  * Improved text cleanup for invalid XML characters and special Unicode ranges.
  * Standardized entity decoding for provider content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->