### PR TITLE
test(providers): the private-decoder guard reported clean over the copy it was written to catch

### DIFF
--- a/providers/jobvite.mjs
+++ b/providers/jobvite.mjs
@@ -2,6 +2,12 @@
 /** @typedef {import('./_types.js').Provider} Provider */
 
 import { fetchTextWithRetry } from './_http.mjs';
+// Shared decoder, not a private copy. This provider's stricter XML 1.0 §2.2 Char
+// guard was upstreamed into _html-entities.mjs (#2623); keeping the local one
+// only risked the two drifting apart again — which is the drift that module
+// exists to end. The numeric references this feed really carries (`&#8217;`,
+// `&#x2013;`) decode identically there.
+import { decodeEntities } from './_html-entities.mjs';
 
 // Jobvite provider — per-tenant public jobs feed.
 // Used by ~3,000 companies across a wide range of industries.
@@ -353,45 +359,6 @@ function tagText(block, name) {
     value = value.slice('<![CDATA['.length, -']]>'.length).trim();
   }
   return value;
-}
-
-const XML_ENTITIES = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'" };
-
-/**
- * Decode the XML entities that appear in this feed.
- *
- * Numeric references matter here and are not decorative: Jobvite titles carry
- * typographic punctuation from the source ATS — `&#8217;` (right single quote)
- * and `&#x2013;` (en dash) both appear in real postings. Leaving them raw puts
- * literal `&#8217;` into a job title, which then reaches the tracker and any
- * generated document.
- *
- * @param {string} s
- */
-function decodeEntities(s) {
-  return String(s).replace(/&(#x[0-9a-fA-F]+|#\d+|amp|lt|gt|quot|apos);/g, (match, body) => {
-    if (body[0] === '#') {
-      const code = body[1] === 'x' || body[1] === 'X'
-        ? Number.parseInt(body.slice(2), 16)
-        : Number.parseInt(body.slice(1), 10);
-      // XML 1.0 §2.2 Char — only these ranges are legal, and a bare
-      // `code <= 0x10ffff` bound is not the same test. It admits NUL, the C0
-      // controls and lone surrogates, all of which String.fromCodePoint will
-      // happily emit; an unpaired surrogate then travels into a job title, the
-      // tracker, and every document generated from it. Anything illegal is left
-      // as written rather than decoded — the raw reference is visible and inert,
-      // which is the better failure.
-      const legalXmlChar = code === 0x9 || code === 0xa || code === 0xd
-        || (code >= 0x20 && code <= 0xd7ff)
-        || (code >= 0xe000 && code <= 0xfffd)
-        || (code >= 0x10000 && code <= 0x10ffff);
-      // NaN and Infinity fail every comparison above, so they need no separate
-      // guard, and fromCodePoint cannot throw on what survives.
-      if (!legalXmlChar) return match;
-      return String.fromCodePoint(code);
-    }
-    return XML_ENTITIES[/** @type {keyof typeof XML_ENTITIES} */ (body)] ?? match;
-  });
 }
 
 /**

--- a/tests/providers/rss-entity-decoding.test.mjs
+++ b/tests/providers/rss-entity-decoding.test.mjs
@@ -161,8 +161,12 @@ for (const [label, getTitle] of checked) {
   // cosmetic variations a re-introduced copy would arrive with, and matching
   // one spelling would let it back in (CodeRabbit on this PR).
   const SHARED_IMPORT = /\bfrom\s*['"]\.\/_html-entities\.mjs['"]/;
+  // The name list is a list of SPELLINGS, so it has to carry the near misses.
+  // senjob (#2962) declared `decodeEntity` — singular — alongside its own
+  // `NAMED_ENTITIES` table, and matched none of the three names below, so this
+  // guard reported a clean repository while a fifth private copy sat in it.
   const PRIVATE_DECL =
-    /(?:function\s*\*?\s+|(?:const|let|var)\s+)(decodeEntities|decodeXmlEntities|fromCodePoint)\b/;
+    /(?:function\s*\*?\s+|(?:const|let|var)\s+)(decodeEntity|decodeEntities|decodeXmlEntity|decodeXmlEntities|fromCodePoint|NAMED_ENTITIES|XML_ENTITIES|HTML_ENTITIES)\b/;
   // Declarations only — remotli.mjs names String.fromCodePoint in a comment
   // explaining why it uses the shared decoder, which is not a private copy.
   // A destructure (`const { decodeEntities } = …`) has a brace after `const`
@@ -172,6 +176,57 @@ for (const [label, getTitle] of checked) {
     'jobspresso.mjs', 'higheredjobs.mjs', 'nodesk.mjs', 'larajobs.mjs',
     'personio.mjs', 'teamtailor.mjs', 'weworkremotely.mjs',
   ];
+
+  // The classification lives in one function so the POSITIVE CONTROL below can
+  // run it on synthetic sources instead of restating the logic. A guard whose
+  // discrimination is only ever demonstrated in a pull-request description is
+  // demonstrated nowhere after the merge (Scott-Emberson on this PR).
+  /** @returns {string|null} offender line, or null when the file is clean. */
+  const classifyProvider = (file, src) => {
+    const local = src.match(PRIVATE_DECL);
+    if (!local) return null;
+    return SHARED_IMPORT.test(src)
+      ? `${file} (declares ${local[1]})`
+      : `${file} (declares ${local[1]}, and does not import the shared decoder)`;
+  };
+
+  // ── Positive control ──
+  // Plant each shape that has actually escaped this guard and assert it fires.
+  // Without these, a regex that later matches NOTHING keeps every run green
+  // over a real private copy — the exact failure this block exists to prevent.
+  {
+    const IMPORT_LINE = "import { decodeEntities } from './_html-entities.mjs';\n";
+    const planted = [
+      // The senjob escape: singular name, no shared import.
+      ['const decodeEntity = (m, r) => m;',
+        'x.mjs (declares decodeEntity, and does not import the shared decoder)'],
+      // The same name as a function declaration.
+      ['function decodeEntity(m) { return m; }',
+        'x.mjs (declares decodeEntity, and does not import the shared decoder)'],
+      // A re-introduced table rather than a function.
+      ['const NAMED_ENTITIES = { amp: "&" };',
+        'x.mjs (declares NAMED_ENTITIES, and does not import the shared decoder)'],
+      // The original shape: a private copy ALONGSIDE the shared import.
+      [IMPORT_LINE + 'function decodeEntities(s) { return s; }',
+        'x.mjs (declares decodeEntities)'],
+    ];
+    const missed = planted.filter(([src, want]) => classifyProvider('x.mjs', src) !== want);
+    if (missed.length === 0) {
+      pass('positive control: every known-offending shape is still detected');
+    } else {
+      fail(`guard no longer fires on: ${JSON.stringify(missed.map(([src]) => src.slice(0, 60)))}`);
+    }
+
+    // Negative control, so the widened pattern cannot pass by matching
+    // everything: importing the shared decoder by destructuring is CORRECT
+    // usage and must stay clean.
+    const legitimate = IMPORT_LINE + 'const title = decodeEntities(raw);\n';
+    if (classifyProvider('x.mjs', legitimate) === null) {
+      pass('negative control: importing and calling the shared decoder is not an offence');
+    } else {
+      fail(`guard flags legitimate usage: ${classifyProvider('x.mjs', legitimate)}`);
+    }
+  }
 
   let files;
   try {
@@ -210,9 +265,14 @@ for (const [label, getTitle] of checked) {
         offenders.push(`${file} (unreadable: ${e.message})`);
         continue;
       }
-      if (!SHARED_IMPORT.test(src)) continue;
-      const local = src.match(PRIVATE_DECL);
-      if (local) offenders.push(`${file} (declares ${local[1]})`);
+      // NOT `if (!SHARED_IMPORT.test(src)) continue;`. Skipping non-importers
+      // is what let senjob through: a brand-new provider that never imports the
+      // shared module and simply writes its own decoder is the re-introduction
+      // this guard exists to fail on, and it was the one shape it could not
+      // see. A provider that declares a decoder is an offender whether or not
+      // it also imports the shared one.
+      const verdict = classifyProvider(file, src);
+      if (verdict) offenders.push(verdict);
     }
 
     if (offenders.length === 0) {


### PR DESCRIPTION
> **Stacked on #3007.** Its commit is the first of the two here, because the widened guard fails on `senjob.mjs` until that migration lands. Merge #3007 first and this reduces to the second commit.

The guard from #2902 was written so "the next re-introduction fails on the commit that adds it instead of drifting quietly for a year". Ten hours earlier, #2962 had added one — and the guard reported a clean repository.

It could not have seen it, for two independent reasons.

## Blind spot 1 — non-importers are skipped

```js
if (!SHARED_IMPORT.test(src)) continue;
```

A provider that never imports the shared module and simply writes its own decoder is **exactly** the re-introduction being guarded against, and it was the one shape excluded from the scan. The check only ever asked "does an importer also keep a private copy?", which its own pass message states accurately — but that is narrower than the goal.

A provider that declares a decoder is now an offender whether or not it also imports the shared one, and the message distinguishes the two cases.

## Blind spot 2 — the name list missed the near misses

```js
(decodeEntities|decodeXmlEntities|fromCodePoint)
```

senjob declared `decodeEntity` — **singular** — next to its own `NAMED_ENTITIES` table. Neither name is in the list. A list of spellings has to carry the near misses, so it now also covers `decodeEntity`, `decodeXmlEntity`, `NAMED_ENTITIES`, `XML_ENTITIES` and `HTML_ENTITIES`.

## What widening it exposed: jobvite

Running the widened guard across all 74 providers flagged exactly two files: `senjob.mjs` (handled by #3007) and **`jobvite.mjs`**.

jobvite's copy is not a divergence — it is the *source* of the shared module's current strictness. `_html-entities.mjs` says so in its own header:

> the jobvite provider (#2623) grew its own copy that was STRICTER than this one … That strictness is now here, in isEmittableCodePoint below, which is the point of a shared decoder — the improvement should not have had to live in one provider.

The improvement was upstreamed; the provider was never migrated. This finishes it.

Verified equivalent on the references that feed really carries, which its own comment names as the reason the decoder exists there at all:

| input | shared decoder |
|---|---|
| `Manager &#8217;s role` | `Manager ’s role` |
| `Lead &#x2013; Platform` | `Lead – Platform` |
| `R&amp;D` | `R&D` |
| `&#0;` | `&#0;` (left literal) |

One behaviour change, in the safe direction: jobvite's private table had no `nbsp`, so `&nbsp;` used to survive literally into a title and now decodes to a space.

## Test plan

- [x] `node test-all.mjs --only jobvite` — 56 passed, 0 failed.
- [x] `node test-all.mjs --only rss-entity-decoding` — 17 passed, and **zero offenders across all 74 providers** once both migrations are in.
- [x] Both blind spots verified to discriminate, by planting each shape and watching the guard fail:
  - a private `decodeEntity` with **no** shared import → `senjob.mjs (declares decodeEntity, and does not import the shared decoder)`
  - a re-introduced `NAMED_ENTITIES` table → `senjob.mjs (declares NAMED_ENTITIES)`
- [x] `node test-all.mjs` — 4080 passed, 0 failed.

A guard that has never been shown to fail is a guard nobody has tested, which is how this one reported clean over a copy it was written to catch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded support for named HTML entities, including Latin-1 characters, punctuation, and currency symbols.
  - Improved case-sensitive handling for letter entities while preserving compatibility for standard XML entities and non-breaking spaces.
  - Correctly decodes additional supported entities, including `&euro;`.

- **Bug Fixes**
  - Standardized entity decoding across job listing and RSS content.
  - Improved handling and validation of numeric character references and unsupported characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->