### PR TITLE
docs(i18n): restore the two anti-fabrication RULES in the French _shared.md (#2573)

### DIFF
--- a/modes/fr/_shared.md
+++ b/modes/fr/_shared.md
@@ -21,6 +21,8 @@
 
 **REGLE : Ne JAMAIS coder en dur des metriques issues des proof points.** Les lire depuis `cv.md` et `article-digest.md` au moment de l'evaluation.
 **REGLE : Pour les metriques d'articles/projets, `article-digest.md` a priorite sur `cv.md`** (`cv.md` peut contenir des chiffres plus anciens).
+**REGLE : Ne JAMAIS affirmer que le candidat est l'auteur d'un projet, d'un depot, d'une bibliotheque, d'un outil, d'un framework ou d'un artefact open source sans attribution explicite dans `cv.md` ou `article-digest.md`.** La confusion outil-de-travail (le candidat utilise X -> le candidat a construit X) est le schema de fabrication le plus frequent, et il est interdit.
+**REGLE : Les mots-cles se reformulent, ils ne s'inventent jamais.** Reordonner, recadrer, mettre en avant -- mais jamais inventer. Si une affirmation n'est etayee par aucun fichier du perimetre, demander au candidat. Sans reponse, omettre. Le silence sur un sujet vaut mieux qu'un detail fabrique.
 
 ---
 


### PR DESCRIPTION
Part of #2573 — French only, per the one-language-per-PR convention (#2426).

## What was missing

`modes/fr/_shared.md` carried two `**REGLE`  blocks, both about metrics. The English source has six, and the two the umbrella targets — authorship and reformulate-never-fabricate — were absent:

```
modes/_shared.md:32   NEVER claim the user authored a project, repo, library…
modes/_shared.md:33   Keywords get reformulated, never fabricated.
```

As the issue puts it: last line of defence intact (`verify-cv-facts.mjs` is language-agnostic and still blocks a fabricated employer at generation time), first line absent. This restores the first line for French.

Placed immediately after the existing metrics rules, which is where the umbrella asks for them and where the English original keeps them.

## Two details that decide whether a translation reads as native

**The file is written in unaccented ASCII.** All of `modes/fr/_shared.md` is — `metriques`, `priorite`, `evaluation`, zero accented characters in the whole file. Adding correctly-accented French would have been *more* correct in isolation and *less* correct here. The addition keeps zero accented characters, verified rather than assumed.

**It says `le candidat`, not `l'utilisateur`.** The English rule says "the user"; this file already uses "le candidat" throughout, so the translation follows the file rather than the source.

Same for `--` as the dash, which is the file's existing convention.

## Scope

French only, deliberately. These are safety rules: a translation I cannot verify to the same standard is worse than an honest gap, because it *looks* like coverage. Fifteen localized `_shared.md` files still need them, and they are visible with:

```bash
grep -c '^\*\*R' modes/*/_shared.md
```

I did not add a source-level guard for the same reason the umbrella exists: any check strong enough to be useful would fail on the fifteen files still waiting, so it belongs with the last translation rather than the first.

## Test plan

- [x] `node test-all.mjs` — 4195 passed, 0 failed.
- [x] Verified the addition introduces no accented character, matching the file's existing convention.
- [x] Verified the rules sit with the other `**REGLE` blocks, not appended elsewhere in the file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance to avoid attributing authorship without explicit supporting evidence.
  * Clarified that keywords must be based on verified source material, with unsupported claims omitted or confirmed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->