### PR TITLE
Fix/stats cli flag validation

### DIFF
--- a/stats.mjs
+++ b/stats.mjs
@@ -1,5 +1,5 @@
-import { validateFlags } from './lib/cli-flags.mjs';
 #!/usr/bin/env node
+import { validateFlags } from './lib/cli-flags.mjs';
 /**
  * stats.mjs — Lifetime pipeline stats aggregator (zero-token). #1604
  *

--- a/stats.mjs
+++ b/stats.mjs
@@ -1,3 +1,4 @@
+import { validateFlags } from './lib/cli-flags.mjs';
 #!/usr/bin/env node
 /**
  * stats.mjs — Lifetime pipeline stats aggregator (zero-token). #1604
@@ -547,11 +548,9 @@ const USAGE = `Usage:
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const args = process.argv.slice(2);
 
-  if (args.includes('--help') || args.includes('-h')) {
-    console.log(USAGE);
-  } else {
-    const stats = computeAllStats();
-    if (args.includes('--summary')) printSummary(stats);
-    else console.log(JSON.stringify(stats, null, 2));
-  }
+  validateFlags(args, KNOWN_FLAGS, USAGE);
+
+  const stats = computeAllStats();
+  if (args.includes('--summary')) printSummary(stats);
+  else console.log(JSON.stringify(stats, null, 2));
 }

--- a/tests/stats.test.mjs
+++ b/tests/stats.test.mjs
@@ -1,5 +1,5 @@
 // tests/stats.test.mjs — moved verbatim from test-all.mjs (#1604).
-import { pass, fail, run, NODE, ROOT } from './helpers.mjs';
+import { pass, fail, run, NODE, ROOT, lastRunFailure } from './helpers.mjs';
 import { join } from 'path';
 import { pathToFileURL } from 'url';
 import { mkdtempSync, writeFileSync, rmSync } from 'fs';
@@ -239,6 +239,16 @@ try {
     pass('stats.mjs -h prints the usage block and exits 0');
   } else {
     fail(`stats.mjs -h missing usage output: ${hOut}`);
+  }
+
+  // Unknown flag smoke: must fail cleanly and report the invalid-flag message.
+  const bogusOut = run(NODE, [join(ROOT, 'stats.mjs'), '--bogus']);
+  const bogusFailure = lastRunFailure();
+  const bogusOutput = `${bogusFailure?.stdout ?? ''}\n${bogusFailure?.stderr ?? ''}`;
+  if (bogusOut === null && bogusFailure?.status !== 0 && /invalid|unrecognized|unknown/i.test(bogusOutput)) {
+    pass('stats.mjs --bogus rejects unknown flags with a non-zero exit status');
+  } else {
+    fail(`stats.mjs --bogus did not fail as expected: exit=${bogusFailure?.status ?? 'null'} output=${bogusOutput.trim()}`);
   }
 
   // --summary cold-classification integration (#2123): the CLI reads its


### PR DESCRIPTION
## What does this PR do?

Validates CLI flags in `stats.mjs` using the shared `validateFlags` helper, so mistyped or unsupported flags fail fast instead of silently running the default report.

## Related issue

Fixes #3003

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read CONTRIBUTING.md
- [ ] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [ ] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the Data Contract (no modifications to user-layer files)
- [x] My changes align with the project roadmap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line option validation by rejecting unsupported flags before generating statistics.
  * Added clearer failure handling for unrecognized options, including a non-zero exit status.
  * Standardized statistics output for summary and JSON formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->