### PR TITLE
fix(web): keep the run stream alive during silent agent phases

### DIFF
--- a/web/src/app/api/run/route.ts
+++ b/web/src/app/api/run/route.ts
@@ -213,9 +213,20 @@ export async function POST(req: Request) {
         if (closed) return;
         try { controller.enqueue(enc.encode(JSON.stringify(obj) + "\n")); } catch { closed = true; }
       };
+      // Time-based keepalive. The stream is silent whenever the agent is thinking
+      // or inside a long tool call, and in pdf mode it is silent for the whole
+      // 15-25 KB <<cv-html>> envelope (cvFilter swallows every byte). Measured
+      // idle gaps on a real pdf run reached 149s — long enough for the browser or
+      // a proxy to drop the connection, after which the client reports
+      // "Connection error" even though the agent finished and the PDF rendered.
+      // It must be a timer, not a hook on incoming text: piggy-backing on agent
+      // output cannot fire during exactly the silences it needs to cover.
+      // Unknown event types are ignored by the client's switch, so old tabs are safe.
+      const heartbeat = setInterval(() => send({ type: "keepalive" }), 10_000);
       const close = () => {
         if (!closed) {
           closed = true;
+          clearInterval(heartbeat);
           if (killer) clearTimeout(killer);
           releaseWriteTokenOnce();
           try { controller.close(); } catch { /* */ }
@@ -226,6 +237,14 @@ export async function POST(req: Request) {
       // holding the 15-25 KB body out of the run log, which is the agent's
       // narration — see cv-envelope.mjs.
       const cvFilter = kind === "pdf" ? createCvEnvelopeFilter() : null;
+      // While the agent emits the 15-25 KB <<cv-html>> envelope, cvFilter swallows
+      // every byte, so the response stream goes completely silent for as long as
+      // the model takes to write the CV — a minute or more. Nothing downstream can
+      // tell that from a hung request, and the browser/proxy drops the connection;
+      // the client then reports "Connection error" even though the agent is fine
+      // and the PDF renders correctly server-side. Emit a throttled keepalive so
+      // the stream never idles during the filtered phase. Unknown event types are
+      // ignored by the client's switch, so this is safe for older tabs too.
       const sendAgentText = (text: string) => {
         const visible = cvFilter ? cvFilter.push(text) : text;
         if (visible) send({ type: "text", text: visible });

--- a/web/src/app/api/run/route.ts
+++ b/web/src/app/api/run/route.ts
@@ -209,9 +209,21 @@ export async function POST(req: Request) {
       killer = setTimeout(() => {
         try { child.kill("SIGTERM"); } catch { /* ignore */ }
       }, killMs);
+      // Declared before send() so send() can clear it the moment it sees the
+      // client disconnect; assigned just below, once close() exists.
+      let heartbeat: ReturnType<typeof setInterval> | undefined;
       const send = (obj: unknown) => {
         if (closed) return;
-        try { controller.enqueue(enc.encode(JSON.stringify(obj) + "\n")); } catch { closed = true; }
+        try {
+          controller.enqueue(enc.encode(JSON.stringify(obj) + "\n"));
+        } catch {
+          // The client is gone. Stop the heartbeat here rather than waiting for
+          // close(): the child can still run for minutes (maxDuration 800s), and
+          // a user retrying a failed run would otherwise accumulate one live
+          // timer per abandoned request.
+          closed = true;
+          if (heartbeat) clearInterval(heartbeat);
+        }
       };
       // Time-based keepalive. The stream is silent whenever the agent is thinking
       // or inside a long tool call, and in pdf mode it is silent for the whole
@@ -222,11 +234,11 @@ export async function POST(req: Request) {
       // It must be a timer, not a hook on incoming text: piggy-backing on agent
       // output cannot fire during exactly the silences it needs to cover.
       // Unknown event types are ignored by the client's switch, so old tabs are safe.
-      const heartbeat = setInterval(() => send({ type: "keepalive" }), 10_000);
+      heartbeat = setInterval(() => send({ type: "keepalive" }), 10_000);
       const close = () => {
         if (!closed) {
           closed = true;
-          clearInterval(heartbeat);
+          if (heartbeat) clearInterval(heartbeat);
           if (killer) clearTimeout(killer);
           releaseWriteTokenOnce();
           try { controller.close(); } catch { /* */ }


### PR DESCRIPTION
Closes #3024

`/api/run` emits nothing for as long as the agent takes to write the 15-25 KB `<<cv-html>>` envelope, because `createCvEnvelopeFilter()` holds every byte back from the stream. The connection gets dropped and the client reports `Connection error` while the agent has finished and the PDF has rendered.

**Measured on a real pdf run** (report 63): idle gaps of **149 s** and 64 s across 64 events, connection dropped. After: **max gap 10 s** over 55 events, 22 keepalives, job completes.

The interval is cleared in `close()`, which every exit path already calls. Unknown event types are ignored by the client's `switch`, so an open tab on the previous build is unaffected.

Note for review: it has to be a timer, not a hook on `sendAgentText()`. I tried the latter first and it still left the 149 s gap — output-driven keepalives cannot fire during the silences they exist to cover.

`tsc --noEmit` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of long-running operations by keeping the response connection active during processing.
  * Prevented connection timeouts while PDF CV content is being filtered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->