### PR TITLE
fix(web): serve the tailored CV for the requested report, not the newest one

### DIFF
--- a/web/src/app/api/cv-pdf/route.ts
+++ b/web/src/app/api/cv-pdf/route.ts
@@ -16,14 +16,20 @@ export async function GET(req: NextRequest) {
   // the same file (Zurich vs Barcelona at ANYbotics). Company stays as the
   // fallback for rows generated before the index existed.
   const byReport = resolveCvByReport(req.nextUrl.searchParams.get("report") ?? undefined);
-  if (byReport) {
+  // An indexed report whose file has since been deleted must 404 rather than
+  // fall back: company matching would hand back another role's CV at the same
+  // employer, which is the bug this endpoint is being fixed for.
+  if (byReport.status === "missing-file") {
+    return new Response("the tailored CV for this report is indexed but missing from output/", { status: 404 });
+  }
+  if (byReport.status === "ok") {
     try {
-      const buf = fs.readFileSync(byReport);
+      const buf = fs.readFileSync(byReport.path);
       return new Response(new Uint8Array(buf), {
         status: 200,
         headers: {
           "Content-Type": "application/pdf",
-          "Content-Disposition": `inline; filename="${path.basename(byReport)}"`,
+          "Content-Disposition": `inline; filename="${path.basename(byReport.path)}"`,
           "Cache-Control": "no-store",
         },
       });

--- a/web/src/app/api/cv-pdf/route.ts
+++ b/web/src/app/api/cv-pdf/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from "next/server";
 import fs from "node:fs";
 import path from "node:path";
 import { careerOpsRoot } from "@/lib/career-ops";
+import { resolveCvByReport } from "@/lib/apply/cv";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -10,6 +11,27 @@ export const dynamic = "force-dynamic";
 // a given offer (matched by company slug, newest first). Inline so it opens in
 // the browser. Local-first: reads the user's own output/ dir.
 export async function GET(req: NextRequest) {
+  // Prefer the exact per-report mapping. Matching on company alone serves the
+  // newest PDF for that employer, so two roles at the same company resolve to
+  // the same file (Zurich vs Barcelona at ANYbotics). Company stays as the
+  // fallback for rows generated before the index existed.
+  const byReport = resolveCvByReport(req.nextUrl.searchParams.get("report") ?? undefined);
+  if (byReport) {
+    try {
+      const buf = fs.readFileSync(byReport);
+      return new Response(new Uint8Array(buf), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/pdf",
+          "Content-Disposition": `inline; filename="${path.basename(byReport)}"`,
+          "Cache-Control": "no-store",
+        },
+      });
+    } catch {
+      return new Response("could not read the PDF", { status: 500 });
+    }
+  }
+
   const company = (req.nextUrl.searchParams.get("company") ?? "").trim();
   if (!company) return new Response("company required", { status: 400 });
   // Token-extract instead of replace-then-trim: same slug, and no `-+$`-style

--- a/web/src/components/generate-pdf-button.tsx
+++ b/web/src/components/generate-pdf-button.tsx
@@ -31,7 +31,7 @@ export function GeneratePdfButton({ n, company, pdfReady }: { n: string; company
     return (
       <span className="inline-flex items-center gap-1">
         <a
-          href={`/api/cv-pdf?company=${encodeURIComponent(company)}`}
+          href={`/api/cv-pdf?report=${encodeURIComponent(n)}&company=${encodeURIComponent(company)}`}
           target="_blank"
           rel="noreferrer"
           className="inline-flex items-center justify-center gap-1.5 rounded-full border border-emerald-500/40 bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-700 transition-colors hover:bg-emerald-500/15 dark:text-emerald-400 max-sm:min-h-[44px]"

--- a/web/src/lib/apply/cv.ts
+++ b/web/src/lib/apply/cv.ts
@@ -9,6 +9,38 @@ import { careerOpsRoot } from "@/lib/career-ops";
  * the matching in /api/cv-pdf so the "View tailored CV" link and the apply
  * file-upload always resolve to the SAME file. Returns an absolute path or null.
  */
+/**
+ * Exact lookup by report/tracker number via data/pdf-index.tsv, which
+ * generate-pdf.mjs keys per report. Company-name matching cannot separate two
+ * roles at the same employer: it takes the newest match, so a second tailored CV
+ * for the same company silently shadows the first (two ANYbotics roles, Zurich
+ * and Barcelona, both resolved to whichever was generated last). Returns an
+ * absolute path, or null when the report has no indexed PDF.
+ */
+export function resolveCvByReport(report?: string | number): string | null {
+  const n = String(report ?? "").trim();
+  if (!/^\d+$/.test(n)) return null;
+  const root = careerOpsRoot();
+  let rows: string[];
+  try {
+    rows = fs.readFileSync(path.join(root, "data", "pdf-index.tsv"), "utf8").split("\n");
+  } catch {
+    return null;
+  }
+  // Last wins: the index is append-only, so a regenerated CV is a later row.
+  let rel: string | null = null;
+  for (const row of rows) {
+    if (row.startsWith("#") || !row.trim()) continue;
+    const col = row.split("\t");
+    if (col[0]?.trim() === n && col[1]?.trim()) rel = col[1].trim();
+  }
+  if (!rel) return null;
+  const abs = path.resolve(root, rel);
+  // Never let an index row escape the project root.
+  if (!abs.startsWith(path.resolve(root) + path.sep)) return null;
+  return fs.existsSync(abs) ? abs : null;
+}
+
 export function resolveTailoredCv(company?: string): string | null {
   const c = (company ?? "").trim();
   if (!c) return null;

--- a/web/src/lib/apply/cv.ts
+++ b/web/src/lib/apply/cv.ts
@@ -17,15 +17,23 @@ import { careerOpsRoot } from "@/lib/career-ops";
  * and Barcelona, both resolved to whichever was generated last). Returns an
  * absolute path, or null when the report has no indexed PDF.
  */
-export function resolveCvByReport(report?: string | number): string | null {
+export type CvByReport =
+  /** The index names a PDF for this report and the file is there. */
+  | { status: 'ok'; path: string }
+  /** The index names a PDF for this report but the file is gone. */
+  | { status: 'missing-file'; path: string }
+  /** No index row for this report — generated before the index existed. */
+  | { status: 'no-entry' };
+
+export function resolveCvByReport(report?: string | number): CvByReport {
   const n = String(report ?? "").trim();
-  if (!/^\d+$/.test(n)) return null;
+  if (!/^\d+$/.test(n)) return { status: 'no-entry' };
   const root = careerOpsRoot();
   let rows: string[];
   try {
     rows = fs.readFileSync(path.join(root, "data", "pdf-index.tsv"), "utf8").split("\n");
   } catch {
-    return null;
+    return { status: 'no-entry' };
   }
   // Last wins: the index is append-only, so a regenerated CV is a later row.
   let rel: string | null = null;
@@ -34,11 +42,14 @@ export function resolveCvByReport(report?: string | number): string | null {
     const col = row.split("\t");
     if (col[0]?.trim() === n && col[1]?.trim()) rel = col[1].trim();
   }
-  if (!rel) return null;
+  if (!rel) return { status: 'no-entry' };
   const abs = path.resolve(root, rel);
   // Never let an index row escape the project root.
-  if (!abs.startsWith(path.resolve(root) + path.sep)) return null;
-  return fs.existsSync(abs) ? abs : null;
+  if (!abs.startsWith(path.resolve(root) + path.sep)) return { status: 'no-entry' };
+  // A named-but-missing file must NOT fall through to company matching: that is
+  // exactly the defect this function exists to fix, and the caller would serve
+  // another role's CV for the same employer.
+  return fs.existsSync(abs) ? { status: 'ok', path: abs } : { status: 'missing-file', path: abs };
 }
 
 export function resolveTailoredCv(company?: string): string | null {


### PR DESCRIPTION
Closes #3025

`/api/cv-pdf` matched `output/` by company slug and served the most recently modified match, so two evaluated roles at the same employer both resolved to the same PDF — ANYbotics report 80 (Barcelona) and report 81 (Zurich) both opened the Barcelona CV.

`data/pdf-index.tsv` already maps report number to PDF path and nothing read it. `resolveCvByReport()` reads it (last row wins so a regenerated CV supersedes; the resolved path is checked to stay inside the project root), the button passes `report=`, and company matching stays as the fallback for rows generated before the index existed.

**Not fixed here:** `resolveTailoredCv()` has the same defect on the apply path, where it picks the file *attached to a real application*. The apply `Session` carries no report number, so that needs the number threaded through the provider — flagged in #3025, happy to take it as a follow-up if you want it.

`tsc --noEmit` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tailored CV PDF requests can now use a specific report identifier for more accurate document retrieval.
  * PDFs open directly in the browser with updated caching behavior.
* **Bug Fixes**
  * Improved handling of missing, invalid, or unavailable report-linked PDFs.
  * Company-based PDF lookup remains available when no matching report entry is found.
  * Requests now return clearer errors when an indexed PDF is missing or cannot be read.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->