### PR TITLE
docs(security): put web/ in scope and say that local does not mean unreachable

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,6 +19,7 @@ Security issues in the following are in scope:
 
 - **Scripts** (`*.mjs`) — command injection, path traversal, SSRF
 - **Dashboard** (`dashboard/`) — any Go binary vulnerabilities
+- **Web dashboard** (`web/`) — anything reachable while it is running, including cross-origin requests from a page the user visits, requests from other hosts on the same network, and command injection through its API
 - **Templates** (`templates/`) — XSS in generated HTML/PDF
 - **Configuration** — secrets exposure, unsafe defaults
 
@@ -27,7 +28,9 @@ Security issues in the following are in scope:
 - Issues in third-party dependencies (report upstream)
 - Issues requiring physical access to the user's machine
 - Social engineering attacks
-- career-ops is a local tool — there is no hosted service to attack
+- Attacks on hosted infrastructure — career-ops runs locally, so there is no server of ours to attack
+
+**"Local" does not mean "unreachable".** The web dashboard is a local HTTP server, and a local server is still reachable by a cross-origin page the user happens to visit and by any device on the same network. If an issue needs nothing more than the user running career-ops and browsing normally, it is in scope — please report it rather than assuming the local-tool line excludes it.
 
 ## Disclosure Policy
 


### PR DESCRIPTION
## What does this PR do?

Puts `web/` in the security **Scope** list, and adds a carve-out saying that "local" does not mean "unreachable".

## Why

The scope section listed scripts, the Go dashboard, templates and configuration — but never the web dashboard. Meanwhile the out-of-scope line, *"career-ops is a local tool — there is no hosted service to attack"*, read as excluding the entire local server.

That combination is a policy bug rather than a wording nit: a reporter has to argue **against** our own SECURITY.md before a genuine finding gets read. The next person may simply not write.

A local HTTP server is still reachable by a cross-origin page the user happens to visit, and by any device on the same network. If an issue needs nothing more than the user running career-ops and browsing normally, it is in scope, and the file now says so.

The out-of-scope line is kept but narrowed to what it actually means: attacks on hosted infrastructure of ours, which genuinely does not exist.

## Type of change

- [x] Documentation

## Checklist

- [x] Docs-only; full suite green (4197 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded security coverage to include web dashboard vulnerabilities involving cross-origin requests, local network hosts, and API command injection.
  * Clarified which hosted infrastructure issues are out of scope.
  * Confirmed that the local web server remains reachable and reportable under normal use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->