### PR TITLE
fix(locks): the other two copies of the protocol had the same Windows bug

### DIFF
--- a/followup-seed.mjs
+++ b/followup-seed.mjs
@@ -59,6 +59,12 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync, rmSync,
 import { join, dirname, basename, resolve, isAbsolute, relative, sep } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { createHash, randomUUID } from 'crypto';
+// Third copy of the directory-lock protocol in this repo, and the one #2984
+// missed: that fix declared "one definition, no sibling drift" while patching
+// pipeline-lock.mjs and tracker-utils.mjs, and this file was carrying all three
+// faces of #2777 the whole time. The classifiers come from pipeline-lock now,
+// so the next Windows-contention finding lands in one place instead of three.
+import { isMkdirContention, isRmContention, rmLockArtifactSync } from './pipeline-lock.mjs';
 import { tmpdir } from 'os';
 import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 import {
@@ -328,8 +334,12 @@ function lockCanRecover(lockDir, staleMs) {
   if (owner?.pid) return !processIsAlive(owner.pid);
   try {
     return Date.now() - statSync(lockDir).mtimeMs > Math.max(staleMs, OWNERLESS_GRACE_MS);
-  } catch {
-    return true;
+  } catch (err) {
+    // Only a genuinely vanished directory means "nothing to recover". Any other
+    // stat failure — a Windows EPERM/EBUSY while the directory is mid-flight —
+    // is "could not look", and answering "recoverable" to that hands the caller
+    // an rmSync of a LIVE lock created microseconds ago (#2777, third face).
+    return err?.code === 'ENOENT';
   }
 }
 
@@ -369,19 +379,33 @@ async function acquireFollowupsLock(lockDir, followupsPath, options = {}) {
           released = true;
           const owner = readLockOwner(lockDir);
           if (owner?.token === token) {
-            rmSync(lockDir, { recursive: true, force: true });
+            // Best-effort: ownership is verified, so a contended rm (Windows
+            // EPERM/EBUSY while another process stats it) must not kill a caller
+            // whose work already succeeded. The orphan ages out via lockCanRecover.
+            rmLockArtifactSync(lockDir);
           }
         },
       };
     } catch (err) {
-      if (err?.code !== 'EEXIST') throw err;
+      // Not just EEXIST: Windows reports a directory that is mid-create or
+      // mid-remove by another process as EPERM/EACCES. That is contention, not
+      // failure — treating it as fatal kills a concurrent writer and loses its
+      // write (#2777, measured on windows-latest).
+      if (!isMkdirContention(err)) throw err;
 
       let hasRecoverGuard = false;
       try {
         mkdirSync(recoverGuardDir);
         hasRecoverGuard = true;
       } catch (guardErr) {
-        if (guardErr?.code !== 'EEXIST') throw guardErr;
+        if (!isMkdirContention(guardErr)) throw guardErr;
+        // Only an EEXIST guard is judged by age: an EPERM/EACCES answer means
+        // the guard is mid-flight right now, and reasoning about the age of a
+        // directory we cannot stat reliably would evict a live guard.
+        if (guardErr.code !== 'EEXIST') {
+          await sleep(retryMs);
+          continue;
+        }
         // A process killed between creating the guard and its cleanup leaves
         // the guard behind forever, permanently disabling stale-lock recovery
         // for every future writer. The guard normally lives for milliseconds,
@@ -391,18 +415,19 @@ async function acquireFollowupsLock(lockDir, followupsPath, options = {}) {
         // instead let two writers recover the same lock at once, which is
         // exactly what the guard exists to prevent.
         if (lockCanRecover(recoverGuardDir, staleMs)) {
-          rmSync(recoverGuardDir, { recursive: true, force: true });
+          rmLockArtifactSync(recoverGuardDir);
         }
       }
 
       if (hasRecoverGuard) {
         try {
           if (lockCanRecover(lockDir, staleMs)) {
-            rmSync(lockDir, { recursive: true, force: true });
-            continue;
+            if (rmLockArtifactSync(lockDir)) continue;
+            // rm hit contention: another process is touching the stale lock at
+            // this instant — back off instead of treating the collision as fatal.
           }
         } finally {
-          rmSync(recoverGuardDir, { recursive: true, force: true });
+          rmLockArtifactSync(recoverGuardDir);
         }
       }
 

--- a/portal-health-lock.mjs
+++ b/portal-health-lock.mjs
@@ -27,6 +27,11 @@
 import { mkdirSync, rmSync, statSync, writeFileSync, readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { randomUUID } from 'crypto';
+// Fourth copy of the directory-lock protocol in this repo. #2984 patched two of
+// them and declared "one definition, no sibling drift"; this one and
+// followup-seed.mjs were still carrying all three faces of #2777. The
+// classifiers live in pipeline-lock.mjs so the next finding lands once.
+import { isMkdirContention, rmLockArtifactSync } from './pipeline-lock.mjs';
 
 const DEFAULT_STALE_MS = 30_000;
 const DEFAULT_RETRY_MS = 80;
@@ -92,8 +97,11 @@ function lockCanRecover(lockDir, staleMs) {
   if (owner?.pid) return !processIsAlive(owner.pid);
   try {
     return Date.now() - statSync(lockDir).mtimeMs > Math.max(staleMs, OWNERLESS_GRACE_MS);
-  } catch {
-    return true; // vanished — nothing to recover, retry acquisition
+  } catch (err) {
+    // Only a vanished directory means "nothing to recover". Any other stat
+    // failure — a Windows EPERM/EBUSY mid-flight — is "could not look", and
+    // answering "recoverable" to that deletes a LIVE lock (#2777, third face).
+    return err?.code === 'ENOENT';
   }
 }
 
@@ -128,7 +136,9 @@ export async function acquirePortalHealthLock(filePath, options = {}) {
     try {
       mkdirSync(lockDir);
     } catch (err) {
-      if (err?.code !== 'EEXIST') throw err;
+      // Windows answers a mid-flight directory with EPERM/EACCES: contention,
+      // not failure. Treating it as fatal kills the writer and loses its write.
+      if (!isMkdirContention(err)) throw err;
 
       // Serialize stale-reclaim behind a second atomic guard so only one
       // caller can be inside the decide-then-delete window at a time.
@@ -137,23 +147,27 @@ export async function acquirePortalHealthLock(filePath, options = {}) {
         mkdirSync(recoverGuardDir);
         hasRecoverGuard = true;
       } catch (guardErr) {
-        if (guardErr?.code !== 'EEXIST') throw guardErr;
+        if (!isMkdirContention(guardErr)) throw guardErr;
+        // Only an EEXIST guard is judged by age: an EPERM/EACCES answer means it
+        // is mid-flight, and judging the age of a directory we cannot stat
+        // reliably would evict a live guard.
+        if (guardErr.code !== 'EEXIST') { await sleep(retryMs); continue; }
         // A process killed between taking the guard and cleaning it up would
         // otherwise disable stale recovery forever. The guard normally lives
         // for milliseconds, so an old one is judged by the same age rule.
         if (lockCanRecover(recoverGuardDir, staleMs)) {
-          rmSync(recoverGuardDir, { recursive: true, force: true });
+          rmLockArtifactSync(recoverGuardDir);
         }
       }
 
       if (hasRecoverGuard) {
         try {
           if (lockCanRecover(lockDir, staleMs)) {
-            rmSync(lockDir, { recursive: true, force: true });
+            rmLockArtifactSync(lockDir);
             continue; // retry acquisition immediately
           }
         } finally {
-          rmSync(recoverGuardDir, { recursive: true, force: true });
+          rmLockArtifactSync(recoverGuardDir);
         }
       }
 
@@ -172,7 +186,7 @@ export async function acquirePortalHealthLock(filePath, options = {}) {
         file: filePath,
       }, null, 2));
     } catch (ownerErr) {
-      rmSync(lockDir, { recursive: true, force: true });
+      rmLockArtifactSync(lockDir);
       throw ownerErr;
     }
 
@@ -202,7 +216,7 @@ export async function acquirePortalHealthLock(filePath, options = {}) {
         }
         if (!sameLockDirectory(before, after)) return; // swapped underneath us
         try {
-          rmSync(lockDir, { recursive: true, force: true });
+          rmLockArtifactSync(lockDir);
         } catch {
           /* best-effort; a stale-reclaim will recover it */
         }

--- a/tests/lock-rm-contention.test.mjs
+++ b/tests/lock-rm-contention.test.mjs
@@ -9,11 +9,13 @@
 //
 // These tests pin three things:
 //   1. the contention classifiers agree on the measured Windows codes,
-//   2. both locks share ONE definition (the drift between the two parallel
-//      lock implementations is how this class survived two earlier fixes),
-//   3. no bare rmSync of a lock artifact remains in either acquisition path.
+//   2. EVERY copy of the protocol shares ONE definition — and the set of copies
+//      is derived from the repo, not listed here. #2984 patched two files and
+//      declared the drift dead; there were four, and the other two carried all
+//      three faces of the bug for weeks,
+//   3. no bare rmSync of a lock artifact remains in any acquisition path.
 
-import { readFileSync, mkdirSync, existsSync, rmSync, mkdtempSync } from 'fs';
+import { readFileSync, readdirSync, mkdirSync, existsSync, rmSync, mkdtempSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { pass, fail, ROOT } from './helpers.mjs';
@@ -22,6 +24,14 @@ import { isMkdirContention, isRmContention, rmLockArtifactSync } from '../pipeli
 console.log('\n🔒 lock artifacts: rm contention is contention, not death (#2777)');
 
 const ok = (cond, msg) => (cond ? pass(msg) : fail(msg));
+
+// Quién implementa el protocolo se PREGUNTA al repo, nunca se escribe aquí: una
+// lista a mano envejece en silencio y así es como #2984 arregló dos copias
+// creyendo que eran todas. La firma es `recoverGuardDir`, el segundo directorio
+// atómico que no usa ningún otro código de este repo.
+const protocolImplementors = () => readdirSync(ROOT)
+  .filter((f) => f.endsWith('.mjs'))
+  .filter((f) => readFileSync(join(ROOT, f), 'utf-8').includes('recoverGuardDir'));
 const mkErr = (code) => Object.assign(new Error(code), { code });
 
 // ── 1. Classifier tables ─────────────────────────────────────────────
@@ -53,21 +63,41 @@ const mkErr = (code) => Object.assign(new Error(code), { code });
   rmSync(dir, { recursive: true, force: true });
 }
 
-// ── 3. One definition, two locks ─────────────────────────────────────
-// tracker-utils.mjs must IMPORT the classifiers from pipeline-lock.mjs, not
-// carry its own copy. Two parallel implementations of the same protocol is
-// exactly how the EEXIST-only check survived in one file after the other
-// learned better.
+// ── 3. One definition, EVERY copy of the protocol ────────────────────
+// The list is DERIVED, not written down. #2984 patched two files and said "one
+// definition, no sibling drift" — and there were four. followup-seed.mjs and
+// portal-health-lock.mjs had been carrying all three faces of #2777 the whole
+// time, invisible because nobody had asked the repo how many copies there were.
+// A hand-kept list would have aged the same way (lesson #52): so the test asks.
+//
+// The signature of the protocol is `recoverGuardDir`, the second atomic guard
+// no other code in this repo uses. Any file that has one is implementing this
+// lock and must derive the classifiers rather than re-deriving the rules.
 {
-  const tracker = readFileSync(join(ROOT, 'tracker-utils.mjs'), 'utf-8');
-  ok(
-    /import\s*\{[^}]*isMkdirContention[^}]*\}\s*from\s*'\.\/pipeline-lock\.mjs'/.test(tracker),
-    'tracker-utils imports the contention classifiers from pipeline-lock',
-  );
-  ok(
-    !/function isMkdirContention/.test(tracker) && !/function isRmContention/.test(tracker),
-    'tracker-utils defines no second copy of the classifiers',
-  );
+  const implementors = protocolImplementors();
+
+  ok(implementors.length >= 2, `found ${implementors.length} files implementing the lock protocol (${implementors.join(', ')})`);
+  ok(implementors.includes('pipeline-lock.mjs'), 'pipeline-lock.mjs is among them (it is the definition)');
+
+  for (const file of implementors.filter((f) => f !== 'pipeline-lock.mjs')) {
+    const src = readFileSync(join(ROOT, file), 'utf-8');
+    ok(
+      /import\s*\{[^}]*isMkdirContention[^}]*\}\s*from\s*'\.\/pipeline-lock\.mjs'/.test(src),
+      `${file} imports the contention classifiers from pipeline-lock`,
+    );
+    ok(
+      !/function isMkdirContention/.test(src) && !/function isRmContention/.test(src),
+      `${file} defines no second copy of the classifiers`,
+    );
+    ok(
+      !/if\s*\([^)]*code\s*!==\s*'EEXIST'\)\s*throw/.test(src),
+      `${file} does not treat a non-EEXIST mkdir answer as fatal (Windows says EPERM under contention)`,
+    );
+    ok(
+      /return err\?\.code === 'ENOENT';/.test(src),
+      `${file} answers "recoverable" only on ENOENT, never on "could not look"`,
+    );
+  }
 }
 
 // ── 3b. "Could not look" is never "recoverable" ──────────────────────
@@ -77,7 +107,7 @@ const mkErr = (code) => Object.assign(new Error(code), { code });
 // winner then died with ENOENT writing owner.json. Only ENOENT (genuinely
 // vanished) may answer "nothing to recover"; both locks must carry the guard.
 {
-  for (const file of ['pipeline-lock.mjs', 'tracker-utils.mjs']) {
+  for (const file of protocolImplementors()) {
     const src = readFileSync(join(ROOT, file), 'utf-8');
     ok(
       /return err\?\.code === 'ENOENT';/.test(src),
@@ -97,15 +127,12 @@ const mkErr = (code) => Object.assign(new Error(code), { code });
 // done by then). A bare call anywhere else reintroduces the crash one
 // refactor from now.
 {
-  for (const file of ['pipeline-lock.mjs', 'tracker-utils.mjs']) {
+  for (const file of protocolImplementors()) {
     const src = readFileSync(join(ROOT, file), 'utf-8');
     const guardCalls = [...src.matchAll(/rmSync\(\s*recoverGuardDir\b/g)].length;
     ok(guardCalls === 0, `${file}: no bare rmSync(recoverGuardDir) remains (found ${guardCalls})`);
+    const lockCalls = [...src.matchAll(/rmSync\(\s*lockDir\b/g)].length;
+    const permitido = file === 'pipeline-lock.mjs' ? 1 : 0;  // release() de pipeline-lock lleva su propio catch deliberado
+    ok(lockCalls <= permitido, `${file}: bare rmSync(lockDir) within budget (found ${lockCalls}, allowed ${permitido})`);
   }
-  const trackerLockCalls = [...readFileSync(join(ROOT, 'tracker-utils.mjs'), 'utf-8')
-    .matchAll(/rmSync\(\s*lockDir\b/g)].length;
-  ok(trackerLockCalls === 0, `tracker-utils.mjs: no bare rmSync(lockDir) remains (found ${trackerLockCalls})`);
-  const pipelineLockCalls = [...readFileSync(join(ROOT, 'pipeline-lock.mjs'), 'utf-8')
-    .matchAll(/rmSync\(\s*lockDir\b/g)].length;
-  ok(pipelineLockCalls <= 1, `pipeline-lock.mjs: at most release()'s guarded rmSync(lockDir) remains (found ${pipelineLockCalls})`);
 }


### PR DESCRIPTION
## What does this PR do?

Fixes the same Windows contention bug in the two copies of the lock protocol that #2984 missed, and replaces the test's hand-written file list with one derived from the repo.

## Why

#2984 patched `pipeline-lock.mjs` and `tracker-utils.mjs` and stated "one definition, no sibling drift". There were **four** implementations of that protocol. `followup-seed.mjs` and `portal-health-lock.mjs` were still carrying all three faces of #2777:

- a non-`EEXIST` mkdir answer treated as fatal — Windows reports a mid-flight directory as `EPERM`/`EACCES`, which killed the writer and lost its write;
- `lockCanRecover`'s stat catch answering "recoverable" to **every** failure, so "could not look" became "nothing to recover" and a live lock got deleted;
- bare `rmSync` of lock artifacts, which throws under the same contention.

Both now import the classifiers from `pipeline-lock.mjs` instead of restating the rules.

## The test change is the point

The previous test listed the two files the fix had touched, so it could only confirm what was already known — it could never have found copies three and four. It now **asks the repo**: any `.mjs` containing a `recoverGuardDir` (the protocol's signature, used nowhere else) must import the classifiers, must not restate the EEXIST-only rule, and must not carry a bare artifact `rmSync`.

Verified in both directions: dropping a fifth copy into the tree gets it named in four separate assertions, and removing it goes green.

## Type of change

- [x] Bug fix

## Checklist

- [x] Full suite green: 4218 passed, 0 failed
- [x] Fifth-copy detection verified by experiment, not by reasoning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lock recovery across supported platforms, including Windows contention scenarios.
  * Prevented unrecoverable lock states when lock metadata cannot be read.
  * Added safer retry and backoff behavior during lock and recovery cleanup.
  * Improved handling of lock creation, guard creation, and release failures.

* **Tests**
  * Expanded coverage to validate lock behavior across all detected implementations.
  * Added checks for consistent contention detection, recovery handling, and artifact cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->