### PR TITLE
feat(followups): export withFollowupsLock so other writers can share the lock

### DIFF
--- a/followup-seed.mjs
+++ b/followup-seed.mjs
@@ -482,6 +482,61 @@ function appendPins(existingContent, pinLines) {
  * @param {number} [options.lockStaleMs]
  * @returns {Promise<object>}
  */
+/**
+ * Run `fn` while holding the cross-process lock on a follow-ups file.
+ *
+ * EXISTS BECAUSE "TAKE A LOCK" IS NOT ENOUGH HERE (#3034). The lock directory
+ * is DERIVED — sha256 of the resolved follow-ups path, under tmpdir — so two
+ * writers that each take "a lock" on separately computed directories exclude
+ * nothing at all. Any second implementation has to reproduce that derivation
+ * exactly, and a derivation copied into another codebase is a second body of
+ * the same truth: it works until the day one side changes.
+ *
+ * So the derivation never leaves this file. Callers outside the core (the web
+ * dashboard's follow-up log and override routes) import this function and get
+ * the same directory by construction.
+ *
+ * TWO PROPERTIES CALLERS DEPEND ON, both deliberate:
+ *
+ *   1. The lock is released on EVERY path, including a throw. A long-lived
+ *      process that returns a 500 without releasing would block the user's own
+ *      CLI until staleMs elapses, so the `finally` lives here rather than in
+ *      each caller's hands.
+ *
+ *   2. It is NOT reentrant. Holding this lock and then invoking a core script
+ *      that also takes it (`followup-seed.mjs` itself) self-deadlocks until the
+ *      timeout. Callers that write the file directly are safe; callers that
+ *      orchestrate core scripts must not wrap them in this.
+ *
+ * An in-process queue is not a substitute: it serialises one process against
+ * itself and is blind to every other one. The two compose — queue inside this
+ * lock — and neither replaces the other.
+ *
+ * @param {string} followupsPath - Path to the follow-ups file to guard.
+ * @param {() => Promise<T>|T} fn - Runs while the lock is held.
+ * @param {object} [options]
+ * @param {string} [options.lockDir] - Explicit lock directory (tests).
+ * @param {number} [options.timeoutMs=60000]
+ * @param {number} [options.retryMs=75]
+ * @param {number} [options.staleMs=600000]
+ * @returns {Promise<T>} Whatever `fn` returned.
+ * @template T
+ */
+export async function withFollowupsLock(followupsPath, fn, options = {}) {
+  const resolvedPath = resolveFollowupsPath(followupsPath);
+  const lockDir = resolveLockDir(options.lockDir, resolvedPath);
+  const lock = await acquireFollowupsLock(lockDir, resolvedPath, {
+    timeoutMs: options.timeoutMs ?? envInt('CAREER_OPS_FOLLOWUPS_LOCK_TIMEOUT_MS', 60_000),
+    retryMs: options.retryMs ?? envInt('CAREER_OPS_FOLLOWUPS_LOCK_RETRY_MS', 75),
+    staleMs: options.staleMs ?? envInt('CAREER_OPS_FOLLOWUPS_LOCK_STALE_MS', 10 * 60_000),
+  });
+  try {
+    return await fn();
+  } finally {
+    lock.release();
+  }
+}
+
 export async function seedFollowup(appNum, options = {}) {
   if (!Number.isInteger(appNum) || appNum <= 0) {
     throw new SeedError('USAGE', `Invalid appNum: ${appNum}`);

--- a/tests/with-followups-lock.test.mjs
+++ b/tests/with-followups-lock.test.mjs
@@ -1,0 +1,94 @@
+// tests/with-followups-lock.test.mjs
+//
+// The point of #3034 is not that follow-ups.md had no lock. It had one, and one
+// of its three writers took it. The other two — the web dashboard's log and
+// override routes — took an in-process queue instead, which serialises a
+// process against itself and is blind to every other one.
+//
+// What makes "just take a lock too" insufficient is that the lock DIRECTORY is
+// derived (sha256 of the resolved path, under tmpdir). Two writers holding
+// separately computed locks exclude nothing, and nothing about that failure is
+// visible: both succeed, and one write disappears.
+//
+// So these tests assert the two things a caller outside this file actually
+// depends on: that the same path lands on the same lock, and that holding it
+// really does exclude a second holder.
+
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { pass, fail } from './helpers.mjs';
+import { withFollowupsLock } from '../followup-seed.mjs';
+
+console.log('\n🔗 withFollowupsLock — the lock other codebases have to share');
+
+const ok = (cond, msg) => (cond ? pass(msg) : fail(msg));
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const dir = mkdtempSync(join(tmpdir(), 'folk-'));
+const followups = join(dir, 'follow-ups.md');
+writeFileSync(followups, '# Follow-ups\n');
+
+// ── It actually excludes: the whole point ────────────────────────────
+// Two overlapping read-modify-write cycles. Without exclusion the second read
+// happens before the first write lands and one append is lost — the exact
+// lost-update shape the tracker had before #2903.
+{
+  const rmw = async (line, holdMs) => withFollowupsLock(followups, async () => {
+    const before = readFileSync(followups, 'utf-8');
+    await sleep(holdMs);              // the window a lost update needs
+    writeFileSync(followups, `${before}${line}\n`);
+  });
+
+  await Promise.all([rmw('first', 60), rmw('second', 10)]);
+
+  const text = readFileSync(followups, 'utf-8');
+  ok(text.includes('first'), 'the slow writer\'s line survived');
+  ok(text.includes('second'), 'the fast writer\'s line survived');
+  ok(
+    text.split('\n').filter((l) => l === 'first' || l === 'second').length === 2,
+    'both writes are present — the second did not read a snapshot the first was about to replace',
+  );
+}
+
+// ── Released on a throw, or the next caller waits out staleMs ────────
+{
+  let threw = false;
+  try {
+    await withFollowupsLock(followups, () => { throw new Error('boom'); });
+  } catch (err) {
+    threw = err.message === 'boom';
+  }
+  ok(threw, 'the error from fn reaches the caller unchanged');
+
+  // If the lock leaked, this second acquisition would block until timeout.
+  let reacquired = false;
+  await withFollowupsLock(followups, () => { reacquired = true; }, { timeoutMs: 3_000 });
+  ok(reacquired, 'and the lock was released anyway, so the next caller gets it immediately');
+}
+
+// ── Same path, same lock — including via a different spelling ────────
+// The derivation runs on the RESOLVED path, so a caller that passes a
+// differently-spelled route to the same file must still collide. A second
+// implementation recomputing the hash is what this export exists to prevent.
+{
+  const spelled = join(dir, '.', 'follow-ups.md');
+  let inner = 'not attempted';
+  await withFollowupsLock(followups, async () => {
+    try {
+      await withFollowupsLock(spelled, () => { inner = 'acquired'; }, { timeoutMs: 400, retryMs: 25 });
+    } catch {
+      inner = 'blocked';
+    }
+  });
+  ok(inner === 'blocked', 'a differently-spelled path to the same file hits the same lock (and is therefore not reentrant)');
+}
+
+// ── The return value passes through ──────────────────────────────────
+{
+  const got = await withFollowupsLock(followups, () => 'value');
+  ok(got === 'value', 'whatever fn returns is what the caller gets');
+}
+
+rmSync(dir, { recursive: true, force: true });
+ok(!existsSync(dir), 'fixture cleaned up');


### PR DESCRIPTION
## What does this PR do?

Exports `withFollowupsLock(followupsPath, fn)` from `followup-seed.mjs`, so writers outside the core can take **the same** lock on `data/follow-ups.md`.

Closes #3034.

## Why the export rather than documentation

`data/follow-ups.md` already had a lock, and `followup-seed.mjs` took it on both of its write paths. The web dashboard's `followups/log` and `followups/override` routes take an in-process queue instead — which serialises one process against itself and is blind to every other one.

The reason "have the web take a lock too" does not close it: the lock directory is **derived**.

```js
const lockKey = createHash('sha256').update(followupsPath).digest('hex').slice(0, 16);
// → <tmpdir>/career-ops-followups-<lockKey>.lock
```

Two writers that each take "a lock" on separately computed directories exclude nothing, and nothing about that failure is visible — both succeed, and one write disappears. A derivation copied into a second codebase is a second body of the same truth: it works until one side changes.

So the derivation never leaves this file.

## Two properties the caller depends on

Both requested by @career-ops-ui from experience with `withTrackerLock`, both documented at the export:

1. **Released on every path, including a throw.** A long-lived process that returns a 500 without releasing would block the user's own CLI until `staleMs` elapses, so the `finally` lives here rather than in each caller's hands.
2. **Not reentrant.** Holding it and then invoking a core script that also takes it self-deadlocks until timeout. Documented for the day someone chains them.

An in-process queue is not replaced by this — they compose, queue inside the file lock.

## The test asserts the exclusion, not the export

Two overlapping read-modify-write cycles, both surviving. Plus release-on-throw, return-value passthrough, and that a differently-spelled path to the same file hits the same lock.

Verified in the red direction: swapping `withFollowupsLock` for a passthrough fails three assertions, including the lost update. A test that passes with and without the mechanism proves nothing.

## Type of change

- [x] New feature (an export other codebases will consume)

## Checklist

- [x] Full suite green: 4226 passed, 0 failed
- [x] `validate-system-paths-coverage.mjs`: OK
- [x] Lands after #3033, which fixes a Windows contention bug this file's lock copy was carrying

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable locking for follow-up operations, preventing conflicting updates when multiple processes run simultaneously.
  * Supports both synchronous and asynchronous operations while preserving callback results.
  * Ensures locks are released even when an operation encounters an error.

* **Tests**
  * Added coverage for concurrent access, error recovery, path handling, result propagation, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->