### PR TITLE
fix(web): take the core follow-ups lock in the log/override routes

### DIFF
--- a/web/src/app/api/followups/log/route.ts
+++ b/web/src/app/api/followups/log/route.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { atomicWrite } from "@/lib/core/safe-write";
 import { CHANNELS, isRealISODate, localISODate } from "@/lib/followups";
-import { followupsLogPath, withLogLock } from "@/lib/followups-server";
+import { followupsLogPath, withFollowupsWrite, followupsWriteError } from "@/lib/followups-server";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -69,7 +69,7 @@ export async function POST(req: Request) {
 
   const file = followupsLogPath();
   try {
-    return await withLogLock(() => {
+    return await withFollowupsWrite(() => {
       fs.mkdirSync(path.dirname(file), { recursive: true });
       let existing = "";
       if (fs.existsSync(file)) existing = fs.readFileSync(file, "utf8");
@@ -100,7 +100,7 @@ export async function POST(req: Request) {
       return Response.json({ ok: true, num, appNum, date, channel });
     });
   } catch (e) {
-    return Response.json({ error: e instanceof Error ? e.message : "write failed" }, { status: 500 });
+    return followupsWriteError(e, "write failed");
   }
 }
 
@@ -121,7 +121,7 @@ export async function DELETE(req: Request) {
   const file = followupsLogPath();
   if (!fs.existsSync(file)) return Response.json({ error: "no follow-up log" }, { status: 404 });
   try {
-    return await withLogLock(() => {
+    return await withFollowupsWrite(() => {
       const lines = fs.readFileSync(file, "utf8").split("\n");
       const idx = lines.findIndex((line) => {
         if (!line.startsWith("|")) return false;
@@ -134,6 +134,6 @@ export async function DELETE(req: Request) {
       return Response.json({ ok: true, num });
     });
   } catch (e) {
-    return Response.json({ error: e instanceof Error ? e.message : "delete failed" }, { status: 500 });
+    return followupsWriteError(e, "delete failed");
   }
 }

--- a/web/src/app/api/followups/override/route.ts
+++ b/web/src/app/api/followups/override/route.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { atomicWrite } from "@/lib/core/safe-write";
 import { isRealISODate, localISODate } from "@/lib/followups";
-import { followupsLogPath, withLogLock } from "@/lib/followups-server";
+import { followupsLogPath, withFollowupsWrite, followupsWriteError } from "@/lib/followups-server";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -34,7 +34,7 @@ export async function POST(req: Request) {
 
   const file = followupsLogPath();
   try {
-    return await withLogLock(() => {
+    return await withFollowupsWrite(() => {
       fs.mkdirSync(path.dirname(file), { recursive: true });
       let existing = fs.existsSync(file) ? fs.readFileSync(file, "utf8") : "# Follow-ups\n\n";
       // Supersede: drop any previous pin lines for this application (the parser
@@ -47,7 +47,7 @@ export async function POST(req: Request) {
       return Response.json({ ok: true, appNum, date });
     });
   } catch (e) {
-    return Response.json({ error: e instanceof Error ? e.message : "write failed" }, { status: 500 });
+    return followupsWriteError(e, "write failed");
   }
 }
 
@@ -67,7 +67,7 @@ export async function DELETE(req: Request) {
   const file = followupsLogPath();
   if (!fs.existsSync(file)) return Response.json({ error: "no follow-up log" }, { status: 404 });
   try {
-    return await withLogLock(() => {
+    return await withFollowupsWrite(() => {
       const lines = fs.readFileSync(file, "utf8").split("\n");
       const kept = lines.filter((line) => !pinRe(appNum).test(line));
       if (kept.length === lines.length) {
@@ -77,6 +77,6 @@ export async function DELETE(req: Request) {
       return Response.json({ ok: true, appNum });
     });
   } catch (e) {
-    return Response.json({ error: e instanceof Error ? e.message : "delete failed" }, { status: 500 });
+    return followupsWriteError(e, "delete failed");
   }
 }

--- a/web/src/lib/core/followups-lock.ts
+++ b/web/src/lib/core/followups-lock.ts
@@ -1,0 +1,106 @@
+import path from "node:path";
+import fs from "node:fs";
+import { pathToFileURL } from "node:url";
+import { careerOpsRoot } from "@/lib/career-ops";
+
+/**
+ * ACL for the core's follow-ups file lock (`followup-seed.mjs`).
+ *
+ * WHY A WEB ROUTE NEEDS IT. `data/follow-ups.md` is a read-modify-write from
+ * two directions: the web's log/override routes AND the core's cadence seeder
+ * (`followup-seed.mjs`, which takes this same lock). `atomicWrite` makes the
+ * WRITE atomic, not the read-modify-write around it — two writers each read the
+ * whole file, each edit, each rename their full copy back, and one change
+ * silently reverts. Same failure family as the tracker (#2900), same cure.
+ *
+ * NOT `withLogLock` (followups-server.ts): that is an in-process promise queue.
+ * It serializes THIS process's own requests and is blind to the user's CLI —
+ * "no cross-process lock needed" is true for web-vs-web and false for
+ * web-vs-seeder. Two guards, different scopes; they compose (see
+ * `withFollowupsWrite`), neither substitutes for the other.
+ *
+ * WE DO NOT DERIVE THE LOCK DIRECTORY. The core computes it from a sha256 of the
+ * resolved path, entirely inside `followup-seed.mjs`. We import `withFollowupsLock`
+ * and pass our path; the core resolves the path and the lockDir. Recomputing the
+ * hash web-side would birth a second body of the same truth that has to stay in
+ * sync forever — the exact class of bug this whole change closes (#3034).
+ *
+ * THE LOCK IS NOT REENTRANT (no owner/pid self-check in the core). A caller
+ * holding it must never orchestrate a core script that also takes it — that
+ * self-deadlocks until the timeout. Our two routes write the file DIRECTLY, so
+ * this is safe today; it is a rule for any future followups writer that shells
+ * out.
+ *
+ * `finally`-release lives in the core export, so it cannot be forgotten here.
+ * The web timeout is deliberately far shorter than the CLI's 60s default: a
+ * minute of silence inside an HTTP handler is indistinguishable from a hang, so
+ * we fail fast and answer the caller "busy, retry" (→ 409) instead.
+ */
+
+type CoreWithFollowupsLock = (
+  followupsPath: string,
+  fn: () => unknown,
+  options?: Record<string, unknown>,
+) => Promise<unknown>;
+
+/** Cached per resolved module path; failures are NEVER cached, so a repaired or
+ *  newly-installed checkout is picked up on the next request. */
+const modCache = new Map<string, CoreWithFollowupsLock>();
+
+/** Resolve the core export, or null when this root has data but no scripts.
+ *  A data-only root cannot host the seeder either, so there is nothing to
+ *  exclude cross-process and the in-process queue alone is correct — see
+ *  `withFollowupsLock` below. */
+async function loadCoreLock(): Promise<CoreWithFollowupsLock | null> {
+  const file = path.join(careerOpsRoot(), "followup-seed.mjs");
+  const cached = modCache.get(file);
+  if (cached) return cached;
+  if (!fs.existsSync(file)) return null;
+  const mod = await import(/* webpackIgnore: true */ pathToFileURL(file).href);
+  if (typeof mod.withFollowupsLock !== "function") {
+    throw new Error("followup-seed.mjs has no withFollowupsLock export");
+  }
+  const api = mod.withFollowupsLock as CoreWithFollowupsLock;
+  modCache.set(file, api);
+  return api;
+}
+
+/** Thrown when the lock is held by someone else for longer than we will wait. */
+export class FollowupsBusyError extends Error {
+  constructor() {
+    super("follow-ups file is being written by another process");
+    this.name = "FollowupsBusyError";
+  }
+}
+
+/**
+ * Run `fn` holding the core's follow-ups lock, releasing it on EVERY path.
+ *
+ * When the core scripts are absent (data-only root), runs `fn` with no file
+ * lock: without the core there is no seeder to race, and `withLogLock` still
+ * serializes this process. When the lock is contended past the web timeout,
+ * throws `FollowupsBusyError` so the route can answer 409 rather than hang.
+ *
+ * @param followupsPath absolute path to data/follow-ups.md (the core resolves
+ *   and normalizes it; do not pre-derive anything from it)
+ * @param fn the read-modify-write to run under the lock
+ */
+export async function withFollowupsLock<T>(followupsPath: string, fn: () => T | Promise<T>): Promise<T> {
+  const core = await loadCoreLock();
+  if (!core) return await fn();
+  try {
+    return (await core(followupsPath, fn as () => unknown, {
+      timeoutMs: Number(process.env.CAREER_OPS_WEB_FOLLOWUPS_LOCK_TIMEOUT_MS) || 5_000,
+    })) as T;
+  } catch (e) {
+    // The core throws SeedError('LOCK_TIMEOUT') only from the lock acquire,
+    // which runs BEFORE fn — and our fn does fs I/O, never mints a SeedError —
+    // so this match is unambiguous: it means "couldn't get the lock", not "the
+    // write failed". Anything else (a real fs error from fn) propagates as-is.
+    const err = e as { name?: string; code?: string } | null;
+    if (err && err.name === "SeedError" && err.code === "LOCK_TIMEOUT") {
+      throw new FollowupsBusyError();
+    }
+    throw e;
+  }
+}

--- a/web/src/lib/followups-server.ts
+++ b/web/src/lib/followups-server.ts
@@ -1,5 +1,8 @@
 import path from "node:path";
 import { careerOpsRoot } from "@/lib/career-ops";
+import { withFollowupsLock, FollowupsBusyError } from "@/lib/core/followups-lock";
+
+export { FollowupsBusyError };
 
 // Server-only helpers shared by the follow-ups API routes (log + override).
 
@@ -8,17 +11,58 @@ export function followupsLogPath(): string {
   return path.join(careerOpsRoot(), "data", "follow-ups.md");
 }
 
-// Serialize every mutation of the log file across routes: POST log derives the
-// next num from a read of the file, DELETE and the override routes do
-// read-modify-write — unserialized, concurrent requests could mint duplicate
-// nums or drop lines. The web app is a single local server process, so an
-// in-process queue is sufficient — no cross-process lock needed.
+// In-process serialization of follow-up mutations: POST log derives the next
+// num from a read of the file, DELETE and the override routes do read-modify-
+// write — unserialized, concurrent requests in THIS process could mint
+// duplicate nums or drop lines. The web app is a single local server process,
+// so a promise queue serializes them.
+//
+// WHAT THIS DOES **NOT** PROTECT: this queue only sees THIS process. It cannot
+// see the user's CLI or the core's cadence seeder (followup-seed.mjs), which
+// read-modify-write the SAME data/follow-ups.md. Its old comment claimed "no
+// cross-process lock needed", and that false comfort is exactly why the gap
+// survived — a reader who sees a guard stops looking for the one that is
+// missing (the same shape as /api/status before #2903). Cross-process exclusion
+// is the core FILE lock, reached via withFollowupsLock; this queue and that
+// lock COMPOSE (see withFollowupsWrite) — neither replaces the other.
 let queue: Promise<unknown> = Promise.resolve();
-export function withLogLock<T>(fn: () => T): Promise<T> {
+export function withLogLock<T>(fn: () => T | Promise<T>): Promise<T> {
   const run = queue.then(fn, fn);
   queue = run.then(
     () => undefined,
     () => undefined,
   );
   return run;
+}
+
+// The full guard for any data/follow-ups.md mutation. Order is load-bearing and
+// agreed with the core maintainer (#3034): the in-process queue OUTSIDE, the
+// cross-process file lock INSIDE.
+//
+//   withLogLock(() => withFollowupsLock(path, fn))
+//
+// Why this order: the queue reduces this process's N concurrent requests to ONE
+// before the file lock is touched, so the file lock only ever arbitrates "the
+// one active web request vs the user's CLI". Reversed, two of the user's own
+// browser tabs would contend on the cross-process lock — one wins, the other
+// eats the timeout and a 409 — for a race the free in-process queue already
+// resolves. Every followups writer goes through here so no call site can get
+// the nesting wrong.
+export function withFollowupsWrite<T>(fn: () => T | Promise<T>): Promise<T> {
+  return withLogLock(() => withFollowupsLock(followupsLogPath(), fn));
+}
+
+// Map a throw from withFollowupsWrite onto an HTTP response, consistently across
+// the four followups mutation handlers. A contended lock is transient (someone
+// else — the CLI, the seeder, another tab — holds it right now), so it is 409 +
+// Retry-After, not a 500: the caller should retry, not treat the write as
+// rejected. Anything else is a real failure on this machine → 500.
+export function followupsWriteError(e: unknown, fallback = "write failed"): Response {
+  if (e instanceof FollowupsBusyError) {
+    return Response.json(
+      { error: "follow-ups file is busy — try again in a moment" },
+      { status: 409, headers: { "Retry-After": "1" } },
+    );
+  }
+  return Response.json({ error: e instanceof Error ? e.message : fallback }, { status: 500 });
 }

--- a/web/tests/lib/followups-lock.test.mjs
+++ b/web/tests/lib/followups-lock.test.mjs
@@ -1,0 +1,114 @@
+// The follow-ups lock exists to stop a LOST UPDATE, so the test has to produce one.
+//
+// data/follow-ups.md is read-modify-written from two directions: the web's
+// log/override routes and the core's cadence seeder (followup-seed.mjs). Each
+// writer reads the whole file, adds its own line, and writes the whole file
+// back. Unserialized, two overlapping writers each start from the same snapshot
+// and the second's full-file write discards the first's line — no error, a
+// well-formed file, one pin silently gone (the same shape as the tracker, #2900).
+//
+// This asserts the failure FIRST (unlocked writers lose data) and then that the
+// core lock removes it. Without the negative half, a lock that never engaged
+// would pass just as happily. Verified red by hand: swap withFollowupsLock for a
+// passthrough and the "both survive" assertion fails.
+//
+// Run:  node --test tests/lib/followups-lock.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+// Resolved from this file, not the cwd: test-all.mjs runs these suites from the
+// repo root, where `cwd/..` points outside the checkout and every core case
+// would skip as "not resolvable" while reporting green.
+const CORE =
+  process.env.CAREER_OPS_ROOT ||
+  path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const coreSeed = path.join(CORE, "followup-seed.mjs");
+
+// The guard has to answer "can this be imported", not "is the file there".
+// followup-seed.mjs imports js-yaml, so a web-only install (web-ci.yml runs
+// `npm ci` in web/ alone) has the file and not its dependencies; existsSync
+// would call that runnable and the cases would fail on ERR_MODULE_NOT_FOUND
+// instead of skipping (mirrors tracker-lock.test.mjs / #2922).
+let core = null;
+let skipCore = false;
+try {
+  core = await import(pathToFileURL(coreSeed).href);
+} catch (err) {
+  const coreAbsent = !fs.existsSync(coreSeed);
+  const packageUnresolvable = err.url == null;
+  const depsAbsent = !fs.existsSync(path.join(CORE, "node_modules"));
+  if (err.code !== "ERR_MODULE_NOT_FOUND") throw err;
+  if (coreAbsent) skipCore = `no core checkout at ${CORE}`;
+  else if (packageUnresolvable && depsAbsent) skipCore = `core dependencies are not installed at ${CORE} (web-only checkout)`;
+  else throw err;
+}
+
+function makeFollowups() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "flwlock-"));
+  const file = path.join(root, "follow-ups.md");
+  fs.writeFileSync(file, "# Follow-ups\n\n");
+  return { root, file };
+}
+
+/** The override route's read-modify-write, verbatim in shape: read the whole
+ *  file, add THIS app's pin, write the whole file back. The pause widens the
+ *  read→write window so two callers reliably overlap. */
+function addPin(file, appNum, date, pauseMs) {
+  const existing = fs.readFileSync(file, "utf8");
+  return new Promise((resolve) => setTimeout(() => {
+    const base = existing.endsWith("\n") ? existing : existing + "\n";
+    const tmp = `${file}.tmp`;
+    fs.writeFileSync(tmp, base + `- next #${appNum} ${date} (set ${date})\n`);
+    fs.renameSync(tmp, file);
+    resolve();
+  }, pauseMs));
+}
+
+const pinCount = (file) =>
+  fs.readFileSync(file, "utf8").split("\n").filter((l) => /^- next #\d+ /.test(l)).length;
+
+test("WITHOUT a lock, two concurrent pin writers lose one update silently", async () => {
+  const { root, file } = makeFollowups();
+  try {
+    await Promise.all([addPin(file, 1, "2026-07-10", 60), addPin(file, 2, "2026-07-11", 10)]);
+    // The bug: no error, file well-formed, only the last writer's pin remains.
+    assert.equal(pinCount(file), 1, "expected the classic lost update to reproduce");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("WITH the core lock, both pins survive", { skip: skipCore }, async () => {
+  const { root, file } = makeFollowups();
+  const guarded = (appNum, date, pauseMs) =>
+    core.withFollowupsLock(file, () => addPin(file, appNum, date, pauseMs), { timeoutMs: 5_000, retryMs: 25 });
+  try {
+    await Promise.all([guarded(1, "2026-07-10", 60), guarded(2, "2026-07-11", 10)]);
+    assert.equal(pinCount(file), 2, "a pin was lost even under the lock");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("the lock is released on a throwing path, not just the happy one", { skip: skipCore }, async () => {
+  // A leaked lock on a long-lived server is worse than the bug: the holder's pid
+  // stays alive, so the core's stale-recovery will not reclaim it and the user's
+  // own CLI is locked out until staleMs.
+  const { root, file } = makeFollowups();
+  try {
+    await assert.rejects(
+      core.withFollowupsLock(file, () => { throw new Error("boom"); }, { timeoutMs: 5_000, retryMs: 25 }),
+      /boom/,
+    );
+    // If the lock had leaked, this second acquire would time out.
+    await core.withFollowupsLock(file, () => addPin(file, 9, "2026-07-12", 0), { timeoutMs: 2_000, retryMs: 25 });
+    assert.equal(pinCount(file), 1, "second acquire after a throw should have written");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## The gap

`data/follow-ups.md` is read-modify-written from **two directions** — the web's `log`/`override` routes and the core cadence seeder (`followup-seed.mjs`) — but the web held only `withLogLock`, an **in-process promise queue**. It serializes this process's own requests and is blind to the user's CLI. Its old comment ("no cross-process lock needed") was true for web-vs-web and false for web-vs-seeder, so an overlapping write and seed silently lost one — well-formed file, no error. Same shape as `/api/status` before #2903. Diagnosed in #3034.

## The fix

Adopt the core's exported `withFollowupsLock` (from #3037). The lockDir derivation (sha256 of the resolved path) stays **entirely core-side** — the web imports the function and passes its path, never recomputes the hash. No second body of the same truth to keep in sync (which is the bug class #3034 set out to close).

The two guards **compose**, they don't replace each other. `withFollowupsWrite` nests them in the order agreed with @santifer (maintainer) on #3034:

```
withLogLock(() => withFollowupsLock(path, fn))   // in-process queue OUTSIDE, file lock INSIDE
```

The queue reduces N concurrent web requests to one before the file lock is touched, so the file lock only ever arbitrates "the one active web request vs the user's CLI". Reversed, two of the user's own browser tabs would contend on the cross-process lock and one would eat a 409 for a race the free queue already resolves. Every followups writer routes through `withFollowupsWrite`, so no call site can get the nesting wrong.

## Details

- **`web/src/lib/core/followups-lock.ts`** — ACL over the core export. Short web timeout (5s, `CAREER_OPS_WEB_FOLLOWUPS_LOCK_TIMEOUT_MS`) so a contended lock answers **409** instead of hanging an HTTP handler; a **data-only root** (core scripts absent, so no seeder to race) degrades to the in-process queue alone; **non-reentrancy** documented (a holder must not orchestrate a core script that also takes the lock).
- **`followups-server.ts`** — `withLogLock` keeps a `WHAT THIS DOES NOT PROTECT` comment so the next reader doesn't mistake the queue for cross-process exclusion.
- **`tests/lib/followups-lock.test.mjs`** — asserts the **behaviour** (two concurrent pin writers lose one without the lock; both survive with it; lock released on a throwing path). **Verified red** with a passthrough (`actual: 1, expected: 2`) — a test that passes with and without the lock proves nothing. Survives a future migration because it asserts behaviour, not who holds the lock.

## Verification

- Full web suite: **264/264 green** (includes the new lock suite + the tracker-lock suite unchanged).
- `tsc --noEmit`: clean.
- The lost-update test verified red→green by hand.

Closes the web half of #3034. Depends on #3037 (already in `main`).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when multiple follow-up changes are saved at the same time.
  * Prevented conflicting updates from overwriting one another.
  * Follow-up write conflicts now return a clear retry response, while unexpected failures are handled consistently.
  * Ensured write locks are released even when an error occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->