### PR TITLE
fix(cover-letter): preserve --out subdirectories inside output/

### DIFF
--- a/generate-cover-letter.mjs
+++ b/generate-cover-letter.mjs
@@ -9,24 +9,65 @@
  * Fills templates/cover-letter-template.html with the payload, then renders
  * it to PDF via the same Playwright pipeline used for CVs (generate-pdf.mjs).
  *
- * `buildHtml` is exported as a pure function so the template can be tested
- * without loading Playwright (renderHtmlToPdf is imported lazily inside main).
+ * `buildHtml` and `safeOutputPath` are exported as pure functions so the
+ * template and --out path guard can be tested without loading Playwright
+ * (renderHtmlToPdf is imported lazily inside main).
  */
 
 import { readFileSync, existsSync, mkdirSync } from "fs";
-import { dirname, resolve, basename, join } from "path";
+import { dirname, resolve, join, relative, isAbsolute } from "path";
 import { fileURLToPath, pathToFileURL } from "url";
 import { parseArgs } from "util";
 import { assertFacts } from "./verify-cv-facts.mjs";
 import { resolveTemplate } from "./cv-templates.mjs";
 
-const OUTPUT_ROOT = resolve("output");
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUTPUT_ROOT = resolve(__dirname, "output");
 
-/** Sanitize a requested output filename and keep it under the output directory. */
-function safeOutputPath(raw) {
-  // Derive a sanitized filename from raw string (strip path separators and dots)
-  const filename = basename(raw).replace(/[^a-zA-Z0-9._-]/g, "-").replace(/\.{2,}/g, "-");
-  return join(OUTPUT_ROOT, filename);
+/**
+ * Resolve a requested cover-letter output path.
+ *
+ * Paths that stay inside `output/` keep their relative subdirectory (the
+ * application-bundle layout `generate-pdf.mjs` already supports). Paths that
+ * would escape `output/` — `..` traversal or an absolute path outside it —
+ * are rejected instead of being silently flattened to `output/<basename>`.
+ *
+ * @param {string} raw - Caller-supplied --out / payload.output_path value.
+ * @returns {string} Absolute path inside OUTPUT_ROOT.
+ */
+export function safeOutputPath(raw) {
+  if (raw == null || String(raw).trim() === "") {
+    throw new Error("Refusing to write the cover letter outside output/: (empty path)");
+  }
+  const trimmed = String(raw).trim();
+
+  const asWritten = resolve(trimmed);
+  if (containedInOutput(asWritten)) return asWritten;
+
+  // Absolute paths and any `..` segment already chose a location; if that
+  // location is not inside output/, refuse instead of rewriting to a basename.
+  if (isAbsolute(trimmed) || /(^|[\\/])\.\.([\\/]|$)/.test(trimmed)) {
+    throw new Error(`Refusing to write the cover letter outside output/: ${raw}`);
+  }
+
+  // Bare filename or a relative path that is not already under output/
+  // (e.g. --out cover.pdf, or --out output/foo/bar.pdf from another cwd).
+  const posix = trimmed.replace(/\\/g, "/").replace(/^\.\//, "");
+  const relativeToRoot = posix === "output" || posix === "output/"
+    ? ""
+    : posix.startsWith("output/")
+      ? posix.slice("output/".length)
+      : posix;
+  const candidate = resolve(OUTPUT_ROOT, relativeToRoot);
+  if (containedInOutput(candidate)) return candidate;
+
+  throw new Error(`Refusing to write the cover letter outside output/: ${raw}`);
+}
+
+/** True when absPath is a file (not output/ itself) still inside OUTPUT_ROOT. */
+function containedInOutput(absPath) {
+  const rel = relative(OUTPUT_ROOT, absPath);
+  return rel !== "" && !rel.startsWith("..") && !isAbsolute(rel);
 }
 
 /** Assert that a payload object contains the required keys. */
@@ -267,7 +308,12 @@ Usage:
     const role    = (payload.letter?.role_title || "role").toLowerCase().replace(/[^a-z0-9]+/g, "-").slice(0, 30);
     payload.output_path = join(OUTPUT_ROOT, `${company}-${role}-cover.pdf`);
   } else {
-    payload.output_path = safeOutputPath(payload.output_path);
+    try {
+      payload.output_path = safeOutputPath(payload.output_path);
+    } catch (err) {
+      console.error(err.message);
+      process.exit(1);
+    }
   }
 
   if (!existsSync(OUTPUT_ROOT)) mkdirSync(OUTPUT_ROOT, { recursive: true });

--- a/tests/cover-letter-output-path.test.mjs
+++ b/tests/cover-letter-output-path.test.mjs
@@ -1,0 +1,83 @@
+// tests/cover-letter-output-path.test.mjs — generate-cover-letter --out
+// must preserve directories that stay inside output/ (#2940).
+//
+// safeOutputPath() used basename() and always wrote output/<file>, so a
+// legitimate bundle path such as output/{NNN}-{company}-{role}/cover-letter/vNNN/
+// was flattened to output/<file> and the process still exited 0. generate-pdf.mjs
+// already keeps those nested paths; cover letters must match.
+//
+// Two directions, matching the maintainer note on #2940:
+//   1. A path that stays inside output/ is honoured, subdirectory included.
+//   2. A path that would escape output/ is rejected — not silently rewritten.
+import { resolve, join, relative, isAbsolute } from 'path';
+import { pass, fail, ROOT } from './helpers.mjs';
+import { safeOutputPath } from '../generate-cover-letter.mjs';
+
+console.log('\nCover letter --out preserves output/ subdirectories (#2940)');
+
+const OUTPUT_ROOT = resolve(ROOT, 'output');
+
+function underOutput(absPath) {
+  const rel = relative(OUTPUT_ROOT, absPath);
+  return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel);
+}
+
+function checkEqual(label, actual, expected) {
+  if (resolve(actual) === resolve(expected)) pass(label);
+  else fail(`${label} — expected ${expected}, got ${actual}`);
+}
+
+function checkThrows(label, raw) {
+  try {
+    const got = safeOutputPath(raw);
+    fail(`${label} — expected a refusal, got ${got}`);
+  } catch (err) {
+    const msg = String(err && err.message);
+    if (/refus/i.test(msg) && /output/i.test(msg)) pass(label);
+    else fail(`${label} — unexpected error: ${msg}`);
+  }
+}
+
+// --- Honour paths that stay inside output/ ---------------------------------
+// The issue repro: --out output/_repro/v001/cover.pdf must not flatten.
+checkEqual(
+  'nested path under output/ keeps its subdirectory',
+  safeOutputPath(join('output', '_repro', 'v001', 'cover.pdf')),
+  join(OUTPUT_ROOT, '_repro', 'v001', 'cover.pdf'),
+);
+
+// Maintainer reproduction: application-scoped bundle layout from modes/pdf.md.
+checkEqual(
+  'application-bundle cover-letter path is preserved',
+  safeOutputPath(join('output', '012-acme-vp-marketing', 'cover-letter', 'v2', 'carta.pdf')),
+  join(OUTPUT_ROOT, '012-acme-vp-marketing', 'cover-letter', 'v2', 'carta.pdf'),
+);
+
+// Bare filename remains the documented default: output/<file>.
+checkEqual(
+  'bare filename still lands in output/',
+  safeOutputPath('cover.pdf'),
+  join(OUTPUT_ROOT, 'cover.pdf'),
+);
+
+// Absolute path already inside output/ is accepted as-is.
+checkEqual(
+  'absolute path inside output/ is accepted',
+  safeOutputPath(join(OUTPUT_ROOT, 'nested', 'letter.pdf')),
+  join(OUTPUT_ROOT, 'nested', 'letter.pdf'),
+);
+
+{
+  const got = safeOutputPath(join('output', '_repro', 'v001', 'cover.pdf'));
+  if (underOutput(got)) pass('honoured nested path stays inside output/');
+  else fail(`honoured nested path escaped output/: ${got}`);
+}
+
+// --- Reject escapes loudly; do not flatten to output/<basename> ------------
+// Pass the raw CLI strings. path.join() collapses `..` before the guard sees
+// them, which is exactly the silent-rewrite behaviour this test must catch.
+checkThrows('parent-directory escape is refused', 'output/../secrets.pdf');
+checkThrows('nested traversal escape is refused', 'output/foo/../../etc/passwd');
+checkThrows('absolute path outside output/ is refused', resolve(ROOT, 'cover.pdf'));
+checkThrows('absolute path in /tmp is refused', join('/tmp', 'cover.pdf'));
+checkThrows('output/ itself (no filename) is refused', 'output');


### PR DESCRIPTION
## What does this PR do?

`generate-cover-letter.mjs --out` used `basename()` and always wrote `output/<file>`, so a legitimate bundle path such as `output/012-acme-vp-marketing/cover-letter/v2/carta.pdf` was flattened to `output/carta.pdf` and the process still exited 0. Honour paths that stay inside `output/` (mkdir is already handled by `generate-pdf.mjs`) and refuse escapes instead of silently rewriting them.

Tests cover both directions from #2940: keep a subdirectory under `output/`, and reject `..` / absolute escapes rather than flattening them.

## Related issue

Fixes #2940

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [ ] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cover-letter output path handling.
  * Preserved valid nested output folders while blocking traversal and external paths.
  * Invalid output paths are now reported before rendering begins.

* **Tests**
  * Added coverage for default, nested, absolute, and invalid output paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->