### PR TITLE
test(hermetic-env): move the regression to its own discovered file

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -55,7 +55,7 @@ import { tmpdir } from 'os';
 import { promisify } from 'util';
 import { fileURLToPath, pathToFileURL } from 'url';
 import * as yaml from 'js-yaml';
-import { pass, fail, warn, run, lastRunFailure, formatRunFailure, fileExists, finish, ROOT, QUICK, NODE, DEFAULT_SCRIPT_TIMEOUT_MS, getBash, toBashPath } from './tests/helpers.mjs';
+import { pass, fail, warn, run, lastRunFailure, formatRunFailure, fileExists, finish, ROOT, QUICK, NODE, DEFAULT_SCRIPT_TIMEOUT_MS, getBash, toBashPath, hermeticGitEnv } from './tests/helpers.mjs';
 import { flagValue, hasFlag } from './lib/cli-flags.mjs';
 
 /**
@@ -6069,110 +6069,6 @@ console.log('\n12b. Skill entrypoint bootstrap (npx / old releases)');
 }
 
 console.log('\n12c. Materialized skill index mode');
-
-/**
- * Build a git environment nothing ambient can reach into.
- *
- * GIT_CONFIG_GLOBAL and GIT_CONFIG_SYSTEM pin the FILE layers. They do not
- * close the RUNTIME layer: GIT_CONFIG_COUNT with its KEY_n / VALUE_n pairs is
- * applied AFTER every config file, so an ambient `core.excludesFile` injected
- * that way overrides even the one a fixture sets for itself, and the isolation
- * silently stops holding - the exact leak this pinning exists to close,
- * arriving through the one door left open (#2567).
- *
- * COUNT is set to 0 rather than deleting the variables: it is a single
- * authoritative value, and git reads KEY_n / VALUE_n only up to COUNT, so any
- * stragglers are inert without having to enumerate them.
- *
- * `base` exists so the regression case below can hand in a parent environment
- * carrying the injection. Both callers share this one construction on purpose:
- * a test that hand-rolled its own env would keep passing if the pin were
- * dropped here, which is how the gap got in.
- */
-function hermeticGitEnv(gitConfigPath, base = process.env) {
-  const env = {
-    ...base,
-    GIT_CONFIG_COUNT: '0',
-    GIT_CONFIG_GLOBAL: gitConfigPath,
-    GIT_CONFIG_SYSTEM: gitConfigPath,
-  };
-  // These two DO have to be enumerated, because COUNT governs KEY_n / VALUE_n
-  // and nothing else, and neither of them is a config FILE that GLOBAL/SYSTEM
-  // could shadow. Both survive all three pins above:
-  //
-  //   GIT_CONFIG_PARAMETERS  the channel git uses to hand `-c` down to a
-  //                          subprocess, so it reaches every git invocation.
-  //                          Measured: with it set, a commit made through this
-  //                          env took its author from the ambient value.
-  //   GIT_CONFIG             redirects the `git config` command, reads AND
-  //                          writes. Both fixtures below call `git config` to
-  //                          set themselves up, so with it set that write lands
-  //                          in the ambient file instead of the fixture: the
-  //                          setting never takes effect, and the suite mutates
-  //                          a file outside its own temp dir.
-  delete env.GIT_CONFIG_PARAMETERS;
-  delete env.GIT_CONFIG;
-  return env;
-}
-
-// Asserted through hermeticGitEnv rather than around it, and on BEHAVIOUR rather
-// than on the absence of a key: a check that the returned object lacks the two
-// names would pass on any implementation that deletes them, including one that
-// deletes them after git has already been handed the environment. What matters
-// is that the injection does not reach git.
-{
-  const root = mkdtempSync(join(tmpdir(), 'career-ops-hermetic-env-'));
-  try {
-    const pinned = join(root, 'gitconfig');
-    writeFileSync(pinned, '');
-    const ambient = join(root, 'ambient-config');
-    writeFileSync(ambient, '[user]\n\tname = ambient-leak\n');
-    const repo = join(root, 'repo');
-    mkdirSync(repo, { recursive: true });
-
-    const gitEnv = hermeticGitEnv(pinned, {
-      ...process.env,
-      GIT_CONFIG_PARAMETERS: "'user.name=parameters-leak'",
-      GIT_CONFIG: ambient,
-    });
-    const gitRun = (args) => execFileSync('git', args, {
-      cwd: repo, encoding: 'utf-8', timeout: 30000, env: gitEnv,
-    }).trim();
-
-    gitRun(['init']);
-    let seenName = '';
-    try {
-      seenName = gitRun(['config', 'user.name']);
-    } catch (err) {
-      // `git config <key>` exits 1 for "not set", which is the outcome this
-      // block asserts. Anything else means the probe never ran: 128 for a
-      // broken repo, 129 for a bad invocation. Swallowing those would turn a
-      // failed probe into evidence that the isolation works.
-      if (err?.status !== 1) throw err;
-      seenName = '';
-    }
-    if (seenName === '') {
-      pass('hermeticGitEnv keeps an ambient GIT_CONFIG_PARAMETERS / GIT_CONFIG out of git');
-    } else {
-      fail(`ambient config reached git through hermeticGitEnv: user.name = ${seenName}`);
-    }
-
-    // The write half. Both fixtures in this file configure themselves with
-    // `git config`, and under an ambient GIT_CONFIG that write leaves the
-    // fixture entirely - so the setting silently does not apply, and the suite
-    // edits a file it does not own.
-    gitRun(['config', 'core.excludesFile', join(root, 'excludes')]);
-    const landedLocally = readFileSync(join(repo, '.git', 'config'), 'utf-8').includes('excludesFile');
-    const escaped = readFileSync(ambient, 'utf-8').includes('excludesFile');
-    if (landedLocally && !escaped) {
-      pass("a fixture's own `git config` write stays inside the fixture");
-    } else {
-      fail(`git config write escaped the fixture: local=${landedLocally} ambient=${escaped}`);
-    }
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
-}
 
 {
   const fixtureRoot = mkdtempSync(join(tmpdir(), 'career-ops-skill-git-'));

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -476,3 +476,48 @@ export async function captureConsoleErrors(fn) {
     console.error = original;
   }
 }
+
+/**
+ * Build a git environment nothing ambient can reach into.
+ *
+ * GIT_CONFIG_GLOBAL and GIT_CONFIG_SYSTEM pin the FILE layers. They do not
+ * close the RUNTIME layer: GIT_CONFIG_COUNT with its KEY_n / VALUE_n pairs is
+ * applied AFTER every config file, so an ambient `core.excludesFile` injected
+ * that way overrides even the one a fixture sets for itself, and the isolation
+ * silently stops holding - the exact leak this pinning exists to close,
+ * arriving through the one door left open (#2567).
+ *
+ * COUNT is set to 0 rather than deleting the variables: it is a single
+ * authoritative value, and git reads KEY_n / VALUE_n only up to COUNT, so any
+ * stragglers are inert without having to enumerate them.
+ *
+ * `base` exists so a regression case can hand in a parent environment
+ * carrying the injection. Every caller shares this one construction on purpose:
+ * a test that hand-rolled its own env would keep passing if the pin were
+ * dropped here, which is how the gap got in.
+ */
+export function hermeticGitEnv(gitConfigPath, base = process.env) {
+  const env = {
+    ...base,
+    GIT_CONFIG_COUNT: '0',
+    GIT_CONFIG_GLOBAL: gitConfigPath,
+    GIT_CONFIG_SYSTEM: gitConfigPath,
+  };
+  // These two DO have to be enumerated, because COUNT governs KEY_n / VALUE_n
+  // and nothing else, and neither of them is a config FILE that GLOBAL/SYSTEM
+  // could shadow. Both survive all three pins above:
+  //
+  //   GIT_CONFIG_PARAMETERS  the channel git uses to hand `-c` down to a
+  //                          subprocess, so it reaches every git invocation.
+  //                          Measured: with it set, a commit made through this
+  //                          env took its author from the ambient value.
+  //   GIT_CONFIG             redirects the `git config` command, reads AND
+  //                          writes. The fixtures in test-all.mjs call `git config` to
+  //                          set themselves up, so with it set that write lands
+  //                          in the ambient file instead of the fixture: the
+  //                          setting never takes effect, and the suite mutates
+  //                          a file outside its own temp dir.
+  delete env.GIT_CONFIG_PARAMETERS;
+  delete env.GIT_CONFIG;
+  return env;
+}

--- a/tests/hermetic-git-env.test.mjs
+++ b/tests/hermetic-git-env.test.mjs
@@ -37,8 +37,19 @@ try {
   const repo = join(root, 'repo');
   mkdirSync(repo, { recursive: true });
 
+  // All three channels at once, each carrying a distinct value, so a failure
+  // names which one got through rather than only that something did.
+  //
+  // GIT_CONFIG_COUNT is the channel the pins were originally built for (#2567),
+  // and the only one closed by overwriting rather than deleting: setting it to 0
+  // makes KEY_n / VALUE_n inert without enumerating them. Injecting it here is
+  // what makes that pin load-bearing in this file — without this pair, removing
+  // `GIT_CONFIG_COUNT: '0'` from the helper leaves this test green.
   const gitEnv = hermeticGitEnv(pinned, {
     ...process.env,
+    GIT_CONFIG_COUNT: '1',
+    GIT_CONFIG_KEY_0: 'user.name',
+    GIT_CONFIG_VALUE_0: 'count-leak',
     GIT_CONFIG_PARAMETERS: "'user.name=parameters-leak'",
     GIT_CONFIG: ambient,
   });

--- a/tests/hermetic-git-env.test.mjs
+++ b/tests/hermetic-git-env.test.mjs
@@ -1,0 +1,78 @@
+// tests/hermetic-git-env.test.mjs — hermeticGitEnv must keep ambient git
+// configuration out of a fixture, in BOTH directions.
+//
+// Two variables walk past all three of its pins, because GIT_CONFIG_COUNT
+// governs GIT_CONFIG_KEY_n / VALUE_n and nothing else, and neither of these is a
+// config FILE that GLOBAL/SYSTEM could shadow:
+//
+//   GIT_CONFIG_PARAMETERS  how git hands `-c` to a subprocess, so it reaches
+//                          every git invocation.
+//   GIT_CONFIG             redirects the `git config` command — reads AND
+//                          writes. The write half is the one that bites: the
+//                          fixtures in test-all.mjs configure themselves by
+//                          calling `git config`, so under an ambient value that
+//                          write leaves the fixture, the setting silently never
+//                          applies, and the suite edits a file it does not own.
+//
+// Asserted through hermeticGitEnv rather than around it, and on BEHAVIOUR rather
+// than on the absence of a key: a check that the returned object lacks the two
+// names would pass on any implementation that deletes them, including one that
+// deletes them after git has already been handed the environment. What matters
+// is what git saw.
+
+import { execFileSync } from 'child_process';
+import { readFileSync, writeFileSync, mkdtempSync, mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { pass, fail, hermeticGitEnv } from './helpers.mjs';
+
+console.log('\nhermetic git env — ambient GIT_CONFIG* must not reach a fixture');
+
+const root = mkdtempSync(join(tmpdir(), 'career-ops-hermetic-env-'));
+try {
+  const pinned = join(root, 'gitconfig');
+  writeFileSync(pinned, '');
+  const ambient = join(root, 'ambient-config');
+  writeFileSync(ambient, '[user]\n\tname = ambient-leak\n');
+  const repo = join(root, 'repo');
+  mkdirSync(repo, { recursive: true });
+
+  const gitEnv = hermeticGitEnv(pinned, {
+    ...process.env,
+    GIT_CONFIG_PARAMETERS: "'user.name=parameters-leak'",
+    GIT_CONFIG: ambient,
+  });
+  const gitRun = (args) => execFileSync('git', args, {
+    cwd: repo, encoding: 'utf-8', timeout: 30000, env: gitEnv,
+  }).trim();
+
+  gitRun(['init']);
+
+  let seenName = '';
+  try {
+    seenName = gitRun(['config', 'user.name']);
+  } catch (err) {
+    // `git config <key>` exits 1 for "not set", which is the outcome this
+    // asserts. Anything else means the probe never ran — 128 for a broken repo,
+    // 129 for a bad invocation — and swallowing those would turn a failed probe
+    // into evidence that the isolation works.
+    if (err?.status !== 1) throw err;
+    seenName = '';
+  }
+  if (seenName === '') {
+    pass('hermeticGitEnv keeps an ambient GIT_CONFIG_PARAMETERS / GIT_CONFIG out of git');
+  } else {
+    fail(`ambient config reached git through hermeticGitEnv: user.name = ${seenName}`);
+  }
+
+  gitRun(['config', 'core.excludesFile', join(root, 'excludes')]);
+  const landedLocally = readFileSync(join(repo, '.git', 'config'), 'utf-8').includes('excludesFile');
+  const escaped = readFileSync(ambient, 'utf-8').includes('excludesFile');
+  if (landedLocally && !escaped) {
+    pass("a fixture's own `git config` write stays inside the fixture");
+  } else {
+    fail(`git config write escaped the fixture: local=${landedLocally} ambient=${escaped}`);
+  }
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}


### PR DESCRIPTION
Follow-up to #3011, closing the convention violation @coderabbitai flagged after it merged. My mistake, and the header of the file says so in capitals:

> **NEW TESTS GO IN A FILE OF THEIR OWN, NOT IN A SECTION HERE.**
> … The inline sections below are history, not a pattern to copy.

The stated cost is collisions: six contributors picking section `60a` in Aug-2026, about fifteen rebases and six serialized CI runs for six lines of test code.

There is a second cost I hit personally while writing #3011, and it is worth recording next to the first: **an inline check cannot be run by `--only`**, which this same header warns about — so the test could not be exercised locally at all while it lived in `test-all.mjs`, and I said as much in that PR. As a discovered file it now runs under `node test-all.mjs --only hermetic`.

`hermeticGitEnv` moves to `tests/helpers.mjs` rather than being exported from `test-all.mjs`, because importing that file runs the whole suite. Both existing fixtures keep calling the one construction — a test that hand-rolled its own env would keep passing if the pins were dropped, which is exactly how the original gap got in, so that property mattered more than where the function sits. `tests/` is already covered by `SYSTEM_PATHS` as a directory, so the new file needs no registration.

**No behaviour change.** The two assertions are the merged ones, verbatim. Seen red by deleting both `delete` lines from the helper:

```
❌ ambient config reached git through hermeticGitEnv: user.name = ambient-leak
❌ git config write escaped the fixture: local=false ambient=true
```

`--only hermetic` 2, `--only skill` 58, `--only git` 49, and the SYSTEM_PATHS coverage validator passes over 1111 tracked files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Centralized Git configuration isolation checks for more consistent automated validation.
  * Added end-to-end coverage for configuration reads, writes, error handling, and temporary repository cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->