### PR TITLE
fix(cli): validate upskill.mjs flags via lib/cli-flags.mjs

### DIFF
--- a/tests/cli-flag-validation.test.mjs
+++ b/tests/cli-flag-validation.test.mjs
@@ -6,7 +6,8 @@
 // the script reports a result for inputs nobody asked for at exit 0. Already
 // fixed in scan-ats-full.mjs (#1633/#1635), reply-watch.mjs (#2743/#2745),
 // dedup-tracker.mjs (#2744/#2746), scan.mjs (#2270), doctor.mjs (#2874),
-// check-table-freshness.mjs (#2873) and plugin-audit.mjs (#2813).
+// check-table-freshness.mjs (#2873), plugin-audit.mjs (#2813) and
+// upskill.mjs.
 //
 // rejection-latency.mjs is the sharpest case and gets its own fixture: its
 // output is a blacklist suggestion, so the silent failure is a FALSE ALL-CLEAR
@@ -45,6 +46,7 @@ const SCRIPTS = [
   ['process-quality.mjs', '--fiel'],
   ['detect-reposts.mjs', '--windo'],
   ['weekly-digest.mjs', '--dri'],
+  ['upskill.mjs', '--min-report'],
 ];
 
 for (const [script, typo] of SCRIPTS) {

--- a/upskill.mjs
+++ b/upskill.mjs
@@ -27,6 +27,7 @@ import { join, dirname, relative, sep } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { load as yamlLoad } from 'js-yaml';
 import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
+import { validateFlags } from './lib/cli-flags.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const APPS_FILE = existsSync(join(CAREER_OPS, 'data/applications.md'))
@@ -846,8 +847,29 @@ async function validateUrlSecurity(urlString) {
 // repo convention is worth more here than covering a path nothing takes.
 const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 
+// An unrecognized or mistyped flag (e.g. `--min-report` for `--min-reports`)
+// used to fall through silently: the aggregate branch just ran with its
+// default MIN_REPORTS, reporting a gap map for a threshold nobody asked for.
+// Handled via lib/cli-flags.mjs's validateFlags() (#2775), same shape as
+// doctor.mjs (#2874) — checked before --self-test/--url-text/--min-reports
+// are read, and before --help, so `--help --bogus` still errors.
+const KNOWN_FLAGS = ['--min-reports', '--summary', '--url-text', '--self-test', '--help', '-h'];
+
+// Only --min-reports and --url-text take their value as the next argv token.
+const VALUE_FLAGS = ['--min-reports', '--url-text'];
+
+const USAGE = `Usage:
+  node upskill.mjs                        # aggregate skill-gap map (JSON)
+  node upskill.mjs --summary              # human-readable table
+  node upskill.mjs --min-reports <n>      # minimum scored reports required (default 5)
+  node upskill.mjs --url-text <url|path>  # targeted gap analysis vs one JD (URL or local file)
+  node upskill.mjs <url>                  # same as --url-text <url>
+  node upskill.mjs --self-test            # run the pure-function self-tests
+  node upskill.mjs --help                 # show this message`;
+
 if (isMain) {
   const args = process.argv.slice(2);
+  validateFlags(args, KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS });
   if (args.includes('--self-test')) runSelfTest();
 
   // ====== SECURE TARGETED MODE PHASE 2a IMPLEMENTATION ======


### PR DESCRIPTION
## What does this PR do?
upskill.mjs parsed flags positionally, so a mistyped flag (--sumary, --min-report) was silently ignored and the script ran on its aggregate defaults with exit 0. This delegates flag validation to validateFlags in lib/cli-flags.mjs, matching doctor.mjs (#2874), so it rejects unrecognised flags before reading any tracker or report file.
<!-- Describe the change in 1-3 sentences -->

## Related issue
Closes #3002

<!-- Link the issue this PR addresses, if it has one. Format: Fixes #123 / Closes #123 -->
<!-- Issue-first is asked for NEW FEATURES, new modes/commands, and architecture changes — it saves you from building something we'd have to redirect. -->
<!-- No issue needed, send the PR straight in: bug fixes, new zero-auth scanner providers, docs, and translations. We don't want to slow these down. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added command-line flag validation to reject unknown or malformed options before processing commands.
  * Corrected handling of the `--min-report` option.
  * Updated validation coverage to include `upskill.mjs`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->