### PR TITLE
fix(test-all): stop Windows EPERM cleanup from aborting a green suite

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -35,7 +35,21 @@
 
 
 import { execSync, execFile, execFileSync, spawn, spawnSync } from 'child_process';
-import { readFileSync, existsSync, readdirSync, mkdtempSync, mkdirSync, writeFileSync, rmSync, statSync, unlinkSync, realpathSync, symlinkSync, copyFileSync } from 'fs';
+import { readFileSync, existsSync, readdirSync, mkdtempSync, mkdirSync, writeFileSync, rmSync as _rmSync, statSync, unlinkSync, realpathSync, symlinkSync, copyFileSync } from 'fs';
+
+// Windows keeps a handle open on a just-exited child process's working files
+// for a short window (antivirus and Search Indexer widen it), so removing a
+// fixture directory the suite created inside the repo can fail with EPERM even
+// though every assertion passed. `force: true` does not cover that — it
+// suppresses ENOENT, not EPERM — and most of these removals sit in `finally`
+// blocks, so one unlucky cleanup aborted the whole run with a stack trace and
+// a non-zero exit. That reads as a broken test suite on Windows when nothing
+// is broken, and it leaves the fixture dir behind for the next run to trip on.
+//
+// Node retries exactly this class of error (EBUSY/EMFILE/ENFILE/ENOTEMPTY/
+// EPERM) with linear backoff when given maxRetries, so default it everywhere
+// rather than at ~95 individual call sites. An explicit option still wins.
+const rmSync = (target, opts = {}) => _rmSync(target, { maxRetries: 10, retryDelay: 100, ...opts });
 import { join, dirname, basename, delimiter } from 'path';
 import { tmpdir } from 'os';
 import { promisify } from 'util';


### PR DESCRIPTION
## The bug

On Windows, `node test-all.mjs` crashes **after every assertion has already passed**:

```
✅ reply-watch.mjs no-args-uses-default and explicit-path behaviors unchanged (#2743 regression)
node:fs:1235
  return binding.rmSync(getValidatedPath(path), opts.maxRetries, opts.recursive, opts.retryDelay);
                 ^
Error: EPERM, Permission denied: \?\C:\...\career-ops\.tmp-script-test-4EXUy0
    at rmSync (node:fs:1235:18)
    at file:///C:/.../test-all.mjs:529:3
Node.js v24.13.0
```

A just-exited child process can keep a handle open on the fixture directory for a short window — antivirus and Search Indexer widen it — and `.tmp-script-test-*` is created **inside the repo**, where those tools are most active.

`force: true` does not cover this. It suppresses `ENOENT`, not `EPERM`.

Two consequences:

1. Because most of these removals sit in `finally` blocks, the throw escapes the `finally` and **aborts the entire run with a non-zero exit** — after the suite was green. It reads as a broken test suite when nothing is broken.
2. The fixture directory is **left behind**, so the next run starts dirty.

Repro: Windows 11, Node 24.13.0, `node test-all.mjs`. Intermittent, and more likely with real-time AV scanning enabled.

## The fix

Node retries exactly this error class — `EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY`, `EPERM` — with linear backoff when given `maxRetries` ([fs.rmSync docs](https://nodejs.org/api/fs.html#fsrmsyncpath-options)).

`test-all.mjs` has ~95 `rmSync` call sites, so rather than touching each one, this wraps the import once:

```js
import { ..., rmSync as _rmSync, ... } from 'fs';

const rmSync = (target, opts = {}) =>
  _rmSync(target, { maxRetries: 10, retryDelay: 100, ...opts });
```

An explicit option still wins, since `...opts` spreads last. No call site changes; no behaviour change on POSIX, where the retry path is simply never taken.

## Result

```
Before: crash at test-all.mjs:529, exit 1, fixture dir left behind
After:  📊 Results: 4311 passed, 0 failed, 4 warnings — exit 0
```

## Scope note

The same pattern appears in other `.mjs` files in the repo. I deliberately kept this PR to `test-all.mjs`, since that is the harness that actually crashed and the one gating CI. Happy to follow up more broadly if you want it.

`docs/WINDOWS.md` is thorough about the `bash`-on-PATH and CRLF gotchas, which is what made it worth reporting this one as a genuine gap rather than local misconfiguration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup reliability during automated operations on Windows.
  * Added retry handling to reduce failures when removing temporary files and directories that are briefly locked by the operating system or background services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->