### PR TITLE
fix(dates): seven more today-gates resolve in UTC — a cooldown opens early, a follow-up comes due early, CI fails early

### DIFF
--- a/assessment-log.mjs
+++ b/assessment-log.mjs
@@ -29,6 +29,7 @@
 import { readFileSync, existsSync, appendFileSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
+import { localToday } from './lib/local-today.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const LOG_PATH = join(CAREER_OPS, 'data/assessments.tsv');
@@ -147,7 +148,10 @@ function addEntry(args) {
     const m = args[i].match(/^--(company|report|platform|subject|threshold|score|stale)$/);
     if (m) { fields[m[1]] = args[i + 1] ?? ''; i++; }
   }
-  const today = new Date().toISOString().slice(0, 10);
+  // LOCAL day: this is the date written into the appended assessments.tsv row,
+  // and the UTC day stamped a user record with a day that had not happened yet
+  // for anyone west of Greenwich (#3070).
+  const today = localToday();
   let row;
   try {
     row = buildRow(fields, today);

--- a/check-table-freshness.mjs
+++ b/check-table-freshness.mjs
@@ -55,6 +55,7 @@ import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import * as yaml from 'js-yaml';
 import { flagValue, validateFlags } from './lib/cli-flags.mjs';
+import { localToday } from './lib/local-today.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = join(CAREER_OPS, 'templates');
@@ -571,7 +572,10 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
       process.exit(1);
     }
   } else {
-    todayDate = parseDate(new Date().toISOString().slice(0, 10));
+    // LOCAL day. `expired` exits 1, so the UTC day failed CI a day early for
+    // anyone west of Greenwich and passed a stale table a day late for anyone
+    // east of it (#3070). --today still overrides for deterministic runs.
+    todayDate = parseDate(localToday());
   }
 
   // Precedence: --max-age-months flag > config table_freshness.max_age_months > default 12.

--- a/company-history.mjs
+++ b/company-history.mjs
@@ -51,6 +51,7 @@ import * as yaml from 'js-yaml';
 import { parseScanHistory, detectReposts } from './detect-reposts.mjs';
 import { normalizeCompany, resolveTrackerPath } from './tracker-utils.mjs';
 import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
+import { localToday } from './lib/local-today.mjs';
 import {
   parseFollowups,
   parseAppliedDate,
@@ -238,7 +239,12 @@ export function resolveDefaultSilenceWindow(rootDir = CAREER_OPS) {
 
 // --- today() — injectable for deterministic tests ---
 export function today() {
-  return new Date(new Date().toISOString().split('T')[0]);
+  // LOCAL calendar day, UTC midnight anchor. toISOString() gives the UTC DAY,
+  // so west of Greenwich an evening run answered "today" with tomorrow and
+  // every age in the report came out one day high (#3070). Only WHICH day
+  // this is moves; parseDate() still anchors at UTC midnight, so the
+  // arithmetic downstream is unchanged.
+  return new Date(localToday());
 }
 
 function resolveNow(now) {

--- a/followup-cadence.mjs
+++ b/followup-cadence.mjs
@@ -17,6 +17,7 @@ import { fileURLToPath, pathToFileURL } from 'url';
 import * as yaml from 'js-yaml';
 import { loadCanonicalStates, foldStatusInput } from './tracker-utils.mjs';
 import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
+import { localToday } from './lib/local-today.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const APPS_FILE = existsSync(join(CAREER_OPS, 'data/applications.md'))
@@ -131,7 +132,14 @@ export function normalizeStatus(raw) {
 
 // --- Date helpers ---
 function today() {
-  return new Date(new Date().toISOString().split('T')[0]);
+  // LOCAL calendar day, UTC midnight anchor. toISOString() gives the UTC DAY,
+  // so west of Greenwich an evening run answered "today" with tomorrow and
+  // every daysSinceApp came out one high — the follow-up came due a day early
+  // (#3070). Same fix as followup-seed (#2765) and set-status (#2932).
+  //
+  // The arithmetic below is unchanged: parseDate() still anchors at UTC
+  // midnight, so only WHICH day this is moves.
+  return new Date(localToday());
 }
 
 export function parseDate(dateStr) {

--- a/funnel-velocity.mjs
+++ b/funnel-velocity.mjs
@@ -43,6 +43,7 @@ import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 import { resolveTrackerPath, loadCanonicalStates, resolveCanonicalState } from './tracker-utils.mjs';
 import { parseAppliedDate, normalizeStatus } from './followup-cadence.mjs';
 import { flagValue, validateFlags } from './lib/cli-flags.mjs';
+import { localToday } from './lib/local-today.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const STATES_FILE = join(CAREER_OPS, 'templates/states.yml');
@@ -700,7 +701,9 @@ function main() {
   const logPath = join(dirname(trackerPath), 'status-log.tsv');
   const trackerContent = existsSync(trackerPath) ? readFileSync(trackerPath, 'utf-8') : '';
   const logContent = existsSync(logPath) ? readFileSync(logPath, 'utf-8') : '';
-  const todayStr = new Date().toISOString().slice(0, 10);
+  // LOCAL day: the UTC day is tomorrow for a west-of-Greenwich evening run, so
+  // every "waiting" figure read one day high (#3070).
+  const todayStr = localToday();
 
   if (!trackerContent) {
     if (summaryMode) console.log(`No tracker found at ${trackerPath} — nothing to calibrate yet.`);

--- a/scan.mjs
+++ b/scan.mjs
@@ -54,6 +54,7 @@ import { normalizeCompanyName } from './invite-match.mjs';
 import { withPipelineLock } from './pipeline-lock.mjs';
 import { flagValue, hasFlag, validateFlags } from './lib/cli-flags.mjs';
 import { withPortalHealthLock } from './portal-health-lock.mjs';
+import { localToday } from './lib/local-today.mjs';
 
 try {
   const { config } = await import('dotenv');
@@ -1047,7 +1048,13 @@ function daysBetweenIsoDates(start, end) {
   return Math.floor((endDate - startDate) / (1000 * 60 * 60 * 24));
 }
 
-export function shouldDedupScanHistoryRow({ firstSeen, status = 'added' }, { recheckAfterDays = null, today = new Date().toISOString().slice(0, 10) } = {}) {
+// `today` defaults to the LOCAL calendar day, not the UTC one. This function
+// gates a COOLDOWN (`today < cooldownUntil`) — the user asked not to see a
+// posting until a date — and the UTC day is tomorrow for a west-of-Greenwich
+// evening run, so the cooldown opened a day early (#3070). The recheck window
+// below reads one day high the same way. Callers may still pass `today`
+// explicitly; only the default moves.
+export function shouldDedupScanHistoryRow({ firstSeen, status = 'added' }, { recheckAfterDays = null, today = localToday() } = {}) {
   if (PERMANENT_SCAN_HISTORY_STATUSES.has(status)) return true;
   if (status.startsWith('cooldown:')) {
     const parts = status.split(':');
@@ -2534,7 +2541,12 @@ async function main() {
   const seenCompanyRoles = dedupSnapshot.seenCompanyRoles;
 
   // 5. Fetch from each target
-  const date = new Date().toISOString().slice(0, 10);
+  // LOCAL day. This one value does two things that both care which day it is:
+  // it is the `today` buildCooldownFilter compares against, and it is the
+  // firstSeen date written into scan-history.tsv. On the UTC day a
+  // west-of-Greenwich evening scan opened cooldowns early AND stamped history
+  // rows with tomorrow, which then read one day old on the next recheck (#3070).
+  const date = localToday();
   const windows = loadReApplyWindows();
   const cooldownFilter = buildCooldownFilter(windows, date);
   let totalFilteredCooldown = 0;

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -8338,6 +8338,10 @@ try {
       // ...and tracker-utils imports the shared lock-contention helpers
       // (#2777 fix), so the fixture carries that import too.
       copyFileSync(join(ROOT, 'pipeline-lock.mjs'), join(e2eTmp, 'pipeline-lock.mjs'));
+      // ...and followup-cadence now resolves "today" as the LOCAL calendar day
+      // via lib/local-today.mjs (#3070), so the fixture carries that too.
+      mkdirSync(join(e2eTmp, 'lib'), { recursive: true });
+      copyFileSync(join(ROOT, 'lib', 'local-today.mjs'), join(e2eTmp, 'lib', 'local-today.mjs'));
       mkdirSync(join(e2eTmp, 'templates'), { recursive: true });
       copyFileSync(join(ROOT, 'templates', 'states.yml'), join(e2eTmp, 'templates', 'states.yml'));
       // 'junction' on Windows, not 'dir': a directory symlink needs

--- a/tests/local-today-gates.test.mjs
+++ b/tests/local-today-gates.test.mjs
@@ -23,11 +23,18 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { localToday } from '../lib/local-today.mjs';
 import { shouldDedupScanHistoryRow } from '../scan.mjs';
 
 const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+
+// A module path embedded in a child script must be a file:// URL. On Windows a
+// bare join() yields `D:\a\career-ops\...`, which is neither a valid ESM
+// specifier nor safe inside a quoted JS string — the backslashes read as escape
+// sequences. POSIX absolute paths happen to work, which is why this only ever
+// reddens on the Windows leg.
+const spec = (rel) => pathToFileURL(join(ROOT, rel)).href;
 
 // 01:30 UTC: still the previous day everywhere west of Greenwich.
 const INSTANT = '2026-08-18T01:30:00Z';
@@ -85,7 +92,7 @@ test('the premise: at this instant the UTC day is tomorrow in New York', () => {
 
 test('localToday resolves the local day, not the UTC one', () => {
   const out = inFrozenTz('America/New_York',
-    `import {localToday} from '${join(ROOT, 'lib/local-today.mjs')}';` +
+    `import {localToday} from '${spec('lib/local-today.mjs')}';` +
     `const i=new Date('${INSTANT}');` +
     `process.stdout.write(localToday(i)+' '+i.toISOString().slice(0,10));`);
   assert.equal(out, `${NY_DAY} ${UTC_DAY}`);
@@ -114,7 +121,7 @@ test("scan's DEFAULT today is the local day, so a cooldown holds", () => {
   // still the day before, so the default must keep the posting silenced —
   // resolving the default as the UTC day opened it a day early.
   const out = inFrozenTz('America/New_York',
-    `const {shouldDedupScanHistoryRow} = await import('${join(ROOT, 'scan.mjs')}');` +
+    `const {shouldDedupScanHistoryRow} = await import('${spec('scan.mjs')}');` +
     `const held = shouldDedupScanHistoryRow({firstSeen:'2026-01-01',status:'cooldown:${UTC_DAY}'});` +
     `process.stdout.write(String(held));`);
   assert.equal(out, 'true', 'the default today opened the cooldown a day early');
@@ -124,7 +131,7 @@ test('company-history today() is the local calendar day at UTC midnight', () => 
   // The UTC-midnight ANCHOR is deliberate and must survive; only WHICH day
   // moves. #2765 drew the same line, so both halves are asserted.
   const out = inFrozenTz('America/New_York',
-    `const {today} = await import('${join(ROOT, 'company-history.mjs')}');` +
+    `const {today} = await import('${spec('company-history.mjs')}');` +
     `process.stdout.write(today().toISOString());`);
   assert.equal(out.slice(0, 10), NY_DAY, `today() returned the UTC day (${out.slice(0, 10)}), not the local one`);
   assert.equal(out.slice(10), 'T00:00:00.000Z', 'the UTC-midnight anchor was lost');

--- a/tests/local-today-gates.test.mjs
+++ b/tests/local-today-gates.test.mjs
@@ -1,0 +1,141 @@
+// tests/local-today-gates.test.mjs — every place that asks "what day is it"
+// must answer with the LOCAL calendar day, not the UTC one (#3070).
+//
+// #2765 fixed followup-seed, #2932 fixed set-status's two. These are the rest,
+// and each GATES a decision rather than stamping a filename:
+//
+//   scan.mjs                 `today < cooldownUntil` — a posting the user
+//                            silenced until a date resurfaces a day early
+//   followup-cadence.mjs     the follow-up due decision
+//   check-table-freshness    `expired`, which exits 1 — a CI gate
+//   funnel-velocity.mjs      the "waiting" figure
+//   company-history.mjs      the `now` all age math runs against
+//   assessment-log.mjs       the date written into a user's assessments.tsv row
+//
+// PINNED INSTANT, not the wall clock. The window where the UTC day and the
+// local day disagree only exists for part of the UTC day, so a test that reads
+// `new Date()` passes for most of the day regardless of the bug — which is how
+// this survived two previous fixes.
+//
+// Run:  node --test tests/local-today-gates.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { localToday } from '../lib/local-today.mjs';
+import { shouldDedupScanHistoryRow } from '../scan.mjs';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+
+// 01:30 UTC: still the previous day everywhere west of Greenwich.
+const INSTANT = '2026-08-18T01:30:00Z';
+const UTC_DAY = '2026-08-18';
+const NY_DAY = '2026-08-17';
+
+/**
+ * Evaluate an expression in a child pinned to a timezone AND a frozen clock.
+ *
+ * Freezing matters more than the timezone. Without it these assertions compare
+ * whatever `new Date()` returns during the run, so they agree with the UTC day
+ * for most of the day and pass whether the fix is present or not — a test that
+ * measures nothing for 20-odd hours out of 24. The first draft of this file did
+ * exactly that and passed with the fix reverted.
+ *
+ * `Date` is replaced before the module under test is imported, and the default
+ * parameters being tested read the clock at CALL time, so the freeze reaches
+ * them.
+ */
+function inFrozenTz(tz, expr) {
+  const preamble =
+    `const RealDate = Date;` +
+    `const FROZEN = new RealDate('${INSTANT}');` +
+    `globalThis.Date = class extends RealDate {` +
+    `  constructor(...a) { if (a.length === 0) { super(FROZEN.getTime()); } else { super(...a); } }` +
+    `  static now() { return FROZEN.getTime(); }` +
+    `};`;
+  const r = spawnSync(process.execPath, ['--input-type=module', '-e', preamble + expr], {
+    cwd: ROOT,
+    encoding: 'utf-8',
+    timeout: 30_000,
+    env: { ...process.env, TZ: tz },
+  });
+  assert.equal(r.error, undefined, `spawn failed: ${r.error?.message}`);
+  assert.equal(r.status, 0, `child exited ${r.status}: ${r.stderr}`);
+  return r.stdout.trim();
+}
+
+test('the frozen clock actually takes effect in the child', () => {
+  // Without this, a broken freeze would make every assertion below vacuous.
+  const out = inFrozenTz('America/New_York', `process.stdout.write(new Date().toISOString());`);
+  assert.equal(out, new Date(INSTANT).toISOString(), 'the clock was not frozen in the child');
+});
+
+test('the premise: at this instant the UTC day is tomorrow in New York', () => {
+  // If this ever stops holding, every assertion below is vacuous rather than
+  // wrong, so it is asserted rather than assumed.
+  const fmt = (tz) =>
+    new Intl.DateTimeFormat('en-CA', { timeZone: tz, year: 'numeric', month: '2-digit', day: '2-digit' })
+      .format(new Date(INSTANT));
+  assert.equal(fmt('UTC'), UTC_DAY);
+  assert.equal(fmt('America/New_York'), NY_DAY);
+  assert.notEqual(fmt('UTC'), fmt('America/New_York'));
+});
+
+test('localToday resolves the local day, not the UTC one', () => {
+  const out = inFrozenTz('America/New_York',
+    `import {localToday} from '${join(ROOT, 'lib/local-today.mjs')}';` +
+    `const i=new Date('${INSTANT}');` +
+    `process.stdout.write(localToday(i)+' '+i.toISOString().slice(0,10));`);
+  assert.equal(out, `${NY_DAY} ${UTC_DAY}`);
+});
+
+// Explicit `today`, so this pins the FUNCTION's comparison rather than the
+// default. The default is covered separately below, under a frozen clock.
+test('scan: a cooldown compares against the day it is given', () => {
+  // The user silenced this posting until UTC_DAY. On NY_DAY it must stay
+  // silenced; resolving "today" as the UTC day opened it early.
+  const row = { firstSeen: '2026-01-01', status: `cooldown:${UTC_DAY}` };
+  assert.equal(shouldDedupScanHistoryRow(row, { today: NY_DAY }), true, 'cooldown opened a day early');
+  assert.equal(shouldDedupScanHistoryRow(row, { today: UTC_DAY }), false, 'cooldown did not open on its date');
+});
+
+test('scan: the recheck window is measured from the day it is given', () => {
+  const row = { firstSeen: '2026-08-11', status: 'added' };
+  // 6 local days elapsed, 7 UTC days. With a 7-day recheck the row is NOT yet
+  // due; reading the UTC day made it due a day early.
+  assert.equal(shouldDedupScanHistoryRow(row, { recheckAfterDays: 7, today: NY_DAY }), true, 'rechecked a day early');
+  assert.equal(shouldDedupScanHistoryRow(row, { recheckAfterDays: 7, today: UTC_DAY }), false);
+});
+
+test("scan's DEFAULT today is the local day, so a cooldown holds", () => {
+  // The cooldown runs to the UTC day. Under the frozen clock the local day is
+  // still the day before, so the default must keep the posting silenced —
+  // resolving the default as the UTC day opened it a day early.
+  const out = inFrozenTz('America/New_York',
+    `const {shouldDedupScanHistoryRow} = await import('${join(ROOT, 'scan.mjs')}');` +
+    `const held = shouldDedupScanHistoryRow({firstSeen:'2026-01-01',status:'cooldown:${UTC_DAY}'});` +
+    `process.stdout.write(String(held));`);
+  assert.equal(out, 'true', 'the default today opened the cooldown a day early');
+});
+
+test('company-history today() is the local calendar day at UTC midnight', () => {
+  // The UTC-midnight ANCHOR is deliberate and must survive; only WHICH day
+  // moves. #2765 drew the same line, so both halves are asserted.
+  const out = inFrozenTz('America/New_York',
+    `const {today} = await import('${join(ROOT, 'company-history.mjs')}');` +
+    `process.stdout.write(today().toISOString());`);
+  assert.equal(out.slice(0, 10), NY_DAY, `today() returned the UTC day (${out.slice(0, 10)}), not the local one`);
+  assert.equal(out.slice(10), 'T00:00:00.000Z', 'the UTC-midnight anchor was lost');
+});
+
+test('check-table-freshness --today still overrides, and reports the date it used', () => {
+  // The flag is the deterministic escape hatch; the local-day default must not
+  // have broken it, or every CI pin in the repo silently drifts.
+  const r = spawnSync(process.execPath, [join(ROOT, 'check-table-freshness.mjs'), '--today', '2026-08-18'], {
+    cwd: ROOT, encoding: 'utf-8', timeout: 30_000,
+  });
+  assert.equal(r.error, undefined);
+  assert.ok(r.stdout.includes('2026-08-18'), `--today was not honoured: ${r.stdout.slice(0, 200)}`);
+});


### PR DESCRIPTION
Fixes #3070.

#2765 fixed "today" in `followup-seed.mjs`; #2932 fixed the two in `set-status.mjs`. Seven call sites across six files still asked `toISOString()` what day it is — which is the **UTC** day, so west of Greenwich an evening run answers "today" with tomorrow.

Each of these **gates a decision** rather than stamping a filename:

| file | what "today" decides |
|---|---|
| `scan.mjs` | `today < cooldownUntil` — a posting the user deliberately silenced until a date **resurfaced a day early**. Same value is the `firstSeen` date written into `scan-history.tsv`, so the row it wrote then read a day old on the next recheck. Both the production call site and the exported default parameter. |
| `followup-cadence.mjs` | `daysSinceApp` — the follow-up **due** decision. The user was told to chase an employer a day before their configured cadence. |
| `check-table-freshness.mjs` | `expired`, which **exits 1**. A CI gate: a day early it fails a run that should pass; a day late it passes a table that has gone stale. |
| `funnel-velocity.mjs` | the "waiting" figure, one day high. |
| `company-history.mjs` | the `now` every age in the report is measured against. |
| `assessment-log.mjs` | the date written into the appended `assessments.tsv` row — a user record dated a day that had not happened. |

```
instant 2026-08-18T01:30:00Z  (UTC day 2026-08-18)

  Pacific/Auckland     local 2026-08-18   agrees
  Europe/Berlin        local 2026-08-18   agrees
  America/New_York     local 2026-08-17   UTC day is TOMORROW here
  America/Los_Angeles  local 2026-08-17   UTC day is TOMORROW here
```

The scan cooldown is the one I'd rank first: the entire point of a cooldown is that the user asked not to see something until a date, and the gate opened early for everyone west of Greenwich for part of every day.

## What deliberately does not change

The line #2765 drew and #2932 kept: only *"what day is it here"* moves. Date **arithmetic** stays on UTC-midnight parsing, which every one of these files depends on. Concretely the fix is `new Date(localToday())` rather than `new Date(utcToday())` — the calendar day becomes local, the midnight anchor stays UTC, every comparison downstream is untouched.

`scan.mjs`'s exported default parameter changes, not its signature; callers passing `today` explicitly are unaffected, and there's a test for that.

## The test caught me first

The window where the UTC day and the local day disagree exists for only *part* of the UTC day. A test that reads `new Date()` therefore agrees with the buggy value most of the time and passes whether the fix is present or not.

**My first draft of the test file did exactly that** — it passed with `scan.mjs` and `company-history.mjs` reverted. I'm flagging it rather than quietly fixing it, because it is precisely the non-discriminating-test failure the file exists to prevent, and it would have shipped looking like coverage.

The tests now replace `Date` in the child process before importing the module under test, pinned to `2026-08-18T01:30:00Z` under `TZ=America/New_York`. Two guards keep that honest: one asserts the freeze actually took effect, one asserts the premise that the two days differ at that instant — so a broken freeze fails loudly instead of making everything else vacuous.

Also pinned as must-not-change: `company-history`'s `today()` keeps its **UTC-midnight anchor** while moving which day it is, and `check-table-freshness --today` still overrides (that flag is the deterministic escape hatch CI pins rely on).

## Verification

Checked for discrimination: with `scan.mjs` and `company-history.mjs` reverted, **exactly the two default-reading tests fail** and the six premise/explicit-value tests still pass.

`node test-all.mjs --quick`: 4319 pass / 0 fail (3 warnings pre-existing and environmental). One test-harness change was needed: the `followup-cadence` e2e fixture copies the script into a tmpdir, so it now stages `lib/local-today.mjs` alongside it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Assessment logs, scans, freshness checks, follow-ups, and reports now use the local calendar date instead of UTC.
  * Scan history deduplication and saved scan dates now align with the local day.
  * Explicitly supplied dates continue to override automatic date detection.

* **Tests**
  * Added timezone-aware coverage for local-date behavior, scan decisions, date anchoring, and freshness checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->