### PR TITLE
fix(ashby): retries a permanent 404 three times and ignores Retry-After

### DIFF
--- a/providers/ashby.mjs
+++ b/providers/ashby.mjs
@@ -11,8 +11,11 @@
 // Ashby a longer timeout plus a backoff+jitter retry (the backoff spaces
 // requests out to dodge rate-limiting).
 // See .planning/codebase/ashby-scan-abort-diagnosis.md.
+import { fetchJsonWithRetry } from './_http.mjs';
+
 const ASHBY_TIMEOUT_MS = 30_000;
 const ASHBY_RETRIES = 2;
+const ASHBY_BACKOFF_BASE_MS = 1_000;
 
 // Annualization multipliers for different compensation intervals
 const INTERVAL_MULTIPLIERS = {
@@ -106,11 +109,6 @@ function resolveApiUrl(entry) {
   return `https://api.ashbyhq.com/posting-api/job-board/${match[1]}?includeCompensation=true`;
 }
 
-function sleep(ms, ctx) {
-  if (typeof ctx?.sleep === 'function') return ctx.sleep(ms);
-  return new Promise((r) => setTimeout(r, ms));
-}
-
 // NaN-safe Date.parse — `|| undefined` would also coerce a valid epoch 0.
 function toEpochMs(value) {
   if (!value) return undefined;
@@ -161,28 +159,40 @@ export default {
     const apiUrl = resolveApiUrl(entry);
     if (!apiUrl) throw new Error(`ashby: cannot derive API URL for ${entry.name}`);
     assertAshbyUrl(apiUrl);
-    let lastErr;
-    for (let attempt = 0; attempt <= ASHBY_RETRIES; attempt++) {
-      if (attempt > 0) {
-        // exponential backoff + jitter — spaces out retries to dodge Ashby rate-limiting
-        const backoff = 1000 * 2 ** (attempt - 1) + Math.floor(Math.random() * 500);
-        await sleep(backoff, ctx);
-      }
-      try {
-        const json = /** @type {any} */ (await ctx.fetchJson(apiUrl, { timeoutMs: ASHBY_TIMEOUT_MS, redirect: 'error' }));
-        const jobs = Array.isArray(json?.jobs) ? json.jobs : [];
-        return jobs.map(/** @param {any} j */ (j) => ({
-          title: j.title || '',
-          url: j.jobUrl || '',
-          company: entry.name,
-          location: formatLocation(j),
-          salary: parseCompensation(j),
-          postedAt: toEpochMs(j.publishedAt),
-        }));
-      } catch (e) {
-        lastErr = e;
-      }
-    }
-    throw lastErr;
+    // Shared retry rather than a local loop (#3072). The local one caught
+    // EVERY error, so a board that is gone was asked three times: 404, 401 and
+    // 410 each bought a second and third request that could only fail again.
+    // withRetry stops on the first non-retryable status via isRetryableError,
+    // and 22% of Ashby boards are permanently 404 (#2840) — re-probing those
+    // is the traffic that provokes the single-host throttle in #2839.
+    //
+    // It also honours Ashby's own Retry-After on a 429, which the local
+    // backoff discarded, while CLAMPING it so a misconfigured
+    // `Retry-After: 86400` cannot stall a sweep.
+    //
+    // ASHBY_RETRIES is passed through as the policy, so the attempt budget is
+    // unchanged — only which errors are worth spending it on. The longer
+    // per-request timeout above still applies: it is the Ashby latency floor
+    // this provider was given a bespoke timeout for, and it travels as `opts`.
+    const json = /** @type {any} */ (await fetchJsonWithRetry(
+      ctx,
+      apiUrl,
+      { timeoutMs: ASHBY_TIMEOUT_MS, redirect: 'error' },
+      // baseDelayMs is ashby's own 1000ms, not the shared 500ms default. The
+      // longer backoff is deliberate here — see the header: Ashby rate-limits
+      // repeated unauthenticated hits, and spacing requests out is why this
+      // provider had a bespoke loop at all. Only WHICH errors are retried
+      // changes; the timing is preserved.
+      { retries: ASHBY_RETRIES, baseDelayMs: ASHBY_BACKOFF_BASE_MS },
+    ));
+    const jobs = Array.isArray(json?.jobs) ? json.jobs : [];
+    return jobs.map(/** @param {any} j */ (j) => ({
+      title: j.title || '',
+      url: j.jobUrl || '',
+      company: entry.name,
+      location: formatLocation(j),
+      salary: parseCompensation(j),
+      postedAt: toEpochMs(j.publishedAt),
+    }));
   },
 };

--- a/tests/providers/ashby-retry.test.mjs
+++ b/tests/providers/ashby-retry.test.mjs
@@ -18,10 +18,13 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const ROOT = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
-const { default: ashby } = await import(join(ROOT, 'providers/ashby.mjs'));
+// pathToFileURL, not a bare path: on Windows `join()` yields `D:\a\...`,
+// which is not a valid ESM specifier, and the whole file fails at import.
+// Same form tests/providers/ashby.test.mjs already uses.
+const { default: ashby } = await import(pathToFileURL(join(ROOT, 'providers/ashby.mjs')).href);
 
 const ENTRY = { name: 'DeadCo', careers_url: 'https://jobs.ashbyhq.com/deadco' };
 

--- a/tests/providers/ashby-retry.test.mjs
+++ b/tests/providers/ashby-retry.test.mjs
@@ -1,0 +1,92 @@
+// tests/providers/ashby-retry.test.mjs — ashby must not retry a permanent
+// failure, and must still retry a transient one (#3072).
+//
+// ashby.mjs hand-rolled its retry loop with an unconditional `catch (e) {
+// lastErr = e; }`, so a board that is GONE was asked three times: 404, 401 and
+// 410 each bought a second and third request that could only fail again.
+// #2840 measured 684 of 3,161 Ashby boards as permanently 404, and argues that
+// re-probing known-dead boards is the traffic that provokes the single-host
+// throttle in #2839 — so tripling it is the same problem, worse.
+//
+// Counting REQUESTS rather than asserting an exit code is the point: the call
+// fails either way, so only the request count distinguishes the fix from the
+// bug. `ctx.sleep` is stubbed, so this exercises the retry policy with no real
+// backoff and no network.
+//
+// Run:  node --test tests/providers/ashby-retry.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+const { default: ashby } = await import(join(ROOT, 'providers/ashby.mjs'));
+
+const ENTRY = { name: 'DeadCo', careers_url: 'https://jobs.ashbyhq.com/deadco' };
+
+/** Run one fetch that always throws `err`; return how many requests it made. */
+async function requestsFor(err) {
+  let calls = 0;
+  const ctx = {
+    fetchJson: async () => { calls++; throw err; },
+    sleep: async () => {}, // no real backoff
+  };
+  await assert.rejects(() => ashby.fetch(ENTRY, ctx));
+  return calls;
+}
+
+const httpErr = (status) => Object.assign(new Error(`HTTP ${status}`), { status });
+
+test('a permanent failure costs exactly one request', async () => {
+  for (const status of [404, 401, 410, 403, 400]) {
+    const calls = await requestsFor(httpErr(status));
+    assert.equal(calls, 1, `HTTP ${status} made ${calls} requests, want 1 — it cannot succeed on a retry`);
+  }
+});
+
+test('a transient failure still gets the full attempt budget', async () => {
+  // The point is narrowing WHICH errors are retried, not retrying less. If
+  // this regressed to 1, the fix would have traded one bug for a worse one.
+  for (const status of [429, 500, 502, 503]) {
+    const calls = await requestsFor(httpErr(status));
+    assert.equal(calls, 3, `HTTP ${status} made ${calls} requests, want 3`);
+  }
+});
+
+test('a network error with no status is still retried', async () => {
+  const calls = await requestsFor(new Error('socket hang up'));
+  assert.equal(calls, 3, `network error made ${calls} requests, want 3`);
+});
+
+test('a successful fetch still parses, and makes exactly one request', async () => {
+  let calls = 0;
+  const ctx = {
+    fetchJson: async () => {
+      calls++;
+      return { jobs: [{ title: 'Staff Engineer', jobUrl: 'https://jobs.ashbyhq.com/deadco/1', publishedAt: '2026-08-01T00:00:00Z' }] };
+    },
+    sleep: async () => {},
+  };
+  const jobs = await ashby.fetch(ENTRY, ctx);
+  assert.equal(calls, 1);
+  assert.equal(jobs.length, 1);
+  assert.equal(jobs[0].title, 'Staff Engineer');
+  assert.equal(jobs[0].company, 'DeadCo');
+  assert.equal(jobs[0].postedAt, Date.parse('2026-08-01T00:00:00Z'));
+});
+
+test('a transient failure that then succeeds returns the jobs', async () => {
+  let calls = 0;
+  const ctx = {
+    fetchJson: async () => {
+      calls++;
+      if (calls === 1) throw httpErr(503);
+      return { jobs: [{ title: 'Recovered', jobUrl: 'https://jobs.ashbyhq.com/deadco/2' }] };
+    },
+    sleep: async () => {},
+  };
+  const jobs = await ashby.fetch(ENTRY, ctx);
+  assert.equal(calls, 2, 'should have retried once and then succeeded');
+  assert.equal(jobs[0].title, 'Recovered');
+});


### PR DESCRIPTION
Fixes #3072.

`providers/ashby.mjs` hand-rolled its retry loop with an unconditional catch:

```js
} catch (e) {
  lastErr = e;        // every error, including permanent ones
}
```

so a board that is **gone** was asked three times. Measured against the provider directly, counting requests:

| error | before | after |
|---|---|---|
| 404 board gone | 3 | **1** |
| 401 unauthorized | 3 | **1** |
| 410 gone | 3 | **1** |
| 429 rate limited | 3 | 3 |
| 503 server error | 3 | 3 |
| network timeout | 3 | 3 |

## Why it costs something

#2840 measured **684 of 3,161** Ashby boards as permanently 404 — 22% — and its argument is that re-probing known-dead boards is the traffic that provokes the single-host throttle in #2839. Asking each of those three times instead of once is that same problem, tripled.

The local loop also **discarded Ashby's own `Retry-After`** on a 429 in favour of a fixed backoff. `_http.mjs` honours the header but CLAMPS it, so a hostile or misconfigured `Retry-After: 86400` still cannot stall a sweep — the local loop had neither half.

## Scope

Routed through `fetchJsonWithRetry`, the same shape `workday.mjs`, `oraclecloud.mjs` and `a16z-speedrun-talent.mjs` already use. ashby was one of only two providers outside it.

**`meituan` is the other, and I left it alone deliberately** — its loop is an *empty-response* retry, not an error retry (errors either rethrow or return what was collected), so it is correct as written and converting it would change different behaviour.

## Timing is preserved, not defaulted

`baseDelayMs` stays at ashby's own **1000ms**, not the shared 500ms default. The longer backoff is why this provider had a bespoke loop in the first place — the file header explains Ashby rate-limits repeated unauthenticated hits — so only *which* errors are retried changes. The bespoke 30s timeout travels through as `opts` for the same reason.

That mattered in practice: the existing `tests/providers/ashby.test.mjs` asserts the first backoff is `>= 1000`, and it caught the shared default when I first passed only `retries`. I preserved the provider's timing rather than relaxing its test.

## Verification

The test counts **requests**, not exit codes — the call fails either way, so only the request count distinguishes the fix from the bug. Both directions are pinned, because narrowing which errors retry could easily have become retrying less:

- 404/401/410/403/400 must cost exactly one request.
- 429/500/502/503 and a status-less network error must still get the full three-attempt budget.
- A transient failure that then succeeds must still return the jobs; a clean fetch must still parse and make exactly one request.

Checked for discrimination: with `providers/ashby.mjs` reverted, **exactly the permanent-failure test fails** and the four others pass — the intended split, since the old loop retried everything and so satisfied every "still retries" assertion.

`node test-all.mjs --quick`: 4319 pass / 0 fail (3 warnings pre-existing and environmental). The existing ashby provider suite is unchanged and still passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ashby job loading reliability by automatically retrying temporary HTTP and network failures.
  * Honors server-provided retry timing when available.
  * Avoids retrying permanent failures while preserving existing timeout and redirect behavior.

* **Tests**
  * Added coverage for transient failures, permanent errors, successful responses, and recovery after a failed attempt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->