### PR TITLE
feat(modes): add quick-evaluate mode (US remote + $200k+ triage)

### DIFF
--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -30,6 +30,13 @@ jobs:
           node-version: 24
           cache: npm
           cache-dependency-path: web/package-lock.json
+      # web/tests/lib/tracker-lock.test.mjs imports the core tracker lock from
+      # the repo root to assert the real primitive rather than a copy of it —
+      # which is what lets that test survive a change of caller. The root module
+      # pulls in js-yaml, so the root install has to happen or the dynamic
+      # import throws and every web PR shows a failure that is not its own.
+      - run: npm ci --ignore-scripts
+        working-directory: .
       - run: npm ci
       - run: npm test
       - run: npx tsc --noEmit

--- a/README.cn.md
+++ b/README.cn.md
@@ -38,9 +38,7 @@
 
 <p align="center"><strong>评估超过 740 个职位 · 生成超过 100 份个性化简历 · 成功拿下理想职位</strong></p>
 
-<p align="center"><a href="https://discord.gg/8pRpHETxa4"><img src="https://img.shields.io/badge/加入社区-Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
-  &nbsp;
-  <a href="https://www.npmjs.com/package/@santifer/career-ops"><img src="https://img.shields.io/npm/dt/@santifer/career-ops?style=for-the-badge&logo=npm&color=CB3837&label=npx%20installs" alt="npm installs"></a></p>
+<p align="center"><a href="https://discord.gg/8pRpHETxa4"><img src="https://img.shields.io/badge/加入社区-Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a></p>
 
 <p align="center">
   <a href="https://claude.com/claude-code"><img src="https://img.shields.io/badge/Built_with-Claude_Code-000?style=for-the-badge&logo=anthropic&logoColor=white" alt="Built with Claude Code"></a>
@@ -98,36 +96,41 @@ career-ops 具备代理式工作能力：Claude Code 会用 Playwright 浏览招
 
 ## 快速开始
 
-**最快的方式 —— 一条命令：**
-
-```bash
-npx @santifer/career-ops init
-```
-
-> 💡 `npx` 随 [Node.js](https://nodejs.org) 一起提供 —— 它只运行一次安装程序，
-> 不会全局安装任何东西。还没有 Node？请先安装它。
-> （已经在用 Claude Code / Gemini / Codex CLI？那你已经有它了。）
-
-这会把最新版本克隆到 `./career-ops` 并安装依赖。然后：
-
-```bash
-cd career-ops
-claude   # 或 gemini / codex / qwen / opencode —— 在这里打开你的 AI CLI
-```
-
-**首次启动时，career-ops 会通过对话带你完成设置 —— 你的简历、个人档案和目标职位 —— 完全无需手动编辑任何文件。**
-
-<details>
-<summary><b>更喜欢手动设置？（git clone）</b></summary>
-
 ```bash
 git clone https://github.com/santifer/career-ops.git
 cd career-ops && npm install
 npx playwright install chromium   # 仅生成 PDF 时需要
-claude   # 打开你的 AI CLI —— 它会在首次启动时引导你完成设置
+
+# 2. 检查设置
+npm run doctor                     # 验证所有前置条件
+
+# 3. 配置
+cp config/profile.example.yml config/profile.yml  # 编辑你的信息
+cp templates/portals.example.yml portals.yml       # 自定义公司列表
+
+# 4. 添加你的简历
+# 在项目根目录创建 cv.md，用 markdown 格式写你的简历
+
+# 5. 在这个目录打开你的 AI CLI
+claude   # 或 codex / opencode / qwen / agy / grok
+
+# 然后告诉 AI CLI 怎么定制系统：
+# "把职业原型改成后端工程师职位"
+# "把所有模式翻译成英文"
+# "在 portals.yml 中添加这 5 家公司"
+# "用我这份简历更新我的个人档案"
+
+# 6. 开始使用
+# 粘贴一个职位 URL 或职位描述，启动自动流程
+# 如果你的 CLI 支持斜杠命令，使用 /career-ops（或对应 CLI 的别名）
+# 在 Codex 中，用自然语言请求相同的模式，例如：
+# "运行 career-ops 扫描模式"
+# "为 data/pipeline.md 运行 career-ops 流程模式"
+# "为最新评估的职位运行 career-ops PDF 生成模式"
+# "运行 career-ops 追踪器模式并总结当前状态"
 ```
 
-</details>
+**首次启动时，career-ops 会通过对话带你完成设置 —— 你的简历、个人档案和目标职位 —— 完全无需手动编辑任何文件。**
 
 > **这个系统本来就是设计给 Claude 直接定制的。** modes、职业原型、评分权重、谈判脚本，直接告诉 Claude 要改什么就行。Claude 读取的正是它自己会使用的那些文件，所以它知道该改哪里。
 

--- a/README.da.md
+++ b/README.da.md
@@ -94,35 +94,41 @@ Bygget af en, der brugte det til at vurdere 740+ stillinger, generere 100+ skræ
 
 ## Hurtig start
 
-**Hurtigste måde — én kommando:**
-
-```bash
-npx @santifer/career-ops init
-```
-
-> 💡 `npx` følger med [Node.js](https://nodejs.org) — det kører installationsprogrammet én gang uden at installere noget globalt. Har du ikke Node.js endnu? Installer det først.
-> (Bruger du allerede Claude Code / Gemini / Codex CLI? Så har du det allerede.)
-
-Dette kloner den nyeste version til `./career-ops` og installerer afhængighederne. Derefter:
-
-```bash
-cd career-ops
-claude   # eller gemini / codex / qwen / opencode — åbn dit AI-CLI her
-```
-
-**Ved første kørsel guider career-ops dig gennem opsætningen — CV, profil og målstillinger — udelukkende via samtale. Intet skal redigeres manuelt.**
-
-<details>
-<summary><b>Foretrækker du manuel opsætning? (git clone)</b></summary>
-
 ```bash
 git clone https://github.com/santifer/career-ops.git
 cd career-ops && npm install
 npx playwright install chromium   # kun nødvendigt til PDF-generering
-claude   # åbn dit AI-CLI — første kørsel guider dig gennem onboarding
+
+# 2. Tjek opsætning
+npm run doctor                     # Validerer alle forudsætninger
+
+# 3. Konfigurér
+cp config/profile.example.yml config/profile.yml  # Rediger med dine oplysninger
+cp templates/portals.example.yml portals.yml       # Tilpas virksomheder
+
+# 4. Tilføj dit CV
+# Opret cv.md i projektets rod med dit CV i markdown
+
+# 5. Åbn dit AI-CLI i denne mappe
+claude   # eller codex / opencode / qwen / agy / grok
+
+# Bed derefter dit CLI om at tilpasse systemet til dig:
+# "Skift arkhetyperne til backend engineering-roller"
+# "Oversæt tilstandene til dansk"
+# "Tilføj disse 5 virksomheder til portals.yml"
+# "Opdater min profil med dette CV, jeg indsætter"
+
+# 6. Begynd at bruge det
+# Indsæt en job-URL eller JD-tekst for at udløse auto-pipeline
+# Hvis dit CLI understøtter slash-kommandoer, skal du bruge /career-ops (eller dets CLI-specifikke alias)
+# I Codex kan du bede om samme tilstand på almindeligt dansk, f.eks.:
+# "Kør career-ops scan-tilstand"
+# "Kør career-ops pipeline-tilstand for data/pipeline.md"
+# "Kør career-ops pdf-tilstand for den seneste evaluerede rolle"
+# "Kør career-ops tracker-tilstand og opsummer de aktuelle statusser"
 ```
 
-</details>
+**Ved første kørsel guider career-ops dig gennem opsætningen — CV, profil og målstillinger — udelukkende via samtale. Intet skal redigeres manuelt.**
 
 > **Systemet er designet til, at Claude tilpasser det.** Tilstande, arketyper, vurderingsvægte, forhandlingsscripts — bed blot Claude om ændringer. Den læser de samme filer, den bruger, så den ved præcis, hvad der skal redigeres.
 

--- a/README.de.md
+++ b/README.de.md
@@ -116,26 +116,6 @@ Gebaut von jemandem, der damit 740+ Stellenanzeigen bewertet, 100+ personalisier
 
 ## Schnellstart
 
-**Der schnellste Weg -- ein Befehl:**
-
-```bash
-npx @santifer/career-ops init
-```
-
-> `npx` wird mit [Node.js](https://nodejs.org) ausgeliefert. Es führt den Installer einmal aus, ohne global etwas zu installieren. Noch kein Node? Installiere es zuerst. Wenn du bereits Claude Code, Gemini oder Codex nutzt, hast du Node wahrscheinlich schon.
-
-Das klont die neueste Version nach `./career-ops` und installiert die Abhängigkeiten. Danach:
-
-```bash
-cd career-ops
-claude   # oder gemini / codex / qwen / opencode / agy / grok -- öffne deine KI-CLI hier
-```
-
-**Beim ersten Start führt dich career-ops per Chat durch die Einrichtung: Lebenslauf, Profil und Zielrollen. Du musst nichts von Hand bearbeiten.**
-
-<details>
-<summary><b>Lieber manuell einrichten? (git clone)</b></summary>
-
 ```bash
 git clone https://github.com/santifer/career-ops.git
 cd career-ops && npm install
@@ -152,10 +132,24 @@ cp templates/portals.example.yml portals.yml       # Unternehmen anpassen
 # Erstelle cv.md im Projekt-Root mit deinem Lebenslauf in Markdown
 
 # 5. KI-CLI in diesem Verzeichnis öffnen
-claude   # oder codex / opencode / gemini / qwen / agy / grok
+claude   # oder codex / opencode / qwen / agy / grok
+
+# Dann bitte deine CLI, das System auf dich anzupassen:
+# "Ändere die Archetypen zu Backend Engineering-Rollen"
+# "Übersetze die Modi ins Deutsche"
+# "Füge diese 5 Unternehmen zu portals.yml hinzu"
+# "Aktualisiere mein Profil mit diesem CV, den ich gerade einfüge"
+
+# 6. Beginne zu nutzen
+# Füge eine Stellenanzeigen-URL oder Stellenbeschreibung ein, um die Auto-Pipeline zu starten
+# Wenn deine CLI Slash-Befehle unterstützt, nutze /career-ops (oder den CLI-spezifischen Alias)
+# In Codex bitte um denselben Modus in normaler Sprache, z.B.:
+# "Starte den career-ops scan mode"
+# "Starte den career-ops pipeline mode für data/pipeline.md"
+# "Starte den career-ops pdf mode für die neueste bewertete Rolle"
+# "Starte den career-ops tracker mode und fasse die aktuellen Statuse zusammen"
 ```
 
-</details>
 
 > **Das System ist darauf ausgelegt, von deiner KI-Coding-CLI selbst angepasst zu werden.** Modi, Archetypen, Scoring-Gewichte, Verhandlungsskripte -- frag einfach danach. Die CLI liest dieselben Dateien, die sie nutzt, und weiß daher genau, was zu ändern ist.
 

--- a/README.es.md
+++ b/README.es.md
@@ -49,8 +49,6 @@
 
 <p align="center">
   <a href="https://discord.gg/8pRpHETxa4"><img src="https://img.shields.io/badge/Unete_a_la_comunidad-Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
-  &nbsp;
-  <a href="https://www.npmjs.com/package/@santifer/career-ops"><img src="https://img.shields.io/npm/dt/@santifer/career-ops?style=for-the-badge&logo=npm&color=CB3837&label=npx%20installs" alt="npm installs"></a>
 </p>
 
 <p align="center">
@@ -107,46 +105,41 @@ Construido por alguien que lo usó para evaluar 740+ ofertas, generar 100+ CVs p
 
 ## Inicio rápido
 
-**La forma más rápida — un solo comando:**
-
-```bash
-npx @santifer/career-ops init
-```
-
-> 💡 `npx` viene incluido con [Node.js](https://nodejs.org) — ejecuta el instalador una vez, sin instalar nada de forma global. ¿No tienes Node? Instálalo primero. (¿Ya usas un CLI como Claude Code / Gemini / Codex? Entonces ya lo tienes.)
-
-Esto clona la última release en `./career-ops` e instala las dependencias. Después:
-
-```bash
-cd career-ops
-claude   # o gemini / codex / qwen / opencode — abre tu CLI de IA aquí
-```
-
-**En el primer arranque, career-ops te guía en la configuración — tu CV, tu perfil y los roles que buscas — simplemente conversando. No hay nada qué editar a mano.**
-
-<details>
-<summary><b>¿Prefieres instalarlo manualmente? (git clone)</b></summary>
-
 ```bash
 git clone https://github.com/santifer/career-ops.git
 cd career-ops && npm install
 npx playwright install chromium   # solo para generar PDFs
-claude   # abre tu CLI de IA — te guiará en el primer arranque
+
+# 2. Verificar configuración
+npm run doctor                     # Valida todas las dependencias
+
+# 3. Configurar
+cp config/profile.example.yml config/profile.yml  # Edita con tus datos
+cp templates/portals.example.yml portals.yml       # Personaliza empresas
+
+# 4. Añade tu CV
+# Crea cv.md en la raíz del proyecto con tu CV en markdown
+
+# 5. Abre tu CLI de IA aquí
+claude   # o codex / opencode / qwen / agy / grok
+
+# Luego pídele a tu CLI que te personalice el sistema:
+# "Cambia los arquetipos a roles de backend engineering"
+# "Traduce los modos a español"
+# "Añade estas 5 empresas a portals.yml"
+# "Actualiza mi perfil con este CV que te pego"
+
+# 6. Empieza a usar
+# Pega una URL de oferta o descripción para trigger el auto-pipeline
+# Si tu CLI soporta slash commands, usa /career-ops (o su alias)
+# En Codex, pide el mismo modo en lenguaje natural, p.ej:
+# "Ejecuta el modo scan de career-ops"
+# "Ejecuta el modo pipeline de career-ops para data/pipeline.md"
+# "Ejecuta el modo pdf de career-ops para el rol más reciente"
+# "Ejecuta el modo tracker de career-ops y resume los estados"
 ```
 
-</details>
-
-### Instalación global
-
-```bash
-npm i -g @santifer/career-ops
-```
-
-Esto instala el binario `career-ops` de forma global para que puedas ejecutarlo directamente en lugar de usar `npx`. A diferencia de `npx @santifer/career-ops init` (que prepara un directorio de proyecto), la instalación global te da un comando `career-ops` persistente disponible en cualquier terminal.
-
-**¿Cuál deberías usar?**
-- `npx @santifer/career-ops init` — mejor para el primer uso; crea una carpeta de proyecto dedicada.
-- `npm i -g @santifer/career-ops` — mejor una vez que tienes una carpeta de proyecto y quieres ejecutar comandos de career-ops directamente.
+**En el primer arranque, career-ops te guía en la configuración — tu CV, tu perfil y los roles que buscas — simplemente conversando. No hay nada qué editar a mano.**
 
 > **El sistema está diseñado para que Claude lo personalice.** Modes, arquetipos, scoring, scripts de negociación -- solo pídelo. Claude lee los mismos archivos que usa, así que sabe exactamente qué editar.
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -104,26 +104,6 @@ Conçu par quelqu'un qui l'a utilisé pour évaluer plus de 740 offres d'emploi,
 
 ## Démarrage rapide
 
-**La méthode la plus rapide — une seule commande :**
-
-```bash
-npx @santifer/career-ops init
-```
-
-> 💡 `npx` est fourni avec [Node.js](https://nodejs.org) — il exécute l'installateur une seule fois, sans rien installer globalement. Si vous n'avez pas encore Node, installez-le d'abord. (Si vous utilisez déjà un CLI Claude Code / Gemini / Codex, vous l'avez déjà.)
-
-Cette commande clone la dernière version dans `./career-ops` et installe les dépendances. Ensuite :
-
-```bash
-cd career-ops
-claude   # ou gemini / codex / qwen / opencode — ouvrez votre CLI d'IA ici
-```
-
-**Lors du premier lancement, career-ops vous guide à travers la configuration — votre CV, votre profil et vos rôles cibles — simplement par chat. Rien à modifier à la main.**
-
-<details>
-<summary><b>Vous préférez le configurer manuellement ? (git clone)</b></summary>
-
 ```bash
 git clone https://github.com/santifer/career-ops.git
 cd career-ops && npm install
@@ -131,7 +111,7 @@ npx playwright install chromium   # requis uniquement pour la génération de PD
 claude   # ouvrez votre CLI d'IA — il vous guidera au premier lancement
 ```
 
-</details>
+**Lors du premier lancement, career-ops vous guide à travers la configuration — votre CV, votre profil et vos rôles cibles — simplement par chat. Rien à modifier à la main.**
 
 > **Le système est conçu pour être personnalisé par Claude lui-même.** Modes, archétypes, pondérations des scores, scripts de négociation — demandez simplement à Claude de les modifier. Il lit les mêmes fichiers qu'il utilise, il sait donc exactement quoi modifier.
 

--- a/README.hi.md
+++ b/README.hi.md
@@ -116,28 +116,6 @@ career-ops agentic है: जो भी AI coding CLI आप चुनें �
 
 ## Quick Start
 
-**सबसे तेज़ तरीका — एक command:**
-
-```bash
-npx @santifer/career-ops init
-```
-
-> 💡 `npx` [Node.js](https://nodejs.org) के साथ आता है — यह installer एक बार run करता है,
-> globally कुछ install किए बिना। Node नहीं है? पहले install करें।
-> (Claude Code / Gemini / Codex CLI पहले से use कर रहे हैं? तो आपके पास पहले से है।)
-
-यह latest release को `./career-ops` में clone करता है और dependencies install करता है। फिर:
-
-```bash
-cd career-ops
-claude   # या gemini / codex / qwen / opencode / agy / grok — यहाँ अपना AI CLI खोलें
-```
-
-**पहले launch पर, career-ops setup के through walk करता है — आपका CV, profile और target roles — simply chatting करके। कुछ manually edit नहीं करना।**
-
-<details>
-<summary><b>Manually setup करना पसंद करते हैं? (git clone)</b></summary>
-
 ```bash
 git clone https://github.com/santifer/career-ops.git
 cd career-ops && npm install
@@ -154,7 +132,7 @@ cp templates/portals.example.yml portals.yml       # Companies customize कर�
 # project root में cv.md बनाएं अपने CV के साथ markdown में
 
 # 5. इस directory में अपना AI CLI खोलें
-claude   # या codex / opencode / gemini / qwen / agy / grok
+claude   # या codex / opencode / qwen / agy / grok
 
 # फिर CLI से system को आप पर adapt करने को कहें:
 # "Archetypes को backend engineering roles में change करो"
@@ -172,7 +150,7 @@ claude   # या codex / opencode / gemini / qwen / agy / grok
 # "Run the career-ops tracker mode and summarize the current statuses"
 ```
 
-</details>
+**पहले launch पर, career-ops setup के through walk करता है — आपका CV, profile और target roles — simply chatting करके। कुछ manually edit नहीं करना।**
 
 > **System को आपका AI coding CLI खुद customize करने के लिए design किया गया है।** Modes, archetypes, scoring weights, negotiation scripts -- बस उसे change करने को कहें। वह वही files पढ़ता है जो वह use करता है, इसलिए उसे exactly पता है क्या edit करना है।
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -38,9 +38,7 @@
 
 <p align="center"><strong>740件以上の求人を評価 · 100件以上のパーソナライズCVを生成 · 理想のポジションを獲得</strong></p>
 
-<p align="center"><a href="https://discord.gg/8pRpHETxa4"><img src="https://img.shields.io/badge/コミュニティに参加-Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
-  &nbsp;
-  <a href="https://www.npmjs.com/package/@santifer/career-ops"><img src="https://img.shields.io/npm/dt/@santifer/career-ops?style=for-the-badge&logo=npm&color=CB3837&label=npx%20installs" alt="npm installs"></a></p>
+<p align="center"><a href="https://discord.gg/8pRpHETxa4"><img src="https://img.shields.io/badge/コミュニティに参加-Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a></p>
 
 <p align="center">
   <a href="https://claude.com/claude-code"><img src="https://img.shields.io/badge/Built_with-Claude_Code-000?style=for-the-badge&logo=anthropic&logoColor=white" alt="Built with Claude Code"></a>
@@ -98,36 +96,41 @@ career-opsはエージェンティックです: Claude CodeがPlaywrightで求�
 
 ## クイックスタート
 
-**最速の方法 — コマンド1つ:**
-
-```bash
-npx @santifer/career-ops init
-```
-
-> 💡 `npx` は [Node.js](https://nodejs.org) に付属しています — グローバルに何もインストールせず、
-> インストーラーを一度だけ実行します。まだNodeがない場合は、先にインストールしてください。
-> （すでにClaude Code / Gemini / Codex CLIを使っているなら、もう持っています。）
-
-これにより最新リリースが `./career-ops` にクローンされ、依存関係がインストールされます。その後:
-
-```bash
-cd career-ops
-claude   # or gemini / codex / qwen / opencode — ここでAI CLIを起動
-```
-
-**初回起動時、career-opsが対話するだけでセットアップ（CV、プロフィール、対象ロール）をご案内します。手で編集するものは何もありません。**
-
-<details>
-<summary><b>手動でセットアップしたいですか？（git clone）</b></summary>
-
 ```bash
 git clone https://github.com/santifer/career-ops.git
 cd career-ops && npm install
 npx playwright install chromium   # PDF生成にのみ必要
-claude   # AI CLIを起動 — 初回起動時にオンボーディングします
+
+# 2. セットアップ確認
+npm run doctor                     # すべての前提条件を検証
+
+# 3. 設定
+cp config/profile.example.yml config/profile.yml  # 詳細情報を入力
+cp templates/portals.example.yml portals.yml       # 企業をカスタマイズ
+
+# 4. CVを追加
+# プロジェクト root に cv.md を作成（Markdown形式のCV）
+
+# 5. このディレクトリでAI CLIを起動
+claude   # or codex / opencode / qwen / agy / grok
+
+# その後、CLIにシステムを調整するよう依頼:
+# "Change the archetypes to backend engineering roles"
+# "Translate the modes to English"
+# "Add these 5 companies to portals.yml"
+# "Update my profile with this CV I'm pasting"
+
+# 6. 利用開始
+# 求人URLまたは記述を貼り付けると自動パイプラインが起動
+# CLIがスラッシュコマンドに対応している場合は /career-ops を使用
+# Codexの場合は、以下のように依頼:
+# "Run the career-ops scan mode"
+# "Run the career-ops pipeline mode for data/pipeline.md"
+# "Run the career-ops pdf mode for the latest evaluated role"
+# "Run the career-ops tracker mode and summarize the current statuses"
 ```
 
-</details>
+**初回起動時、career-opsが対話するだけでセットアップ（CV、プロフィール、対象ロール）をご案内します。**
 
 > **このシステムはClaude自身がカスタマイズする前提で設計されています。** モード、アーキタイプ、スコアリング重み、交渉スクリプト -- すべてClaudeに依頼すれば変更してくれます。Claudeは自分が使うのと同じファイルを読むので、どこを編集すればよいか正確に把握しています。
 

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -38,9 +38,7 @@
 
 <p align="center"><strong>740개 이상의 채용 공고 평가 · 100개 이상의 맞춤형 이력서 생성 · 꿈의 직장 1곳 합격</strong></p>
 
-<p align="center"><a href="https://discord.gg/8pRpHETxa4"><img src="https://img.shields.io/badge/커뮤니티_참여하기-Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
-  &nbsp;
-  <a href="https://www.npmjs.com/package/@santifer/career-ops"><img src="https://img.shields.io/npm/dt/@santifer/career-ops?style=for-the-badge&logo=npm&color=CB3837&label=npx%20installs" alt="npm installs"></a></p>
+<p align="center"><a href="https://discord.gg/8pRpHETxa4"><img src="https://img.shields.io/badge/커뮤니티_참여하기-Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a></p>
 
 <p align="center">
   <a href="https://claude.com/claude-code"><img src="https://img.shields.io/badge/Built_with-Claude_Code-000?style=for-the-badge&logo=anthropic&logoColor=white" alt="Built with Claude Code"></a>
@@ -95,39 +93,43 @@ career-ops는 에이전트 기반으로 작동합니다: Claude Code가 Playwrig
 | **Dashboard TUI**      | 터미널 UI에서 파이프라인 탐색, 필터링, 정렬                                                                                         |
 | **Human-in-the-Loop**  | AI가 평가하고 추천하면, 당신이 판단하고 행동합니다. 시스템은 절대 지원서를 자동 제출하지 않습니다 -- 최종 결정은 항상 당신의 몫     |
 | **파이프라인 무결성**  | 자동 병합, 중복 제거, 상태 정규화, 헬스 체크                                                                                        |
-
 ## 빠른 시작
-
-**가장 빠른 방법 — 명령어 하나:**
-
-```bash
-npx @santifer/career-ops init
-```
-
-> 💡 `npx`는 [Node.js](https://nodejs.org)에 함께 제공됩니다 — 전역으로 아무것도
-> 설치하지 않고 인스톨러를 한 번만 실행합니다. 아직 Node가 없다면 먼저 설치하세요.
-> (이미 Claude Code / Gemini / Codex CLI를 사용 중이라면 이미 가지고 있습니다.)
-
-이 명령어는 최신 릴리스를 `./career-ops`에 클론하고 의존성을 설치합니다. 그다음:
-
-```bash
-cd career-ops
-claude   # or gemini / codex / qwen / opencode — open your AI CLI here
-```
-
-**처음 실행하면 career-ops가 대화만으로 설정 과정을 안내합니다 — 이력서, 프로필, 목표 직무까지. 손으로 편집할 것이 없습니다.**
-
-<details>
-<summary><b>수동으로 설정하고 싶으신가요? (git clone)</b></summary>
 
 ```bash
 git clone https://github.com/santifer/career-ops.git
 cd career-ops && npm install
 npx playwright install chromium   # only needed for PDF generation
-claude   # open your AI CLI — it onboards you on first launch
+
+# 2. Check setup
+npm run doctor                     # Validates all prerequisites
+
+# 3. Configure
+cp config/profile.example.yml config/profile.yml  # Edit with your details
+cp templates/portals.example.yml portals.yml       # Customize companies
+
+# 4. Add your CV
+# Create cv.md in the project root with your CV in markdown
+
+# 5. Open your AI CLI in this directory
+claude   # or codex / opencode / qwen / agy / grok
+
+# Then ask your CLI to adapt the system to you:
+# "Change the archetypes to backend engineering roles"
+# "Translate the modes to English"
+# "Add these 5 companies to portals.yml"
+# "Update my profile with this CV I'm pasting"
+
+# 6. Start using
+# Paste a job URL or JD text to trigger auto-pipeline
+# If your CLI supports slash commands, use /career-ops (or its CLI-specific alias)
+# In Codex, ask for the same mode in plain language, e.g.:
+# "Run the career-ops scan mode"
+# "Run the career-ops pipeline mode for data/pipeline.md"
+# "Run the career-ops pdf mode for the latest evaluated role"
+# "Run the career-ops tracker mode and summarize the current statuses"
 ```
 
-</details>
+**처음 실행하면 career-ops가 대화만으로 설정 과정을 안내합니다 — 이력서, 프로필, 목표 직무까지. 손으로 편집할 것이 없습니다.**
 
 > **이 시스템은 Claude가 직접 커스터마이즈하도록 설계되었습니다.** 모드, 아키타입, 스코어링 가중치, 협상 스크립트 -- 그냥 요청하세요. Claude가 사용하는 파일을 직접 읽기 때문에, 무엇을 수정해야 하는지 정확히 알고 있습니다.
 

--- a/README.md
+++ b/README.md
@@ -129,28 +129,6 @@ career-ops is the first reference implementation of [the CareerOps Manifesto](ht
 
 ## Quick Start
 
-**Fastest way — one command:**
-
-```bash
-npx @santifer/career-ops init
-```
-
-> 💡 `npx` ships with [Node.js](https://nodejs.org) — it runs the installer once,
-> without installing anything globally. No Node yet? Install it first.
-> (Already using a Claude Code / Gemini / Codex CLI? Then you already have it.)
-
-This clones the latest release into `./career-ops` and installs dependencies. Then:
-
-```bash
-cd career-ops
-claude   # or codex / qwen / opencode / agy / grok — open your AI CLI here
-```
-
-**On first launch, career-ops walks you through setup — your CV, profile and target roles — just by chatting. Nothing to edit by hand.**
-
-<details>
-<summary><b>Prefer to set it up manually? (git clone)</b></summary>
-
 ```bash
 git clone https://github.com/santifer/career-ops.git
 cd career-ops && npm install
@@ -185,19 +163,7 @@ claude   # or codex / opencode / qwen / agy / grok
 # "Run the career-ops tracker mode and summarize the current statuses"
 ```
 
-</details>
-
-### Global install
-
-```bash
-npm i -g @santifer/career-ops
-```
-
-This installs the `career-ops` binary globally so you can run it directly instead of via `npx`. Unlike `npx @santifer/career-ops init` (which bootstraps a project directory), the global install gives you a persistent `career-ops` command available anywhere in your terminal.
-
-**Which one should you use?**
-- `npx @santifer/career-ops init` — best for first use; creates a dedicated project folder.
-- `npm i -g @santifer/career-ops` — best once you have a project folder and want to run career-ops commands directly.
+**On first launch, career-ops walks you through setup — your CV, profile and target roles — just by chatting. Nothing to edit by hand.**
 
 > **The system is designed to be customized by your AI coding CLI itself.** Modes, archetypes, scoring weights, negotiation scripts -- just ask it to change them. It reads the same files it uses, so it knows exactly what to edit.
 

--- a/README.pl.md
+++ b/README.pl.md
@@ -94,35 +94,41 @@ Zbudowany przez kogoś, kto użył go do oceny 740+ ofert pracy, wygenerowania 1
 
 ## Szybki start
 
-**Najszybszy sposób — jedno polecenie:**
-
-```bash
-npx @santifer/career-ops init
-```
-
-> 💡 `npx` jest dołączone do [Node.js](https://nodejs.org) — uruchamia instalator jednorazowo, bez instalowania czegokolwiek globalnie. Nie masz jeszcze Node.js? Najpierw go zainstaluj.
-> (Używasz już Claude Code / Gemini / Codex CLI? To już go masz.)
-
-To sklonuje najnowszą wersję do `./career-ops` i zainstaluje zależności. Następnie:
-
-```bash
-cd career-ops
-claude   # lub gemini / codex / qwen / opencode — otwórz tutaj swój AI CLI
-```
-
-**Przy pierwszym uruchomieniu career-ops przeprowadza Cię przez konfigurację — CV, profil i docelowe stanowiska — wyłącznie przez rozmowę. Nic nie trzeba edytować ręcznie.**
-
-<details>
-<summary><b>Wolisz skonfigurować ręcznie? (git clone)</b></summary>
-
 ```bash
 git clone https://github.com/santifer/career-ops.git
 cd career-ops && npm install
 npx playwright install chromium   # wymagane tylko do generowania PDF
-claude   # otwórz swój AI CLI — przy pierwszym uruchomieniu przeprowadzi Cię przez onboarding
+
+# 2. Check setup
+npm run doctor                     # Validates all prerequisites
+
+# 3. Configure
+cp config/profile.example.yml config/profile.yml  # Edit with your details
+cp templates/portals.example.yml portals.yml       # Customize companies
+
+# 4. Add your CV
+# Create cv.md in the project root with your CV in markdown
+
+# 5. Open your AI CLI in this directory
+claude   # lub gemini / codex / qwen / opencode — otwórz tutaj swój AI CLI
+
+# Then ask your CLI to adapt the system to you:
+# "Change the archetypes to backend engineering roles"
+# "Translate the modes to English"
+# "Add these 5 companies to portals.yml"
+# "Update my profile with this CV I'm pasting"
+
+# 6. Start using
+# Paste a job URL or JD text to trigger auto-pipeline
+# If your CLI supports slash commands, use /career-ops (or its CLI-specific alias)
+# In Codex, ask for the same mode in plain language, e.g.:
+# "Run the career-ops scan mode"
+# "Run the career-ops pipeline mode for data/pipeline.md"
+# "Run the career-ops pdf mode for the latest evaluated role"
+# "Run the career-ops tracker mode and summarize the current statuses"
 ```
 
-</details>
+**Przy pierwszym uruchomieniu career-ops przeprowadza Cię przez konfigurację — CV, profil i docelowe stanowiska — wyłącznie przez rozmowę. Nic nie trzeba edytować ręcznie.**
 
 > **System jest zaprojektowany tak, żeby Claude go dostosowywał.** Tryby, archetypy, wagi oceniania, skrypty negocjacyjne — po prostu poproś Claude o zmiany. Czyta te same pliki, których używa, więc wie dokładnie, co edytować.
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -38,9 +38,7 @@
 
 <p align="center"><strong>740+ vagas avaliadas · 100+ CVs personalizados · 1 vaga dos sonhos conquistada</strong></p>
 
-<p align="center"><a href="https://discord.gg/8pRpHETxa4"><img src="https://img.shields.io/badge/Join_the_community-Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
-&nbsp;
-<a href="https://www.npmjs.com/package/@santifer/career-ops"><img src="https://img.shields.io/npm/dt/@santifer/career-ops?style=for-the-badge&logo=npm&color=CB3837&label=npx%20installs" alt="npm installs"></a></p>
+<p align="center"><a href="https://discord.gg/8pRpHETxa4"><img src="https://img.shields.io/badge/Join_the_community-Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a></p>
 
 <p align="center">
   <a href="https://claude.com/claude-code"><img src="https://img.shields.io/badge/Built_with-Claude_Code-000?style=for-the-badge&logo=anthropic&logoColor=white" alt="Built with Claude Code"></a>
@@ -94,40 +92,43 @@ Construído por alguém que usou isso para avaliar 740+ vagas, gerar 100+ CVs pe
 | **Processamento em lote**            | Avaliação paralela com workers `claude -p`                                                                                                     |
 | **Dashboard TUI**                    | Interface no terminal para navegar, filtrar e ordenar seu pipeline                                                                             |
 | **Humano no loop**                   | A IA avalia e recomenda, você decide e age. O sistema nunca envia candidatura automaticamente -- a decisão final é sempre sua                  |
-| **Integridade do pipeline**          | Merge automatizado, deduplicação, normalização de status e health checks                                                                       |
-
 ## Início rápido
-
-**Forma mais rápida — um único comando:**
-
-```bash
-npx @santifer/career-ops init
-```
-
-> 💡 `npx` já vem com o [Node.js](https://nodejs.org) — ele roda o instalador uma vez,
-> sem instalar nada globalmente. Ainda não tem Node? Instale-o primeiro.
-> (Já usa uma CLI Claude Code / Gemini / Codex? Então você já tem.)
-
-Isso clona o último release em `./career-ops` e instala as dependências. Depois:
-
-```bash
-cd career-ops
-claude   # ou gemini / codex / qwen / opencode — abra sua CLI de IA aqui
-```
-
-**No primeiro uso, o career-ops conduz você pela configuração — seu CV, perfil e vagas-alvo — apenas conversando. Nada para editar à mão.**
-
-<details>
-<summary><b>Prefere configurar manualmente? (git clone)</b></summary>
 
 ```bash
 git clone https://github.com/santifer/career-ops.git
 cd career-ops && npm install
 npx playwright install chromium   # necessário apenas para geração de PDF
-claude
+
+# 2. Verificar configuração
+npm run doctor                     # Valida todos os pré-requisitos
+
+# 3. Configurar
+cp config/profile.example.yml config/profile.yml  # Edite com seus dados
+cp templates/portals.example.yml portals.yml       # Customize as empresas
+
+# 4. Adicionar seu CV
+# Crie cv.md na raiz do projeto com seu CV em markdown
+
+# 5. Abra sua CLI de IA neste diretório
+claude   # ou codex / opencode / qwen / agy / grok
+
+# Então peça para sua CLI adaptar o sistema para você:
+# "Mude os arquétipos para funções de backend engineering"
+# "Traduza os modos para Português"
+# "Adicione estas 5 empresas no portals.yml"
+# "Atualize meu perfil com este CV que estou colando"
+
+# 6. Comece a usar
+# Cole uma URL de vaga ou texto com JD para disparar o auto-pipeline
+# Se sua CLI suporta slash commands, use /career-ops (ou seu alias)
+# No Codex, peça o mesmo modo em linguagem natural, ex:
+# "Execute o career-ops scan mode"
+# "Execute o career-ops pipeline mode para data/pipeline.md"
+# "Execute o career-ops pdf mode para a vaga mais recente avaliada"
+# "Execute o career-ops tracker mode e resuma os status atuais"
 ```
 
-</details>
+**No primeiro uso, o career-ops conduz você pela configuração — seu CV, perfil e vagas-alvo — apenas conversando. Nada para editar à mão.**
 
 > **O sistema foi projetado para ser customizado pelo próprio Claude.** Modos, arquétipos, pesos de pontuação, scripts de negociação -- é só pedir para ele alterar. Ele lê os mesmos arquivos que usa, então sabe exatamente o que editar.
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -40,8 +40,6 @@
 
 <p align="center">
   <a href="https://discord.gg/8pRpHETxa4"><img src="https://img.shields.io/badge/Присоединиться_к_сообществу-Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
-  &nbsp;
-  <a href="https://www.npmjs.com/package/@santifer/career-ops"><img src="https://img.shields.io/npm/dt/@santifer/career-ops?style=for-the-badge&logo=npm&color=CB3837&label=npx%20installs" alt="npm installs"></a>
 </p>
 
 <p align="center">
@@ -94,36 +92,38 @@ career-ops превращает любой AI-CLI в полноценный ко
 
 ## Быстрый старт
 
-**Самый быстрый способ — одна команда:**
-
 ```bash
-npx @santifer/career-ops init
-```
+git clone https://github.com/santifer/career-ops.git
+cd career-ops && npm install
+npx playwright install chromium   # только для генерации PDF
 
-> 💡 `npx` поставляется вместе с [Node.js](https://nodejs.org) — он один раз запускает
-> установщик, ничего не устанавливая глобально. Ещё нет Node? Установи его сначала.
-> (Уже используешь Claude Code / Gemini / Codex CLI? Значит, он у тебя уже есть.)
+# 2. Проверь настройку
+npm run doctor                     # Проверяет все зависимости
 
-Это клонирует последний релиз в `./career-ops` и устанавливает зависимости. Затем:
+# 3. Конфигурация
+cp config/profile.example.yml config/profile.yml  # Отредактируй с твоими данными
+cp templates/portals.example.yml portals.yml       # Добавь нужные компании
 
-```bash
-cd career-ops
-claude   # или gemini / codex / qwen / opencode — открой здесь свой AI-CLI
+# 4. Загрузи свое резюме
+# Создай cv.md в корне проекта с резюме в markdown
+
+# 5. Открой свой AI-CLI в этой директории
+claude   # или codex / opencode / qwen / agy / grok
+
+# Затем попроси свой CLI адаптировать систему к себе:
+# "Измени архетипы на backend engineering роли"
+# "Переведи режимы на английский"
+# "Добавь эти 5 компаний в portals.yml"
+# "Обнови мой профиль с этим CV"
+
+# 6. Начни использовать
+# Вставь URL вакансии или текст JD — сработает авто-пайплайн
+# Если твой CLI поддерживает slash-команды, используй /career-ops (или его аналог)
 ```
 
 **При первом запуске career-ops проведёт тебя через настройку — твоё CV, профиль и целевые роли — просто через диалог. Ничего не нужно править вручную.**
 
-<details>
-<summary><b>Предпочитаешь настроить вручную? (git clone)</b></summary>
-
-```bash
-git clone https://github.com/santifer/career-ops.git
-cd career-ops && npm install
-npx playwright install chromium   # нужно только для генерации PDF
-claude   # открой свой AI-CLI — он проведёт онбординг при первом запуске
-```
-
-</details>
+> **Система разработана для кастомизации твоим AI-командным центром.** Попроси своего CLI переводить режимы, адаптировать архетипы и управлять опциями через диалог.
 
 ## Использование
 

--- a/README.ta.md
+++ b/README.ta.md
@@ -119,30 +119,6 @@ career-ops ஒரு **Agentic** அமைப்பு. நீங்கள் �
 
 ## Quick Start
 
-**வேகமாக தொடங்குவதற்கான வழி — ஒரு கட்டளை போதும்:**
-
-```bash
-npx @santifer/career-ops init
-```
-
-> 💡 `npx` என்பது [Node.js](https://nodejs.org)-உடன் கிடைக்கிறது. இது எந்த Global Installation-மும் இல்லாமல் Installer-ஐ ஒருமுறை இயக்கும்.
->
-> இன்னும் Node.js நிறுவவில்லையா? முதலில் அதை நிறுவுங்கள்.
->
-> (ஏற்கனவே Claude Code / Gemini / Codex CLI பயன்படுத்துகிறீர்களா? அப்படியானால் தேவையானவை ஏற்கனவே உங்களிடம் உள்ளன.)
-
-இந்தக் கட்டளை, சமீபத்திய Release-ஐ `./career-ops` கோப்பகத்தில் Clone செய்து, தேவையான Dependencies-ஐ நிறுவும். அதன் பிறகு:
-
-```bash
-cd career-ops
-claude   # அல்லது codex / qwen / opencode / agy / grok — உங்கள் AI CLI-ஐ இங்கே திறக்கவும்
-```
-
-**முதல் முறையாக இயக்கும்போது, career-ops உங்களுடன் உரையாடி உங்கள் CV, Profile மற்றும் இலக்கு பணியிடங்களை (Target Roles) அமைக்க உதவும். கைமுறையாக எந்த கோப்பையும் திருத்த வேண்டியதில்லை.**
-
-<details>
-<summary><b>கைமுறையாக அமைக்க விரும்புகிறீர்களா? (git clone)</b></summary>
-
 ```bash
 git clone https://github.com/santifer/career-ops.git
 cd career-ops && npm install
@@ -153,7 +129,7 @@ npm run doctor                     # தேவையான அனைத்து
 
 # 3. அமைப்புகளை உள்ளமைக்கவும்
 cp config/profile.example.yml config/profile.yml  # உங்கள் விவரங்களைப் புதுப்பிக்கவும்
-cp templates/portals.example.yml portals.yml      # நிறுவனங்களின் பட்டியலை மாற்றிக்கொள்ளவும்
+cp templates/portals.example.yml portals.yml       # நிறுவனங்களின் பட்டியலை மாற்றிக்கொள்ளவும்
 
 # 4. உங்கள் CV-ஐ சேர்க்கவும்
 # Project Root-இல் cv.md என்ற Markdown கோப்பை உருவாக்கி உங்கள் CV-ஐ சேர்க்கவும்
@@ -177,7 +153,7 @@ claude   # அல்லது codex / opencode / qwen / agy / grok
 # "Run the career-ops tracker mode and summarize the current statuses"
 ```
 
-</details>
+**முதல் முறையாக இயக்கும்போது, career-ops உங்களுடன் உரையாடி உங்கள் CV, Profile மற்றும் இலக்கு பணியிடங்களை (Target Roles) அமைக்க உதவும். கைமுறையாக எந்த கோப்பையும் திருத்த வேண்டியதில்லை.**
 
 > **இந்த அமைப்பு, நீங்கள் பயன்படுத்தும் AI Coding CLI மூலம் எளிதாக தனிப்பயனாக்கப்படுமாறு வடிவமைக்கப்பட்டுள்ளது.** Modes, Archetypes, Scoring Weights, Negotiation Scripts போன்றவற்றை மாற்ற AI-யிடம் கேட்டாலே போதும். அது பயன்படுத்தும் அதே கோப்புகளைப் படிப்பதால், எந்த இடத்தில் என்ன மாற்ற வேண்டும் என்பதைத் துல்லியமாக அறியும்.
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -123,28 +123,6 @@ career-ops, [CareerOps Manifestosu](https://career-ops.org/manifesto?utm_source=
 
 ## Hızlı Başlangıç
 
-**En hızlı yol — tek komut:**
-
-```bash
-npx @santifer/career-ops init
-```
-
-> 💡 `npx`, [Node.js](https://nodejs.org) ile birlikte gelir — herhangi bir şeyi global olarak
-> kurmadan yükleyiciyi bir kez çalıştırır. Node yoksa önce onu kurun.
-> (Zaten bir Claude Code / Gemini / Codex CLI kullanıyor musunuz? O zaman zaten sahipsiniz.)
-
-Bu, en güncel sürümü `./career-ops` içine klonlar ve bağımlılıkları kurar. Ardından:
-
-```bash
-cd career-ops
-claude   # veya codex / qwen / opencode / agy / grok — yapay zekâ CLI'nizi burada açın
-```
-
-**İlk açılışta career-ops sizi kurulum boyunca yönlendirir — CV'niz, profiliniz ve hedef rolleriniz — sadece sohbet ederek. Elle düzenlenecek hiçbir şey yok.**
-
-<details>
-<summary><b>Elle kurmayı mı tercih edersiniz? (git clone)</b></summary>
-
 ```bash
 git clone https://github.com/santifer/career-ops.git
 cd career-ops && npm install
@@ -179,7 +157,7 @@ claude   # veya codex / opencode / qwen / agy / grok
 # "career-ops tracker modunu çalıştır ve mevcut durumları özetle"
 ```
 
-</details>
+**İlk açılışta career-ops sizi kurulum boyunca yönlendirir — CV'niz, profiliniz ve hedef rolleriniz — sadece sohbet ederek. Elle düzenlenecek hiçbir şey yok.**
 
 > **Sistem, yapay zekâ kodlama CLI'nizin kendisi tarafından özelleştirilmek üzere tasarlanmıştır.** Modlar, arketipler, puanlama ağırlıkları, pazarlık senaryoları -- onlardan bunları değiştirmesini istemeniz yeterli. Kullandığı dosyaların aynılarını okur, bu yüzden tam olarak neyi düzenleyeceğini bilir.
 

--- a/README.ua.md
+++ b/README.ua.md
@@ -40,8 +40,7 @@
 
 <p align="center">
   <a href="https://discord.gg/8pRpHETxa4"><img src="https://img.shields.io/badge/Приєднатися_до_спільноти-Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
-  &nbsp;
-  <a href="https://www.npmjs.com/package/@santifer/career-ops"><img src="https://img.shields.io/npm/dt/@santifer/career-ops?style=for-the-badge&logo=npm&color=CB3837&label=npx%20installs" alt="npm installs"></a>
+
 </p>
 
 <p align="center">
@@ -100,37 +99,41 @@ career-ops працює агентно: Claude Code переходить на к
 
 ## Швидкий старт
 
-**Найшвидший спосіб — одна команда:**
-
-```bash
-npx @santifer/career-ops init
-```
-
-> 💡 `npx` постачається разом із [Node.js](https://nodejs.org) — він запускає
-> інсталятор один раз, нічого не встановлюючи глобально. Ще немає Node?
-> Спочатку встановіть його.
-> (Уже користуєтеся Claude Code / Gemini / Codex CLI? Тоді він у вас уже є.)
-
-Це клонує останній реліз у `./career-ops` та встановлює залежності. Потім:
-
-```bash
-cd career-ops
-claude   # or gemini / codex / qwen / opencode — open your AI CLI here
-```
-
-**Під час першого запуску career-ops проведе вас через налаштування — ваше резюме, профіль і цільові ролі — просто у форматі діалогу. Нічого не треба редагувати вручну.**
-
-<details>
-<summary><b>Бажаєте налаштувати вручну? (git clone)</b></summary>
-
 ```bash
 git clone https://github.com/santifer/career-ops.git
 cd career-ops && npm install
 npx playwright install chromium   # only needed for PDF generation
-claude
+
+# 2. Check setup
+npm run doctor                     # Validates all prerequisites
+
+# 3. Configure
+cp config/profile.example.yml config/profile.yml  # Edit with your details
+cp templates/portals.example.yml portals.yml       # Customize companies
+
+# 4. Add your CV
+# Create cv.md in the project root with your CV in markdown
+
+# 5. Open your AI CLI in this directory
+claude   # or codex / opencode / qwen / agy / grok
+
+# Then ask your CLI to adapt the system to you:
+# "Change the archetypes to backend engineering roles"
+# "Translate the modes to English"
+# "Add these 5 companies to portals.yml"
+# "Update my profile with this CV I'm pasting"
+
+# 6. Start using
+# Paste a job URL or JD text to trigger auto-pipeline
+# If your CLI supports slash commands, use /career-ops (or its CLI-specific alias)
+# In Codex, ask for the same mode in plain language, e.g.:
+# "Run the career-ops scan mode"
+# "Run the career-ops pipeline mode for data/pipeline.md"
+# "Run the career-ops pdf mode for the latest evaluated role"
+# "Run the career-ops tracker mode and summarize the current statuses"
 ```
 
-</details>
+**Під час першого запуску career-ops проведе вас через налаштування — ваше резюме, профіль і цільові ролі — просто у форматі діалогу.**
 
 > **Система створена для налаштування самим Claude.** Режими, архетипи, оцінювання, скрипти переговорів — просто попросіть Claude їх змінити. Він читає ті самі файли, які використовує, тому точно знає, що редагувати.
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -41,7 +41,6 @@
 <p align="center">
   <a href="https://discord.gg/8pRpHETxa4"><img src="https://img.shields.io/badge/加入社群-Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
   &nbsp;
-  <a href="https://www.npmjs.com/package/@santifer/career-ops"><img src="https://img.shields.io/npm/dt/@santifer/career-ops?style=for-the-badge&logo=npm&color=CB3837&label=npx%20installs" alt="npm installs"></a>
 </p>
 
 <p align="center">
@@ -100,36 +99,41 @@ career-ops 具有代理能力：Claude Code 透過 Playwright 瀏覽求職頁面
 
 ## 快速開始
 
-**最快的方式 — 一行指令：**
-
-```bash
-npx @santifer/career-ops init
-```
-
-> 💡 `npx` 隨 [Node.js](https://nodejs.org) 一起提供 — 它會執行安裝程式一次，
-> 而不會在全域安裝任何東西。還沒有 Node？請先安裝它。
-> （已經在使用 Claude Code / Gemini / Codex CLI？那你已經有了。）
-
-這會把最新版本複製到 `./career-ops` 並安裝相依套件。接著：
-
-```bash
-cd career-ops
-claude   # 或 gemini / codex / qwen / opencode — 在此開啟你的 AI CLI
-```
-
-**首次啟動時，career-ops 會透過對話帶你完成設定 — 你的履歷、個人檔案與目標職位 — 完全不需要手動編輯。**
-
-<details>
-<summary><b>偏好手動設定？（git clone）</b></summary>
-
 ```bash
 git clone https://github.com/santifer/career-ops.git
 cd career-ops && npm install
 npx playwright install chromium   # 僅 PDF 生成所需
-claude   # 開啟你的 AI CLI — 首次啟動時會帶你完成設定
+
+# 2. 檢查設定
+npm run doctor                     # 驗證所有先決條件
+
+# 3. 設定
+cp config/profile.example.yml config/profile.yml  # 編輯成你的詳情
+cp templates/portals.example.yml portals.yml       # 自訂要掃描的企業
+
+# 4. 新增你的履歷
+# 在專案根目錄建立 cv.md，用 markdown 格式寫你的履歷
+
+# 5. 在此開啟你的 AI CLI
+claude   # 或 codex / opencode / qwen / agy / grok
+
+# 接著告訴你的 CLI 來幫你客製化系統：
+# "把職位類型改成後端工程職位"
+# "翻譯模式成繁體中文"
+# "把這 5 家公司加進 portals.yml"
+# "用我貼的履歷更新我的個人檔案"
+
+# 6. 開始使用
+# 貼上職缺 URL 或職缺說明，觸發自動管道
+# 如果你的 CLI 支援斜線指令，使用 /career-ops（或 CLI 的別名）
+# 在 Codex，用純文本方式要求同一個模式，例如：
+# "執行 career-ops 掃描模式"
+# "在 data/pipeline.md 上執行 career-ops 管道模式"
+# "在最新評估職位上執行 career-ops pdf 模式"
+# "執行 career-ops 追蹤器模式並總結目前的狀態"
 ```
 
-</details>
+**首次啟動時，career-ops 會透過對話帶你完成設定 — 你的履歷、個人檔案與目標職位 — 完全不需要手動編輯。**
 
 > **這個系統設計上就是讓 Claude 來客製化的。** 模式、職位類型、評分權重、談判腳本 — 直接告訴 Claude 要修改什麼，它就會動手。Claude 讀取的是它自己使用的相同檔案，所以它確切知道要編輯哪裡。
 

--- a/detect-reposts.mjs
+++ b/detect-reposts.mjs
@@ -28,13 +28,16 @@ import { fileURLToPath, pathToFileURL } from 'url';
 
 import { roleFuzzyMatch, roleTokens, BASELINE_TOKENS } from './role-matcher.mjs';
 import { normalizeCompanyName } from './invite-match.mjs';
-import { flagValue } from './lib/cli-flags.mjs';
+import { flagValue, validateFlags } from './lib/cli-flags.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const SCAN_HISTORY_PATH = join(CAREER_OPS, 'data/scan-history.tsv');
 const DEFAULT_WINDOW_DAYS = 90;
 
 // --- CLI args ---
+
+const KNOWN_FLAGS = ['--window', '--summary', '--self-test', '--help', '-h'];
+const VALUE_FLAGS = ['--window'];
 
 const USAGE = `Usage:
   node detect-reposts.mjs                       # full JSON repost clusters to stdout
@@ -490,10 +493,16 @@ function runSelfTest() {
 
 // --- Run (CLI only; guarded so the module is safely importable for tests) ---
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  if (args.includes('--help') || args.includes('-h')) {
-    console.log(USAGE);
-    process.exit(0);
-  }
+  // Replaces a bare --help check that never looked at the other flags, so a
+  // mistyped --window was ignored and the scan silently used the 90-day
+  // default instead of the window that was asked for (#2919). validateFlags
+  // also runs the unrecognized-flag check BEFORE --help, so `--help --bogus`
+  // errors rather than exiting 0 unread.
+  //
+  // Inside the main-module guard, not at import time: company-history.mjs
+  // imports detectReposts/parseScanHistory from here, so a top-level check
+  // would judge the IMPORTER's argv.
+  validateFlags(args, KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS });
 
   if (selfTestMode) {
     runSelfTest();

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -6,7 +6,7 @@ Common questions from the community, answered in one place. For setup details se
 
 ## 1. Skills aren't loading on Windows — symlink error on install
 
-Windows does not create symlinks by default, so Git checks out the CLI skill entrypoints (`.claude/skills/`, `.opencode/skills/`, etc.) as plain pointer files instead of real symlinks. The installer and updater both detect this automatically: run `node update-system.mjs apply` (or `npx @santifer/career-ops init` on a fresh install) and the `materializeSkillEntrypoints` step will replace the pointer files with the full canonical skill content. No manual `mklink` or Developer Mode changes are needed.
+Windows does not create symlinks by default, so Git checks out the CLI skill entrypoints (`.claude/skills/`, `.opencode/skills/`, etc.) as plain pointer files instead of real symlinks. The installer and updater both detect this automatically: run `node update-system.mjs apply` after cloning and the `materializeSkillEntrypoints` step will replace the pointer files with the full canonical skill content. No manual `mklink` or Developer Mode changes are needed.
 
 ## 2. What is the difference between `scan` and `scan:full`?
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -3,18 +3,18 @@
 ## Prerequisites
 
 - An AI coding CLI — [Claude Code](https://claude.ai/code), Gemini CLI, Codex, Qwen Code, OpenCode, GitHub Copilot CLI, Antigravity CLI, or Grok Build CLI (see [Supported CLIs](SUPPORTED_CLIS.md))
-- [Node.js](https://nodejs.org) 18+ and `git` (`npx` ships with Node — the installer refuses to run without them) — note: the Gemini CLI integration requires Node.js 20+
+- [Node.js](https://nodejs.org) 18+ and `git` — note: the Gemini CLI integration requires Node.js 20+
 - (Optional) Go 1.21+ (for the dashboard TUI)
 
 ## Quick Start
 
-### Recommended — one command
-
 ```bash
-npx @santifer/career-ops init
+git clone https://github.com/santifer/career-ops.git
+cd career-ops
+npm install
 ```
 
-`npx` ships with Node.js — it runs the installer once without installing anything globally. This clones the latest release into `./career-ops` and installs dependencies. Then move into the workspace and open your AI CLI:
+Then move into the workspace and open your AI CLI:
 
 ```bash
 cd career-ops
@@ -44,21 +44,6 @@ codex exec "Run career-ops pdf mode for the latest evaluated role."
 codex exec "Run career-ops email mode for the latest evaluated role. Draft only; do not send, submit, or click anything."
 codex exec "Run career-ops tracker mode and summarize the current statuses."
 ```
-
-### Advanced — clone manually
-
-<details>
-<summary>Prefer to clone the repo yourself?</summary>
-
-```bash
-git clone https://github.com/santifer/career-ops.git
-cd career-ops
-npm install
-```
-
-Then open your AI CLI in the folder — the same first-run onboarding applies. Use this path if you want to track a specific branch, contribute, or audit the code before installing dependencies.
-
-</details>
 
 ### PDF rendering (one-time)
 

--- a/funnel-velocity.mjs
+++ b/funnel-velocity.mjs
@@ -51,10 +51,13 @@ const summaryMode = args.includes('--summary');
 const selfTestMode = args.includes('--self-test');
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
-const VALID_SOURCES = new Set(['set-status', 'correction', 'backfill', 'manual']);
+const VALID_SOURCES = new Set(['set-status', 'correction', 'backfill', 'manual', 'web']);
 // Sources whose dates are trusted for day-math. backfill/manual are parsed and
 // counted but excluded: they are reconstructed after the fact, not observed.
-const DAY_MATH_SOURCES = new Set(['set-status', 'correction']);
+// `web` IS observed: it is the same event as a `set-status`, recorded live at
+// the moment the user changes the status, just entering through the web app
+// instead of the CLI. By the rule above it belongs in both sets.
+const DAY_MATH_SOURCES = new Set(['set-status', 'correction', 'web']);
 
 // The hops a candidate can measure from their own tracker. Applied→Rejected is
 // tracked separately from the forward hops — a "days to terminal" number that
@@ -484,6 +487,23 @@ function selfTest() {
   check(unparseable.some(u => u.reason.includes('unknown to-state')), 'parser: non-canonical state reported');
   check(unknownSources.length === 1 && unknownSources[0].source === 'future-import', 'parser: unknown source counted');
   check(observations.find(o => o.source === 'future-import')?.dayMath === false, 'parser: unknown source excluded from day-math');
+  // The writer and the reader must agree on the source string, and nothing
+  // asserted that: the web app records 'web' and this parser did not know it,
+  // so every web-driven transition landed in unknownSources and out of
+  // day-math. Counted, flagged as suspect, and silently absent from the one
+  // number this file exists to produce.
+  //
+  // Fixture APARTE a propósito: dentro del compartido, sus dos transiciones
+  // entraban en la mediana de velocidad y ponían en rojo tres checks ajenos que
+  // no tenían nada que ver. Un caso nuevo no debe mover el de los que ya están.
+  const WEB_FIXTURE = [
+    '9\t2026-06-01\tEvaluated\tApplied\tweb\tobserved live, from the web app',
+    '9\t2026-06-06\tApplied\tResponded\tweb\t',
+  ].join('\n');
+  const web = parseStatusLog(WEB_FIXTURE, states);
+  check(web.observations.length === 2, 'parser: web source parsed');
+  check(web.observations.every(o => o.dayMath === true), 'parser: web source counts for day-math (observed live, not reconstructed)');
+  check(web.unknownSources.length === 0, 'parser: web is a known source');
   check(observations.find(o => o.num === 2 && o.from === null), 'parser: "-" from-state parses as null');
 
   // -- fold --

--- a/lib/ascii-fold.mjs
+++ b/lib/ascii-fold.mjs
@@ -1,0 +1,46 @@
+/**
+ * ascii-fold.mjs — fold a name to ASCII for comparison against an ASCII target.
+ *
+ * Two places in the tree build a private key by DELETING every character
+ * outside `[a-z0-9]` instead of folding it. The deletion is always wrong when
+ * the thing being compared against is ASCII, because the accented letter has an
+ * obvious ASCII counterpart that the target actually uses:
+ *
+ *   - verify-portals.mjs      "Telefónica"       -> "telefnica", never the real
+ *                                                   Greenhouse slug "telefonica" (#2930)
+ *   - providers/_trust-validator.mjs
+ *                             "Société Générale" -> "socit gnrale", so the company
+ *                                                   failed to match its own domain (#2924)
+ *
+ * WHY NFD IS RIGHT HERE AND WRONG IN foldStatusInput (tracker-utils.mjs, #2705):
+ * there the fold must not collapse distinct identities — Żubr must never become
+ * Zubr, because two different companies would merge. Here the comparison target
+ * is ASCII by construction (a hostname, an ATS slug), so folding to the ASCII
+ * base letter IS the intent: "telefonica" is the ASCII folding of "Telefónica".
+ * Different question, different answer.
+ *
+ * A name with no Latin content at all (CJK, Cyrillic, Greek) folds to ''. That
+ * is a real answer, not a failure: no ASCII target can contain it. Callers must
+ * decide what '' means for them — see each call site.
+ */
+
+/**
+ * Latin letters that do NOT decompose under NFD, so stripping combining marks
+ * alone still deletes them. Lowercase only; `asciiFold` lowercases first.
+ */
+const NON_DECOMPOSING_LATIN = [
+  [/ø/g, 'o'], [/æ/g, 'ae'], [/œ/g, 'oe'], [/ß/g, 'ss'],
+  [/đ/g, 'd'], [/ł/g, 'l'], [/þ/g, 'th'], [/ð/g, 'd'],
+];
+
+/**
+ * Lowercase and fold a name to ASCII letters, digits and single spaces.
+ *
+ * @param {string} value - Raw display name.
+ * @returns {string} Folded name, or '' when nothing Latin survives.
+ */
+export function asciiFold(value) {
+  let out = String(value ?? '').toLowerCase().normalize('NFD').replace(/\p{M}+/gu, '');
+  for (const [re, to] of NON_DECOMPOSING_LATIN) out = out.replace(re, to);
+  return out.replace(/[^a-z0-9\s]/g, ' ').replace(/\s+/g, ' ').trim();
+}

--- a/lib/latex-escape.mjs
+++ b/lib/latex-escape.mjs
@@ -10,10 +10,18 @@
  * @returns {string}
  */
 export function escapeLatex(text, mode = 'text') {
-  if (typeof text !== 'string') return '';
-  if (mode === 'url') return text;
+  // Blank out only truly absent/structural values, and coerce scalars — the
+  // same rule #2641 applied to escapeHtml, which this function mirrors.
+  // `typeof text !== 'string' -> ''` silently dropped NUMBERS: a payload with
+  // `year: 2019` or `dates: 2024` (JSON numbers, not strings) rendered an empty
+  // \resumeSubheading date field while the section stayed present, so the .tex
+  // shipped without employment dates or graduation years — and the builder
+  // still reported "valid": true and exited 0.
+  if (text === null || text === undefined || typeof text === 'object') return '';
+  const value = String(text);
+  if (mode === 'url') return value;
   const out = [];
-  for (const ch of text) {
+  for (const ch of value) {
     switch (ch) {
       case '\\': out.push('\\textbackslash{}'); break;
       case '{': case '}': out.push('\\' + ch); break;

--- a/lib/local-today.mjs
+++ b/lib/local-today.mjs
@@ -1,0 +1,30 @@
+/**
+ * local-today.mjs — the calendar day where the user actually is.
+ *
+ * `new Date().toISOString().slice(0, 10)` is the UTC day, and using it for
+ * "today" is wrong in both directions:
+ *
+ *   - West of Greenwich, an evening run answers "today" with TOMORROW. That is
+ *     the defect #2765 fixed in followup-seed.mjs ("at 20:00 US Eastern this
+ *     returned the next calendar day").
+ *   - East of Greenwich, the user's own today reads as a FUTURE date for the
+ *     first N hours of their local day, so a validity check that rejects
+ *     future dates rejects the present one (#2932).
+ *
+ * Only "what day is it here" belongs here. Date ARITHMETIC elsewhere stays on
+ * UTC-midnight parsing — `new Date('2026-06-20T00:00:00Z')` round-tripping
+ * through `toISOString()` is internally consistent and deliberate; #2765 drew
+ * the same line.
+ */
+
+/**
+ * Today's date in the host's local timezone, as YYYY-MM-DD.
+ *
+ * @param {Date} [now] - Instant to resolve; defaults to the current time.
+ *   Injectable so tests can pin an instant instead of depending on wall clock.
+ * @returns {string} Local calendar day, YYYY-MM-DD.
+ */
+export function localToday(now = new Date()) {
+  const p = (n) => String(n).padStart(2, '0');
+  return `${now.getFullYear()}-${p(now.getMonth() + 1)}-${p(now.getDate())}`;
+}

--- a/liveness-browser.mjs
+++ b/liveness-browser.mjs
@@ -201,7 +201,13 @@ async function resolveDnsCached(hostname) {
   try {
     const addresses = await hostResolver(hostname);
     if (addresses.length === 0) {
-      throw new Error(`DNS resolution returned no addresses for ${hostname}`);
+      // Tagged so the route guard can tell "this host does not exist" apart from
+      // "this host resolves into private space". The first is a dead third-party
+      // script, the second is an egress-guard hit. Only the second says anything
+      // about the page being checked.
+      const missing = new Error(`DNS resolution returned no addresses for ${hostname}`);
+      missing.livenessCode = 'dns_no_addresses';
+      throw missing;
     }
     dnsCache.set(hostname, addresses);
     return addresses;
@@ -256,7 +262,36 @@ export async function checkUrlLiveness(page, url, { extraSettleMs = 0 } = {}) {
         return route.continue();
       } catch (err) {
         console.warn(`Blocked request to restricted destination (DNS): ${requestUrl} - ${err.message}`);
-        page._blockedByGuard = { code: 'blocked_host', reason: err.message };
+        // A host that resolves to nothing is a DEAD THIRD-PARTY SCRIPT, not a
+        // statement about the posting. Measured 2026-08-14 over a 217-URL
+        // recheck: 78 live postings were returned as `uncertain` because an
+        // analytics or ad host on the page no longer exists — 53 on
+        // personalisation.visitorqueue.com, 17 on s7.addthis.com (AddThis was
+        // shut down in 2023), the rest on fluidads and cloudfront. One was
+        // opened by hand to confirm: 11,178 characters of live posting and a
+        // working apply control, called uncertain because of a dead tracker.
+        //
+        // The request is still aborted either way, so the egress guard loses
+        // nothing. Only the VERDICT stops being poisoned, and only for a
+        // subresource: if the main document itself cannot resolve, that is a
+        // real finding about the posting and still counts.
+        // Whether this was the main document or a subresource can only be asked
+        // of a real Playwright request. Callers may pass a lighter route double
+        // (the test suite does, with request() returning just a url()), and for
+        // those the answer is unknowable — so default to TRUE, which keeps the
+        // pre-existing behaviour of poisoning the verdict. The relaxation only
+        // applies where we can positively establish it was a subresource.
+        const request = typeof route?.request === 'function' ? route.request() : null;
+        const canTell =
+          typeof request?.isNavigationRequest === 'function' &&
+          typeof request?.frame === 'function' &&
+          typeof page?.mainFrame === 'function';
+        const isMainDocument = canTell
+          ? request.isNavigationRequest() && request.frame() === page.mainFrame()
+          : true;
+        if (err?.livenessCode !== 'dns_no_addresses' || isMainDocument) {
+          page._blockedByGuard = { code: 'blocked_host', reason: err.message };
+        }
         return route.abort('blockedbyclient');
       }
     });

--- a/liveness-browser.mjs
+++ b/liveness-browser.mjs
@@ -10,6 +10,27 @@ import { BROWSER_LIKE_USER_AGENT } from './user-agent.mjs';
 
 const NAVIGATE_TIMEOUT_MS = 15_000;
 const HYDRATION_WAIT_MS = 2_000;
+// Upper bound on the extra wait for a same-origin child frame to populate, and
+// the poll interval inside it. Only spent when such a frame exists at all.
+const FRAME_CONTENT_TIMEOUT_MS = 6_000;
+const FRAME_CONTENT_POLL_MS = 500;
+
+/**
+ * Same-origin test used to decide whether a child frame is part of the posting
+ * or somebody else's widget. Deliberately strict: about:blank, data: frames,
+ * tag managers and ad iframes all fail it, so only the ATS's own embedded
+ * document contributes text and apply controls.
+ */
+export function sameOrigin(frameUrl, pageUrl) {
+  try {
+    const a = new URL(frameUrl);
+    const b = new URL(pageUrl);
+    if (a.protocol !== 'http:' && a.protocol !== 'https:') return false;
+    return a.origin === b.origin;
+  } catch {
+    return false;
+  }
+}
 
 // The default Playwright headless UA contains "HeadlessChrome", which Cloudflare
 // and similar WAFs flag — portals like pracuj.pl then serve a 403 challenge page
@@ -250,7 +271,7 @@ export async function checkUrlLiveness(page, url, { extraSettleMs = 0 } = {}) {
 
     const finalUrl = page.url();
     const bodyText = await page.evaluate(() => document.body?.innerText ?? '');
-    const applyControls = await page.evaluate(() => {
+    const extractApplyControls = () => {
       const candidates = Array.from(
         document.querySelectorAll('a, button, input[type="submit"], input[type="button"], [role="button"]')
       );
@@ -281,13 +302,103 @@ export async function checkUrlLiveness(page, url, { extraSettleMs = 0 } = {}) {
           return label;
         })
         .filter(Boolean);
-    });
+    };
+
+    let applyControls = await page.evaluate(extractApplyControls);
+    let frameText = '';
+
+    // Some ATS render the whole posting inside a same-origin iframe and leave the
+    // top-level document as an empty shell. iCIMS is the reference case: measured
+    // 2026-08-14, the outer document of a LIVE posting held 13 characters and no
+    // apply control, so classifyLiveness reached `insufficient_content` and called
+    // it expired. 92 live postings were closed that way in one sweep, and a false
+    // `expired` is the expensive direction — it is written to scan-history as
+    // skipped_expired and dedup-filters the job out of every later scan.
+    //
+    // Reading same-origin child frames cannot resurrect a dead posting: a removed
+    // iCIMS job answers HTTP 410 at the top level (verified on two fabricated job
+    // ids and one genuinely dead posting), so it short-circuits on status long
+    // before any content check, and its error frame carries zero apply controls.
+    // The frame ATTACHES fast but FILLS late. Measured on iCIMS 2026-08-14: the
+    // same-origin child frame is present at 2000ms with 0 characters and only
+    // populates between 3000 and 4000ms, so reading it at HYDRATION_WAIT_MS gets
+    // an empty document and changes nothing. Poll until it has content, bounded.
+    // The cost is only paid on pages that actually have a same-origin child
+    // frame, so the ATS that render inline are unaffected.
+    // Frame aggregation is an enhancement, never a requirement. Callers may pass
+    // a lightweight page object that only implements goto/url/evaluate — the
+    // test doubles in test-all.mjs do — and such a caller must keep getting the
+    // top-level verdict rather than a navigation_error.
+    const supportsFrames = typeof page?.frames === 'function' && typeof page?.mainFrame === 'function';
+
+    const childFrames = () =>
+      !supportsFrames
+        ? []
+        : page.frames().filter((frame) => {
+            if (frame === page.mainFrame()) return false;
+            try {
+              return sameOrigin(frame.url() || '', finalUrl); // excludes about:blank, ads, tag managers
+            } catch {
+              return false;
+            }
+          });
+
+    // A 404/410 is decided by the status line alone, so no amount of frame
+    // content can change it. Without this, a dead posting whose error page also
+    // renders into an iframe pays the poll while that error page fills, purely
+    // to be told what the status already said. Measured on two dead iCIMS
+    // postings: 5822ms and 3314ms end to end, the spread being poll iterations.
+    //
+    // The status rule is NOT restated here. classifyLiveness owns it, so this
+    // asks it and keys off the code it returns; a duplicated `status === 410`
+    // would be a second copy of that rule waiting to drift.
+    const topLevelVerdict = classifyLiveness({ status, requestedUrl: url, finalUrl, bodyText, applyControls });
+    if (topLevelVerdict.code === 'http_gone') {
+      return topLevelVerdict;
+    }
+
+    if (childFrames().length > 0) {
+      const deadline = Date.now() + FRAME_CONTENT_TIMEOUT_MS;
+      // Wait for EVERY qualifying frame, not merely the first one to fill: with
+      // two same-origin frames the posting could otherwise be read while still
+      // empty. Measured across five iCIMS tenants there is exactly one
+      // qualifying frame per page, so in practice this is the same loop.
+      for (;;) {
+        let anyEmpty = false;
+        for (const frame of childFrames()) {
+          try {
+            const probe = await frame.evaluate(() => document.body?.innerText ?? '');
+            if (!probe.trim()) anyEmpty = true;
+          } catch {
+            // detached mid-poll; try again on the next tick
+          }
+        }
+        if (!anyEmpty || Date.now() >= deadline) break;
+        await page.waitForTimeout(FRAME_CONTENT_POLL_MS);
+      }
+    }
+
+    for (const frame of childFrames()) {
+      try {
+        const text = await frame.evaluate(() => document.body?.innerText ?? '');
+        if (text && text.trim()) frameText += '\n' + text;
+        applyControls = applyControls.concat(await frame.evaluate(extractApplyControls));
+      } catch {
+        // detached or cross-origin mid-read; the top-level reading still stands
+      }
+    }
 
     if (page && page._blockedByGuard) {
       return { result: 'uncertain', code: page._blockedByGuard.code, reason: page._blockedByGuard.reason };
     }
 
-    return classifyLiveness({ status, requestedUrl: url, finalUrl, bodyText, applyControls });
+    return classifyLiveness({
+      status,
+      requestedUrl: url,
+      finalUrl,
+      bodyText: bodyText + frameText,
+      applyControls,
+    });
   } catch (err) {
     if (page && page._blockedByGuard) {
       return { result: 'uncertain', code: page._blockedByGuard.code, reason: page._blockedByGuard.reason };

--- a/merge-tracker.mjs
+++ b/merge-tracker.mjs
@@ -228,8 +228,19 @@ function resolveReportUrl(reportField) {
   // [ \t]* NOT \s*: \s matches newlines, so an empty `**URL:**` header swallowed
   // the line break and captured the NEXT header's text. Every such report then
   // minted the same bogus key (`**Legitimacy:**`), and the backfill counted it
-  // as a successful fill.
-  const m = readFileSync(reportPath, 'utf-8').match(/^\*\*URL:\*\*[ \t]*(\S+)/m);
+  // as a successful fill. `\S+` cannot cross a newline, so an empty header now
+  // just fails to match at that position instead of reaching into the next line.
+  //
+  // Deliberately NOT anchored to line start. AGENTS.md requires `**URL:**` "in
+  // the header (between Score and PDF)" — that is, INLINE:
+  //   **Score:** 4.1/5 | **URL:** https://… | **Legitimacy:** High | **PDF:** …
+  // which a `^`-anchored pattern cannot see. Every report written in the
+  // documented format reported "no **URL:** header" and silently fell back to
+  // fuzzy company+role dedup — the exact matching that let a new Google req
+  // overwrite a different, concurrently-live one. Checked against all 399
+  // reports: 376 match both ways and agree on the URL 376/376, so dropping the
+  // anchor cannot change a URL that already resolved.
+  const m = readFileSync(reportPath, 'utf-8').match(/\*\*URL:\*\*[ \t]*(\S+)/);
   if (!m) return { url: '', reason: 'no-url' };
   // Strip a markdown autolink wrapper and trailing punctuation, then require a
   // real http(s) URL. `**URL:** N/A` is legitimate for recruiter-sourced roles,

--- a/process-quality.mjs
+++ b/process-quality.mjs
@@ -36,7 +36,7 @@
 import { readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
-import { flagValue } from './lib/cli-flags.mjs';
+import { flagValue, validateFlags } from './lib/cli-flags.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_ACTIVE_INTERVIEWS_PATH = existsSync(join(CAREER_OPS, 'data/active-interviews.md'))
@@ -316,7 +316,26 @@ function runSelfTest() {
 }
 
 // --- Run (CLI only; guarded so the module is safely importable for tests) ---
+const KNOWN_FLAGS = ['--file', '--min-threshold', '--summary', '--self-test', '--help', '-h'];
+const VALUE_FLAGS = ['--file', '--min-threshold'];
+
+const USAGE = `Usage:
+  node process-quality.mjs                        # JSON report
+  node process-quality.mjs --summary              # human-readable table
+  node process-quality.mjs --file <path>          # a different active-interviews.md
+  node process-quality.mjs --min-threshold <N>    # minimum rounds before a company is reported (default 1)
+  node process-quality.mjs --self-test            # run the built-in fixtures
+  node process-quality.mjs --help                 # show this message`;
+
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  // Inside the main-module guard, not at import time: rejection-latency.mjs
+  // imports parseActiveInterviews from here, so a top-level check would judge
+  // the IMPORTER's argv and reject its flags as unrecognized (#2919).
+  //
+  // A mistyped --file was previously ignored, so the script silently reported
+  // on data/active-interviews.md instead of the path that was asked for.
+  validateFlags(args, KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS });
+
   if (selfTestMode) {
     runSelfTest();
   }

--- a/providers/_trust-validator.mjs
+++ b/providers/_trust-validator.mjs
@@ -102,6 +102,35 @@ export function matchesDomainList(hostname, domainList) {
   return false;
 }
 
+// Latin letters that do NOT decompose under NFD, so stripping combining marks
+// alone still deletes them. Lowercase only — the caller lowercases first.
+const NON_DECOMPOSING_LATIN = [
+  [/ø/g, 'o'], [/æ/g, 'ae'], [/œ/g, 'oe'], [/ß/g, 'ss'],
+  [/đ/g, 'd'], [/ł/g, 'l'], [/þ/g, 'th'], [/ð/g, 'd'],
+];
+
+/**
+ * ASCII-fold a company name for comparison against a hostname.
+ *
+ * NFD is the right tool HERE and the wrong one in foldStatusInput()
+ * (tracker-utils.mjs, #2705). There the fold must not collapse distinct
+ * identities — Żubr must never become Zubr. Here we are deliberately comparing
+ * against an ASCII hostname, so folding to the ASCII base letter is the whole
+ * point: "societegenerale.com" IS the ASCII folding of "Société Générale".
+ *
+ * The previous `[^a-z0-9 ]` strip DELETED accented letters instead of folding
+ * them, so "Société Générale" became "socit gnrale" and matched neither the
+ * slug nor any word of its own domain (#2924).
+ *
+ * @param {string} company
+ * @returns {string} Lowercased, space-separated ASCII, or '' when nothing Latin remains.
+ */
+export function asciiFoldForHostname(company) {
+  let out = String(company ?? '').toLowerCase().normalize('NFD').replace(/\p{M}+/gu, '');
+  for (const [re, to] of NON_DECOMPOSING_LATIN) out = out.replace(re, to);
+  return out.replace(/[^a-z0-9 ]/g, '').replace(/\s+/g, ' ').trim();
+}
+
 /**
  * Heuristic: does the company name plausibly match the URL hostname?
  *
@@ -116,7 +145,12 @@ export function matchesDomainList(hostname, domainList) {
 export function companyMatchesHostname(company, hostname) {
   if (!company || !hostname) return true; // can't evaluate → no flag
 
-  const normalized = company.toLowerCase().replace(/[^a-z0-9 ]/g, '').trim();
+  const normalized = asciiFoldForHostname(company);
+  // Nothing Latin survived (a CJK, Cyrillic, Greek, … name). Deliberate, not
+  // an oversight: hostnames are effectively ASCII, so such a name can never
+  // appear in one and the absence of a match proves nothing. "Working" here
+  // would flag every non-Latin company posting on its own legitimate domain —
+  // trading a silent skip for a systematic false positive (#2924).
   if (!normalized) return true;
 
   // Full slug check (all spaces removed)

--- a/providers/beesite.mjs
+++ b/providers/beesite.mjs
@@ -30,6 +30,13 @@
 //     searchCriteria:
 //       - { CriterionName: PositionLocation.Country, CriterionValue: [329] }
 
+// Titles arrive HTML-escaped, so the tag strip below is not enough on its own:
+// an undecoded "R&amp;D Engineer" fails the user's own title_filter positive
+// "r&d" and is silently dropped, and a negative like "sales & marketing" never
+// vetoes "Sales &amp; Marketing Lead". Shared decoder, same as softgarden and
+// radancy (#2487, #2921).
+import { decodeEntities } from './_html-entities.mjs';
+
 const PAGE_SIZE = 100; // verified: the endpoint happily serves 100+/page
 const MAX_PAGES = 40; // safety cap on request count (40*100 = 4000 postings)
 const MAX_JOBS = 1000; // cap total postings pulled (newest-first sort)
@@ -104,7 +111,7 @@ export function parseSearchResult(json) {
     const d = item?.MatchedObjectDescriptor;
     if (!d) continue;
     const id = item.MatchedObjectId != null ? String(item.MatchedObjectId) : String(d.PositionID || '');
-    const title = String(d.PositionTitle || '').replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+    const title = decodeEntities(String(d.PositionTitle || '').replace(/<[^>]*>/g, ' ')).replace(/\s+/g, ' ').trim();
     const url = String(d.PositionURI || '').trim();
     if (!id || !title || !/^https?:\/\//i.test(url)) continue;
     const locs = Array.isArray(d.PositionLocation) ? d.PositionLocation : [];

--- a/providers/csod.mjs
+++ b/providers/csod.mjs
@@ -27,6 +27,13 @@
 // shape; the branded corporate page goes in careers_url and the csod.com URL in
 // `api:` (same convention as workday/successfactors).
 
+// Titles arrive HTML-escaped, so the tag strip below is not enough on its own:
+// an undecoded "R&amp;D Engineer" fails the user's own title_filter positive
+// "r&d" and is silently dropped, and a negative like "sales & marketing" never
+// vetoes "Sales &amp; Marketing Lead". Shared decoder, same as softgarden and
+// radancy (#2487, #2921).
+import { decodeEntities } from './_html-entities.mjs';
+
 const PAGE_SIZE = 25; // server default; verified OHB serves exactly 25/page
 const MAX_PAGES = 40; // safety cap on request count (40*25 = 1000 postings)
 const MAX_JOBS = 1000; // cap total postings pulled per site
@@ -137,7 +144,7 @@ export function parseRequisitions(json, cfg) {
   for (const r of list) {
     if (!r || typeof r !== 'object') continue;
     const id = r.requisitionId != null ? String(r.requisitionId) : '';
-    const title = String(r.displayJobTitle || '').replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+    const title = decodeEntities(String(r.displayJobTitle || '').replace(/<[^>]*>/g, ' ')).replace(/\s+/g, ' ').trim();
     if (!id || !title) continue;
     out.push({
       id,

--- a/providers/hackernews.mjs
+++ b/providers/hackernews.mjs
@@ -43,18 +43,12 @@ function extractUrl(text) {
   return m ? m[0].replace(/[.,;!?)]+$/, '') : '';
 }
 
-// Named HTML entities we decode in comment bodies. Kept in single map
-/** @type {Record<string, string>} */
-const ENTITY_MAP = {
-  '&amp;': '&',
-  '&lt;': '<',
-  '&gt;': '>',
-  '&quot;': '"',
-  '&#x27;': "'",
-  '&#39;': "'",
-  '&nbsp;': ' ',
-};
-const ENTITY_RE = /&amp;|&lt;|&gt;|&quot;|&#x27;|&#39;|&nbsp;/g;
+// Shared decoder instead of a local map (#2487, #2921). The local ENTITY_RE
+// was a literal alternation of seven forms, so it decoded &#39; but left every
+// OTHER numeric entity (&#8211;, &#232;, &#x2013;) and every other named one
+// (&uuml;, &eacute;) sitting in the title — where an undecoded entity does not
+// just look wrong, it fails the user's title_filter and the posting is dropped.
+import { decodeEntities } from './_html-entities.mjs';
 
 /**
  * Parse a single HN comment text into a normalized job object.
@@ -76,11 +70,10 @@ export function parseHnComment(text, threadUrl = '') {
   // Strip HTML. Anchors: keep the href value in place so URL extraction works.
   // Block-level tags (<p>, <br>, <div>, <li>, headings) become newlines so that
   // body paragraphs never bleed into the first header line after the join.
-  const plain = text
+  const plain = decodeEntities(text
     .replace(/<a\s[^>]*href="([^"]+)"[^>]*>.*?<\/a>/gi, (_, href) => href)
     .replace(/<\/?(?:p|br|div|li|h[1-6])\b[^>]*>/gi, '\n')
-    .replace(/<[^>]+>/g, ' ')
-    .replace(ENTITY_RE, (m) => ENTITY_MAP[m])
+    .replace(/<[^>]+>/g, ' '))
     .replace(/\r\n/g, '\n')
     .replace(/\r/g, '\n');
 

--- a/providers/phenom.mjs
+++ b/providers/phenom.mjs
@@ -2,6 +2,12 @@
 /** @typedef {import('./_types.js').Provider} Provider */
 
 import { fetchJsonWithRetry } from './_http.mjs';
+// Titles arrive HTML-escaped, so the tag strip below is not enough on its own:
+// an undecoded "R&amp;D Engineer" fails the user's own title_filter positive
+// "r&d" and is silently dropped, and a negative like "sales & marketing" never
+// vetoes "Sales &amp; Marketing Lead". Shared decoder, same as softgarden and
+// radancy (#2487, #2921).
+import { decodeEntities } from './_html-entities.mjs';
 
 // Phenom People provider — the "CareerConnect" career sites many large
 // enterprises run (branded domains like careers.exampleco.com). The search
@@ -110,7 +116,7 @@ export function parsePhenomDate(raw) {
 // and collapses whitespace.
 /** @param {any} job @returns {string} */
 export function jobLocation(job) {
-  const direct = String(job?.location || job?.cityStateCountry || job?.cityState || '').replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+  const direct = decodeEntities(String(job?.location || job?.cityStateCountry || job?.cityState || '').replace(/<[^>]*>/g, ' ')).replace(/\s+/g, ' ').trim();
   if (direct) return direct;
   const parts = [job?.city, job?.state, job?.country].map((p) => String(p || '').trim()).filter(Boolean);
   return [...new Set(parts)].join(', ');
@@ -129,7 +135,7 @@ export function parseRefineSearch(json, cfg) {
   for (const job of list) {
     if (!job || typeof job !== 'object') continue;
     const id = job.jobId != null ? String(job.jobId) : '';
-    const title = String(job.title || '').replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+    const title = decodeEntities(String(job.title || '').replace(/<[^>]*>/g, ' ')).replace(/\s+/g, ' ').trim();
     if (!id || !title) continue;
     rows.push({
       id,

--- a/providers/tkms.mjs
+++ b/providers/tkms.mjs
@@ -21,6 +21,13 @@
 // Detection: jobs.tkmsgroup.com is the only known host, and it carries no
 // generic platform token, so detect() claims that host explicitly.
 
+// Titles arrive HTML-escaped, so the tag strip below is not enough on its own:
+// an undecoded "R&amp;D Engineer" fails the user's own title_filter positive
+// "r&d" and is silently dropped, and a negative like "sales & marketing" never
+// vetoes "Sales &amp; Marketing Lead". Shared decoder, same as softgarden and
+// radancy (#2487, #2921).
+import { decodeEntities } from './_html-entities.mjs';
+
 const MAX_PAGES = 60; // safety cap on request count (60*20 = 1200 postings)
 const MAX_JOBS = 1000; // cap total postings pulled
 const PAGE_DELAY_MS = 150; // polite pacing between page requests
@@ -102,7 +109,7 @@ export function parseQuery(json, cfg) {
     const d = item?.data;
     if (!d) continue;
     const id = d.id != null ? String(d.id) : '';
-    const title = String(d.title || '').replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+    const title = decodeEntities(String(d.title || '').replace(/<[^>]*>/g, ' ')).replace(/\s+/g, ' ').trim();
     if (!id || !title) continue;
     rows.push({
       id,

--- a/rejection-latency.mjs
+++ b/rejection-latency.mjs
@@ -53,6 +53,7 @@ import * as yaml from 'js-yaml';
 import { parseActiveInterviews } from './process-quality.mjs';
 import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 import { roleFuzzyMatch } from './role-matcher.mjs';
+import { flagValue, hasFlag, validateFlags } from './lib/cli-flags.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_ACTIVE_INTERVIEWS_PATH = existsSync(join(CAREER_OPS, 'data/active-interviews.md'))
@@ -71,19 +72,54 @@ export const DISCLAIMER =
 
 // --- CLI args ---
 const args = process.argv.slice(2);
+
+const KNOWN_FLAGS = [
+  '--file', '--tracker', '--courtesy-days', '--today',
+  '--summary', '--self-test', '--help', '-h',
+];
+const VALUE_FLAGS = ['--file', '--tracker', '--courtesy-days', '--today'];
+
+const USAGE = `Usage:
+  node rejection-latency.mjs                        # JSON report
+  node rejection-latency.mjs --summary              # human-readable table
+  node rejection-latency.mjs --file <path>          # a different active-interviews.md
+  node rejection-latency.mjs --tracker <path>       # a different applications.md
+  node rejection-latency.mjs --courtesy-days <N>    # override the courtesy threshold (default ${DEFAULT_COURTESY_DAYS})
+  node rejection-latency.mjs --today <YYYY-MM-DD>   # evaluate as of a fixed date
+  node rejection-latency.mjs --self-test            # run the built-in fixtures
+  node rejection-latency.mjs --help                 # show this message
+
+Suggestion-only: nothing is ever written to data/blacklist.md for you.
+${DISCLAIMER}`;
+
+// A mistyped flag used to be ignored, so --traker fell back to
+// DEFAULT_TRACKER_PATH and the tool reported "no post-interview silence
+// exceeded the configured thresholds" at exit 0 — a false all-clear computed
+// from a tracker the caller never named (#2919). Same shape as doctor.mjs's
+// --targe (#2874). Runs before --help so `--help --bogus` still errors.
+validateFlags(args, KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS });
+
 const summaryMode = args.includes('--summary');
 const selfTestMode = args.includes('--self-test');
-// A flag's value must be present and must not itself look like another flag
-// (e.g. `--today --summary` must not silently set cliToday to '--summary').
+// Shared flagValue so `--tracker=path` is honoured too: the previous
+// indexOf-only lookup returned -1 for the `=` form and silently discarded the
+// value, the defect lib/cli-flags.mjs documents as #2401/#2402.
+//
+// The "value must not itself look like another flag" check is kept — it is
+// stricter than the shared helper, and it is what stops `--today --summary`
+// from setting cliToday to '--summary'.
 const argValue = (flag) => {
-  const idx = args.indexOf(flag);
-  if (idx === -1) return null;
-  const next = args[idx + 1];
-  if (next === undefined || next.startsWith('--')) {
+  // hasFlag before flagValue: flagValue returns undefined for BOTH an absent
+  // flag and one supplied with no value, so testing it alone would turn a
+  // trailing `--tracker` from a usage error into a silent fall back to the
+  // default path. lib/cli-flags.mjs documents pairing the two for exactly this.
+  if (!hasFlag(args, flag)) return null;
+  const value = flagValue(args, flag);
+  if (value === undefined || value === '' || value.startsWith('--')) {
     console.error(`${flag} requires a value.`);
     process.exit(2);
   }
-  return next;
+  return value;
 };
 const ACTIVE_INTERVIEWS_PATH = argValue('--file') || DEFAULT_ACTIVE_INTERVIEWS_PATH;
 const TRACKER_PATH = argValue('--tracker') || DEFAULT_TRACKER_PATH;

--- a/set-status-tests.mjs
+++ b/set-status-tests.mjs
@@ -1241,5 +1241,62 @@ const TRACKER_REPORT_MISMATCH = `# Applications Tracker
   }
 }
 
+// ── #2932: "today" is the LOCAL calendar day, never the UTC one ──────────
+{
+  // Auckland is always at or ahead of the UTC day, so for the first hours of
+  // its local day the UTC day is still yesterday. Comparing --on against the
+  // UTC day therefore rejected the user's own today:
+  //   TZ=Pacific/Auckland --on 2026-08-16  ->  "date is in the future"
+  const nzToday = execFileSync(NODE, ['-e',
+    "const d=new Date(),p=n=>String(n).padStart(2,'0');process.stdout.write(`${d.getFullYear()}-${p(d.getMonth()+1)}-${p(d.getDate())}`)",
+  ], { env: { ...process.env, TZ: 'Pacific/Auckland' }, encoding: 'utf-8' }).trim();
+
+  const sandbox = makeSandbox(TRACKER_9);
+  try {
+    const r = runSetStatus(['Globex', 'Interview', '--on', nzToday, '--dry-run'], sandbox, { TZ: 'Pacific/Auckland' });
+    if (r.code === 0) pass('#2932: --on accepts the local today east of UTC');
+    else fail(`#2932: --on rejected Auckland's own today (${nzToday}): code=${r.code} ${(r.stderr || r.stdout).split('\n')[0]}`);
+  } finally {
+    rmSync(sandbox.dir, { recursive: true, force: true });
+  }
+
+  // MUST NOT CHANGE: a genuinely future date is still refused. Without this,
+  // deleting the check entirely would pass the assertion above.
+  const sandbox2 = makeSandbox(TRACKER_9);
+  try {
+    const r = runSetStatus(['Globex', 'Interview', '--on', '2099-01-01', '--dry-run'], sandbox2, { TZ: 'Pacific/Auckland' });
+    if (r.code === 1) pass('#2932: a genuinely future --on is still rejected');
+    else fail(`#2932: future date not rejected (code=${r.code})`);
+  } finally {
+    rmSync(sandbox2.dir, { recursive: true, force: true });
+  }
+
+  // The west-of-UTC half, pinned to an instant so it does not depend on when
+  // the suite runs: at 01:30 UTC it is still the previous day in New York, and
+  // the UTC-day form would write tomorrow into status-log.tsv.
+  const probe = execFileSync(NODE, ['-e',
+    "const {localToday}=await import('./lib/local-today.mjs');" +
+    "const i=new Date('2026-08-16T01:30:00Z');" +
+    "process.stdout.write(localToday(i)+' '+i.toISOString().slice(0,10));",
+    '--input-type=module',
+  ], { cwd: ROOT, env: { ...process.env, TZ: 'America/New_York' }, encoding: 'utf-8' }).trim();
+  if (probe === '2026-08-15 2026-08-16') {
+    pass('#2932: localToday() resolves the local day west of UTC where the UTC day is tomorrow');
+  } else {
+    fail(`#2932: localToday() west-of-UTC probe returned "${probe}", want "2026-08-15 2026-08-16"`);
+  }
+
+  // MUST NOT CHANGE: the round-trip validity check is date PARSING on UTC
+  // midnight and is deliberately untouched, so a malformed date still fails.
+  const sandbox3 = makeSandbox(TRACKER_9);
+  try {
+    const r = runSetStatus(['Globex', 'Interview', '--on', '2026-02-30', '--dry-run'], sandbox3, { TZ: 'Pacific/Auckland' });
+    if (r.code === 1) pass('#2932: an impossible calendar date is still rejected');
+    else fail(`#2932: 2026-02-30 accepted (code=${r.code})`);
+  } finally {
+    rmSync(sandbox3.dir, { recursive: true, force: true });
+  }
+}
+
 console.log(`\n${passed} passed, ${failed} failed`);
 process.exit(failed > 0 ? 1 : 0);

--- a/set-status.mjs
+++ b/set-status.mjs
@@ -72,6 +72,7 @@ import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { extractTrackerReportNumbers, resolveColumns, parseTrackerRow, normalizeTextKey } from './tracker-parse.mjs';
 import { roleFuzzyMatch } from './role-matcher.mjs';
+import { localToday } from './lib/local-today.mjs';
 import {
   rebuildRow, resolveTrackerPath, writeFileAtomic, loadCanonicalStates, resolveCanonicalState,
   normalizeCompany, cell, CLI_EXIT, makeCliFailWith, acquireTrackerLockForCli,
@@ -161,7 +162,13 @@ if (flags.on !== null) {
   const d = m ? new Date(`${flags.on}T00:00:00Z`) : null;
   const roundTrips = d && !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === flags.on;
   if (!roundTrips) failUsage(`--on expects a real date as YYYY-MM-DD, got "${flags.on}"`);
-  if (flags.on > new Date().toISOString().slice(0, 10)) failUsage(`--on date is in the future: "${flags.on}"`);
+  // LOCAL today, not the UTC day. At a positive UTC offset the UTC day is
+  // still yesterday for the first hours of the local day, so comparing against
+  // it rejected the user's own today: `TZ=Pacific/Auckland --on 2026-08-16`
+  // failed with "date is in the future" on 2026-08-16 (#2932). The round-trip
+  // check above deliberately stays on UTC — that is date PARSING, not "what
+  // day is it here".
+  if (flags.on > localToday()) failUsage(`--on date is in the future: "${flags.on}"`);
 }
 
 const selector = explicitSelector ? null : positional[0];
@@ -499,7 +506,12 @@ if (changed && !flags.dryRun) {
 let statusLogged = false;
 if (statusChanged && !flags.dryRun) {
   const logPath = join(dirname(APPS_FILE), 'status-log.tsv');
-  const eventDate = flags.on ?? new Date().toISOString().slice(0, 10);
+  // LOCAL today: the UTC day is TOMORROW for a west-of-Greenwich evening run,
+  // so this appended a status-log row dated a day that had not happened yet
+  // (#2932, mirroring #2765). status-log.tsv is what funnel-velocity reads for
+  // time-between-stages, so a future-dated transition skews the interval it
+  // measures rather than just looking odd in the file.
+  const eventDate = flags.on ?? localToday();
   try {
     appendFileSync(logPath, `${target.num}\t${eventDate}\t${oldStatus}\t${newStatus}\tset-status\t\n`);
     statusLogged = true;

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4806,6 +4806,42 @@ try {
     fail(`verify-portals adopted another employer's board: ${JSON.stringify(nimbus.suggested)}`);
   }
 
+  // ── ASCII fold (#2930) ──
+  // The bug: `[^a-z0-9\s]` turned an accented letter into a SEPARATOR, so
+  // "Telefónica" became the two words "telef nica" and never produced
+  // "telefonica" — the slug the board actually uses. --add then reported a live
+  // board as missing. "Société Générale" shattered into four fragments, so even
+  // the first-word heuristic yielded "soci" instead of "societe".
+  const accented = [
+    ['Telefónica', 'telefonica'],
+    ['Société Générale', 'societegenerale'],
+    ['Nestlé', 'nestle'],
+    ['Ørsted', 'orsted'],   // ø does not decompose under NFD
+    ['Æon', 'aeon'],        // æ expands to two letters
+  ];
+  const missedFold = accented.filter(([name, want]) => !deriveSlugCandidates(name).includes(want));
+  if (missedFold.length === 0) {
+    pass('verify-portals ASCII-folds accented names to the slug the board actually uses');
+  } else {
+    fail(`verify-portals slug fold missed: ${missedFold.map(([n, w]) => `${n}->${w}`).join(', ')}`);
+  }
+
+  // The fold must not turn every name into a match: a distinct company must
+  // still derive a distinct slug. Without this, returning a constant passes.
+  if (!deriveSlugCandidates('Telefónica').includes('vodafone') && deriveSlugCandidates('Société Générale').includes('societe')) {
+    pass('verify-portals fold keeps distinct names distinct and preserves the first-word candidate');
+  } else {
+    fail('verify-portals fold collapsed distinct names or lost the first-word candidate');
+  }
+
+  // A name with no Latin content folds to '' — a real answer (ATS slugs are
+  // ASCII), which runAdd now reports as such instead of "needs a company name".
+  if (deriveSlugCandidates('楽天').length === 0 && deriveSlugCandidates('Сбербанк').length === 0) {
+    pass('verify-portals derives no slug from a name with no Latin content');
+  } else {
+    fail('verify-portals derived an ASCII slug from a non-Latin name');
+  }
+
   if (
     classifyFetchError({ status: 404 }) === 'slug_gone' &&
     classifyFetchError({ name: 'AbortError' }) === 'network' &&

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -872,6 +872,102 @@ try {
     applyControls: ['Apply for this job'],
   });
 
+  // --- iframe-embedded postings -------------------------------------------
+  // Some ATS (iCIMS) render the posting inside a same-origin iframe and leave
+  // the top-level document as a ~13-character shell, which used to reach
+  // insufficient_content and return `expired` for a live job.
+  //
+  // `fillAfter` models the part that made the first attempt at this fix a
+  // no-op: the frame ATTACHES immediately but POPULATES late (measured 0 chars
+  // at 2000ms, 3887 at 4000ms), so a reader that does not wait sees an empty
+  // document and nothing changes.
+  const framedPage = ({ status = 200, finalUrl, shellText = 'Careers', frames = [] }) => {
+    const page = {};
+    const main = { __main: true };
+    const built = frames.map((spec) => {
+      let textReads = 0;
+      return {
+        url: () => spec.url,
+        async evaluate(fn) {
+          // Both extractors mention innerText, so discriminate on the selector
+          // call that only the apply-control extractor makes.
+          const isControls = String(fn).includes('querySelectorAll');
+          const filled = textReads >= (spec.fillAfter ?? 0);
+          if (!isControls) textReads += 1;
+          if (isControls) return filled ? (spec.controls ?? []) : [];
+          return filled ? spec.text : '';
+        },
+      };
+    });
+    let evalCall = 0;
+    Object.assign(page, {
+      async goto() { return { status: () => status }; },
+      async waitForTimeout() {},
+      url() { return finalUrl; },
+      frames() { return [main, ...built]; },
+      mainFrame() { return main; },
+      async evaluate() { evalCall += 1; return evalCall === 1 ? shellText : []; },
+    });
+    return page;
+  };
+
+  const SHELL = 'https://careers-example.icims.com/jobs/1/role/job';
+  const framedLive = await checkUrlLiveness(framedPage({
+    finalUrl: SHELL,
+    frames: [{ url: SHELL + '?in_iframe=1', text: 'Senior Analyst. '.repeat(30), controls: ['Apply for this job online'], fillAfter: 2 }],
+  }), SHELL);
+  if (framedLive.result === 'active' && framedLive.code === 'apply_control_visible') {
+    pass('liveness reads a same-origin posting frame that populates late');
+  } else {
+    fail(`late-filling posting frame not read: ${JSON.stringify(framedLive)}`);
+  }
+
+  const crossOrigin = await checkUrlLiveness(framedPage({
+    finalUrl: SHELL,
+    frames: [{ url: 'https://ads.example.net/widget', text: 'Sponsored. '.repeat(30), controls: ['Apply now'] }],
+  }), SHELL);
+  if (crossOrigin.result === 'expired' && crossOrigin.code === 'insufficient_content') {
+    pass('a cross-origin frame cannot make an empty shell look active');
+  } else {
+    fail(`cross-origin frame leaked into the verdict: ${JSON.stringify(crossOrigin)}`);
+  }
+
+  const goneWithFrame = await checkUrlLiveness(framedPage({
+    status: 410,
+    finalUrl: SHELL,
+    frames: [{ url: SHELL + '?in_iframe=1', text: 'Job not found. '.repeat(30), controls: ['Apply for this job online'] }],
+  }), SHELL);
+  if (goneWithFrame.result === 'expired' && goneWithFrame.code === 'http_gone') {
+    pass('HTTP 410 still wins over a frame carrying an apply control');
+  } else {
+    fail(`410 precedence lost to frame aggregation: ${JSON.stringify(goneWithFrame)}`);
+  }
+
+  // A 410 must not pay the frame poll: the status already decided it, and a
+  // dead posting whose error page renders into an iframe would otherwise wait
+  // for that error page to fill before saying what it knew at byte one.
+  // Count only the 500ms poll waits; the 2000ms hydration wait always happens.
+  let pollWaits = 0;
+  const gonePage = framedPage({
+    status: 410,
+    finalUrl: SHELL,
+    frames: [{ url: SHELL + '?in_iframe=1', text: '', controls: [], fillAfter: 999 }],
+  });
+  gonePage.waitForTimeout = async (ms) => { if (ms === 500) pollWaits += 1; };
+  const goneFast = await checkUrlLiveness(gonePage, SHELL);
+  if (goneFast.result === 'expired' && goneFast.code === 'http_gone' && pollWaits === 0) {
+    pass('HTTP 410 short-circuits before the frame poll (no wait spent)');
+  } else {
+    fail(`410 did not short-circuit: ${JSON.stringify(goneFast)}, poll waits=${pollWaits}`);
+  }
+
+  const legacyDouble = await checkUrlLiveness(livePage(), URL);
+  if (legacyDouble.result === 'active') {
+    pass('a page object without frames()/mainFrame() still returns a top-level verdict');
+  } else {
+    fail(`frame aggregation broke a frameless page object: ${JSON.stringify(legacyDouble)}`);
+  }
+
   if (isChallengeResult({ result: 'uncertain', code: 'bot_challenge' }) &&
       isChallengeResult({ result: 'uncertain', code: 'access_blocked' }) &&
       !isChallengeResult({ result: 'expired', code: 'http_gone' }) &&

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -1079,6 +1079,10 @@ try {
   // the whole section off the network.
   const restoreHostResolver = setHostResolver(async (hostname) => {
     if (hostname === 'ssrf-blocked-host.local') return ['127.0.0.1'];
+    // A shut-down analytics vendor: the name still appears in the page, but it
+    // resolves to nothing at all. Distinct from the loopback case above, which
+    // resolves fine and is blocked for being private.
+    if (hostname === 'dead-analytics-vendor.invalid') return [];
     // Every other host in this section is a stand-in for a normal public site.
     return ['93.184.216.34'];
   });
@@ -1163,6 +1167,67 @@ try {
       pass('SSRF redirect guard allows legitimate subresource requests');
     } else {
       fail(`SSRF redirect guard blocked legitimate requests: ${JSON.stringify(legitimateResult)}`);
+    }
+
+    // A dead THIRD-PARTY host must not decide the verdict for the posting.
+    // Analytics vendors get shut down and their script tags stay in career
+    // pages forever; without this, every posting on such a page reports
+    // uncertain. The route double here is real-shaped (isNavigationRequest and
+    // frame), because that is the only way the guard can tell a subresource
+    // from the main document.
+    const deadThirdParty = (navigation) => {
+      let cb = null;
+      let abortCount = 0;
+      const main = {};
+      return {
+        _blockedByGuard: null,
+        // The verdict is only half the claim. The other half is that the egress
+        // guard still ABORTS the request in both cases — relaxing the verdict
+        // must not quietly start letting a non-resolving host through.
+        get abortCount() { return abortCount; },
+        mainFrame: () => main,
+        async route(_pattern, callback) { cb = callback; },
+        async goto() {
+          await cb({
+            request: () => ({
+              url: () => 'https://dead-analytics-vendor.invalid/widget.js',
+              isNavigationRequest: () => navigation,
+              frame: () => (navigation ? main : {}),
+            }),
+            abort: async () => { abortCount += 1; },
+            continue: async () => {},
+          });
+          return { status: () => 200 };
+        },
+        async waitForTimeout() {},
+        url: () => 'https://careers.example.com/jobs/1',
+        async evaluate() {
+          this._n = (this._n || 0) + 1;
+          return this._n === 1 ? 'Senior Analyst. '.repeat(30) : ['Apply for this job'];
+        },
+      };
+    };
+
+    const subresourcePage = deadThirdParty(false);
+    const subresourceDead = await checkUrlLiveness(subresourcePage, 'https://careers.example.com/jobs/1');
+    if (subresourceDead.result === 'active' && subresourcePage.abortCount === 1) {
+      pass('a dead third-party subresource is still aborted, but no longer decides the verdict');
+    } else {
+      fail(
+        `dead third-party subresource handled wrongly: ${JSON.stringify(subresourceDead)}, ` +
+        `aborts=${subresourcePage.abortCount} (want result active, aborts 1)`
+      );
+    }
+
+    const mainDocPage = deadThirdParty(true);
+    const mainDocDead = await checkUrlLiveness(mainDocPage, 'https://careers.example.com/jobs/1');
+    if (mainDocDead.result === 'uncertain' && mainDocDead.code === 'blocked_host' && mainDocPage.abortCount === 1) {
+      pass('a non-resolving MAIN DOCUMENT is aborted and still returns blocked_host');
+    } else {
+      fail(
+        `main-document DNS failure handled wrongly: ${JSON.stringify(mainDocDead)}, ` +
+        `aborts=${mainDocPage.abortCount} (want uncertain/blocked_host, aborts 1)`
+      );
     }
   } finally {
     // Always put the real resolver back, even if an assertion above throws:

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -4602,6 +4602,49 @@ try {
     fail('verify-portals missing deepsetai suffix for Deepset');
   }
 
+  // ── First-word suffixes are probe-only, never repair candidates (#2937) ──
+  // Crossing the bare first word with an invented suffix does not build a
+  // variant of the company's name, it builds a DIFFERENT company's name:
+  // "Nimbus Data" yields `nimbusai`, `nimbustech`, `nimbuslabs`. That is fine
+  // for `--add`, where a human reads the slug next to the name and picks one.
+  // It is not fine for discoverAlternates, whose `suggested` fix-slugs --fix
+  // writes into portals.yml unreviewed. The bare first word stays on BOTH sets
+  // on purpose: it adds no token the company lacks, and boards really are often
+  // just the brand (the "Diabolocom EU Discovery" row below relies on it).
+  const probeSet = deriveSlugCandidates('Nimbus Data');
+  const repairSet = deriveSlugCandidates('Nimbus Data', { firstWordSuffixes: false });
+  const coined = ['nimbusai', 'nimbustech', 'nimbusio', 'nimbushq', 'nimbuslabs', 'nimbus.tech', 'nimbus.io'];
+  const ownName = ['nimbusdata', 'nimbus-data', 'nimbus_data', 'nimbus', 'nimbusdataai', 'nimbusdata.io'];
+  if (
+    coined.every((s) => probeSet.includes(s)) &&
+    ownName.every((s) => probeSet.includes(s)) &&
+    coined.every((s) => !repairSet.includes(s)) &&
+    ownName.every((s) => repairSet.includes(s))
+  ) {
+    pass('verify-portals keeps first-word suffixes for --add and drops them from the repair set');
+  } else {
+    fail(`verify-portals first-word-suffix split wrong: probe=${JSON.stringify(probeSet)} repair=${JSON.stringify(repairSet)}`);
+  }
+
+  // End to end: the tracked company is "Nimbus Data" and its board has 404'd.
+  // The only live board belongs to "Nimbus AI". Nothing on the repair path
+  // checks identity, so a coined candidate becomes a portals.yml write that
+  // relabels another employer's postings. It must go unresolved instead.
+  const wrongEmployerBoard = 'https://boards-api.greenhouse.io/v1/boards/nimbusai/jobs';
+  const nimbusFetch = async (url) => {
+    if (url === wrongEmployerBoard) return { jobs: [{ id: 7788, title: 'VP Marketing' }] };
+    const err = new Error('HTTP 404'); err.status = 404; throw err;
+  };
+  const [nimbus] = await verifyCompanies(
+    [{ name: 'Nimbus Data', careers_url: 'https://job-boards.greenhouse.io/nimbusdata' }],
+    { fetchJson: nimbusFetch },
+  );
+  if (nimbus.status === 'missing' && !nimbus.suggested) {
+    pass('verify-portals does not suggest a board matched only by a truncation of the name');
+  } else {
+    fail(`verify-portals adopted another employer's board: ${JSON.stringify(nimbus.suggested)}`);
+  }
+
   if (
     classifyFetchError({ status: 404 }) === 'slug_gone' &&
     classifyFetchError({ name: 'AbortError' }) === 'network' &&

--- a/test-trust-validator.mjs
+++ b/test-trust-validator.mjs
@@ -133,6 +133,42 @@ assert(companyMatchesHostname(null, 'example.com') === true, 'null company → n
 assert(companyMatchesHostname(undefined, 'example.com') === true, 'undefined company → no flag');
 assert(companyMatchesHostname('   ', 'example.com') === true, 'whitespace-only company → no flag');
 
+section('companyMatchesHostname — accented Latin folds to its own domain (#2924)');
+
+// The bug: `[^a-z0-9 ]` DELETED the accent instead of folding it, so
+// "Société Générale" became "socit gnrale" — not a substring of
+// "societegenerale" and neither are its words. Rule 4 then charged the posting
+// a 15-point company_domain_mismatch penalty, dropping a clean 100 to 85 and
+// crossing the high→medium boundary, purely because the company spells its
+// name with an accent.
+assert(companyMatchesHostname('Société Générale', 'careers.societegenerale.com') === true, 'Société Générale matches its own domain');
+assert(companyMatchesHostname('Telefónica', 'jobs.telefonica.com') === true, 'Telefónica matches its own domain');
+assert(companyMatchesHostname('Schrödinger', 'schrodinger.com') === true, 'Schrödinger matches its own domain');
+assert(companyMatchesHostname('Citroën', 'careers.citroen.com') === true, 'Citroën matches its own domain');
+
+// These two passed BEFORE the fix, but by luck rather than design: "nestl" is
+// a substring of "nestle" and "rsted" of "orsted". Pinned so the fold, not the
+// coincidence, is what keeps them passing.
+assert(companyMatchesHostname('Nestlé', 'www.nestle.com') === true, 'Nestlé matches (by fold now, not coincidence)');
+assert(companyMatchesHostname('Ørsted', 'orsted.com') === true, 'Ørsted: ø folds to o');
+assert(companyMatchesHostname('Æon', 'aeon.co.jp') === true, 'Æon: æ folds to ae');
+
+// The fold must not turn the check into "always true" — a hostile host is
+// still a mismatch. Without these, deleting the function body would pass.
+assert(companyMatchesHostname('Société Générale', 'evil-phishing.example') === false, 'accented name still flags a hostile host');
+assert(companyMatchesHostname('Telefónica', 'totally-unrelated.example') === false, 'accented name still flags an unrelated host');
+
+section('companyMatchesHostname — a non-Latin name cannot be evaluated (deliberate)');
+
+// NOT a hole to be closed. Hostnames are effectively ASCII, so a CJK or
+// Cyrillic name can never appear in one and the absence of a match proves
+// nothing. Making this "work" would flag every non-Latin company posting on
+// its own legitimate domain — a systematic false positive in place of a
+// silent skip.
+assert(companyMatchesHostname('楽天', 'evil-phishing.example') === true, 'CJK name → cannot evaluate, no flag');
+assert(companyMatchesHostname('Сбербанк', 'evil-phishing.example') === true, 'Cyrillic name → cannot evaluate, no flag');
+assert(companyMatchesHostname('Ελλάκτωρ', 'ellaktor.com') === true, 'Greek name → cannot evaluate, no flag');
+
 // ══════════════════════════════════════════════════════════════════════
 // PART 5: buildTrustValidator — disabled / no-op cases
 // ══════════════════════════════════════════════════════════════════════

--- a/tests/cli-flag-validation.test.mjs
+++ b/tests/cli-flag-validation.test.mjs
@@ -1,0 +1,165 @@
+// tests/cli-flag-validation.test.mjs — four reporting CLIs must reject a
+// mistyped flag instead of answering from their defaults (#2919).
+//
+// The failure class lib/cli-flags.mjs exists to end: an unrecognized flag is
+// ignored, the value flag it was meant to be falls back to its default, and
+// the script reports a result for inputs nobody asked for at exit 0. Already
+// fixed in scan-ats-full.mjs (#1633/#1635), reply-watch.mjs (#2743/#2745),
+// dedup-tracker.mjs (#2744/#2746), scan.mjs (#2270), doctor.mjs (#2874),
+// check-table-freshness.mjs (#2873) and plugin-audit.mjs (#2813).
+//
+// rejection-latency.mjs is the sharpest case and gets its own fixture: its
+// output is a blacklist suggestion, so the silent failure is a FALSE ALL-CLEAR
+// the user then acts on. The fixture below has one company 217 days past the
+// 30-day courtesy threshold, so "no post-interview silence exceeded" is proof
+// the flag was dropped and a different tracker was read.
+//
+// HERMETIC: every path is a tmpdir fixture; nothing reads or writes the real
+// data/ directory. Each run asserts the subprocess actually ran (no spawn
+// error, no signal), so a timeout cannot pass as a silent success.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function runScript(script, ...args) {
+  const r = spawnSync(process.execPath, [join(ROOT, script), ...args], {
+    cwd: ROOT,
+    encoding: 'utf-8',
+    timeout: 30_000,
+  });
+  assert.equal(r.error, undefined, `${script} failed to spawn: ${r.error?.message}`);
+  assert.equal(r.signal, null, `${script} was killed by ${r.signal} (timeout?)`);
+  return { ...r, all: `${r.stdout ?? ''}${r.stderr ?? ''}` };
+}
+
+// Each script paired with a realistic typo of one of ITS OWN value flags —
+// the transposition a user actually makes, not an obviously bogus token.
+const SCRIPTS = [
+  ['rejection-latency.mjs', '--traker'],
+  ['process-quality.mjs', '--fiel'],
+  ['detect-reposts.mjs', '--windo'],
+  ['weekly-digest.mjs', '--dri'],
+];
+
+for (const [script, typo] of SCRIPTS) {
+  test(`${script} rejects ${typo} instead of falling back to its default`, () => {
+    const r = runScript(script, typo, 'some-value');
+    assert.equal(r.status, 1, `${script} ${typo} exited ${r.status}, want 1`);
+    assert.match(r.all, /unrecognized flag/i, `${script} did not name the unrecognized flag`);
+    assert.match(r.all, new RegExp(typo.replace(/^--/, '--')), `${script} did not echo ${typo} back`);
+  });
+
+  test(`${script} --help exits 0 and prints usage`, () => {
+    const r = runScript(script, '--help');
+    assert.equal(r.status, 0, `${script} --help exited ${r.status}, want 0`);
+    assert.match(r.all, /Usage:/i, `${script} --help printed no usage block`);
+  });
+
+  // CodeRabbit caught the reverse ordering as a bug on #2745 and #2746: the
+  // unrecognized-flag check must run BEFORE --help, or `--help --bogus` exits
+  // 0 having never looked at --bogus.
+  test(`${script} --help --bogus still errors`, () => {
+    const r = runScript(script, '--help', '--bogus');
+    assert.equal(r.status, 1, `${script} --help --bogus exited ${r.status}, want 1`);
+    assert.match(r.all, /unrecognized flag/i);
+  });
+}
+
+// --- rejection-latency: the false all-clear, and the `=` form (#2401) -------
+
+function withFixture(fn) {
+  const dir = mkdtempSync(join(tmpdir(), 'career-ops-flagval-'));
+  try {
+    mkdirSync(join(dir, 'data'), { recursive: true });
+    const tracker = join(dir, 'data', 'applications.md');
+    const active = join(dir, 'data', 'active-interviews.md');
+    writeFileSync(
+      tracker,
+      '# Applications Tracker\n\n' +
+        '| # | Date | Company | Role | Score | Status | PDF | Report | Notes |\n' +
+        '|---|------|---------|------|-------|--------|-----|--------|-------|\n' +
+        '| 1 | 2026-01-05 | SandboxCo | Staff Eng | 4.5/5 | Interview | ✅ | [1](reports/001-sandboxco-2026-01-05.md) | — |\n',
+    );
+    writeFileSync(
+      active,
+      '# Active Interviews\n\n' +
+        '| Company | Role | Round | Date/Time | Interviewer | Status | Notes |\n' +
+        '|---------|------|-------|-----------|-------------|--------|-------|\n' +
+        '| SandboxCo | Staff Eng | Round 3 | 2026-01-10 | Panel | Done | #1 in tracker |\n',
+    );
+    return fn({ tracker, active });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const FLAGGED = /SandboxCo/;
+const ALL_CLEAR = /No post-interview silence exceeded/i;
+
+test('rejection-latency finds the 217-day row with space-separated flags', () => {
+  withFixture(({ tracker, active }) => {
+    const r = runScript(
+      'rejection-latency.mjs',
+      '--tracker', tracker, '--file', active, '--today', '2026-08-15', '--summary',
+    );
+    assert.equal(r.status, 0);
+    assert.match(r.all, FLAGGED, 'the flagged company is missing — fixture or join broke');
+    assert.doesNotMatch(r.all, ALL_CLEAR);
+  });
+});
+
+test('rejection-latency honours the --flag=value form (#2401)', () => {
+  withFixture(({ tracker, active }) => {
+    const r = runScript(
+      'rejection-latency.mjs',
+      `--tracker=${tracker}`, `--file=${active}`, '--today=2026-08-15', '--summary',
+    );
+    assert.equal(r.status, 0);
+    // Before the fix this printed the all-clear: indexOf() cannot see the `=`
+    // form, so both paths silently fell back to the real data/ directory.
+    assert.match(r.all, FLAGGED, 'the `=` form was silently discarded');
+    assert.doesNotMatch(r.all, ALL_CLEAR);
+  });
+});
+
+test('rejection-latency: a trailing value flag is a usage error, not a default', () => {
+  // hasFlag is paired with flagValue precisely so this stays an error —
+  // flagValue alone returns undefined for both "absent" and "no value given",
+  // which would silently reinstate the default tracker.
+  const r = runScript('rejection-latency.mjs', '--summary', '--tracker');
+  assert.equal(r.status, 2, `want exit 2, got ${r.status}`);
+  assert.match(r.all, /--tracker requires a value/);
+});
+
+test('rejection-latency: --today --summary does not set the date to "--summary"', () => {
+  const r = runScript('rejection-latency.mjs', '--today', '--summary');
+  assert.equal(r.status, 2);
+  assert.match(r.all, /--today requires a value/);
+});
+
+// --- the importer hazard ---------------------------------------------------
+
+// process-quality.mjs and detect-reposts.mjs are imported by other CLIs, so
+// their validateFlags call must sit inside the main-module guard. At top level
+// it would judge the IMPORTER's argv and reject its valid flags.
+test('validating importable modules does not break their importers', () => {
+  withFixture(({ tracker, active }) => {
+    // rejection-latency imports parseActiveInterviews from process-quality
+    const r1 = runScript(
+      'rejection-latency.mjs',
+      '--tracker', tracker, '--file', active, '--today', '2026-08-15', '--summary',
+    );
+    assert.equal(r1.status, 0, 'process-quality rejected its importer\'s flags');
+    assert.doesNotMatch(r1.all, /unrecognized flag/i);
+  });
+  // company-history imports detectReposts/parseScanHistory from detect-reposts
+  const r2 = runScript('company-history.mjs', '--help');
+  assert.equal(r2.status, 0, 'detect-reposts rejected its importer\'s flags');
+  assert.doesNotMatch(r2.all, /unrecognized flag/i);
+});

--- a/tests/cv-latex-numeric-scalars.test.mjs
+++ b/tests/cv-latex-numeric-scalars.test.mjs
@@ -1,0 +1,66 @@
+// tests/cv-latex-numeric-scalars.test.mjs — the LaTeX mirror of #2641.
+//
+// #2641 removed `typeof text !== 'string' -> ''` from escapeHtml because a
+// machine-authored payload with `dates: 2024` (a JSON number, not "2024")
+// rendered an empty field while the section stayed present. escapeLatex — the
+// function build-cv-latex.mjs runs every value through — kept the same guard,
+// so the .tex shipped without employment dates, education dates, project dates
+// or award years, and the builder still reported "valid": true and exited 0.
+//
+// End-to-end through the real builder and the shipped template, because
+// build-cv-latex.mjs exports nothing. Field names are the ones THIS builder
+// reads (education uses `dates`, awards use `year`) — they differ from the HTML
+// builder's in places, which is a schema question this test does not touch.
+import { pass, fail, ROOT, NODE, run, lastRunFailure } from './helpers.mjs';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+console.log('\nbuild-cv-latex — numeric scalars');
+
+// Numbers on purpose: every date/year below is a JSON number, not a string.
+const PAYLOAD = {
+  lang: 'en',
+  page_format: 'letter',
+  candidate: { name: 'Numeric Scalars', email: 'num@example.com' },
+  summary: 'Summary.',
+  competencies: ['Competency'],
+  experience: [{ company: 'Corp', role: 'Engineer', dates: 2024, bullets: ['Did a thing'] }],
+  education: [{ institution: 'Uni', degree: 'BSc Computing', dates: 2019 }],
+  awards: [{ title: 'Prize', year: 2025 }],
+  projects: [{ name: 'Proj', dates: 2023, bullets: ['Built a thing'] }],
+};
+
+const dir = mkdtempSync(join(tmpdir(), 'cv-latex-numeric-'));
+try {
+  const input = join(dir, 'num.json');
+  const output = join(dir, 'num.tex');
+  writeFileSync(input, JSON.stringify(PAYLOAD));
+
+  if (run(NODE, [join(ROOT, 'build-cv-latex.mjs'), input, output]) === null) {
+    const f = lastRunFailure();
+    fail(`build-cv-latex.mjs crashed (exit ${f?.status}) - ${(f?.stderr || '').trim().split('\n').pop()}`);
+  } else if (!existsSync(output)) {
+    fail('build-cv-latex.mjs exited 0 but wrote no output file');
+  } else {
+    const tex = readFileSync(output, 'utf-8');
+    const missing = [
+      ['experience dates', '2024'],
+      ['education dates', '2019'],
+      ['award year', '2025'],
+      ['project dates', '2023'],
+    ].filter(([, value]) => !tex.includes(value));
+
+    missing.length === 0
+      ? pass('numeric date/year scalars render into the .tex instead of vanishing')
+      : fail(`numeric scalars dropped from the .tex: ${missing.map(([what, v]) => `${what} (${v})`).join(', ')}`);
+
+    // The empty-field shape this produced, asserted directly: a dropped date
+    // leaves `{Corp}{}` rather than `{Corp}{2024}`.
+    /\{Corp\}\{2024\}/.test(tex)
+      ? pass('the experience subheading carries its date rather than an empty brace pair')
+      : fail(`experience subheading lost its date: ${(tex.match(/\{Corp\}\{[^}]*\}/) || ['(not found)'])[0]}`);
+  }
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}

--- a/tests/providers/title-entity-decode.test.mjs
+++ b/tests/providers/title-entity-decode.test.mjs
@@ -1,0 +1,107 @@
+// tests/providers/title-entity-decode.test.mjs — titles must be entity-decoded
+// before they reach title_filter (#2921).
+//
+// Not cosmetic. scan.mjs's buildTitleFilter lowercases and substring-matches,
+// so an undecoded "R&amp;D Engineer" fails a positive keyword "r&d" and the
+// posting is silently dropped — it never reaches pipeline.md and the user
+// never learns it existed. A negative keyword fails the opposite way: the veto
+// never fires. Zero-token scanning is what makes this invisible; there is no
+// LLM pass downstream that would notice the mangled title.
+//
+// #2487 fixed this shape in softgarden and radancy; these five were the
+// remainder. Numeric entities matter as much as &amp; here: beesite and tkms
+// point at DACH postings where "Syst&#232;mes" and "&#8211;" are routine.
+import { pass, fail, ROOT } from '../helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+const load = (f) => import(pathToFileURL(join(ROOT, `providers/${f}`)).href);
+
+console.log('\nProviders — title entity decoding (#2921)');
+try {
+  const { buildTitleFilter } = await load('../scan.mjs');
+
+  // The end-to-end claim: the decoded title survives the user's own filter.
+  const keepsRnD = buildTitleFilter({ positive: ['r&d'], negative: [] });
+  const vetoesSales = buildTitleFilter({ positive: [], negative: ['sales & marketing'] });
+
+  const check = (name, title) => {
+    if (title === 'R&D Engineer') pass(`${name} decodes &amp; in the title`);
+    else fail(`${name} title is ${JSON.stringify(title)}, want "R&D Engineer"`);
+    if (keepsRnD(title)) pass(`${name} title survives a positive "r&d" filter`);
+    else fail(`${name} title ${JSON.stringify(title)} was dropped by positive "r&d"`);
+  };
+
+  // ── beesite ── (parseSearchResult -> { jobs })
+  {
+    const { parseSearchResult } = await load('beesite.mjs');
+    const json = { SearchResult: { SearchResultCount: 1, SearchResultCountAll: 1, SearchResultItems: [{
+      MatchedObjectId: '1',
+      MatchedObjectDescriptor: {
+        PositionID: 'x1', PositionTitle: 'R&amp;D Engineer',
+        PositionURI: 'https://jobs.example.com/a-1',
+        PositionLocation: [{ CityName: 'Bremen' }], PublicationStartDate: '2026-07-04',
+      },
+    }] } };
+    const out = parseSearchResult(json);
+    check('beesite', (out.jobs ?? out.rows ?? out)[0].title);
+  }
+
+  // ── csod ── (parseRequisitions -> array)
+  {
+    const { parseRequisitions } = await load('csod.mjs');
+    const json = { data: { totalCount: 1, requisitions: [
+      { requisitionId: 8410, postingEffectiveDate: '7/3/2026', displayJobTitle: 'R&amp;D Engineer', locations: [{ city: 'Bremen', country: 'DE' }] },
+    ] } };
+    const reqs = parseRequisitions(json, { origin: 'https://career-ohb.csod.com', siteId: 4, corpName: 'career-ohb' });
+    check('csod', reqs[0].title);
+  }
+
+  // ── tkms ── (parseQuery -> { rows })
+  {
+    const { parseQuery } = await load('tkms.mjs');
+    const json = { totalHits: 1, nextPage: null, jobs: [
+      { data: { id: '964694', title: 'R&amp;D Engineer', city: 'Kiel', country: 'Germany' } },
+    ] };
+    const { rows } = parseQuery(json, { origin: 'https://jobs.tkmsgroup.com', locale: 'en' });
+    check('tkms', rows[0].title);
+  }
+
+  // ── phenom ── (parseRefineSearch -> { rows }); title AND location
+  {
+    const { parseRefineSearch, jobLocation } = await load('phenom.mjs');
+    const json = { refineSearch: { status: 200, totalHits: 1, data: { jobs: [
+      { jobId: '98098', title: 'R&amp;D Engineer', location: 'M&#252;nchen', postedDate: '2026-05-07T18:25:30.000+0000' },
+    ] } } };
+    const { rows } = parseRefineSearch(json, { origin: 'https://careers.exampleco.com', urlPrefix: 'global/en' });
+    check('phenom', rows[0].title);
+    const loc = jobLocation({ location: 'M&#252;nchen' });
+    if (loc === 'München') pass('phenom decodes a numeric entity in the location');
+    else fail(`phenom location is ${JSON.stringify(loc)}, want "München"`);
+  }
+
+  // ── the negative side: an undecoded title bypasses the user's veto ──
+  if (vetoesSales('Sales & Marketing Lead') === false && vetoesSales('Sales &amp; Marketing Lead') === true) {
+    pass('an UNDECODED title bypasses a negative filter (why decoding is a filter fix)');
+  } else {
+    fail('negative-filter premise no longer holds — buildTitleFilter changed?');
+  }
+
+  // ── hackernews: the local map decoded &#39; but no other numeric entity ──
+  {
+    const hn = await load('hackernews.mjs');
+    const out = hn.parseHnComment(
+      '<p>Acme GmbH | Softwareentwickler &#8211; R&amp;D | M&#252;nchen | https://acme.example/jobs</p>',
+      'https://news.ycombinator.com/item?id=1',
+    );
+    if (out && out.title.includes('–') && out.title.includes('R&D')) {
+      pass('hackernews decodes numeric entities its local 7-form map missed');
+    } else {
+      fail(`hackernews title is ${JSON.stringify(out && out.title)}`);
+    }
+    if (out && out.location === 'München') pass('hackernews decodes &#252; in the location');
+    else fail(`hackernews location is ${JSON.stringify(out && out.location)}, want "München"`);
+  }
+} catch (err) {
+  fail(`title entity decode suite threw: ${err.message}`);
+}

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -153,6 +153,7 @@ const SYSTEM_PATHS = [
   'extract-latex-content.mjs',
   'patch-latex-content.mjs',
   'lib/cli-flags.mjs',
+  'lib/local-today.mjs',
   'lib/latex-escape.mjs',
   'lib/latex-content.mjs',
   'lib/context-budget.mjs',

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -152,6 +152,7 @@ const SYSTEM_PATHS = [
   'generate-latex.mjs',
   'extract-latex-content.mjs',
   'patch-latex-content.mjs',
+  'lib/ascii-fold.mjs',
   'lib/cli-flags.mjs',
   'lib/local-today.mjs',
   'lib/latex-escape.mjs',

--- a/verify-portals.mjs
+++ b/verify-portals.mjs
@@ -31,6 +31,7 @@ import { fileURLToPath, pathToFileURL } from 'url';
 import * as yaml from 'js-yaml';
 
 import { fetchJson as defaultFetchJson, makeHttpCtx } from './providers/_http.mjs';
+import { asciiFold } from './lib/ascii-fold.mjs';
 import { loadProviders, resolveProvider } from './providers/_registry.mjs';
 
 const DEFAULT_PORTALS_PATH = process.env.CAREER_OPS_PORTALS || 'portals.yml';
@@ -152,16 +153,13 @@ export function parseAtsSlug(url) {
 const SLUG_SUFFIXES = ['ai', 'tech', 'io', 'hq', 'labs'];
 
 export function deriveSlugCandidates(name, { firstWordSuffixes = true } = {}) {
-  const lower = String(name || '')
-    .toLowerCase()
-    .trim();
-  if (!lower) return [];
-  const words = lower
-    .replace(/[^a-z0-9\s]/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim()
-    .split(' ')
-    .filter(Boolean);
+  if (!String(name ?? '').trim()) return [];
+  // ASCII-fold BEFORE splitting. The previous `[^a-z0-9\s]` pass turned an
+  // accented letter into a SEPARATOR, so "Telefónica" became the two words
+  // "telef nica" and never produced "telefonica" — the slug the board actually
+  // uses — while "Société Générale" shattered into four fragments and even the
+  // first-word heuristic above yielded "soci" (#2930).
+  const words = asciiFold(name).split(' ').filter(Boolean);
   if (words.length === 0) return [];
   const candidates = [
     words.join(''), // acmecorp
@@ -503,7 +501,18 @@ function printResults(results) {
 async function runAdd(name, { fetchJson }) {
   const candidates = deriveSlugCandidates(name);
   if (candidates.length === 0) {
-    console.error('verify-portals: --add needs a company name');
+    // Distinguish "you gave me nothing" from "nothing sluggable survived".
+    // A CJK/Cyrillic/Greek name folds to '' because ATS slugs are ASCII, and
+    // reporting that as a missing argument told the user they had omitted an
+    // argument they did supply (#2930).
+    if (!String(name ?? '').trim()) {
+      console.error('verify-portals: --add needs a company name');
+    } else {
+      console.error(
+        `verify-portals: no ASCII slug can be derived from '${name}' — ` +
+        'ATS slugs are ASCII, so pass the latinized brand name (or add the board URL to portals.yml directly).',
+      );
+    }
     process.exit(1);
   }
   console.log(

--- a/verify-portals.mjs
+++ b/verify-portals.mjs
@@ -121,12 +121,37 @@ export function parseAtsSlug(url) {
  * boards use just the brand, e.g. 'Acme Corp' → 'acme'). Order is deterministic
  * and duplicates are removed so `--add` probes each distinct candidate once.
  *
+ * SUFFIXES ON THE FIRST WORD ARE PROBE-ONLY (#2937). Every other candidate here
+ * either reformats the whole name ('nimbus-data'), abbreviates it without
+ * adding anything ('nimbus'), or extends it ('nimbusdataai'). Building a suffix
+ * on the FIRST WORD is the one rule that both drops part of the name AND
+ * substitutes a token for what it dropped, so what comes out is not a form of
+ * this company's name, it is a different company's: 'Nimbus Data' yields
+ * 'nimbusai', 'nimbustech', 'nimbuslabs'. The rule has no legitimate yield to
+ * lose either. When the name already ends in a suffix word ('Scale AI'), it
+ * just reproduces words.join('') and is deduped away, so every candidate it
+ * contributes uniquely belongs to somebody else.
+ *
+ * Offering those to `--add` is fine: an operator reads the slug beside the
+ * company name and picks one, and a wrong guess costs a 404. Offering them to
+ * discoverAlternates is not. That result is attached as `suggested`, and
+ * `fix-slugs --fix` writes it into portals.yml with no further identity check,
+ * after which scan.mjs labels the other employer's postings with this
+ * company's name. Pass `firstWordSuffixes: false` on any path that writes.
+ *
+ * The bare first word stays on both paths deliberately: many boards really are
+ * just the brand ('Acme Corp' → 'acme'), and it adds no token that the company
+ * does not have. It is a narrower risk than this change addresses, not a
+ * blessed one.
+ *
  * @param {string} name - Company display name.
+ * @param {{firstWordSuffixes?: boolean}} [opts] - `false` omits the suffix
+ *   variants built on the first word alone.
  * @returns {string[]} Distinct candidate slugs, most-specific first.
  */
 const SLUG_SUFFIXES = ['ai', 'tech', 'io', 'hq', 'labs'];
 
-export function deriveSlugCandidates(name) {
+export function deriveSlugCandidates(name, { firstWordSuffixes = true } = {}) {
   const lower = String(name || '')
     .toLowerCase()
     .trim();
@@ -144,7 +169,7 @@ export function deriveSlugCandidates(name) {
     words.join('_'), // acme_corp
     words[0], // acme
   ];
-  const bases = [words.join(''), words[0]].filter(Boolean);
+  const bases = (firstWordSuffixes ? [words.join(''), words[0]] : [words.join('')]).filter(Boolean);
   for (const base of bases) {
     for (const suf of SLUG_SUFFIXES) candidates.push(`${base}${suf}`);
     candidates.push(`${base}.tech`, `${base}.io`);
@@ -234,10 +259,19 @@ export async function probeSlug(
   }
 }
 
-/** Probe slug variants across all ATSes; prefer live boards over empty ones. */
+/**
+ * Probe slug variants across all ATSes; prefer live boards over empty ones.
+ *
+ * No first-word suffix variants (#2937). Nothing downstream re-checks identity:
+ * the winner is attached as `suggested` and `fix-slugs --fix` writes it into
+ * portals.yml, so 'Nimbus Data' adopting the live board 'nimbusai' silently
+ * relabels Nimbus AI's postings. Those candidates are never this company's name
+ * to begin with, so dropping them here costs nothing and they stay available to
+ * `--add`, where an operator sees the slug beside the name before adopting it.
+ */
 async function discoverAlternates(name, { fetchJson }) {
   let bestEmpty = null;
-  for (const slug of deriveSlugCandidates(name)) {
+  for (const slug of deriveSlugCandidates(name, { firstWordSuffixes: false })) {
     for (const ats of Object.keys(ATS)) {
       // Lever no longer has a separate 'lever-eu' registry key (unified into a
       // single 'lever' + eu flag), so both instances must be probed explicitly

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -3,40 +3,12 @@
 // core: normalize-statuses.mjs (aliases) + the Go TUI dashboard (score/status
 // colours = the current state-of-the-art).
 
-// Spanish + legacy aliases → canonical English tokens (normalize-statuses.mjs).
-const STATUS_ALIAS: Record<string, string> = {
-  evaluada: "EVALUATED",
-  evaluado: "EVALUATED",
-  condicional: "EVALUATED",
-  hold: "EVALUATED",
-  evaluar: "EVALUATED",
-  verificar: "EVALUATED",
-  aplicada: "APPLIED",
-  aplicado: "APPLIED",
-  enviada: "APPLIED",
-  sent: "APPLIED",
-  respondida: "RESPONDED",
-  respondido: "RESPONDED",
-  contestada: "RESPONDED",
-  entrevista: "INTERVIEW",
-  oferta: "OFFER",
-  rechazada: "REJECTED",
-  rechazado: "REJECTED",
-  descartada: "DISCARDED",
-  descartado: "DISCARDED",
-  cerrada: "DISCARDED",
-  cancelada: "DISCARDED",
-  duplicado: "DISCARDED",
-  repost: "DISCARDED",
-  monitor: "SKIP",
-  no_aplicar: "SKIP",
-  "no aplicar": "SKIP",
-  // Hired — terminal success (offer accepted), added to states.yml in #2050.
-  contratado: "HIRED",
-  contratada: "HIRED",
-  accepted: "HIRED",
-  accept: "HIRED",
-};
+// Alias → canonical stage. Lives in status-alias.mjs so a `node --test` unit
+// test can load it and assert it still covers templates/states.yml (#2917);
+// a hand-maintained copy is what drifted in #2249 and again after #2705.
+import { canonStatus } from "@/lib/status-alias.mjs";
+
+export { canonStatus };
 
 export const CANONICAL_STATES = [
   "Evaluated",
@@ -49,12 +21,6 @@ export const CANONICAL_STATES = [
   "Discarded",
   "SKIP",
 ] as const;
-
-export function canonStatus(s: string): string {
-  const k = s.trim().toLowerCase();
-  if (k === "" || k === "—" || k === "-") return "DISCARDED";
-  return STATUS_ALIAS[k] ?? s.toUpperCase();
-}
 
 /** Status dot colour, mirroring the Go TUI: green hired/interview/offer, sky
  *  applied/responded, red skip/rejected, gray discarded, neutral evaluated. */

--- a/web/src/lib/status-alias.mjs
+++ b/web/src/lib/status-alias.mjs
@@ -1,0 +1,134 @@
+// Status alias → canonical stage, mirroring `templates/states.yml`.
+//
+// Pure JS (no TS types) so it can be imported both by format.ts and by a
+// `node --test` unit test, matching funnel-tiles.mjs / clean-chips.mjs /
+// stream-parse.mjs.
+//
+// This map is a LITERAL rather than a read of states.yml because format.ts is
+// node-free on purpose — it is imported by client components, so it cannot
+// touch fs at runtime. The map has to ship in the bundle as data.
+//
+// Kept honest by tests/lib/status-alias.test.mjs, which loads states.yml and
+// asserts every alias in it resolves here. A copy with nothing checking it is
+// what #2249 fixed by hand for `Hired` and what drifted again as #2917.
+//
+// Entries marked `web-only` have no counterpart in states.yml; they predate it
+// and are kept so this cannot regress an existing tracker. The sync is
+// one-directional: states.yml is a floor, not a cap.
+
+/** @type {Record<string, string>} */
+export const STATUS_ALIAS = {
+  // Evaluated — states.yml `evaluated`
+  evaluada: "EVALUATED",
+  condicional: "EVALUATED",
+  hold: "EVALUATED",
+  evaluar: "EVALUATED",
+  verificar: "EVALUATED",
+  "değerlendirildi": "EVALUATED",
+  degerlendirildi: "EVALUATED",
+  evaluado: "EVALUATED", // web-only: not in states.yml
+  // Applied — states.yml `applied`
+  aplicado: "APPLIED",
+  enviada: "APPLIED",
+  aplicada: "APPLIED",
+  sent: "APPLIED",
+  "başvuruldu": "APPLIED",
+  basvuruldu: "APPLIED",
+  // Responded — states.yml `responded`
+  respondido: "RESPONDED",
+  "yanıt verildi": "RESPONDED",
+  "yanıt_verildi": "RESPONDED",
+  "yanit verildi": "RESPONDED",
+  yanit_verildi: "RESPONDED",
+  respondida: "RESPONDED", // web-only: not in states.yml
+  contestada: "RESPONDED", // web-only: not in states.yml
+  // Interview — states.yml `interview`
+  entrevista: "INTERVIEW",
+  "mülakat": "INTERVIEW",
+  mulakat: "INTERVIEW",
+  // Offer — states.yml `offer`
+  oferta: "OFFER",
+  teklif: "OFFER",
+  // Rejected — states.yml `rejected`
+  rechazado: "REJECTED",
+  rechazada: "REJECTED",
+  reddedildi: "REJECTED",
+  // Discarded — states.yml `discarded`
+  descartado: "DISCARDED",
+  descartada: "DISCARDED",
+  cerrada: "DISCARDED",
+  cancelada: "DISCARDED",
+  "iptal edildi": "DISCARDED",
+  iptal_edildi: "DISCARDED",
+  "ıptal edildi": "DISCARDED",
+  "ıptal_edildi": "DISCARDED",
+  duplicado: "DISCARDED", // web-only: not in states.yml
+  repost: "DISCARDED", // web-only: not in states.yml
+  // SKIP — states.yml `skip`
+  no_aplicar: "SKIP",
+  "no aplicar": "SKIP",
+  skip: "SKIP",
+  monitor: "SKIP",
+  "geo blocker": "SKIP",
+  geo_blocker: "SKIP",
+  "uygun değil": "SKIP",
+  "uygun_değil": "SKIP",
+  "uygun degil": "SKIP",
+  uygun_degil: "SKIP",
+  // Hired — states.yml `hired`
+  contratado: "HIRED",
+  contratada: "HIRED",
+  hired: "HIRED",
+  accepted: "HIRED",
+  accept: "HIRED",
+  "kabul edildi": "HIRED",
+  kabul_edildi: "HIRED",
+  "işe alındı": "HIRED",
+  "ise alindi": "HIRED",
+  "işe alindi": "HIRED",
+};
+
+/**
+ * Fold raw status text to a lookup key.
+ *
+ * Mirrors foldStatusInput() in tracker-utils.mjs (#2705). The `\u0307` strip is
+ * what makes a capitalised Turkish status resolve: JS lowercases `İ` to `i` +
+ * U+0307 COMBINING DOT ABOVE, so "İşe alındı" keys as "i̇şe alındı" and misses
+ * the "işe alındı" entry. Real tracker rows are capitalised, so without this
+ * the alias table is only reachable by input that is already lowercase.
+ *
+ * NFKC and NOT NFD, deliberately: NFD decomposes precomposed letters too, so
+ * the same strip would reach the dots of ż / ė / ġ and collapse Żubr onto
+ * Zubr, Ėmė onto Eme, Ġenerali onto Generali.
+ *
+ * Markdown bold is stripped because AGENTS.md forbids it in the status field —
+ * which is exactly why it turns up there.
+ *
+ * @param {string} s - Raw status text from the tracker.
+ * @returns {string} Lookup key.
+ */
+function foldStatus(s) {
+  return String(s ?? "")
+    .replace(/\*\*/g, "")
+    .trim()
+    .normalize("NFKC")
+    .toLowerCase()
+    .replace(/\u0307/gu, "");
+}
+
+/**
+ * Normalize a raw tracker status to a canonical stage token.
+ *
+ * Unknown input is passed through uppercased rather than rejected, so a status
+ * this map has never seen still renders as itself. Consumers substring-test the
+ * result, which is why an alias missing from the map above resolves to no stage
+ * at all — see tests/lib/status-alias.test.mjs.
+ *
+ * @param {string} s - Raw status text from the tracker.
+ * @returns {string} Canonical stage token, or the uppercased input.
+ */
+export function canonStatus(s) {
+  const k = foldStatus(s);
+  if (k === "" || k === "—" || k === "-") return "DISCARDED";
+  return STATUS_ALIAS[k] ?? String(s ?? "").toUpperCase();
+}

--- a/web/tests/lib/status-alias.test.mjs
+++ b/web/tests/lib/status-alias.test.mjs
@@ -1,0 +1,119 @@
+// Drift guard: web's STATUS_ALIAS literal vs templates/states.yml.
+//
+// format.ts is node-free (client components import it), so it cannot read
+// states.yml at runtime — the alias map has to ship in the bundle as a
+// literal. This test is what makes that copy safe: it loads the real
+// states.yml and asserts every alias in it still resolves here.
+//
+// Without it, an alias added to states.yml silently resolves to nothing in the
+// dashboard. `canonStatus` ends in `STATUS_ALIAS[k] ?? s.toUpperCase()`, so an
+// unknown alias is not rejected — it is passed through as raw uppercased text,
+// and every consumer substring-tests it against the canonical names, which it
+// matches none of. The row then shows under ALL and no other tracker tab, is
+// absent from every tab badge and stage bar, and reads as zero in the
+// analytics achievement tiles — re-firing the #2410 "keep follow-ups warm"
+// nudge at someone who is mid-interview. That is #2249 (fixed by hand for one
+// state) recurring as #2917 with 27 aliases.
+//
+// Imports from status-alias.mjs rather than format.ts because `node --test`
+// has no TS runner. Reading up out of web/ follows clean-chips.test.mjs, which
+// loads ../../../templates/portals.example.yml the same way.
+//
+// Run:  node --test tests/lib/status-alias.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+// Namespace import, not default: js-yaml has no default export (test-all.mjs
+// enforces this — a default import breaks on js-yaml 5).
+import * as yaml from "js-yaml";
+import { STATUS_ALIAS, canonStatus } from "../../src/lib/status-alias.mjs";
+
+const states = yaml.load(
+  readFileSync(new URL("../../../templates/states.yml", import.meta.url), "utf8"),
+).states;
+const STAGES = states.map((s) => s.label.toUpperCase());
+
+test("every states.yml alias resolves to its own canonical stage", () => {
+  const broken = [];
+  for (const st of states) {
+    const canon = st.label.toUpperCase();
+    for (const alias of st.aliases ?? []) {
+      const got = canonStatus(String(alias));
+      // Consumers test with `.includes`, so that is the contract to assert.
+      if (!got.includes(canon)) broken.push(`${JSON.stringify(alias)} -> ${JSON.stringify(got)}, want ${canon}`);
+    }
+  }
+  assert.deepEqual(
+    broken,
+    [],
+    `${broken.length} states.yml alias(es) resolve to no canonical stage in the dashboard (#2917).\n` +
+      `Add them to web/src/lib/status-alias.mjs:\n  ${broken.join("\n  ")}`,
+  );
+});
+
+test("no alias maps to a stage the dashboard does not know", () => {
+  for (const [alias, canon] of Object.entries(STATUS_ALIAS)) {
+    assert.ok(STAGES.includes(canon), `alias ${JSON.stringify(alias)} maps to unknown stage ${JSON.stringify(canon)}`);
+  }
+});
+
+test("a bare canonical label resolves to itself with no alias entry", () => {
+  for (const st of states) {
+    const label = st.label;
+    assert.ok(canonStatus(label).includes(label.toUpperCase()), `${label} does not resolve to itself`);
+  }
+});
+
+test("aliases states.yml does not list are still honoured", () => {
+  // These predate states.yml. Dropping them would regress an existing tracker,
+  // so the sync above is one-directional: states.yml is a floor, not a cap.
+  for (const [alias, canon] of [
+    ["evaluado", "EVALUATED"],
+    ["respondida", "RESPONDED"],
+    ["contestada", "RESPONDED"],
+    ["duplicado", "DISCARDED"],
+    ["repost", "DISCARDED"],
+  ]) {
+    assert.equal(canonStatus(alias), canon, `web-only alias ${alias} was dropped`);
+  }
+});
+
+test("empty and placeholder statuses are Discarded, not a crash", () => {
+  for (const blank of ["", "   ", "—", "-"]) assert.equal(canonStatus(blank), "DISCARDED");
+});
+
+// The drift test above feeds aliases exactly as states.yml spells them, which
+// is lowercase — so it cannot see a folding bug. A real tracker row is
+// capitalised, and that is where the Turkish dotted capital breaks: JS
+// lowercases "İ" to "i" + U+0307, so "İşe alındı" keys as "i̇şe alındı" and
+// misses the "işe alındı" entry however complete the map is.
+test("a capitalised status resolves, including Turkish dotted İ", () => {
+  for (const [input, canon] of [
+    ["İşe alındı", "HIRED"],
+    ["Mülakat", "INTERVIEW"],
+    ["Teklif", "OFFER"],
+    ["Değerlendirildi", "EVALUATED"],
+    ["Başvuruldu", "APPLIED"],
+    ["Uygun değil", "SKIP"],
+    ["Reddedildi", "REJECTED"],
+    ["Entrevista", "INTERVIEW"],
+  ]) {
+    assert.equal(canonStatus(input), canon, `${input} did not resolve to ${canon}`);
+  }
+});
+
+test("the İ fold does not reach other languages' dots", () => {
+  // Why the fold is NFKC and not NFD: NFD decomposes precomposed letters too,
+  // so stripping U+0307 afterwards would eat the dot of ż / ė / ġ and collapse
+  // these onto Zubr / Eme / Generali. None is a status, so each must simply
+  // pass through unrecognised rather than silently become a different word.
+  for (const name of ["Żubr", "Ėmė", "Ġenerali"]) {
+    assert.equal(canonStatus(name), name.toUpperCase(), `${name} was over-folded`);
+  }
+});
+
+test("a bolded alias resolves — AGENTS.md forbids bold, so it turns up", () => {
+  assert.equal(canonStatus("**Oferta**"), "OFFER");
+  assert.equal(canonStatus("**Mülakat**"), "INTERVIEW");
+});

--- a/weekly-digest.mjs
+++ b/weekly-digest.mjs
@@ -42,6 +42,10 @@ import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import * as yaml from 'js-yaml';
 
+// Only validateFlags: this module keeps its own flagValue (see below), so
+// importing the shared one too would shadow it.
+import { validateFlags } from './lib/cli-flags.mjs';
+
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_SESSIONS_DIR = join(CAREER_OPS, 'interview-prep', 'sessions');
 const DEFAULT_QUESTION_BANK_PATH = join(CAREER_OPS, 'interview-prep', 'question-bank.md');
@@ -650,8 +654,31 @@ async function runSelfTest() {
 
 // ── CLI ──────────────────────────────────────────────────────────────
 
+const KNOWN_FLAGS = ['--from', '--to', '--dir', '--summary', '--self-test', '--help', '-h'];
+const VALUE_FLAGS = ['--from', '--to', '--dir'];
+
+const USAGE = `Usage:
+  node weekly-digest.mjs                        # JSON digest for the current ISO week
+  node weekly-digest.mjs --summary              # human-readable roll-up
+  node weekly-digest.mjs --from <YYYY-MM-DD>    # start of the window
+  node weekly-digest.mjs --to <YYYY-MM-DD>      # end of the window
+  node weekly-digest.mjs --dir <path>           # a different interview-prep/sessions dir
+  node weekly-digest.mjs --self-test            # run the built-in fixtures
+  node weekly-digest.mjs --help                 # show this message
+
+Both bounds are optional; supplying one without the other is rejected rather
+than silently widened.`;
+
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const args = process.argv.slice(2);
+
+  // The script had no --help and no unrecognized-flag check at all, so a
+  // mistyped --dir was ignored and the digest silently rolled up
+  // interview-prep/sessions instead of the directory that was asked for —
+  // the same silent discard #2402 already fixed here for the `--from=` form
+  // (#2919). Inside the main-module guard so importers are unaffected.
+  validateFlags(args, KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS });
+
   if (args.includes('--self-test')) {
     await runSelfTest();
   }


### PR DESCRIPTION
## Summary
- Adds a new `quick` mode (`modes/quick.md`) that skips the full A-G evaluation pipeline and instead writes a short paragraph assessment.
- Scoring is binary: **5/5** if the role is US remote AND states a base salary of $200k+; **1/5** otherwise (either bar missed, or the JD leaves the fact unstated — fail closed rather than guessed).
- Reuses the existing liveness and blacklist gates from `oferta.md`/`auto-pipeline.md` before doing anything.
- Does **not** write to `data/applications.md` or emit a tracker-additions TSV, and skips the `## Machine Summary` YAML block — this mode is meant as a cheap pre-filter before a real `oferta`/`auto-pipeline` evaluation, and a tracker row would misrepresent it as a full evaluation to `merge-tracker.mjs`/`stats.mjs`. The report file is still saved under `reports/` using the same atomic numbering as `oferta`.
- Wires `quick` into the router: `argument-hint`, the mode routing table, the discovery menu, and the "standalone modes with profile/custom context" loading rules in `.agents/skills/career-ops/SKILL.md` (the source of truth — `.claude/skills/career-ops/SKILL.md` is a symlink to it).

## Test plan
- [ ] Run `/career-ops quick` (or the CLI-equivalent prompt) against a JD that is US remote + $200k+ base and confirm it produces a 5/5 paragraph report with no tracker write.
- [ ] Run it against a JD missing one or both bars and confirm it scores 1/5 and names which bar failed.
- [ ] Confirm the discovery menu (`/career-ops` with no args) shows the new `quick` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for detecting job postings embedded in same-origin frames.
  - Added consistent status normalization for dashboard data.
  - Added broader handling for accented company names and international text.
  - Web activity is now included in funnel calculations.

- **Bug Fixes**
  - Corrected local-date handling across time zones.
  - Improved job-title decoding for encoded characters.
  - Preserved numeric CV values during LaTeX generation.
  - Improved report URL recognition and portal matching.

- **Documentation**
  - Replaced one-command setup instructions with guided manual setup steps across translated guides.
  - Added prerequisite checks, configuration, browser setup, and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->