### PR TITLE
fix(set-status): --report cannot find a row on the customized layout merge-tracker just learned to read

### DIFF
--- a/set-status-tests.mjs
+++ b/set-status-tests.mjs
@@ -1351,5 +1351,68 @@ for (const bad of ['correction', 'backfill', 'cell-edit', 'nonsense']) {
   }
 }
 
+// ── #3075: --report resolves a report link kept in Notes ────────────────────
+// merge-tracker learned this layout in 8668ac1 — a customized tracker with no
+// dedicated Report column keeps the link in Notes prose. set-status read only
+// the Report cell, so --report could not find a row merge-tracker linked
+// happily, and the error even advised --row for the wrong reason.
+{
+  const CUSTOM = `# Applications Tracker
+
+| # | Date | Company | Role | Score | Status | Materials | Apply Link | Follow-up | Notes |
+|---|------|---------|------|-------|--------|-----------|------------|-----------|-------|
+| 7 | 2026-06-01 | Acme | Staff Eng | 4.2/5 | Applied | CV v3 | https://acme.example/jobs/7 | 2026-06-14 | strong fit; report [12](reports/012-acme-2026-06-01.md) |
+`;
+
+  {
+    const sb = makeSandbox(CUSTOM);
+    try {
+      const r = runSetStatus(['--report', '12', 'Interview', '--dry-run'], sb);
+      if (r.code === 0) pass('#3075: --report resolves a report link kept in the Notes cell');
+      else fail(`#3075: --report 12 failed on a custom layout (code=${r.code}) ${(r.stderr || r.stdout).split('\n')[0]}`);
+    } finally { rmSync(sb.dir, { recursive: true, force: true }); }
+  }
+
+  // MUST NOT CHANGE: a report nobody links is still not found. Without this,
+  // making the lookup match anything would pass the assertion above.
+  {
+    const sb = makeSandbox(CUSTOM);
+    try {
+      const r = runSetStatus(['--report', '99', 'Interview', '--dry-run'], sb);
+      if (r.code !== 0) pass('#3075: an unlinked report number is still not found');
+      else fail('#3075: --report 99 resolved a row nothing links');
+    } finally { rmSync(sb.dir, { recursive: true, force: true }); }
+  }
+
+  // MUST NOT CHANGE: Notes is prose, so the fallback is scoped to reports/.
+  // A job-posting URL and an unrelated markdown link both sit in Notes here.
+  {
+    const NOISY = CUSTOM.replace(
+      'strong fit; report [12](reports/012-acme-2026-06-01.md)',
+      'applied via https://acme.example/jobs/9 — see [9](../notes/9-thing.md)',
+    );
+    const sb = makeSandbox(NOISY);
+    try {
+      const r = runSetStatus(['--report', '9', 'Interview', '--dry-run'], sb);
+      if (r.code !== 0) pass('#3075: a non-report link in Notes does not claim a report number');
+      else fail('#3075: --report 9 matched a non-report markdown link in Notes');
+    } finally { rmSync(sb.dir, { recursive: true, force: true }); }
+  }
+
+  // MUST NOT CHANGE: a real Report cell still wins over anything in Notes.
+  {
+    const CONFLICT = TRACKER_9.replace(
+      '| 2 | 2026-06-02 | Globex | Platform Engineer | 4.0/5 | Evaluated | ✅ | [2](../reports/002-globex-2026-06-02.md) | — |',
+      '| 2 | 2026-06-02 | Globex | Platform Engineer | 4.0/5 | Evaluated | ✅ | [2](../reports/002-globex-2026-06-02.md) | also [77](reports/077-other.md) |',
+    );
+    const sb = makeSandbox(CONFLICT);
+    try {
+      const r = runSetStatus(['--report', '77', 'Interview', '--dry-run'], sb);
+      if (r.code !== 0) pass('#3075: Notes is a fallback only — a populated Report cell wins');
+      else fail('#3075: a Notes link overrode a populated Report cell');
+    } finally { rmSync(sb.dir, { recursive: true, force: true }); }
+  }
+}
+
 console.log(`\n${passed} passed, ${failed} failed`);
 process.exit(failed > 0 ? 1 : 0);

--- a/set-status.mjs
+++ b/set-status.mjs
@@ -320,7 +320,7 @@ function resolveRow(rows) {
   if (flags.report !== null) {
     const num = parseInt(flags.report, 10);
     return resolveCandidates(
-      rows.filter(r => extractTrackerReportNumbers(r.report).includes(num)),
+      rows.filter(r => extractTrackerReportNumbers(r.report, r.notes).includes(num)),
       {
         notFound: `No tracker row links report #${num}. (Report IDs and tracker row IDs differ — ` +
           'use --row N to select by tracker #.)',
@@ -399,7 +399,7 @@ const target = resolveRow(rows);
 // teaches callers to pass --force, which disables it everywhere including the
 // cases it was written for.
 if (isBareNumericSelector && !flags.force) {
-  const reportNums = extractTrackerReportNumbers(target.report);
+  const reportNums = extractTrackerReportNumbers(target.report, target.notes);
   const mismatched = reportNums.filter(num => num !== target.num);
   if (mismatched.length > 0) {
     failWith(
@@ -425,7 +425,7 @@ if (isBareNumericSelector && !flags.force) {
   // not see. Bare "#N" then names two applications at once and must not write.
   if (reportNums.length === 0) {
     const num = parseInt(selector, 10);
-    const linkers = rows.filter(r => r !== target && extractTrackerReportNumbers(r.report).includes(num));
+    const linkers = rows.filter(r => r !== target && extractTrackerReportNumbers(r.report, r.notes).includes(num));
     if (linkers.length > 0) {
       const listing = linkers.map(r => `#${r.num}\t${r.company}\t${r.role}`).join('\n');
       failWith(

--- a/tracker-parse.mjs
+++ b/tracker-parse.mjs
@@ -304,9 +304,9 @@ function parseMarkdownLinks(value) {
   return links;
 }
 
-export function extractTrackerReportNumbers(reportCell) {
+export function extractTrackerReportNumbers(reportCell, notesCell = '') {
   const value = String(reportCell ?? '').trim();
-  if (!value || value === '-' || value === '—') return [];
+  if (!value || value === '-' || value === '—') return scanNotesForReportNumbers(notesCell);
 
   const numbers = new Set();
   const numberFromTarget = (rawTarget) => {
@@ -335,6 +335,48 @@ export function extractTrackerReportNumbers(reportCell) {
   if (markdownLinks.length === 0) {
     const pathNum = numberFromTarget(value);
     if (pathNum != null) numbers.add(pathNum);
+  }
+  // A layout with a Report column that simply has no link yet still falls back
+  // to Notes, so a customized tracker behaves the same whether its Report cell
+  // is absent or empty.
+  return numbers.size > 0 ? [...numbers] : scanNotesForReportNumbers(notesCell);
+}
+
+/**
+ * Report numbers named by a report link inside a free-form Notes cell.
+ *
+ * Customized trackers with no dedicated Report column embed the link in Notes
+ * prose instead — the layout merge-tracker.mjs learned to read in 8668ac1, via
+ * its own `extractReportNum(reportStr, notesStr)`. set-status.mjs read only the
+ * Report cell, so `--report N` could not find a row merge-tracker had linked
+ * happily (#3075).
+ *
+ * DELIBERATELY STRICTER than the Report-cell scan above, which is the same
+ * scoping merge-tracker applies. The Report cell holds a report link by
+ * contract, so a loose match there is safe; Notes is prose, and a link like
+ * `[9](../notes/9-thing.md)` satisfies the generic `N-*.md` shape without being
+ * a report at all. Requiring a `reports/` path segment is what keeps an
+ * unrelated markdown link — or a job-posting URL in the same sentence — from
+ * claiming to be a report number.
+ *
+ * @param {string} [notesCell] - Free-form Notes cell.
+ * @returns {number[]} Report numbers, or [] when the cell names none.
+ */
+function scanNotesForReportNumbers(notesCell) {
+  const notes = String(notesCell ?? '').trim();
+  if (!notes) return [];
+  const numbers = new Set();
+  for (const link of parseMarkdownLinks(notes)) {
+    const target = String(link.target).trim().replace(/^<|>$/g, '');
+    // Absolute URLs are never a local report path, and a posting URL is the
+    // most likely thing to sit next to a report link in the same note.
+    if (/^(?:[a-z][a-z\d+.-]*:|\/\/)/i.test(target)) continue;
+    const pathname = target.split(/[?#]/, 1)[0];
+    if (!/(?:^|[\\/])reports[\\/]/i.test(pathname)) continue;
+    const match = pathname.match(/(?:^|[\\/])reports[\\/]0*(\d+)-/i);
+    if (!match) continue;
+    const num = parseInt(match[1], 10);
+    if (Number.isInteger(num) && num > 0) numbers.add(num);
   }
   return [...numbers];
 }


### PR DESCRIPTION
Fixes #3075.

8668ac1 taught `merge-tracker` that a customized tracker with no dedicated Report column keeps its report link in **Notes** prose. `set-status.mjs` — the canonical write path — was not taught the same thing, so on exactly the layout that fix added support for, `--report N` fails on a row merge-tracker links happily.

```
| # | Date | Company | Role | Score | Status | Materials | Apply Link | Follow-up | Notes |
| 7 | 2026-06-01 | Acme | Staff Eng | 4.2/5 | Applied | CV v3 | https://acme.example/jobs/7 | 2026-06-14 | strong fit; report [12](reports/012-acme-2026-06-01.md) |
```

```
$ node set-status.mjs --report 12 Interview --dry-run
❌ No tracker row links report #12. (Report IDs and tracker row IDs differ — use --row N to select by tracker #.)

$ node set-status.mjs --row 7 Interview --dry-run
✅ #7 Acme — Staff Eng: would set Applied → Interview
```

The row is fine; only the `--report` lookup cannot see it. The error is misleading on top of being wrong — it blames the row/report counter divergence, when the real reason is that this layout keeps its link somewhere `set-status` never reads.

## Not a missing capability, an unpassed argument

`extractTrackerReportNumbers` already finds it when handed the text. All three call sites now pass the Notes cell, so both readers share one function instead of each carrying its own idea of where a report link lives.

## The part worth reviewing

Notes is **free-form prose**, so the fallback has to be scoped — which is why merge-tracker's own pattern requires a literal `reports/`. Handing the current matcher raw Notes is slightly too loose. Measured:

```
'applied via https://acme.example/jobs/7'      -> []    ✔ absolute URLs already rejected
'req JR-10423; also mentioned #99 in passing'  -> []    ✔
'#154 Sr PM is already live in the same ATS'   -> []    ✔
'see [9](../notes/9-thing.md)'                 -> [9]   ✘ not a report
```

That last case is harmless for the Report *cell*, which holds a report link by contract, and wrong for prose. So the new notes scan requires a `reports/` path segment: an unrelated markdown link, or a posting URL in the same sentence, cannot claim to be a report number.

Notes is a **fallback only** — a Report cell that yields a number is never overridden. An *empty* Report cell also falls through, so a customized tracker behaves the same whether its Report column is absent or merely blank.

## Verification

Three of the four new assertions pin what must **not** change, because a lookup that matched more freely would satisfy the fix while breaking the guard rails:

- an unlinked report number is still not found
- a non-report markdown link in Notes does not claim a number
- a populated Report cell still wins over Notes

Checked for discrimination: with `tracker-parse.mjs` and `set-status.mjs` reverted, **exactly the custom-layout assertion fails** and the three guards pass.

`set-status-tests.mjs`: 96 passed / 0 failed. `node test-all.mjs --quick`: 4318 pass / 0 fail (3 warnings pre-existing and environmental).

## Follow-up, deliberately not here

Converging `merge-tracker`'s own `extractReportNum` onto the shared function is the obvious next step. Its report-cell branch is looser (`/\[(\d+)\]/`, no target validation), so unifying that is a behaviour change on a separate path — better on its own than mixed into this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved report detection when report links are stored in tracker notes instead of a dedicated report field.
  * Ignored unrelated external URLs and markdown links during report matching.
  * Preserved dedicated report-field precedence when conflicting links appear in notes.
  * Prevented unlinked report numbers from being incorrectly resolved.

* **Tests**
  * Added regression coverage for report resolution, fallback behavior, link filtering, and precedence rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->