### PR TITLE
fix(web-pipeline): first_seen was stamped with the UTC day, not the local one — the web/ site #3071 doesn't reach (#3070)

### DIFF
--- a/web/src/lib/core/pipeline.ts
+++ b/web/src/lib/core/pipeline.ts
@@ -51,7 +51,10 @@ process.stdin.on("data", (d) => { input += d; });
 process.stdin.on("end", async () => {
   try {
     const offers = JSON.parse(input);
-    const date = new Date().toISOString().slice(0, 10);
+    // LOCAL calendar day, not the UTC one — west of Greenwich, an evening
+    // add would otherwise stamp scan-history.tsv's first_seen a day ahead,
+    // opening scan.mjs's recheck/cooldown gate a day late for this row (#3070).
+    const date = localToday();
     await appendToPipeline(offers);
     await appendToScanHistory(offers, date, "added");
     process.stdout.write(JSON.stringify({ added: offers.length }));

--- a/web/src/lib/core/pipeline.ts
+++ b/web/src/lib/core/pipeline.ts
@@ -41,8 +41,10 @@ export function addOffersToPipeline(offers: DiscoveredOffer[]): Promise<AddResul
   }
 
   const scanUrl = pathToFileURL(rootScript("scan")).href;
+  const localTodayUrl = pathToFileURL(path.join(careerOpsRoot(), "lib", "local-today.mjs")).href;
   const code = `
 import { appendToPipeline, appendToScanHistory } from ${JSON.stringify(scanUrl)};
+import { localToday } from ${JSON.stringify(localTodayUrl)};
 let input = "";
 process.stdin.setEncoding("utf8");
 process.stdin.on("data", (d) => { input += d; });

--- a/web/src/lib/core/pipeline.ts
+++ b/web/src/lib/core/pipeline.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import fs from "node:fs";
+import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { careerOpsRoot, rootScript } from "@/lib/career-ops";
 import type { DiscoveredOffer } from "./scan";

--- a/web/tests/lib/pipeline-local-today.test.mjs
+++ b/web/tests/lib/pipeline-local-today.test.mjs
@@ -1,0 +1,85 @@
+// Guards the date computed by the child-process snippet in
+// src/lib/core/pipeline.ts (`addOffersToPipeline`) — the "Add to pipeline"
+// writer that stamps data/scan-history.tsv's first_seen column (#3070).
+//
+// `new Date().toISOString().slice(0, 10)` is the UTC day. West of Greenwich,
+// an evening "Add to pipeline" click stamped first_seen one day ahead of the
+// user's own clock, so scan.mjs's shouldDedupScanHistoryRow recheck/cooldown
+// window opened a day late for that row. #3071 fixed the same pattern in six
+// core .mjs call sites (including scan.mjs's own DEFAULT for this argument),
+// but pipeline.ts always passes an explicit `date` argument, which overrides
+// that default — so this call site needed its own fix and its own guard.
+//
+// pipeline.ts is TypeScript, imports via the `@/` path alias (which plain
+// `node --test` cannot resolve without the Next.js build), and computes the
+// date inside a template-literal string executed in a SEPARATE spawned
+// process — so, same as tests/lib/core-writer-await.test.mjs, it cannot be
+// imported and exercised here. This reads the source and asserts the shape.
+// The fix itself was verified by execution in a frozen-clock scratch child
+// (see the PR description) before this guard was written.
+//
+// Run (from web/, as `npm test` does):  node --test tests/lib/pipeline-local-today.test.mjs
+// From the repo root:                   node --test web/tests/lib/pipeline-local-today.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const SRC = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "src", "lib", "core", "pipeline.ts");
+const src = readFileSync(SRC, "utf8");
+
+// The generated child-process code lives inside the backtick template
+// assigned to `code`. Isolating it keeps the assertions below from also
+// matching an unrelated `new Date()` elsewhere in the (TypeScript) file.
+function extractChildProcessCode() {
+  const m = src.match(/const code = `([\s\S]*?)`;/);
+  assert.ok(m, `${SRC}: could not find the \`const code = \`...\`;\` template — the writer snippet was restructured. Update this extractor.`);
+  return m[1];
+}
+
+test("the child-process snippet still exists at the shape this test extracts", () => {
+  assert.ok(extractChildProcessCode().length > 0);
+});
+
+test("the legacy UTC-day pattern is gone from the child-process snippet", () => {
+  const code = extractChildProcessCode();
+  assert.doesNotMatch(
+    code,
+    /new Date\(\)\.toISOString\(\)\.slice\(0,\s*10\)/,
+    `${SRC}: the child-process snippet resolves "today" with the UTC day again. ` +
+      `West of Greenwich this stamps scan-history.tsv's first_seen a day ahead of the ` +
+      `user's own clock (#3070) — use localToday() from lib/local-today.mjs instead.`,
+  );
+});
+
+test("the date handed to appendToScanHistory comes from localToday()", () => {
+  const code = extractChildProcessCode();
+  assert.match(
+    code,
+    /const\s+date\s*=\s*localToday\(\)\s*;/,
+    `${SRC}: expected \`const date = localToday();\` in the child-process snippet.`,
+  );
+});
+
+test("localToday is imported into the spawned child from lib/local-today.mjs", () => {
+  const code = extractChildProcessCode();
+  assert.match(
+    code,
+    /import\s*{\s*localToday\s*}\s*from\s+\$\{JSON\.stringify\(localTodayUrl\)\}\s*;/,
+    `${SRC}: the child process resolves imports independently of the TypeScript module's own ` +
+      `cwd, so localToday must be imported via an interpolated absolute file:// URL — the same ` +
+      `pattern already used for scanUrl — not a bare relative specifier that would only resolve ` +
+      `by coincidence of the spawn's cwd.`,
+  );
+});
+
+test("localTodayUrl is built the same way scanUrl is: an absolute file:// URL under careerOpsRoot()", () => {
+  assert.match(
+    src,
+    /const localTodayUrl = pathToFileURL\(path\.join\(careerOpsRoot\(\),\s*["']lib["'],\s*["']local-today\.mjs["']\)\)\.href;/,
+    `${SRC}: localTodayUrl must resolve lib/local-today.mjs under careerOpsRoot(), so the import ` +
+      `works regardless of the checkout the web dashboard is pointed at.`,
+  );
+});

--- a/web/tests/lib/pipeline-local-today.test.mjs
+++ b/web/tests/lib/pipeline-local-today.test.mjs
@@ -61,6 +61,16 @@ test("the date handed to appendToScanHistory comes from localToday()", () => {
     /const\s+date\s*=\s*localToday\(\)\s*;/,
     `${SRC}: expected \`const date = localToday();\` in the child-process snippet.`,
   );
+  // The assertion above only proves `date` is ASSIGNED from localToday() — not
+  // that the call site actually passes it on. A rename at the call (e.g. back
+  // to an inline `new Date()...`, or a stray second variable) would leave the
+  // `date` assignment unused and this bug's actual symptom would resurface.
+  assert.match(
+    code,
+    /appendToScanHistory\(\s*offers\s*,\s*date\s*,\s*["']added["']\s*\)/,
+    `${SRC}: expected appendToScanHistory(offers, date, "added") — the local-day ` +
+      `value must reach the writer, not just get computed and discarded.`,
+  );
 });
 
 test("localToday is imported into the spawned child from lib/local-today.mjs", () => {


### PR DESCRIPTION
#3070/#3071 catalog and fix six core `.mjs` call sites that resolve "today" as the UTC calendar day instead of the local one — each one *gates a decision* rather than merely stamping a filename, per that issue's own scope line.

There is a seventh site, in `web/`, that the audit didn't reach: `web/src/lib/core/pipeline.ts`'s "Add to pipeline" writer (`addOffersToPipeline`). It spawns a short-lived child process that calls the core's own `appendToScanHistory(offers, date, "added")`, and computes `date` itself with `new Date().toISOString().slice(0, 10)`.

**Why #3071 doesn't cover this.** #3071 fixes `scan.mjs`'s *default* for this same parameter. `pipeline.ts` always passes an explicit `date` argument, which overrides the default — so the core fix lands and this call site is still wrong.

**Impact.** West of Greenwich, an evening "Add to pipeline" click in the web dashboard stamps `data/scan-history.tsv`'s `first_seen` one calendar day ahead of the user's own clock. That date then drives `scan.mjs`'s `shouldDedupScanHistoryRow` recheck/cooldown window for that row — same mechanism, same consequence #3070 describes for the core sites, just reached from the web UI instead of a CLI scan.

**Verified by execution**, not reasoning — frozen clock at `2026-08-18T01:30:00Z` under `TZ=America/New_York` (same instant #3070/#3071 use):

```
before: new Date().toISOString().slice(0, 10)  -> 2026-08-18  (UTC day — tomorrow, from here)
after:  localToday()                           -> 2026-08-17  (correct local day)
```

**The fix** imports `lib/local-today.mjs`'s `localToday()` into the spawned child the same way `scanUrl` is already injected — an absolute `file://` URL built from `careerOpsRoot()`, since the child resolves imports independently of any relative path — and uses it in place of the UTC computation. Three-commit shape: wire the import, flip the one line, then the test.

**Test.** `pipeline.ts` is TypeScript, imports via the `@/` alias (unresolvable by plain `node --test`), and computes the date inside a template-literal string executed in a *separate* spawned process — so, same reasoning already documented in `tests/lib/core-writer-await.test.mjs`, it can't be imported and exercised directly from a test. `web/tests/lib/pipeline-local-today.test.mjs` follows that same source-text-extraction convention: it isolates the child-process template, asserts the legacy UTC pattern is gone, and asserts `localToday()` is both called and imported via the expected absolute-URL pattern. Confirmed the extractor's UTC-pattern regex matches the pre-fix line, so it would have caught this regression.

Full suite: `node test-all.mjs` — 4321 passed / 0 failed (2 pre-existing, unrelated warnings: the Go dashboard build skip and a PII-heuristic false positive on santifer.io in untouched Go source). `web`: `npm test` 269/269, `npm run typecheck` clean.

## Test plan
- [x] `node test-all.mjs` — 4321 passed, 0 failed
- [x] `cd web && npm test` — 269 passed, 0 failed
- [x] `cd web && npm run typecheck` — clean
- [x] Fix verified by execution under a frozen clock (`TZ=America/New_York`, instant `2026-08-18T01:30:00Z`) before writing the regression test
- [x] New test confirmed to catch the pre-fix line (regex matches the old source text)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scan history now records the correct local calendar date instead of potentially using the previous or next day due to UTC conversion.

* **Tests**
  * Added regression coverage to verify local-date handling remains correct when recording scan history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->