### PR TITLE
fix(web-explore): canon() discarded the entire query string, silently collapsing distinct postings into one dedup key

### DIFF
--- a/web/src/lib/core/url-key.mjs
+++ b/web/src/lib/core/url-key.mjs
@@ -1,0 +1,79 @@
+/**
+ * Canonical posting-URL key — algorithm mirror of the core's `normalizeUrl`
+ * in url-key.mjs (root).
+ *
+ * Plain .mjs (same pattern as normalize-text-key.mjs) so node:test and client
+ * bundles can import it without a TS runner or Node-only deps — this file has
+ * none, same as the core it mirrors (only the global `URL`).
+ *
+ * WHY A COPY EXISTS AT ALL: the live core lives in the user's career-ops
+ * checkout and is resolved at runtime via careerOpsRoot() — unavailable to the
+ * client bundle. Unlike normalize-text-key.mjs's split (a Node-only live
+ * loader server-side, this mirror client-side), the URL key here is used to
+ * build ONE Set server-side (assembleDedupContext, from data/scan-history.tsv)
+ * that the CLIENT then does membership lookups against on each AI-streamed
+ * offer (explore-ai.ts's canon()). Server and client MUST key with the exact
+ * same function or `known.has(key)` silently stops matching anything — so both
+ * sides import this one mirror rather than the server preferring a live-loaded
+ * copy that could drift from what the client bundle was built with.
+ *
+ * Keep the body byte-for-byte aligned with url-key.mjs `normalizeUrl`. The
+ * parity test in tests/lib/url-key.test.mjs fails the build if they drift.
+ *
+ * UNDER-STRIP ON PURPOSE (see the root file's docstring for the full RFC 3986
+ * rationale). Never add path/query lowercasing or a broader strip list here:
+ * that is exactly the over-normalization that collapsed two different
+ * Greenhouse postings (same host+path, distinct `?gh_jid=`) into one dedup
+ * key and silently dropped every opening after the first at that employer —
+ * the bug this mirror exists to stop reintroducing.
+ */
+
+// Query params that identify a click/campaign, never the posting itself. Keep
+// this list literal and board-specific, identical to the core's denylist.
+const TRACKING_PARAMS = [
+  /^utm_/i, /^gh_src$/i, /^fbclid$/i, /^gclid$/i,
+  /^mc_cid$/i, /^mc_eid$/i, /^igshid$/i, /^_hsenc$/i, /^_hsmi$/i, /^trk$/i, /^trackingid$/i,
+];
+
+/**
+ * Reduce a posting URL to a stable comparison key.
+ *
+ * @param {string} raw - A posting URL (or any string).
+ * @returns {string} A normalized key, or '' when there is nothing to key on.
+ *   '' means NO KEY — callers must treat it as unknown, never as a value that
+ *   can match another ''.
+ */
+export function normalizeUrl(raw) {
+  if (typeof raw !== "string") return "";
+  const s = raw.trim();
+  if (!s) return "";
+
+  let u;
+  try {
+    u = new URL(s);
+  } catch {
+    return "";
+  }
+
+  if (u.protocol !== "http:" && u.protocol !== "https:") return "";
+
+  u.protocol = "https:";
+  u.hostname = u.hostname.toLowerCase();
+  u.hash = "";
+
+  const keep = [];
+  for (const [k, v] of u.searchParams.entries()) {
+    if (!TRACKING_PARAMS.some((re) => re.test(k))) keep.push([k, v]);
+  }
+  keep.sort((x, y) => (x[0] !== y[0] ? (x[0] < y[0] ? -1 : 1) : (x[1] < y[1] ? -1 : x[1] > y[1] ? 1 : 0)));
+  u.search = "";
+  for (const [k, v] of keep) u.searchParams.append(k, v);
+
+  if (u.pathname.length > 1 && u.pathname.endsWith("/")) {
+    u.pathname = u.pathname.slice(0, -1);
+  }
+
+  return u.toString();
+}
+
+export default normalizeUrl;

--- a/web/src/lib/explore-ai.ts
+++ b/web/src/lib/explore-ai.ts
@@ -6,6 +6,7 @@
 
 import type { DiscoveredOffer } from "./explore";
 import { pendingOpenerLen } from "./stream-parse.mjs";
+import { normalizeUrl } from "./core/url-key.mjs";
 
 const OPEN = "<<offer:";
 const CLOSE = ">>";
@@ -15,14 +16,19 @@ export type AiTraceChunk =
   | { kind: "narration"; text: string }
   | { kind: "malformed"; raw: string };
 
-/** Normalize a URL for dedup: host+path, lowercased, no query/fragment/trailing slash. */
+/**
+ * Normalize a URL for dedup. Delegates to the parity-tested normalizeUrl
+ * mirror (url-key.mjs) instead of host+pathname — a bare host+path key
+ * discarded the query string unconditionally, so two DIFFERENT postings that
+ * share a path and differ only by a functional query id (e.g. Greenhouse's
+ * `?gh_jid=`) collapsed onto one key and every opening after the first at
+ * that host+path was silently dropped from AI Discover results.
+ *
+ * Can return '' for an unparseable / non-http(s) input — callers must treat
+ * that as NO KEY, never as a value that matches another ''.
+ */
 export function canon(u: string): string {
-  try {
-    const x = new URL(u);
-    return (x.host + x.pathname).toLowerCase().replace(/\/$/, "");
-  } catch {
-    return u.toLowerCase().replace(/[?#].*$/, "").replace(/\/$/, "");
-  }
+  return normalizeUrl(u);
 }
 
 function toOffer(raw: unknown): DiscoveredOffer | null {

--- a/web/src/lib/explore-ai.ts
+++ b/web/src/lib/explore-ai.ts
@@ -97,8 +97,10 @@ export function makeAiStreamParser(opts?: { knownUrls?: Set<string> }) {
           continue;
         }
         const key = canon(offer.url);
-        if (seen.has(key) || known.has(key)) continue; // intra-run + known dedup
-        seen.add(key);
+        // '' means NO KEY (an unparseable-but-regex-passing url) — never treat
+        // two such offers as duplicates of EACH OTHER just because both are ''.
+        if (key && (seen.has(key) || known.has(key))) continue; // intra-run + known dedup
+        if (key) seen.add(key);
         out.push({ kind: "offer", offer });
       }
       return out;

--- a/web/tests/lib/explore-ai-dedup.test.mjs
+++ b/web/tests/lib/explore-ai-dedup.test.mjs
@@ -1,0 +1,57 @@
+// Executes the REAL makeAiStreamParser / canon() from explore-ai.ts — the file
+// has no `@/` alias imports and no Node-only deps ("Client-safe (NO node
+// imports)" per its own header), so unlike pipeline.ts it can be imported
+// directly here rather than needing source-text extraction.
+//
+// Covers the silent-drop bug: canon() used to key on host+pathname only,
+// discarding the query string, so two DIFFERENT Greenhouse postings sharing a
+// path (distinct only by `?gh_jid=`) collapsed onto one dedup key and every
+// opening after the first was silently absent from AI Discover results.
+//
+// Run:  node --test tests/lib/explore-ai-dedup.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { makeAiStreamParser, canon } from "../../src/lib/explore-ai.ts";
+
+const envelope = (offer) => `<<offer:${JSON.stringify(offer)}>>`;
+
+test("two distinct postings that share host+path but differ by a functional query id are BOTH kept", () => {
+  const parser = makeAiStreamParser();
+  const jobA = "https://boards.greenhouse.io/acme/jobs/apply?gh_jid=4471829005";
+  const jobB = "https://boards.greenhouse.io/acme/jobs/apply?gh_jid=5501203417";
+  const chunks = [
+    ...parser.feed(envelope({ url: jobA, company: "Acme", title: "Backend Engineer" })),
+    ...parser.feed(envelope({ url: jobB, company: "Acme", title: "Frontend Engineer" })),
+  ];
+  const offers = chunks.filter((c) => c.kind === "offer");
+  assert.equal(offers.length, 2, "the second, genuinely different posting was silently dropped");
+  assert.equal(offers[0].offer.url, jobA);
+  assert.equal(offers[1].offer.url, jobB);
+});
+
+test("a TRUE duplicate (same posting, tracking param added) is still deduped within a run", () => {
+  const parser = makeAiStreamParser();
+  const base = "https://boards.greenhouse.io/acme/jobs/apply?gh_jid=4471829005";
+  const tracked = base + "&utm_source=linkedin";
+  const chunks = [
+    ...parser.feed(envelope({ url: base, company: "Acme", title: "Backend Engineer" })),
+    ...parser.feed(envelope({ url: tracked, company: "Acme", title: "Backend Engineer" })),
+  ];
+  const offers = chunks.filter((c) => c.kind === "offer");
+  assert.equal(offers.length, 1, "the same posting with a tracking param appended should dedup, not double-post");
+});
+
+test("knownUrls filters an already-seen posting by its exact gh_jid, not by host+path alone", () => {
+  const known = new Set([canon("https://boards.greenhouse.io/acme/jobs/apply?gh_jid=4471829005")]);
+  const parser = makeAiStreamParser({ knownUrls: known });
+  const sameJob = "https://boards.greenhouse.io/acme/jobs/apply?gh_jid=4471829005";
+  const differentJob = "https://boards.greenhouse.io/acme/jobs/apply?gh_jid=9999999999";
+  const chunks = [
+    ...parser.feed(envelope({ url: sameJob, company: "Acme", title: "Already known" })),
+    ...parser.feed(envelope({ url: differentJob, company: "Acme", title: "New opening" })),
+  ];
+  const offers = chunks.filter((c) => c.kind === "offer");
+  assert.equal(offers.length, 1, "a genuinely new posting at the same host+path was filtered as if already known");
+  assert.equal(offers[0].offer.url, differentJob);
+});

--- a/web/tests/lib/explore-ai-dedup.test.mjs
+++ b/web/tests/lib/explore-ai-dedup.test.mjs
@@ -55,3 +55,24 @@ test("knownUrls filters an already-seen posting by its exact gh_jid, not by host
   assert.equal(offers.length, 1, "a genuinely new posting at the same host+path was filtered as if already known");
   assert.equal(offers[0].offer.url, differentJob);
 });
+
+test("two scheme-valid but URL-unparseable offers BOTH survive — an empty key must not dedup against itself", () => {
+  // Both pass toOffer()'s /^https?:\/\// gate (so they reach canon()) but throw
+  // in `new URL(...)`, so canon() returns '' for each. Without the `key &&`
+  // guard, the second offer's '' would match the first's '' in `seen` and get
+  // silently dropped — two UNRELATED malformed entries treated as duplicates
+  // of each other purely because neither could be keyed.
+  const parser = makeAiStreamParser();
+  const unparseableA = "https://[bad";
+  const unparseableB = "http:// space.example.com";
+  assert.equal(canon(unparseableA), "", "test premise: A must canonicalize to the empty key");
+  assert.equal(canon(unparseableB), "", "test premise: B must canonicalize to the empty key");
+  const chunks = [
+    ...parser.feed(envelope({ url: unparseableA, company: "Acme", title: "Role A" })),
+    ...parser.feed(envelope({ url: unparseableB, company: "Acme", title: "Role B" })),
+  ];
+  const offers = chunks.filter((c) => c.kind === "offer");
+  assert.equal(offers.length, 2, "an empty canonical key deduped against another empty key");
+  assert.equal(offers[0].offer.url, unparseableA);
+  assert.equal(offers[1].offer.url, unparseableB);
+});

--- a/web/tests/lib/url-key.test.mjs
+++ b/web/tests/lib/url-key.test.mjs
@@ -1,0 +1,62 @@
+// Parity + regression tests for the web's normalizeUrl (posting-key) mirror.
+// Imports the core and the web copy side-by-side so they can never drift, same
+// pattern as normalize-text-key.test.mjs (#2369/#2666).
+//
+// Run:  node --test tests/lib/url-key.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { pathToFileURL } from "node:url";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { normalizeUrl as webKey } from "../../src/lib/core/url-key.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const { normalizeUrl: coreKey } = await import(pathToFileURL(join(ROOT, "url-key.mjs")).href);
+
+test("web mirror matches core on ordinary postings (https upgrade, hostname lowercase, trailing slash)", () => {
+  const CASES = [
+    "http://Boards.Greenhouse.io/acme/jobs/apply",
+    "https://boards.greenhouse.io/acme/jobs/apply/",
+    "https://jobs.example.com/role#applyNow",
+  ];
+  for (const input of CASES) {
+    assert.equal(webKey(input), coreKey(input), `parity: ${input}`);
+  }
+});
+
+test("web mirror strips the same tracking-param denylist as core, in the same sorted order", () => {
+  const url = "https://boards.greenhouse.io/acme/jobs/apply?utm_source=li&gh_jid=4471829005&fbclid=xyz";
+  assert.equal(
+    webKey(url),
+    "https://boards.greenhouse.io/acme/jobs/apply?gh_jid=4471829005",
+  );
+  assert.equal(webKey(url), coreKey(url));
+});
+
+test("the reported bug: two DIFFERENT Greenhouse postings (same host+path, distinct gh_jid) key DIFFERENTLY", () => {
+  const jobA = "https://boards.greenhouse.io/acme/jobs/apply?gh_jid=4471829005";
+  const jobB = "https://boards.greenhouse.io/acme/jobs/apply?gh_jid=5501203417";
+  assert.notEqual(webKey(jobA), webKey(jobB), "two distinct openings collapsed to one dedup key");
+  assert.equal(webKey(jobA), coreKey(jobA));
+  assert.equal(webKey(jobB), coreKey(jobB));
+});
+
+test("host+pathname-only shape must not return (regression lock on the pre-fix canon())", () => {
+  // The pre-fix canon() discarded the ENTIRE query string, so both of these
+  // collapsed to "boards.greenhouse.io/acme/jobs/apply". If that shape comes
+  // back, this fails loudly.
+  const jobA = "https://boards.greenhouse.io/acme/jobs/apply?gh_jid=4471829005";
+  const jobB = "https://boards.greenhouse.io/acme/jobs/apply?gh_jid=5501203417";
+  assert.notEqual(webKey(jobA), "boards.greenhouse.io/acme/jobs/apply");
+  assert.notEqual(webKey(jobB), "boards.greenhouse.io/acme/jobs/apply");
+});
+
+test("unparseable / non-http(s) input keys to '' on both sides (NO KEY IS NOT A KEY)", () => {
+  for (const bad of ["not a url", "ftp://example.com/x", "", "   "]) {
+    assert.equal(webKey(bad), "", `web: ${JSON.stringify(bad)}`);
+    assert.equal(coreKey(bad), "", `core: ${JSON.stringify(bad)}`);
+  }
+  assert.equal(webKey(null), "");
+  assert.equal(webKey(undefined), "");
+});

--- a/web/tests/lib/url-key.test.mjs
+++ b/web/tests/lib/url-key.test.mjs
@@ -34,6 +34,18 @@ test("web mirror strips the same tracking-param denylist as core, in the same so
   assert.equal(webKey(url), coreKey(url));
 });
 
+test("two RETAINED (non-tracking) params in opposite input order sort to the same key, on both sides", () => {
+  // A single retained param (the test above) never exercises keep.sort() —
+  // there is nothing to order. This pins order-independence with two.
+  const orderA = "https://boards.greenhouse.io/acme/jobs/apply?location=paris&gh_jid=4471829005&utm_source=li";
+  const orderB = "https://boards.greenhouse.io/acme/jobs/apply?utm_source=li&gh_jid=4471829005&location=paris";
+  const expected = "https://boards.greenhouse.io/acme/jobs/apply?gh_jid=4471829005&location=paris";
+  assert.equal(webKey(orderA), expected);
+  assert.equal(webKey(orderB), expected, "opposite input order must sort to the identical key");
+  assert.equal(webKey(orderA), coreKey(orderA));
+  assert.equal(webKey(orderB), coreKey(orderB));
+});
+
 test("the reported bug: two DIFFERENT Greenhouse postings (same host+path, distinct gh_jid) key DIFFERENTLY", () => {
   const jobA = "https://boards.greenhouse.io/acme/jobs/apply?gh_jid=4471829005";
   const jobB = "https://boards.greenhouse.io/acme/jobs/apply?gh_jid=5501203417";


### PR DESCRIPTION
`web/src/lib/explore-ai.ts`'s `canon()` — the URL-dedup key for the AI \"Discover\" feature — keyed on `host + pathname` only, unconditionally dropping the query string:

```ts
export function canon(u: string): string {
  try {
    const x = new URL(u);
    return (x.host + x.pathname).toLowerCase().replace(/\/$/, "");
  } catch { ... }
}
```

`canon()` builds the server-side "already known" `Set` (`web/src/lib/core/discover.ts`'s `assembleDedupContext`, from `data/scan-history.tsv` + inbox + applications) **and** the client-side per-offer key the AI stream parser checks each candidate against (`makeAiStreamParser`'s `feed()`). Any host+path collision — real or coincidental — silently drops the offer: `if (seen.has(key) || known.has(key)) continue;`, no log, no visible "duplicate" marker.

**The concrete failure case.** Some ATS boards embed the job identity in the query string rather than the path — Greenhouse's `?gh_jid=` on corporate-hosted boards is the one already documented in this repo (see `url-key.mjs`'s own comment). Two genuinely different openings at the same employer, same `careers_url` page, different `gh_jid`:

```
https://boards.greenhouse.io/acme/jobs/apply?gh_jid=4471829005
https://boards.greenhouse.io/acme/jobs/apply?gh_jid=5501203417
```

both keyed to `boards.greenhouse.io/acme/jobs/apply`. Once either has ever appeared in `scan-history.tsv`/inbox/applications, **every subsequent distinct opening at that host+path is silently absent from AI Discover results** — not shown as a duplicate, just gone.

**Why this is a fresh regression of an already-fixed bug class.** The core already solved this exact problem for the tracker: `url-key.mjs`'s `normalizeUrl` exists specifically because over-normalizing a posting URL causes silent data loss, and its docstring states the design goal directly — *"UNDER-STRIP ON PURPOSE... over-normalizing collapses two genuinely different postings into one key → a SILENT merge / data loss."* It strips only a narrow tracking-param denylist and deliberately keeps functional params like `gh_jid`. `explore-ai.ts`'s `canon()` reimplemented URL keying independently on the web side and reintroduced exactly the failure mode `url-key.mjs` was written to prevent.

**Why not just import `url-key.mjs` directly.** `canon()` runs in the browser (`explore-provider.tsx` is a client component; the file's own header says "Client-safe (NO node imports)"), and the SAME function has to run server-side too (`discover.ts`, building the known-URL `Set`) — the client's per-offer key and the server-built `Set`'s keys must be byte-identical or `known.has(key)` silently stops matching anything. `url-key.mjs` itself has zero Node dependencies (only the global `URL`), so this repo's own established pattern for exactly this constraint — see `normalize-text-key.mjs` next to `text-key.ts` (#2369/#2666) — is a parity-tested static mirror under `web/src/lib/core/`. `web/src/lib/core/url-key.mjs` is that mirror here, body byte-for-byte aligned with the root `url-key.mjs`, guarded by a parity test that imports both side-by-side.

**Secondary fix.** `normalizeUrl` returns `''` for an unparseable-but-regex-passing URL (explicit "NO KEY IS NOT A KEY" contract — a placeholder must never collide with another placeholder). The stream parser's dedup check didn't have this guard yet (`canon()` never used to return `''`), so two such offers would have been wrongly treated as duplicates of each other. Fixed alongside: `if (key && (seen.has(key) || known.has(key))) continue;`.

**Verified by execution**, not reasoning — both from the parity test (imports the real root `url-key.mjs` and the mirror side-by-side) and from exercising the real `makeAiStreamParser`/`canon()` end-to-end (`explore-ai.ts` has no `@/` alias and no Node-only deps, so unlike `web/src/lib/core/pipeline.ts` it can be imported directly in a test rather than needing source-text extraction):

```
core normalizeUrl:  jobA -> .../apply?gh_jid=4471829005
                     jobB -> .../apply?gh_jid=5501203417   (different key — correct)

pre-fix canon():    jobA -> boards.greenhouse.io/acme/jobs/apply
                     jobB -> boards.greenhouse.io/acme/jobs/apply   (SAME key — the bug)
```

**Severity:** high — silent, user-invisible data loss in a user-facing discovery feature. Query-string job ids are not a corner case; they're how one common ATS integration identifies postings.

**Not already tracked** — searched issues/PRs for `canon`, `gh_jid`, `dedup discover`: no hits. #2369/#2666 are the historical issues that built `normalizeUrl`'s asymmetric-strip design and the `normalize-text-key.mjs` mirror pattern in the first place; this is a fresh instance of the same class on the untouched `explore-ai.ts` path.

Five-commit shape: add the mirror → parity-test it → wire `canon()` to it → fix the empty-key guard → exercise the real stream parser end-to-end.

## Test plan
- [x] `node test-all.mjs` — 4321 passed, 0 failed (2 pre-existing unrelated warnings: Go dashboard build skip, PII-heuristic false positive on santifer.io in untouched Go source)
- [x] `cd web && npm test` — 272 passed, 0 failed
- [x] `cd web && npm run typecheck` — clean
- [x] Parity test imports the real root `url-key.mjs` and the new mirror side-by-side and asserts they agree, including the concrete `gh_jid` case
- [x] `explore-ai-dedup.test.mjs` exercises the real `makeAiStreamParser`/`canon()`: two distinct postings sharing host+path are both kept, a true duplicate still dedups, and `knownUrls` filters by exact key rather than host+path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved posting URL normalization for consistent HTTPS handling, hostname casing, trailing slashes, and tracking parameters.
  * Preserved meaningful query parameters so distinct postings are no longer incorrectly merged.
  * Invalid or unsupported URLs are safely ignored during deduplication.

* **Tests**
  * Added coverage for URL normalization, tracking removal, posting uniqueness, and invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->