### PR TITLE
fix(funnel-velocity): validate CLI flags

### DIFF
--- a/funnel-velocity.mjs
+++ b/funnel-velocity.mjs
@@ -42,13 +42,20 @@ import { computeFunnel, computeTrackerStats } from './stats.mjs';
 import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
 import { resolveTrackerPath, loadCanonicalStates, resolveCanonicalState } from './tracker-utils.mjs';
 import { parseAppliedDate, normalizeStatus } from './followup-cadence.mjs';
+import { flagValue, validateFlags } from './lib/cli-flags.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 const STATES_FILE = join(CAREER_OPS, 'templates/states.yml');
 
-const args = process.argv.slice(2);
-const summaryMode = args.includes('--summary');
-const selfTestMode = args.includes('--self-test');
+const KNOWN_FLAGS = ['--summary', '--self-test', '--benchmarks', '--help', '-h'];
+const VALUE_FLAGS = ['--benchmarks'];
+
+const USAGE = `Usage:
+  node funnel-velocity.mjs                       # JSON report
+  node funnel-velocity.mjs --summary             # human-readable report
+  node funnel-velocity.mjs --benchmarks <path>   # override the benchmark YAML file
+  node funnel-velocity.mjs --self-test           # run the built-in fixtures
+  node funnel-velocity.mjs --help|-h              # show this message`;
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 // `web` sits alongside `set-status` because it is the same class of event: a
@@ -673,17 +680,17 @@ function selfTest() {
 }
 
 // --- Main ---
-function flagValue(name) {
-  const i = args.indexOf(name);
-  return i !== -1 && args[i + 1] && !args[i + 1].startsWith('--') ? args[i + 1] : null;
-}
-
 function main() {
+  const args = process.argv.slice(2);
+  validateFlags(args, KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS, requireOperand: true });
+
+  const summaryMode = args.includes('--summary');
+  const selfTestMode = args.includes('--self-test');
   if (selfTestMode) { selfTest(); return; }
 
   let benchmarks;
   try {
-    benchmarks = loadBenchmarks(flagValue('--benchmarks')).benchmarks;
+    benchmarks = loadBenchmarks(flagValue(args, '--benchmarks')).benchmarks;
   } catch (err) {
     console.error(`Error: ${err.message}`);
     process.exit(1);

--- a/tests/funnel-velocity-flags.test.mjs
+++ b/tests/funnel-velocity-flags.test.mjs
@@ -1,0 +1,96 @@
+// funnel-velocity.mjs must handle help and reject unknown flags before it
+// reads report inputs. A typo must never fall through to a plausible JSON
+// report at exit 0.
+import { after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const SCRIPT = join(ROOT, 'funnel-velocity.mjs');
+const SANDBOX = mkdtempSync(join(tmpdir(), 'career-ops-funnel-flags-'));
+const NO_TRACKER = join(SANDBOX, 'applications.md');
+const NO_BENCHMARKS = join(SANDBOX, 'benchmarks.yml');
+
+after(() => rmSync(SANDBOX, { recursive: true, force: true }));
+
+function runFunnel(...args) {
+  const result = spawnSync(process.execPath, [SCRIPT, ...args], {
+    cwd: ROOT,
+    encoding: 'utf-8',
+    timeout: 30_000,
+    env: { ...process.env, CAREER_OPS_TRACKER: NO_TRACKER },
+  });
+  assert.equal(result.error, undefined, `funnel-velocity.mjs failed to spawn: ${result.error?.message}`);
+  assert.equal(result.signal, null, `funnel-velocity.mjs was killed by ${result.signal} (timeout?)`);
+  return { ...result, all: `${result.stdout ?? ''}${result.stderr ?? ''}` };
+}
+
+test('--help prints usage and exits 0', () => {
+  const result = runFunnel('--help');
+  assert.equal(result.status, 0, `expected exit 0, got ${result.status}: ${result.all}`);
+  assert.match(result.stdout, /Usage:/);
+  assert.match(result.stdout, /node funnel-velocity\.mjs/);
+  assert.match(result.stdout, /--summary/);
+  assert.match(result.stdout, /--benchmarks <path>/);
+});
+
+test('-h prints usage and exits 0', () => {
+  const result = runFunnel('-h');
+  assert.equal(result.status, 0, `expected exit 0, got ${result.status}: ${result.all}`);
+  assert.match(result.stdout, /Usage:/);
+});
+
+test('help exits before reading report inputs', () => {
+  const result = runFunnel('--benchmarks', NO_BENCHMARKS, '--help');
+  assert.equal(result.status, 0, `expected exit 0, got ${result.status}: ${result.all}`);
+  assert.match(result.stdout, /Usage:/);
+  assert.doesNotMatch(result.all, /benchmark file not found/i);
+});
+
+test('an unknown flag exits 1 and names the flag', () => {
+  const result = runFunnel('--bogus');
+  assert.equal(result.status, 1, `expected exit 1, got ${result.status}: ${result.all}`);
+  assert.match(result.stderr, /unrecognized flag\(s\): --bogus/);
+  assert.match(result.stderr, /Valid flags:/);
+});
+
+test('--help plus an unknown flag still fails', () => {
+  const result = runFunnel('--help', '--bogus');
+  assert.equal(result.status, 1, `expected exit 1, got ${result.status}: ${result.all}`);
+  assert.match(result.stderr, /unrecognized flag\(s\): --bogus/);
+  assert.doesNotMatch(result.stdout, /Usage:/);
+});
+
+test('--benchmarks=value is recognized and reaches normal validation', () => {
+  const result = runFunnel(`--benchmarks=${NO_BENCHMARKS}`);
+  assert.equal(result.status, 1, `expected missing benchmark to fail, got ${result.status}: ${result.all}`);
+  assert.match(result.stderr, /Cannot read benchmarks/i);
+  assert.doesNotMatch(result.stderr, /unrecognized flag/i);
+});
+
+test('--benchmarks without a value is rejected instead of using the default', () => {
+  const result = runFunnel('--benchmarks');
+  assert.equal(result.status, 1, `expected exit 1, got ${result.status}: ${result.all}`);
+  assert.match(result.stderr, /--benchmarks requires a value/);
+});
+
+test('a normal run preserves the existing no-tracker JSON bytes', () => {
+  const result = runFunnel();
+  const expected = `${JSON.stringify({
+    calibration: null,
+    waiting: null,
+    velocity: null,
+    dataQuality: {
+      trackerRows: 0,
+      note: `no tracker at ${NO_TRACKER}`,
+    },
+  }, null, 2)}\n`;
+
+  assert.equal(result.status, 0, `expected exit 0, got ${result.status}: ${result.all}`);
+  assert.equal(result.stderr, '');
+  assert.equal(result.stdout, expected);
+});


### PR DESCRIPTION
## Summary

- add usage output for `--help` and `-h`
- reject unknown flags before report processing
- validate the value-taking `--benchmarks` flag
- use the shared `flagValue` helper, supporting both argument forms
- preserve normal report output byte-for-byte
- add focused CLI regression tests

## Testing

- `node --test tests/funnel-velocity-flags.test.mjs` — 8 passed
- `node funnel-velocity.mjs --self-test` — passed
- `node test-all.mjs` — 4,312 passed, 0 failed

Fixes #2853

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Centralized command-line option handling for more consistent behavior.
  * Added updated usage guidance for supported options.
  * Added validation for unknown options and benchmark arguments.

* **Bug Fixes**
  * Invalid command-line input is now rejected before execution.
  * Preserved JSON output when running without a tracker.

* **Tests**
  * Added coverage for help handling, argument validation, successful execution, and temporary test environment cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->