### PR TITLE
docs: add apiKeyHelper and batch auth to budget guide

### DIFF
--- a/docs/RUNNING_ON_A_BUDGET.md
+++ b/docs/RUNNING_ON_A_BUDGET.md
@@ -80,21 +80,29 @@ Then export the value it prints as `CLAUDE_CODE_OAUTH_TOKEN` in the environment 
 export CLAUDE_CODE_OAUTH_TOKEN="<your-generated-token>"
 ```
 
-It is a credential: treat it like one, and never commit it.
+### Subscription Usage and Billing
+
+Providing the `CLAUDE_CODE_OAUTH_TOKEN` selects subscription authentication instead of API-key billing. Keep in mind that batch usage still consumes your plan allowance and can consume enabled usage credits after the allowance is reache
 
 ### Batch Preflight for Credential Precedence
 
-Before executing the batch run, you must clear out any competing credentials. The `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_API_KEY`, and cloud-provider switches take precedence over `CLAUDE_CODE_OAUTH_TOKEN`. If left active, they can select an unintended billing path or cause authentication to fail altogether.
+Before executing the batch run, you must clear out any competing credentials. The `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_API_KEY`, and cloud-provider switches (`CLAUDE_CODE_USE_ANTHROPIC_AWS`, `CLAUDE_CODE_USE_BEDROCK`, `CLAUDE_CODE_USE_VERTEX`, and `CLAUDE_CODE_USE_FOUNDRY`) take precedence over `CLAUDE_CODE_OAUTH_TOKEN`. If left active, they can select an unintended billing path or cause authentication to fail altogether.
 
 Ensure you do the following prior to the run:
 
-1. **Unset environment variables:** Unset `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_API_KEY`, and any cloud-provider switches.
-2. **Clear Claude Code settings:** Remove `apiKeyHelper` from your Claude Code configuration.
+1. **Unset environment variables:** Unset `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_API_KEY`, and all cloud-provider switches.
+2. **Clear Claude Code settings:** Remove competing credentials (such as `apiKeyHelper`) and provider switches from your effective Claude Code `settings.json` configuration. This is crucial because values defined in the settings JSON file will override shell `unset` commands.
 
 ```bash
+# Unset API and Auth tokens
 unset ANTHROPIC_AUTH_TOKEN
 unset ANTHROPIC_API_KEY
-# Unset any active cloud-provider switches as well         # requires an active Claude subscription
+
+# Unset cloud-provider switches
+unset CLAUDE_CODE_USE_ANTHROPIC_AWS
+unset CLAUDE_CODE_USE_BEDROCK
+unset CLAUDE_CODE_USE_VERTEX
+unset CLAUDE_CODE_USE_FOUNDRY
 ```
 
 ### Two things worth expecting

--- a/docs/RUNNING_ON_A_BUDGET.md
+++ b/docs/RUNNING_ON_A_BUDGET.md
@@ -53,21 +53,32 @@ Inside Claude Code, `/status` reports the active login and shows an API-key row 
 
 ### Switch to the subscription
 
-1. Remove the key from wherever it is exported (`~/.zshrc`, `~/.bashrc`, `~/.profile`, a project `.env`, or another tool that sets it for you). `unset ANTHROPIC_API_KEY` only affects the current shell, so edit the file too or it comes back on the next terminal.
-2. Restart the terminal.
-3. Run `/login` in Claude Code and sign in.
+Remove the key from wherever it is exported (`~/.zshrc`, `~/.bashrc`, `~/.profile`, a project `.env`, or another tool that sets it for you). `unset ANTHROPIC_API_KEY` only affects the current shell, so edit the file too or it comes back on the next terminal.
+
+Check your Claude Code settings for `apiKeyHelper`. A configured helper re-injects an API key even after you clean your environment.
+
+1. Open `~/.claude/settings.json`.
+2. Remove or comment out the `apiKeyHelper` key.
+3. Restart the terminal.
+4. Run `/login` in Claude Code and sign in.
 
 `ANTHROPIC_AUTH_TOKEN` and the cloud-provider switches (`CLAUDE_CODE_USE_BEDROCK`, `CLAUDE_CODE_USE_VERTEX`) take precedence too, so check those if a stray key is not the culprit.
 
-### The batch mode is the exception worth knowing
+### Authenticate for Headless or Batch Runs
 
-`batch/batch-runner.sh` drives `claude -p` workers, and the headless path does not use the interactive login. If you want batch runs on your subscription rather than on credits, generate a long-lived token once:
+For `claude -p` batch runs (cron, CI), headless paths do not use the interactive login. If you want batch runs on your subscription rather than on credits, generate a long-lived token once:
 
 ```bash
 claude setup-token          # requires an active Claude subscription
 ```
 
-Then export the value it prints as `CLAUDE_CODE_OAUTH_TOKEN` in the environment the batch runs in. It is a credential: treat it like one, and never commit it.
+Then export the value it prints as `CLAUDE_CODE_OAUTH_TOKEN` in the environment the batch runs in:
+
+```bash
+export CLAUDE_CODE_OAUTH_TOKEN="<your-generated-token>"
+```
+
+It is a credential: treat it like one, and never commit it.
 
 ### Two things worth expecting
 

--- a/docs/RUNNING_ON_A_BUDGET.md
+++ b/docs/RUNNING_ON_A_BUDGET.md
@@ -62,7 +62,7 @@ Check your Claude Code settings for `apiKeyHelper`. A configured helper re-injec
 3. Restart the terminal.
 4. Run `/login` in Claude Code and sign in.
 
-`ANTHROPIC_AUTH_TOKEN` and the cloud-provider switches (`CLAUDE_CODE_USE_BEDROCK`, `CLAUDE_CODE_USE_VERTEX`) take precedence too, so check those if a stray key is not the culprit.
+`ANTHROPIC_AUTH_TOKEN` and the cloud-provider switches (`CLAUDE_CODE_USE_BEDROCK`, `CLAUDE_CODE_USE_VERTEX`, `CLAUDE_CODE_USE_FOUNDRY`) take precedence too, so check those if a stray key is not the culprit.
 
 ### Authenticate for Headless or Batch Runs
 

--- a/docs/RUNNING_ON_A_BUDGET.md
+++ b/docs/RUNNING_ON_A_BUDGET.md
@@ -82,6 +82,21 @@ export CLAUDE_CODE_OAUTH_TOKEN="<your-generated-token>"
 
 It is a credential: treat it like one, and never commit it.
 
+### Batch Preflight for Credential Precedence
+
+Before executing the batch run, you must clear out any competing credentials. The `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_API_KEY`, and cloud-provider switches take precedence over `CLAUDE_CODE_OAUTH_TOKEN`. If left active, they can select an unintended billing path or cause authentication to fail altogether.
+
+Ensure you do the following prior to the run:
+
+1. **Unset environment variables:** Unset `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_API_KEY`, and any cloud-provider switches.
+2. **Clear Claude Code settings:** Remove `apiKeyHelper` from your Claude Code configuration.
+
+```bash
+unset ANTHROPIC_AUTH_TOKEN
+unset ANTHROPIC_API_KEY
+# Unset any active cloud-provider switches as well         # requires an active Claude subscription
+```
+
 ### Two things worth expecting
 
 - **Plan limits are windows, not balances.** On a subscription you get rolling usage windows rather than a credit balance, so a heavy scan can pause you until the window resets. `spend_tier: economy` and the pre-screen gate above exist precisely to make high-volume days cheaper.

--- a/docs/RUNNING_ON_A_BUDGET.md
+++ b/docs/RUNNING_ON_A_BUDGET.md
@@ -58,7 +58,7 @@ Remove the key from wherever it is exported (`~/.zshrc`, `~/.bashrc`, `~/.profil
 Check your Claude Code settings for `apiKeyHelper`. A configured helper re-injects an API key even after you clean your environment.
 
 1. Open `~/.claude/settings.json`.
-2. Remove or comment out the `apiKeyHelper` key.
+2. Remove the `apiKeyHelper` key.
 3. Restart the terminal.
 4. Run `/login` in Claude Code and sign in.
 
@@ -66,7 +66,9 @@ Check your Claude Code settings for `apiKeyHelper`. A configured helper re-injec
 
 ### Authenticate for Headless or Batch Runs
 
-For `claude -p` batch runs (cron, CI), headless paths do not use the interactive login. If you want batch runs on your subscription rather than on credits, generate a long-lived token once:
+For `claude -p` batch runs (cron, CI), headless paths do not use the interactive login. If you want batch runs on your subscription rather than on credits, you must perform an interactive setup step beforehand:
+
+Run `claude setup-token` once in an environment with browser access. Store the printed token in your batch environment's secret store and provide it at runtime via the `CLAUDE_CODE_OAUTH_TOKEN` environment variable. **Do not run the `claude setup-token` command directly from cron or CI.**
 
 ```bash
 claude setup-token          # requires an active Claude subscription


### PR DESCRIPTION
## What does this PR do?

This PR updates `docs/RUNNING_ON_A_BUDGET.md` to document two authentication edge cases for Claude Code. It adds instructions on how to disable the `apiKeyHelper` setting to prevent unwanted API key injections, and explains how to authenticate headless/batch environments using `claude setup-token`.

## Related issue

Fixes #2978

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated subscription-switching instructions to include checking `~/.claude/settings.json` and removing `apiKeyHelper`.
  - Added `CLAUDE_CODE_USE_FOUNDRY` to authentication-precedence guidance.
  - Clarified authentication guidance for `claude -p` runs in cron and CI environments.
  - Added interactive token setup steps and guidance for `CLAUDE_CODE_OAUTH_TOKEN`.
  - Expanded credential-precedence checks for automated and headless workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->