### PR TITLE
fix(add-entry): prevent prefix false positives in articleDigestHasEntry

### DIFF
--- a/add-entry.mjs
+++ b/add-entry.mjs
@@ -138,15 +138,15 @@ export function insertIntoCvSection(md, section, entry) {
 
 // article-digest.md is a sequence of `## <name> -- <tagline>` blocks separated
 // by `---`. Dedup on the name (the heading text before the dash), matched by
-// normalized equality or prefix so "## FraudShield -- Detection" matches the key
-// "FraudShield" without a short key colliding on unrelated heading text.
+// normalized equality so "## FraudShield -- Detection" matches the key
+// "FraudShield" without a short key colliding on other project names.
 export function articleDigestHasEntry(md, dedupKey) {
   const key = normalizeKey(dedupKey);
   if (!key) return false;
   for (const m of md.matchAll(/^##\s+(.*\S)\s*$/gm)) {
     const name = m[1].split(/\s+[—–-]{1,2}\s+/)[0];
     const n = normalizeKey(name);
-    if (n === key || n.startsWith(key)) return true;
+    if (n === key) return true;
   }
   return false;
 }

--- a/tests/add-entry-dedup.test.mjs
+++ b/tests/add-entry-dedup.test.mjs
@@ -1,0 +1,69 @@
+// tests/add-entry-dedup.test.mjs — articleDigestHasEntry must not false-positive on prefix of existing entry
+import { pass, fail } from './helpers.mjs';
+import { articleDigestHasEntry, applyAdd } from '../add-entry.mjs';
+
+console.log('\nadd-entry.mjs — dedup key prefix false positive prevention');
+
+// 1. articleDigestHasEntry: exact match vs prefix
+const md = [
+  '# Article Digest',
+  '',
+  '---',
+  '',
+  '## Airflow Pipeline — Data Engineering',
+  '',
+  '**Hero metrics:** 99.9% uptime',
+  '',
+  '## Reactive Architecture — Distributed Systems',
+  '',
+  '**Hero metrics:** 10x throughput',
+  '',
+].join('\n');
+
+if (articleDigestHasEntry(md, 'Airflow Pipeline')) {
+  pass('articleDigestHasEntry matches exact project name');
+} else {
+  fail('articleDigestHasEntry should match exact project name');
+}
+
+if (!articleDigestHasEntry(md, 'AI')) {
+  pass('articleDigestHasEntry does not false-match "AI" against "Airflow Pipeline" prefix');
+} else {
+  fail('articleDigestHasEntry should not match "AI" when only "Airflow Pipeline" exists');
+}
+
+if (!articleDigestHasEntry(md, 'Airflow')) {
+  pass('articleDigestHasEntry does not false-match "Airflow" against "Airflow Pipeline" prefix');
+} else {
+  fail('articleDigestHasEntry should not match "Airflow" when only "Airflow Pipeline" exists');
+}
+
+if (!articleDigestHasEntry(md, 'React')) {
+  pass('articleDigestHasEntry does not false-match "React" against "Reactive Architecture" prefix');
+} else {
+  fail('articleDigestHasEntry should not match "React" when only "Reactive Architecture" exists');
+}
+
+// 2. applyAdd end-to-end: adding a project whose name is a prefix of an existing one succeeds
+const sampleCv = [
+  '# CV -- Test',
+  '',
+  '## Projects',
+  '',
+  '- **Airflow Pipeline** (OSS) -- data engineering',
+  '',
+].join('\n');
+
+const res = applyAdd(
+  {
+    cv: { section: 'Projects', dedupKey: 'AI', entry: '- **AI** (OSS) -- AI agent framework' },
+    articleDigest: { dedupKey: 'AI', entry: '## AI — Intelligent Agent\n\n**Hero metrics:** 5x speedup' },
+  },
+  { cvText: sampleCv, articleText: md },
+);
+
+if (res.result.articleDigest.status === 'added' && res.result.cv.status === 'added') {
+  pass('applyAdd successfully adds distinct entry whose key is a prefix of an existing entry');
+} else {
+  fail(`applyAdd failed to add prefix-keyed entry: ${JSON.stringify(res.result)}`);
+}


### PR DESCRIPTION
## What does this PR do?

Fixes a false-positive duplicate detection bug in `articleDigestHasEntry()` where adding a project whose name is a prefix substring of an existing project (e.g., adding `dedupKey: "AI"` when `## Airflow Pipeline` already exists) was falsely rejected as a duplicate. It updates `articleDigestHasEntry()` in `add-entry.mjs` to enforce exact normalized equality (`n === key`) and adds dedicated regression test coverage in `tests/add-entry-dedup.test.mjs`.

## Related issue

None (Bug fixes are exempt from issue-first requirement per `CONTRIBUTING.md`).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate detection by requiring exact normalized matches.
  * Distinct entries with similar prefixes are no longer incorrectly treated as duplicates.

* **Tests**
  * Added coverage for exact duplicate matches.
  * Added validation that distinct prefix-keyed entries are added correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->