### PR TITLE
fix(cli): close the missing-operand hole for value-taking flags (#3087)

### DIFF
--- a/archive-posting.mjs
+++ b/archive-posting.mjs
@@ -101,11 +101,24 @@ function parseCliArgs(args) {
       dryRun = true;
     } else if (arg.startsWith('--company=')) {
       overrideCompany = arg.slice('--company='.length).trim();
-    } else if (arg === '--company' && args[i + 1]) {
+    } else if (arg === '--company') {
+      // The old `args[i + 1]` truthiness check consumed the NEXT flag as the
+      // company name whenever --company was given with no value (e.g.
+      // `--company --pipeline` set overrideCompany to "--pipeline" and left
+      // pipeline mode off, silently, at exit 0 (#3087)). A value that starts
+      // with `--` is another flag, not a company name.
+      if (args[i + 1] === undefined || args[i + 1].startsWith('--')) {
+        console.error('--company requires a value.');
+        process.exit(1);
+      }
       overrideCompany = args[++i].trim();
     } else if (arg.startsWith('--role=')) {
       overrideRole = arg.slice('--role='.length).trim();
-    } else if (arg === '--role' && args[i + 1]) {
+    } else if (arg === '--role') {
+      if (args[i + 1] === undefined || args[i + 1].startsWith('--')) {
+        console.error('--role requires a value.');
+        process.exit(1);
+      }
       overrideRole = args[++i].trim();
     } else if (arg.startsWith('--report=')) {
       reportNum = arg.slice('--report='.length).trim();

--- a/detect-reposts.mjs
+++ b/detect-reposts.mjs
@@ -502,7 +502,12 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
   // Inside the main-module guard, not at import time: company-history.mjs
   // imports detectReposts/parseScanHistory from here, so a top-level check
   // would judge the IMPORTER's argv.
-  validateFlags(args, KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS });
+  // requireOperand: without it, `--window --summary` reads --summary as the
+  // window value; flagValue() has no adjacency check, parseInt('--summary')
+  // is NaN, and windowDays silently falls back to DEFAULT_WINDOW_DAYS at exit
+  // 0 instead of reporting the malformed flag (#3087). Nothing more specific
+  // to say than the shared message.
+  validateFlags(args, KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS, requireOperand: true });
 
   if (selfTestMode) {
     runSelfTest();

--- a/detect-reposts.test.mjs
+++ b/detect-reposts.test.mjs
@@ -1187,13 +1187,22 @@ const badWindowOut = execFileSync('node', [scriptPath, '--window', 'abc'], {
 const badWindowJson = JSON.parse(badWindowOut);
 eq('--window abc falls back to 90', badWindowJson.metadata.windowDays, 90);
 
-// Test --window with no value (falls back to default)
-const noWindowOut = execFileSync('node', [scriptPath, '--window'], {
-  encoding: 'utf-8', timeout: 10000,
-  cwd: dirname(scriptPath),
-});
-const noWindowJson = JSON.parse(noWindowOut);
-eq('--window without value falls back to 90', noWindowJson.metadata.windowDays, 90);
+// Test --window with no value: a usage error, not a silent fallback (#3087).
+// This used to fall back to the 90-day default silently at exit 0 — the same
+// shape as `--window abc` above, except there `abc` is a value the caller
+// actually typed (just an invalid one), while a bare trailing `--window` has
+// no value at all. requireOperand distinguishes the two: a missing operand is
+// now a validateFlags usage error, before the script ever computes a window.
+try {
+  execFileSync('node', [scriptPath, '--window'], {
+    encoding: 'utf-8', timeout: 10000,
+    cwd: dirname(scriptPath),
+  });
+  ok('--window without value exits non-zero', false);
+} catch (e) {
+  ok('--window without value exits non-zero', e.status === 1);
+  ok('--window without value reports the missing operand', /--window requires a value/.test(e.stderr || ''));
+}
 
 // Test --help flag
 const helpOut = execFileSync('node', [scriptPath, '--help'], {

--- a/doctor.mjs
+++ b/doctor.mjs
@@ -43,7 +43,13 @@ const USAGE = `Usage:
 
 CLIs: ${VALID_CLIS.join(', ')}`;
 
-validateFlags(argv, KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS });
+// requireOperand: without it, `--target --json` reads --json as the target
+// path (argv[targetIdx + 1] below has no adjacency check of its own), and the
+// doctor silently diagnoses a directory literally named "--json" at exit 0
+// (#3087) — this is the onboarding entrypoint, so that's a user told to
+// create files that already exist. Nothing more specific to say than the
+// shared message.
+validateFlags(argv, KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS, requireOperand: true });
 
 const targetIdx = argv.indexOf('--target');
 const projectRoot =

--- a/process-quality.mjs
+++ b/process-quality.mjs
@@ -361,7 +361,12 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
   //
   // A mistyped --file was previously ignored, so the script silently reported
   // on data/active-interviews.md instead of the path that was asked for.
-  validateFlags(args, KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS });
+  //
+  // requireOperand: without it, `--file --min-threshold` reads --min-threshold
+  // as the file path and `--min-threshold --summary` parses to NaN and falls
+  // back to the default of 1 — both silently, at exit 0 (#3087). Neither flag
+  // has a more specific missing-value message of its own.
+  validateFlags(args, KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS, requireOperand: true });
 
   if (selfTestMode) {
     runSelfTest();

--- a/tests/cli-flag-validation.test.mjs
+++ b/tests/cli-flag-validation.test.mjs
@@ -163,3 +163,59 @@ test('validating importable modules does not break their importers', () => {
   assert.equal(r2.status, 0, 'detect-reposts rejected its importer\'s flags');
   assert.doesNotMatch(r2.all, /unrecognized flag/i);
 });
+
+// --- missing operand for a RECOGNIZED value-taking flag (#3087) ------------
+//
+// A different defect than an unrecognized flag: the flag is spelled right,
+// but nothing (or another flag) follows it, so flagValue()/indexOf() reads
+// the wrong thing as the value and the script proceeds on it silently at
+// exit 0 — doctor.mjs diagnosing a directory literally named "--json" is the
+// sharpest case. validateFlags's `requireOperand` option closes this for
+// callers that opt in; each case below fails inside validateFlags itself,
+// before any data/ access, so — like the --today/--summary case above — no
+// fixture is needed.
+
+test('doctor: --target --json does not diagnose a directory named "--json"', () => {
+  const r = runScript('doctor.mjs', '--target', '--json');
+  assert.equal(r.status, 1, `want exit 1, got ${r.status}`);
+  assert.match(r.all, /--target requires a value/);
+});
+
+test('detect-reposts: --window --summary does not silently fall back to the default window', () => {
+  const r = runScript('detect-reposts.mjs', '--window', '--summary');
+  assert.equal(r.status, 1, `want exit 1, got ${r.status}`);
+  assert.match(r.all, /--window requires a value/);
+});
+
+test('process-quality: --file --min-threshold does not read --min-threshold as a path', () => {
+  const r = runScript('process-quality.mjs', '--file', '--min-threshold');
+  assert.equal(r.status, 1, `want exit 1, got ${r.status}`);
+  assert.match(r.all, /--file requires a value/);
+});
+
+test('process-quality: --min-threshold --summary does not silently fall back to threshold 1', () => {
+  const r = runScript('process-quality.mjs', '--min-threshold', '--summary');
+  assert.equal(r.status, 1, `want exit 1, got ${r.status}`);
+  assert.match(r.all, /--min-threshold requires a value/);
+});
+
+test('weekly-digest: --dir --summary does not scan a directory named "--summary"', () => {
+  const r = runScript('weekly-digest.mjs', '--dir', '--summary');
+  assert.equal(r.status, 1, `want exit 1, got ${r.status}`);
+  assert.match(r.all, /--dir requires a value/);
+});
+
+// archive-posting.mjs hand-rolls its own argv loop rather than going through
+// validateFlags, so its --company/--role handling needed its own adjacency
+// check (the same class of bug through a different door — see archive-posting.mjs).
+test('archive-posting: --company --pipeline does not set the company slug to "--pipeline"', () => {
+  const r = runScript('archive-posting.mjs', 'https://example.com/job', '--company', '--pipeline');
+  assert.equal(r.status, 1, `want exit 1, got ${r.status}`);
+  assert.match(r.all, /--company requires a value/);
+});
+
+test('archive-posting: --role --dry-run does not set the role slug to "--dry-run"', () => {
+  const r = runScript('archive-posting.mjs', 'https://example.com/job', '--role', '--dry-run');
+  assert.equal(r.status, 1, `want exit 1, got ${r.status}`);
+  assert.match(r.all, /--role requires a value/);
+});

--- a/weekly-digest.mjs
+++ b/weekly-digest.mjs
@@ -677,7 +677,14 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
   // interview-prep/sessions instead of the directory that was asked for —
   // the same silent discard #2402 already fixed here for the `--from=` form
   // (#2919). Inside the main-module guard so importers are unaffected.
-  validateFlags(args, KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS });
+  // requireOperand: --from/--to already reject a swallowed flag indirectly
+  // (isValidDateStr fails on e.g. "--dir" below), but --dir has no validation
+  // at all — `--dir --from 2020-01-01` would silently scan a directory
+  // literally named "--from" at exit 0 (#3087). Opting in here closes that
+  // gap; it only changes the --from/--to message in the same edge case, from
+  // "Invalid --from/--to date" to "requires a value" — still a clear, non-zero
+  // exit either way.
+  validateFlags(args, KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS, requireOperand: true });
 
   if (args.includes('--self-test')) {
     await runSelfTest();


### PR DESCRIPTION
## Summary

Fixes #3087. Completes the audit the issue asked for: a value-taking CLI flag that's *recognized* but given with no value (nothing follows it, or the next token is itself another `--flag`) silently fell through instead of erroring — `validateFlags`'s unrecognized-flag check doesn't catch this, because the flag itself is spelled correctly.

The sharpest case, from the issue: `doctor.mjs`'s `--target`/`--cli` resolution (`argv.indexOf('--target')` + `argv[idx+1]`) has no adjacency check, so `node doctor.mjs --target --json` reads `--json` as the target path and silently diagnoses a directory that doesn't exist, at exit 0 — telling a user following onboarding to create files that already exist.

`lib/cli-flags.mjs`'s `validateFlags()` already had an opt-in `requireOperand` option (added for `batch-tailor.mjs`, per its own comment: *"This script has nothing more specific to say about a missing operand than the shared message, which is exactly when opting in is right"*), but most callers with value flags never passed it.

## Audit

Went through every caller of `validateFlags` that passes `valueFlags`:

**Needed `requireOperand: true` (no guard against a missing operand):**
- `doctor.mjs` — `--target`/`--cli`, the issue's headline example.
- `detect-reposts.mjs` — `--window`: swallowed value fails `parseInt`, falls back to the 90-day default silently.
- `process-quality.mjs` — `--file`/`--min-threshold`: same silent-fallback shape.
- `weekly-digest.mjs` — `--from`/`--to` happen to reject a swallowed flag indirectly (fails `isValidDateStr`), but `--dir` has no validation at all and would silently point the digest at a directory literally named `--from`.

**Already correct, left alone** (matching the issue's own "has its own guard, leave alone" criterion):
- `contacts.mjs` — `--vcf`'s value is optional by design (`node contacts.mjs --vcf [path]`) and already checks `.startsWith('--')` to fall back to `null` rather than swallow a flag.
- `scan-ats-full.mjs` — has its own adjacency-checked `valueOf()` helper.
- `check-table-freshness.mjs` — already parses and validates both `--max-age-months` and `--today` with `process.exit(1)` and a specific message.
- `rejection-latency.mjs`, `scan.mjs`, `batch-tailor.mjs` — the issue's own "not affected"/"already opts in" list, unchanged.

**Not applicable** — `invite-match.mjs`, `classify-tier.mjs`, `reply-watch.mjs`, `dedup-tracker.mjs` don't take any value flags.

**`archive-posting.mjs`** doesn't use `validateFlags` at all — it hand-rolls its own argv loop. Its `--company`/`--role` handling (`arg === '--company' && args[i + 1]`) has the identical defect through a different door: any truthy next token, including another flag, gets accepted as the value. `node archive-posting.mjs <url> --company --pipeline` used to set the company slug to `"--pipeline"` and silently leave pipeline mode off. Added the same "next token must not start with `--`" adjacency check directly, matching the convention `cli-flags.mjs` already documents.

## Test plan

- [x] Reproduced and fixed both headline examples from the issue directly:
  ```
  $ node doctor.mjs --target --json
  Error: --target requires a value
  $ node archive-posting.mjs https://example.com/job --company --pipeline
  --company requires a value.
  ```
- [x] Confirmed the valid cases still work (`doctor.mjs --json`, `detect-reposts.mjs --window 60 --summary`) and that callers with their own message still keep it (`rejection-latency.mjs --summary --tracker` still exits 2 with `--tracker requires a value.`, unchanged).
- [x] Found and fixed a stale assertion in `detect-reposts.test.mjs` that encoded the *old* behavior as correct — `--window` with no value was expected to silently fall back to the 90-day default. It now expects the exit-1 usage error, which is what this PR intentionally changes.
- [x] Added 7 new cases to `tests/cli-flag-validation.test.mjs` covering all five fixed spots, following the file's existing hermetic/no-fixture pattern for cases that fail inside `validateFlags` before any `data/` access.
- [x] `node --test tests/cli-flag-validation.test.mjs` → 24/24 passed.
- [x] `node test-all.mjs` → **4320 passed, 0 failed** (3 pre-existing warnings, unrelated to these files — present before this change too).

## Acceptance criteria from the issue

- [x] `node doctor.mjs --target --json` exits non-zero instead of diagnosing a directory named `--json`.
- [x] `node archive-posting.mjs <url> --company --pipeline` exits non-zero instead of writing `…_pipeline_job.pdf`.
- [x] Callers with their own message keep it (`rejection-latency.mjs --summary --tracker` still exits 2 with `--tracker requires a value.`).
- [x] Coverage in `tests/cli-flag-validation.test.mjs`, alongside the unrecognized-flag cases.
- [x] `node test-all.mjs` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved command-line validation across archive, repost detection, diagnostics, quality processing, and digest tools.
  - Value-based options now require an explicit value and reject another option used accidentally as that value.
  - Prevented missing inputs from being silently ignored or replaced with default settings.
  - Error messages now clearly identify options that require a value.
- **Tests**
  - Added regression coverage for missing values across supported command-line tools.
  - Updated expectations to confirm invalid commands exit with an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->