### PR TITLE
fix(providers): raise inter-page pacing to 250 ms on the eight providers still at 150

### DIFF
--- a/providers/avature.mjs
+++ b/providers/avature.mjs
@@ -36,7 +36,7 @@ const HARD_MAX_PAGES = 200;
 // large boards request-heavy (a 999+ board is ~170 pages); firing those with no
 // gap risks the tenant's WAF rate-limiting the burst. Mirrors workday's
 // INTER_PAGE_DELAY_MS — only boards that paginate past page 0 pay it.
-const INTER_PAGE_DELAY_MS = 150;
+const INTER_PAGE_DELAY_MS = 250;
 // The bare key we self-heal to when the primary (`jobOffset`) proves inert.
 const FALLBACK_OFFSET_PARAM = 'offset';
 

--- a/providers/eightfold.mjs
+++ b/providers/eightfold.mjs
@@ -51,7 +51,7 @@ const DEFAULT_MAX_PAGES = 200;
 const MAX_PAGES_CAP = 1000;
 // Same-host pacing between pages inside one tenant's own pagination loop.
 // Eightfold's edge rate-limits bursts, and a 616-job board is 62 requests.
-const INTER_PAGE_DELAY_MS = 150;
+const INTER_PAGE_DELAY_MS = 250;
 
 const RETRY_POLICY = { retries: 3, baseDelayMs: 500, maxDelayMs: 8_000 };
 

--- a/providers/getro.mjs
+++ b/providers/getro.mjs
@@ -77,7 +77,7 @@ const DEFAULT_MAX_AGE_DAYS = 90;   // pagination bound only; global filter does 
 // between tenants). Getro showed no rate-limit evidence in manual testing,
 // but a large board is still a long burst of same-host requests without some
 // pacing.
-const INTER_PAGE_DELAY_MS = 150;
+const INTER_PAGE_DELAY_MS = 250;
 
 function sleep(ms, ctx) {
   if (typeof ctx?.sleep === 'function') return ctx.sleep(ms);

--- a/providers/icims.mjs
+++ b/providers/icims.mjs
@@ -19,7 +19,7 @@ import { decodeEntities } from './_html-entities.mjs';
 // are rare on iCIMS and a reverse scan only needs the fresh slice anyway.
 const ICIMS_MAX_PAGES = 30;
 // Same per-tenant courtesy delay as workday.mjs — only multi-page tenants pay it.
-const INTER_PAGE_DELAY_MS = 150;
+const INTER_PAGE_DELAY_MS = 250;
 
 // iCIMS serves 200 directly to a browser-like UA (verified live); the default
 // career-ops UA risks WAF interstitials, same as workday/glints.

--- a/providers/oraclecloud.mjs
+++ b/providers/oraclecloud.mjs
@@ -52,7 +52,7 @@ const ORACLE_HOST_RE = /^[a-z0-9-]+\.fa\.(?:[a-z0-9-]+\.)?(?:ocs\.)?oraclecloud(
 const PAGE_SIZE = 200;
 const MAX_PAGES = 25;             // safety cap (~5000 jobs); hard ceiling like workday
 const RETRY_POLICY = { retries: 3 };
-const INTER_PAGE_DELAY_MS = 150;  // WAF-aware spacing between same-host pages
+const INTER_PAGE_DELAY_MS = 250;  // WAF-aware spacing between same-host pages
 
 // facetsList is a fixed constant on the finder; %3B is the encoded ';' separator.
 const FACETS_LIST = 'LOCATIONS%3BWORK_LOCATIONS%3BWORKPLACE_TYPES%3BTITLES%3BCATEGORIES%3BORGANIZATIONS%3BPOSTING_DATES%3BFLEX_FIELDS';

--- a/providers/tencent.mjs
+++ b/providers/tencent.mjs
@@ -21,7 +21,7 @@ const DEFAULT_KEYWORDS = [''];  // empty keyword = the whole board, no topical b
 const DEFAULT_MAX_PAGES = 20;
 // Every request after the first pays it — across pages and keyword switches
 // (same idiom as avature/workday).
-const INTER_PAGE_DELAY_MS = 150;
+const INTER_PAGE_DELAY_MS = 250;
 
 /** Parse "2026年06月23日" → epoch ms. NaN-safe. */
 function parseCnDate(value) {

--- a/providers/themuse.mjs
+++ b/providers/themuse.mjs
@@ -27,7 +27,7 @@ const RETRY_MAX_DELAY_MS = 8_000;
 
 // Delay between successive pages so a 100-page walk doesn't fire as a burst
 // against the same host (mirrors workday.mjs / oraclecloud.mjs).
-const INTER_PAGE_DELAY_MS = 150;
+const INTER_PAGE_DELAY_MS = 250;
 
 function sleep(ms, ctx) {
   if (typeof ctx?.sleep === 'function') return ctx.sleep(ms);

--- a/providers/workday.mjs
+++ b/providers/workday.mjs
@@ -41,7 +41,7 @@ const RETRY_POLICY = { retries: 3 };
 // WAF-level rate limiting on any tenant that paginates several pages deep
 // (large boards like rollsroyce, sec, roche). Only tenants that loop past
 // page 1 pay this; no-date-skip and early-stopped tenants never do.
-const INTER_PAGE_DELAY_MS = 150;
+const INTER_PAGE_DELAY_MS = 250;
 
 // Workday returns postings newest-first, so pagination can stop once a
 // page's oldest *dated* posting is well past --since — no point paying for


### PR DESCRIPTION
Closes the gap #2842 left open. @Zoubeir23 measured the failure in #2706: a 150 ms inter-page cadence earned a 2.5-hour WAF ban on a Datadog Workday board. His #2842 raised the paginated providers to 250 ms but was closed during a branch reshuffle, and the fix never re-landed: eight providers still carry 150 ms on main (workday, icims, avature, eightfold, oraclecloud, tencent, getro, themuse).

This re-lands it: the eight literals to 250 ms, nothing else. alibaba (300), meituan (400) and senjob (250) already meet the floor. Credit for the measurement and the original fix goes to @Zoubeir23.

Suite: 4321 passed, 0 failed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination reliability across supported job providers by increasing the delay between page requests.
  * Updated request pacing for Avature, Eightfold, Getro, iCIMS, Oracle Cloud, Tencent, The Muse, and Workday integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->