### PR TITLE
fix(batch-runner): emit the JD word count color-independently

### DIFF
--- a/batch/batch-runner.sh
+++ b/batch/batch-runner.sh
@@ -800,8 +800,13 @@ process_offer() {
             .replace(/\s+/g, ' ')
             .trim();
           fs.writeFileSync(process.argv[1], text);
-          console.log(text.split(' ').filter(Boolean).length);
-        } catch (e) { console.log(0); }
+          // process.stdout.write, not console.log: with FORCE_COLOR set, Node
+          // decorates console.log(number) with ANSI codes (\x1b[33m42\x1b[39m), and
+          // the digit sanitizer below turns those escapes into extra digits, so a
+          // 79-word shell counted as 337939 words and every thin page passed the
+          // threshold (#2858).
+          process.stdout.write(String(text.split(' ').filter(Boolean).length));
+        } catch (e) { process.stdout.write('0'); }
       " "$jd_file" 2>/dev/null) || jd_prefetch_words=0
       # Ensure jd_prefetch_words is always a non-negative integer. A non-integer
       # (e.g. empty string, "NaN") would cause bash arithmetic to fail or


### PR DESCRIPTION
Hotfix for the P0 #2816 left on main: with `FORCE_COLOR` set (common in CIs, agent terminals, and this maintainer's own machine), Node decorates `console.log(number)` with ANSI codes, and the digit sanitizer turns `\x1b[33m79\x1b[39m` into `337939` — every thin JS shell passed the 80-word threshold, and the prefetch's own tests fail on any FORCE_COLOR machine (5 red on main right now).

Two-line fix: `process.stdout.write(String(n))`, which never decorates. Credit to @luochen211, who identified exactly this failure in #2858 before it merged; the redirect re-validation half of #2858 remains open and welcome on top.

Suite: 4391 passed, 0 failed with FORCE_COLOR=3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected word-count detection for prefetched job descriptions.
  * Prevented formatting characters from being interpreted as extra digits, ensuring pages are evaluated against the minimum word-count requirement accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->