### PR TITLE
fix(intake): treat a nonzero version probe as present, not missing

### DIFF
--- a/intake.mjs
+++ b/intake.mjs
@@ -101,9 +101,30 @@ function defaultProbe(candidate) {
     // Bounded like extract() below: a wedged binary must not hang every run.
     execFileSync(candidate.name, candidate.probeArgs, { stdio: 'pipe', timeout: 5_000 });
     return true;
-  } catch {
-    return false;
+  } catch (err) {
+    return probeRan(err);
   }
+}
+
+/**
+ * Given whatever execFileSync threw from a version probe, did the binary
+ * actually run? Pure and exported so the self-test can cover every error shape
+ * without needing a real binary on PATH.
+ *
+ * A nonzero exit is NOT proof of absence. Poppler's pdftotext exits 0 on `-v`,
+ * but Xpdf's — the Glyph & Cog build shipped by xpdfreader.com and by
+ * MSYS2/mingw64 — prints its version and exits 99. Reading that as "not
+ * installed" silently skipped every PDF on a machine where extraction worked
+ * perfectly, and the scan summary blamed a missing extractor.
+ *
+ * What separates present-but-grumpy from absent is whether the process ran at
+ * all: execFileSync sets `status` to the exit code when it did, and leaves it
+ * null with code ENOENT / EACCES / ETIMEDOUT when the binary is missing,
+ * unrunnable, or wedged. A wedged binary stays excluded on purpose — extract()
+ * would hit the same timeout on every source.
+ */
+export function probeRan(err) {
+  return typeof err?.status === 'number';
 }
 
 export function sha256(text) {
@@ -353,6 +374,18 @@ function runSelfTest() {
   eq('ladder picks first probing rung',
     detectPdfExtractor(() => true)?.name, 'pdftotext');
   eq('ladder degrades to null', detectPdfExtractor(() => false), null);
+
+  // A version probe that exits nonzero is not proof the binary is absent:
+  // Xpdf's pdftotext prints its version and exits 99. Only a process that never
+  // ran counts as missing.
+  eq('exit 99 (Xpdf -v) counts as present', probeRan({ status: 99 }), true);
+  eq('exit 1 counts as present', probeRan({ status: 1 }), true);
+  eq('exit 0 counts as present', probeRan({ status: 0 }), true);
+  eq('ENOENT counts as absent', probeRan({ code: 'ENOENT', status: null }), false);
+  eq('EACCES counts as absent', probeRan({ code: 'EACCES', status: null }), false);
+  eq('timeout counts as absent',
+    probeRan({ code: 'ETIMEDOUT', status: null, signal: 'SIGTERM' }), false);
+  eq('missing error object counts as absent', probeRan(undefined), false);
 
   const state = { ingested: { 'cv/master.md': { hash: sha256('old') } } };
   const delta = computeDelta(state, [


### PR DESCRIPTION
## What does this PR do?

`intake.mjs` skipped every PDF source on machines where `pdftotext` is installed
and working, because its version probe treated any nonzero exit as "binary not
found". This fixes the probe to distinguish *a binary that ran and exited
nonzero* from *a binary that never ran*, and adds self-test coverage for every
error shape `execFileSync` produces.

## Related issue

None — bug fix, exempt from issue-first per CONTRIBUTING.md.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## The bug

`pdftotext -v` is not portable across builds:

| Build | `pdftotext -v` |
|---|---|
| Poppler (`brew install poppler`, `apt install poppler-utils`) | prints version, **exits 0** |
| Xpdf — Glyph & Cog (xpdfreader.com installer, MSYS2/mingw64 package) | prints version, **exits 99** |

`defaultProbe()` wrapped the probe in `try/catch` and returned `true` only from
the success path, so an exit-99 `pdftotext` was classified as absent. The visible
result on such a machine:

```
$ node intake.mjs --summary
PDF extractor: none — No PDF text extractor found. Optional: install poppler ...

source          status    detail
cv/resume.pdf   skipped   No PDF text extractor found. ...
linkedin/p.pdf  skipped   No PDF text extractor found. ...

0 source(s) with new material.
```

…while extraction itself worked perfectly:

```
$ pdftotext -layout documents/cv/resume.pdf - | wc -c
6392
$ pdftotext -v; echo "exit=$?"
pdftotext version 4.06 [www.xpdfreader.com]
Copyright 1996-2025 Glyph & Cog, LLC
exit=99
```

(Transcripts are from a real run; the two source filenames are genericized.)

The failure is quiet in the worst way: the user is told to install a tool they
already have, and `intake` silently proposes nothing from their CV. It also
defeats the state-file idempotency, since `commitState()` skips sources with no
`hash`.

## The fix

What separates *present-but-grumpy* from *absent* is whether the process ran at
all. `execFileSync` sets `status` to the exit code when the child ran, and leaves
it `null` with `code` `ENOENT` / `EACCES` / `ETIMEDOUT` when the binary is
missing, unrunnable, or wedged.

The predicate is extracted as a pure exported `probeRan(err)` so the self-test
can cover every error shape without needing a real binary on `PATH`.

A wedged binary (`ETIMEDOUT`) stays excluded deliberately — `extract()` would hit
the same timeout on every source, so degrading to the install hint is the better
outcome there.

Behaviour on a Poppler machine is unchanged: it exits 0 and never reaches the
catch.

## Test evidence

Adds 7 self-test cases (12 → 19), covering exit 99 / 1 / 0 as present and
`ENOENT` / `EACCES` / `ETIMEDOUT` / missing-error as absent:

```
$ node intake.mjs --self-test
self-test: 19 passed, 0 failed
```

Full suite, run on `main` both with and without the change:

```
$ node test-all.mjs          # with the fix
📊 Results: 4310 passed, 0 failed, 5 warnings

$ git stash && node test-all.mjs    # baseline, same checkout
📊 Results: 4310 passed, 0 failed, 5 warnings
```

Identical, including the warning count — `test-all.mjs` runs the intake self-test
as a single check, so the 7 new assertions are inside it rather than added to the
total. The 5 warnings are environmental and present on unmodified `main` too:
no Go toolchain for the dashboard build, no user data for `cv-sync-check.mjs`,
`santifer.io` matched by the personal-data scan in `dashboard/internal/ui/
screens/stats.go`, and two symlink test groups skipped for lack of symlink
privilege on Windows.

End-to-end on the affected machine (Windows 11, Xpdf 4.06 `pdftotext`), after the
fix:

```
$ node intake.mjs --summary
PDF extractor: pdftotext

source          status  detail
cv/resume.pdf   new     6392 chars via pdftotext
linkedin/p.pdf  new     3073 chars via pdftotext

2 source(s) with new material.
```

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

## Optional follow-up, not in this PR

`PDF_INSTALL_HINT` names only Poppler. Now that Xpdf's build works, the hint
could mention it as an alternative. Happy to add it here or in a separate PR —
left out to keep this diff to the bug.

## Disclosure

Written with Claude Code (Opus 5), and verified by me on the machine that hit the
bug — Windows 11 with Xpdf 4.06's `pdftotext`. The transcripts above are from
that machine, and I ran the suite before and after the change. Flagging it
because I'd want to know as a reviewer; happy to change anything here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PDF extraction reliability by recognizing extractor processes that ran successfully, even when they returned a nonzero status.
  - Continued to reject missing, unrunnable, or timed-out extraction processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->