### PR TITLE
fix(scan): anchor title keywords on word edges, not keyword length

### DIFF
--- a/scan.mjs
+++ b/scan.mjs
@@ -97,14 +97,31 @@ const CONCURRENCY = 10;
 
 // ── Title filter ────────────────────────────────────────────────────
 
-// Compile a lowercased keyword into a matcher. Short all-letter acronyms
-// (2-3 chars: cfo, coo, sdr, bdr, gsi…) match on WORD BOUNDARIES so "COO" no
-// longer matches "Coordinator", "SDR" no longer matches anything mid-word, etc.
-// Multi-word phrases and keywords containing non-letters (".NET", "SAP ",
-// "L&D") keep fast, permissive substring matching.
+// Compile a lowercased keyword into a matcher. Any keyword that BEGINS and
+// ENDS with a word character matches on WORD BOUNDARIES: "COO" no longer
+// matches "Coordinator" (#1101), and by the same rule "Rust Engineer" no
+// longer matches "Zero Trust Engineer", "DeFi" no longer matches "Software
+// Defined Networking", "Solana" no longer matches "Genomic Breeder
+// (Solanaceae)", and "Fuel" no longer matches "Diesel Mechanic
+// Assistant/Fueler". Length was never the property that made a substring
+// match wrong - being a word was.
+//
+// A trailing plural is still accepted, because a keyword is written in the
+// singular and boards post both: "Smart Contract" has to keep matching
+// "Senior Software Engineer, Blockchain (Smart Contracts)". Anchoring
+// without this exception silently drops real roles, which is a worse failure
+// than the false positives it fixes (see #2544 on silent title drops).
+//
+// Keywords containing non-word characters at either end (".NET", "SAP ",
+// "ink!", "C++", "L&D") keep permissive substring matching: \b is defined
+// against word characters, so anchoring "c++" would demand a word character
+// after "+" and the keyword would never match anything.
+const WORD_EDGED = /^\w[\s\S]*\w$|^\w$/;
+const REGEX_SPECIAL = /[.*+?^${}()|[\]\\]/g;
+
 export function compileKeyword(kw) {
-  if (/^[a-z]{2,3}$/.test(kw)) {
-    const re = new RegExp(`\\b${kw}\\b`);
+  if (WORD_EDGED.test(kw)) {
+    const re = new RegExp(`\\b${kw.replace(REGEX_SPECIAL, '\\$&')}(?:e?s)?\\b`);
     return (lower) => re.test(lower);
   }
   return (lower) => lower.includes(kw);

--- a/tests/title-keyword-word-boundaries.test.mjs
+++ b/tests/title-keyword-word-boundaries.test.mjs
@@ -1,0 +1,62 @@
+// tests/title-keyword-word-boundaries.test.mjs — compileKeyword anchors any
+// word-edged keyword on word boundaries, not just 2-3 letter acronyms (#1101),
+// while keeping trailing plurals and punctuation-bearing keywords working.
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+import { pass, fail, ROOT } from './helpers.mjs';
+
+console.log('\ntitle_filter — word-boundary keyword matching');
+
+const { compileKeyword, buildTitleFilter } = await import(pathToFileURL(join(ROOT, 'scan.mjs')).href);
+
+const check = (kw, title, expected, why) => {
+  const got = compileKeyword(kw)(title);
+  if (got === expected) pass(why);
+  else fail(`${why} — "${kw}" vs "${title}": expected ${expected}, got ${got}`);
+};
+
+// #1101 behaviour is preserved exactly.
+check('cfo', 'group cfo, emea', true, 'short acronym still matches as a word');
+check('cfo', 'cfom', false, 'short acronym still refuses a mid-word hit');
+
+// The same rule now applies to longer keywords. Each of these was a real
+// posting written to a live pipeline by a reverse ATS sweep.
+check('rust engineer', 'sr. zero trust engineer iii (6794)', false, '"Rust Engineer" does not match "Trust Engineer"');
+check('defi', 'senior engineer system software, software defined networking', false, '"DeFi" does not match "Software Defined"');
+check('solana', 'genomic breeder (solanaceae)', false, '"Solana" does not match "Solanaceae"');
+check('fuel', 'diesel mechanic assistant/fueler', false, '"Fuel" does not match "Fueler"');
+check('near', 'praktikum im bereich near patient care biostatistics', true, '"NEAR" still matches a standalone word');
+
+// Real matches must survive.
+check('rust engineer', 'senior rust engineer', true, '"Rust Engineer" still matches its own title');
+check('solana', 'solana program engineer', true, '"Solana" still matches');
+check('fuel', 'fuel network protocol engineer', true, '"Fuel" still matches as a word');
+
+// Trailing plural: keywords are written singular, boards post both. Anchoring
+// without this drops real roles silently, which is worse than the noise fixed.
+check('smart contract', 'senior software engineer, blockchain (smart contracts)', true, 'singular keyword matches a plural title');
+check('canister', 'rust canisters engineer', true, 'plural tolerated on a one-word keyword');
+check('smart contract', 'smart contract engineer', true, 'singular keyword still matches singular title');
+
+// Punctuation-bearing keywords keep substring matching: \b is defined against
+// word characters, so anchoring "c++" would require a word char after "+" and
+// the keyword could never match.
+check('c++', 'principal backend development engineer(c++)', true, '"C++" still matches');
+check('ink!', 'ink! smart contract developer', true, '"ink!" still matches');
+check('.net', 'senior .net developer', true, '".NET" still matches');
+
+// End to end through buildTitleFilter, including an AND-group whose terms each
+// keep the boundary rule.
+{
+  const f = buildTitleFilter({ positive: ['Rust Engineer', 'Smart Contract', 'DeFi + Engineer'] });
+  const cases = [
+    ['Sr. Zero Trust Engineer III', false],
+    ['Senior Rust Engineer', true],
+    ['Blockchain Engineer (Smart Contracts)', true],
+    ['Senior Engineer System Software, Software Defined Networking', false],
+    ['DeFi Engineer', true],
+  ];
+  const wrong = cases.filter(([t, want]) => f(t) !== want);
+  if (wrong.length === 0) pass('buildTitleFilter applies boundaries through plain keywords and AND-groups');
+  else fail(`buildTitleFilter mismatches: ${JSON.stringify(wrong)}`);
+}


### PR DESCRIPTION
Closes #3103.

## Problem

`compileKeyword` gates word-boundary matching on keyword *length*:

```js
if (/^[a-z]{2,3}$/.test(kw)) { /* \b anchored */ }
return (lower) => lower.includes(kw);   // 4+ chars: substring
```

Length was never the property that made a substring match wrong - being a word was. Every 4+ character keyword still matches mid-word, on real postings:

|Keyword|Matched|
|---|---|
|`Rust Engineer`|`Sr. Zero Trust Engineer III (6794)`|
|`DeFi`|`Senior Engineer System Software, Software Defined Networking`|
|`Solana`|`Genomic Breeder (Solanaceae)`|
|`Fuel`|`Diesel Mechanic Assistant/Fueler`|

## Change

`compileKeyword` now anchors any keyword that **begins and ends with a word character**, which subsumes the `/^[a-z]{2,3}$/` branch rather than replacing it, so #1101 and #1169 behaviour is preserved.

Two deliberate details:

1. **A trailing plural is accepted** (`(?:e?s)?`). Keywords are written singular and boards post both, so strict anchoring makes `"Smart Contract"` miss `Senior Software Engineer, Blockchain (Smart Contracts)`. I hit that during measurement - the naive rule dropped 75 titles and one was a genuine smart-contract role. Per #2544, trading false positives for silent false negatives is not an improvement.
2. **Keywords with a non-word character at either edge keep substring matching** (`.NET`, `SAP `, `L&D`, `ink!`, `C++`). This is a correctness requirement, not a preference: `\b` is defined against word characters, so anchoring `c++` would demand a word character after `+` and the keyword could never match anything.

## Measured impact

Over the 488 distinct titles in my `scan-history.tsv`, against my own `title_filter`:

|  | naive `\b` | with the plural exception |
|---|---|---|
| titles no longer matching | 75 | **68** |
| real roles lost | 1 | **0** |
| newly matching | 0 | **0** |

The three the measurement initially flagged as possible losses were `Solanaceae` and the two `Zero Trust Engineer` postings. My own detector regex had the same substring bug the change fixes.

## Tests

`tests/title-keyword-word-boundaries.test.mjs`, 17 assertions: #1101's acronym cases still pass, each real-world bleed above is refused, the same keywords still match their own titles, plurals resolve, `.NET`/`ink!`/`C++` keep matching, and one end-to-end pass through `buildTitleFilter` covering a plain keyword and an AND-group.

`node test-all.mjs`: 4433 passed, 0 failed, 3 warnings (all environmental - no user data in a clean checkout, no Go compiler).

This is a behaviour change to a matcher every scan path shares, so it is worth a close look at the plural exception specifically. I am happy to drop it and make plural spellings the user's job, if that is the call - the tradeoff is discussed in #3103.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved keyword matching to avoid unintended matches within larger words.
  - Added support for valid singular, plural, and trailing “e” keyword variations.
  - Preserved matching for keywords containing punctuation.
  - Special characters in keywords are now handled safely.

- **Tests**
  - Expanded coverage for acronym compatibility, standalone matches, plural forms, punctuation, and combined title filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->