### PR TITLE
fix(web): carry location_filter.block_hard through Explore (#3102)

### DIFF
--- a/web/src/components/explore/filter-builder.tsx
+++ b/web/src/components/explore/filter-builder.tsx
@@ -209,6 +209,10 @@ export function FilterBuilder({
             </div>
           </div>
           <div>
+            <Label hint="hard reject — overrides Always include">Never in (hard)</Label>
+            <KeywordField values={filters.blockHard} tone="exc" placeholder="USA, Brazil…" onChange={(v) => set({ blockHard: v })} />
+          </div>
+          <div>
             <Label hint={`${filters.limitPerAts} companies / source`}>Scan depth</Label>
             <input
               type="range"

--- a/web/src/lib/core/portals-serialize.mjs
+++ b/web/src/lib/core/portals-serialize.mjs
@@ -1,0 +1,46 @@
+// Pure serializer for the ephemeral Explorer portals.yml — extracted from
+// portals.ts so a `node --test` can load it (the web suite is .mjs and cannot
+// import a .ts), matching clean-chips.mjs / profile-keywords.mjs.
+//
+// Kept dependency-free on purpose: it takes a plain filter-lists object and
+// returns YAML text, nothing else. The correctness this guards is that NO
+// location tier is silently dropped when the Explorer writes the file the
+// scanner reads — the bug block_hard hit (#3102): a tier the type carried but
+// the serializer never emitted is a filter the user set and the scan ignored.
+
+/** One YAML list block, or "" when empty. Scalars go through JSON.stringify (a
+ *  valid YAML double-quoted scalar) so arbitrary keywords — colons, quotes,
+ *  leading dashes — can never break the document or inject YAML. */
+function block(key, items) {
+  return items.length
+    ? `  ${key}:\n` + items.map((k) => `    - ${JSON.stringify(k)}`).join("\n") + "\n"
+    : "";
+}
+
+/**
+ * Serialize filters into a minimal, valid portals.yml.
+ *
+ * location tiers mirror scan.mjs precedence block_hard > always_allow > block >
+ * allow. The `location_filter:` header is emitted when ANY tier is non-empty —
+ * block_hard included, or a config that hard-blocks and nothing else would write
+ * no location_filter at all and the scan would honor none of it (#3102).
+ *
+ * @param {{positive:string[], negative:string[], allow:string[], block:string[], alwaysAllow:string[], blockHard:string[]}} f
+ * @returns {string}
+ */
+export function serializePortals(f) {
+  let out = "# Ephemeral Explorer filters — generated per-search, safe to delete.\n";
+  if (f.positive.length || f.negative.length) {
+    out += "title_filter:\n";
+    out += block("positive", f.positive);
+    out += block("negative", f.negative);
+  }
+  if (f.blockHard.length || f.allow.length || f.block.length || f.alwaysAllow.length) {
+    out += "location_filter:\n";
+    out += block("block_hard", f.blockHard);
+    out += block("always_allow", f.alwaysAllow);
+    out += block("allow", f.allow);
+    out += block("block", f.block);
+  }
+  return out;
+}

--- a/web/src/lib/core/portals.ts
+++ b/web/src/lib/core/portals.ts
@@ -18,35 +18,20 @@ import { profileTargetKeywords } from "@/lib/profile-keywords.mjs";
  * Filter semantics mirror scan.mjs::buildTitleFilter / buildLocationFilter:
  *   title positive → substring match (empty = everything matches)
  *   title negative → substring reject
- *   location always_allow > block > allow (case-insensitive substring)
+ *   location block_hard > always_allow > block > allow (case-insensitive substring);
+ *   block_hard is the one tier always_allow cannot override (scan.mjs, #2956)
  */
-type FilterLists = Pick<ExploreFilters, "positive" | "negative" | "allow" | "block" | "alwaysAllow">;
+type FilterLists = Pick<ExploreFilters, "positive" | "negative" | "allow" | "block" | "alwaysAllow" | "blockHard">;
 
 function listFrom(v: unknown): string[] {
   return cleanChips(v);
 }
 
-/** Serialize filters into a minimal, valid portals.yml. Scalars go through
- *  JSON.stringify (a valid YAML double-quoted scalar) so arbitrary keywords —
- *  colons, quotes, leading dashes — can never break the document or inject YAML. */
-export function serializePortals(f: FilterLists): string {
-  const block = (key: string, items: string[]) =>
-    items.length ? `  ${key}:\n` + items.map((k) => `    - ${JSON.stringify(k)}`).join("\n") + "\n" : "";
-
-  let out = "# Ephemeral Explorer filters — generated per-search, safe to delete.\n";
-  if (f.positive.length || f.negative.length) {
-    out += "title_filter:\n";
-    out += block("positive", f.positive);
-    out += block("negative", f.negative);
-  }
-  if (f.allow.length || f.block.length || f.alwaysAllow.length) {
-    out += "location_filter:\n";
-    out += block("always_allow", f.alwaysAllow);
-    out += block("allow", f.allow);
-    out += block("block", f.block);
-  }
-  return out;
-}
+// serializePortals lives in portals-serialize.mjs (pure, no TS deps) so the web
+// `node --test` suite can load it — the block_hard round-trip (#3102) is exactly
+// a "don't silently drop a tier" property that has to be asserted, not eyeballed.
+export { serializePortals } from "./portals-serialize.mjs";
+import { serializePortals } from "./portals-serialize.mjs";
 
 /** Write the ephemeral filter file to a temp path; caller cleans it up. */
 export function writeTempPortals(f: FilterLists): string {
@@ -91,7 +76,8 @@ export function seedExploreFilters(): { filters: ExploreFilters; seededFrom: str
     filters.allow = listFrom(lf.allow);
     filters.block = listFrom(lf.block);
     filters.alwaysAllow = listFrom(lf.always_allow);
-    if (filters.positive.length || filters.allow.length || filters.block.length) seededFrom.push("portals.yml");
+    filters.blockHard = listFrom(lf.block_hard);
+    if (filters.positive.length || filters.allow.length || filters.block.length || filters.blockHard.length) seededFrom.push("portals.yml");
   }
 
   if (filters.positive.length === 0) {

--- a/web/src/lib/explore.ts
+++ b/web/src/lib/explore.ts
@@ -21,6 +21,7 @@ export type ExploreFilters = {
   negative: string[];
   allow: string[];
   block: string[];
+  blockHard: string[];
   alwaysAllow: string[];
   sinceDays: number;
   ats: AtsSource[];
@@ -32,6 +33,7 @@ export const DEFAULT_FILTERS: ExploreFilters = {
   negative: [],
   allow: [],
   block: [],
+  blockHard: [],
   alwaysAllow: [],
   sinceDays: 7,
   ats: [...ATS_SOURCES],
@@ -127,6 +129,7 @@ export function parseExplorePatch(
     ["negative", "negative"],
     ["allow", "allow"],
     ["block", "block"],
+    ["blockHard", "blockHard"],
     ["alwaysAllow", "alwaysAllow"],
   ];
   for (const [field, key] of lists) {
@@ -149,6 +152,7 @@ export function filtersToParams(f: ExploreFilters): string {
   if (f.negative.length) sp.set("not", f.negative.join(","));
   if (f.allow.length) sp.set("loc", f.allow.join(","));
   if (f.block.length) sp.set("noloc", f.block.join(","));
+  if (f.blockHard.length) sp.set("hardno", f.blockHard.join(","));
   if (f.alwaysAllow.length) sp.set("home", f.alwaysAllow.join(","));
   if (f.sinceDays !== DEFAULT_FILTERS.sinceDays) sp.set("since", String(f.sinceDays));
   if (f.ats.length !== ATS_SOURCES.length) sp.set("ats", f.ats.join(","));
@@ -164,6 +168,7 @@ export function paramsToFilters(sp: URLSearchParams, base: ExploreFilters = DEFA
       negative: split(sp.get("not")),
       allow: split(sp.get("loc")),
       block: split(sp.get("noloc")),
+      blockHard: split(sp.get("hardno")),
       alwaysAllow: split(sp.get("home")),
       since: sp.get("since") ?? undefined,
       ats: split(sp.get("ats")),

--- a/web/tests/lib/portals-serialize.test.mjs
+++ b/web/tests/lib/portals-serialize.test.mjs
@@ -1,0 +1,52 @@
+// The Explorer writes an ephemeral portals.yml and points the scanner at it. If
+// the serializer omits a location tier the type carries, that filter is silently
+// dropped — the user set it, the scan ignores it. block_hard (#2956/#3102) is the
+// tier this test exists to protect: it is the ONE tier always_allow cannot
+// override, so dropping it doesn't loosen results, it lets through jobs the user
+// hard-rejected.
+//
+// Run:  node --test tests/lib/portals-serialize.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as yaml from "js-yaml";
+import { serializePortals } from "../../src/lib/core/portals-serialize.mjs";
+
+const empty = { positive: [], negative: [], allow: [], block: [], alwaysAllow: [], blockHard: [] };
+
+test("block_hard is written under location_filter", () => {
+  const doc = yaml.load(serializePortals({ ...empty, blockHard: ["usa", "brazil"] }));
+  assert.deepEqual(doc.location_filter.block_hard, ["usa", "brazil"]);
+});
+
+test("a hard-block-ONLY config still emits location_filter (the #3102 drop)", () => {
+  // The bug the guard fixes: the location_filter header used to be gated on
+  // allow/block/always_allow only, so a config that hard-blocks and nothing else
+  // wrote no location_filter at all and the scan honored none of it.
+  const doc = yaml.load(serializePortals({ ...empty, blockHard: ["usa"] }));
+  assert.ok(doc.location_filter, "location_filter must be present for a block_hard-only config");
+  assert.deepEqual(doc.location_filter.block_hard, ["usa"]);
+});
+
+test("all location tiers round-trip through YAML", () => {
+  const f = { ...empty, allow: ["remote"], block: ["india"], alwaysAllow: ["london"], blockHard: ["usa"] };
+  const lf = yaml.load(serializePortals(f)).location_filter;
+  assert.deepEqual(lf.block_hard, ["usa"]);
+  assert.deepEqual(lf.always_allow, ["london"]);
+  assert.deepEqual(lf.allow, ["remote"]);
+  assert.deepEqual(lf.block, ["india"]);
+});
+
+test("no location tiers → no location_filter section", () => {
+  const doc = yaml.load(serializePortals({ ...empty, positive: ["engineer"] }));
+  assert.equal(doc.location_filter, undefined);
+  assert.deepEqual(doc.title_filter.positive, ["engineer"]);
+});
+
+test("a keyword that could break YAML is quoted, not injected", () => {
+  // A hard-block keyword is user input; a bare `- key: value` or a leading dash
+  // would corrupt the document or smuggle structure. JSON.stringify makes each a
+  // double-quoted scalar.
+  const doc = yaml.load(serializePortals({ ...empty, blockHard: ["a: b", "- x", '"q"'] }));
+  assert.deepEqual(doc.location_filter.block_hard, ["a: b", "- x", '"q"']);
+});


### PR DESCRIPTION
Closes #3102. Lands on top of #2956 (already in `main`).

## The gap

#2956 added a **`block_hard`** location tier to the core scanner — the one tier `always_allow` cannot override. But the Explorer never serialized it: when a search wrote its ephemeral `portals.yml`, a user's hard-block was dropped and the scan returned jobs the CLI would have rejected. The web is a **writer** of this format, so a missing tier isn't a parse it tolerates — it's a filter it silently omits.

## Carried through the whole round-trip, not just the serializer

Scoped as type + seed + serializer, but the Explorer also hydrates filters from the URL (`paramsToFilters`), so `block_hard` has to survive `filtersToParams` / `paramsToFilters` too — otherwise it's dropped the first time the URL round-trips, the same silent drop one hop earlier. Touch points:

- `ExploreFilters` + `DEFAULT_FILTERS`
- `mergeFilters` list
- `filtersToParams` (`hardno`) / `paramsToFilters`
- `seedExploreFilters` — reads `lf.block_hard` from the user's real portals.yml
- `serializePortals` — emits `block_hard`, and **includes it in the `location_filter` guard** so a hard-block-ONLY config still writes a `location_filter` section (that guard omission was the actual bug)

## Testability

`serializePortals` is extracted to **`portals-serialize.mjs`** (pure, no TS deps) so the web `node --test` suite can load it — a "don't silently drop a tier" property has to be asserted, not eyeballed. `portals-serialize.test.mjs` covers: `block_hard` written; the **hard-block-only guard case** (verified red against the old guard: `actual undefined, expected location_filter`); all tiers round-tripping; and YAML-injection safety of a hostile keyword (`a: b`, `- x`, `"q"`).

## UI

A **"Never in (hard)"** field in the Explore filter builder, so a `block_hard` seeded from portals.yml is visible and editable rather than applied invisibly.

## Verification

- Full web suite **290/0**, `tsc --noEmit` clean.
- The drop reproduced red, then green under the fix.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Never in (hard)” location filter for excluding matches with highest priority.
  - Added support for saving and sharing hard location exclusions through filters and URLs.
  - Portal configuration exports now preserve all location filter levels and safely handle custom keywords.

- **Bug Fixes**
  - Clarified location filter precedence to ensure hard exclusions override other location rules.

- **Tests**
  - Added coverage for serialization, filter round-tripping, omission of empty filters, and safe keyword handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->