### PR TITLE
fix(agent-inbox): seed the queue under the lock, not before it

### DIFF
--- a/agent-inbox-tests.mjs
+++ b/agent-inbox-tests.mjs
@@ -14,16 +14,20 @@
  *      the personal queue isn't accidentally tracked.
  *   7. Concurrent `add` calls all survive — the queue is appended to, never
  *      rewritten, so simultaneous writers cannot clobber each other.
+ *   8. The queue file is SEEDED under the lock too, not merely appended to under
+ *      it. Creating it is open() then write(), and a writer that observed the
+ *      gap appended into a zero-byte file and lost its item to the header.
  *
  * Provisions a throwaway queue via CAREER_OPS_INBOX and a temp CWD; never
  * touches real user data.
  */
 
 import { execFileSync, spawn } from 'child_process';
-import { readFileSync, writeFileSync, mkdtempSync } from 'fs';
+import { readFileSync, writeFileSync, mkdtempSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { tmpdir } from 'os';
 import { fileURLToPath } from 'url';
+import { acquirePipelineLock } from './pipeline-lock.mjs';
 
 const ROOT = dirname(fileURLToPath(import.meta.url));
 const NODE = process.execPath;
@@ -186,6 +190,62 @@ console.log('7. concurrent adds do not lose items (append, not rewrite)');
   const expected = new Set(Array.from({ length: N }, (_, i) => `item-${i}`));
   const complete = actual.size === expected.size && [...expected].every((item) => actual.has(item));
   check('no item is duplicated or truncated', complete, `actual=${[...actual].join(', ')}`);
+}
+
+// ---------------------------------------------------------------------------
+console.log('8. the queue file is seeded under the lock, not before it');
+{
+  // §7 asserts the concurrent adds all survive. This asserts the reason they
+  // can: the file is created AND its header written while the lock is held, so
+  // no other writer can ever observe it mid-initialisation.
+  //
+  // The distinction is not academic. `wx` makes the CREATE atomic but not the
+  // INITIALISATION — writeFileSync is open() then write(), and between them the
+  // file exists at zero bytes. Measured on Windows, a second process polling
+  // existsSync saw it empty in 303 of 400 rounds. A writer that looked in that
+  // window skipped creation, appended into the empty file, and had its line
+  // overwritten when the 479-byte header landed at offset 0: every process
+  // exited 0 and the queue came out well-formed and one item short — §7's
+  // `kept=29 of 30` with nothing to show for it. Seeding OUTSIDE the lock is
+  // what made that window reachable.
+  //
+  // Asserted deterministically rather than by racing for it: the test holds the
+  // lock itself, so a seed that happens before acquisition shows up as a file
+  // existing at a moment when no writer can possibly be in the critical
+  // section. Racing would reproduce it only on a loaded multi-core runner,
+  // which is precisely the flake this replaces.
+  const dir = tmp('inbox-seed-');
+  const inbox = join(dir, 'agent-inbox.md');
+  const held = await acquirePipelineLock(inbox, { timeoutMs: 10_000 });
+
+  const child = spawn(NODE, [CLI, 'add', 'seeded under the lock'], {
+    cwd: ROOT, env: { ...process.env, CAREER_OPS_INBOX: inbox }, stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  let childErr = '';
+  child.stderr.on('data', (c) => { childErr += c; });
+  const finished = new Promise((res) => child.on('exit', res));
+
+  // Generous, because a false green here is the one outcome worth avoiding: the
+  // pre-fix ensureFile() ran before the first lock attempt, so the file
+  // appeared as soon as the process finished booting.
+  const appearedWhileLocked = await new Promise((res) => {
+    const deadline = Date.now() + 2_000;
+    const poll = () => {
+      if (existsSync(inbox)) return res(true);
+      if (Date.now() > deadline) return res(false);
+      setTimeout(poll, 25);
+    };
+    poll();
+  });
+  check('queue file is NOT created while another process holds the lock', appearedWhileLocked === false);
+
+  held.release();
+  const code = await finished;
+  check('the blocked add still completes once the lock frees', code === 0,
+    childErr.trim().split('\n').slice(-2).join(' | '));
+  const md = existsSync(inbox) ? readFileSync(inbox, 'utf8') : '';
+  check('header was seeded', /^# Agent Inbox/.test(md) && /Agent protocol:/.test(md), md.slice(0, 60));
+  check('the item landed after the header', /^- \[ \] .*seeded under the lock/m.test(md), md);
 }
 
 console.log(`\nResults: ${passed} passed, ${failed} failed`);

--- a/agent-inbox.mjs
+++ b/agent-inbox.mjs
@@ -70,6 +70,9 @@ function oneLine(s) {
   return String(s ?? '').replace(/\s*\n\s*/g, ' ').trim();
 }
 
+// MUST be called with the queue lock held — see add(). Creating the file is
+// only half of it; the file is not usable until the header is IN it, and that
+// is two syscalls, not one.
 function ensureFile() {
   if (existsSync(PATH)) return;
   ensureGitignored();
@@ -80,6 +83,19 @@ function ensureFile() {
   // lands after the first has already appended its item and wipes it back to
   // just the header. 'wx' makes only one of them win the create — the loser
   // gets EEXIST and does nothing, same as if it had seen existsSync === true.
+  //
+  // 'wx' settles the two-creator case and nothing else. It makes the CREATE
+  // atomic, not the INITIALISATION: writeFileSync is open() then write(), and
+  // between those two syscalls the file EXISTS and is ZERO BYTES. Measured on
+  // Windows, a second process polling existsSync and stat-ing the moment the
+  // file appeared saw it at 0 bytes in 303 of 400 rounds.
+  //
+  // So there is a third participant the exclusive flag cannot see: a writer
+  // that arrives INSIDE that window, finds existsSync === true, skips creation,
+  // and appends — into a file this call is about to overwrite from offset 0.
+  // Its item is gone, with no error anywhere; the write below simply lands on
+  // top of it. That is why the caller holds the lock across this function
+  // rather than around the append alone.
   try {
     writeFileSync(PATH, HEADER, { flag: 'wx' });
   } catch (err) {
@@ -125,7 +141,6 @@ function opt(name, def = '') {
 async function add() {
   const text = oneLine(process.argv.slice(3).join(' '));
   if (!text) fail('add needs a request, e.g. node agent-inbox.mjs add "evaluate https://..."');
-  ensureFile();
   // Append rather than rewrite. This is the queue's concurrent path — anything
   // running in the background can drop an item in — and a read-whole-file /
   // write-whole-file cycle loses every request that lands between the two. With
@@ -159,7 +174,22 @@ async function add() {
   // cure"; the fit-for-purpose budget for a burst-write queue is the contained
   // fix. 30s gives ~375 rounds of headroom, well past the herd's worst case,
   // while the critical section itself is a single sub-millisecond append.
+  //
+  // ensureFile() is INSIDE the lock, not before it. Seeding the file is a
+  // check-create-initialise sequence, and run unlocked it loses items the same
+  // way the unlocked append did: a writer that observes the file between the
+  // creator's open() and its write() sees a zero-byte file, appends into it,
+  // and has its line overwritten when the header lands at offset 0. Every
+  // writer exits 0 and the queue is left perfectly well-formed, one item
+  // shorter — the silent drop the lock was added to end, one step earlier in
+  // the same function.
+  //
+  // Holding the lock across the seed makes the window unreachable rather than
+  // narrow: no writer can observe the file until the creator has released, and
+  // the creator writes the header before it releases. 'wx' above stays as the
+  // guard against writers that are not this function.
   await withPipelineLock(PATH, () => {
+    ensureFile();
     const separator = needsLeadingNewline(PATH) ? '\n' : '';
     appendFileSync(PATH, `${separator}- [ ] ${stamp()} — ${text}\n`);
   }, { timeoutMs: 30_000 });


### PR DESCRIPTION
## The bug

`ensureFile()` ran **outside** the queue lock:

```js
if (existsSync(PATH)) return;                    // (1)
writeFileSync(PATH, HEADER, { flag: 'wx' });     // (2) open(O_CREAT|O_EXCL) … then write()
```

`wx` closed the case it was added for — two writers both passing (1), the second's
default-`w` write truncating the first's item. But `wx` makes the **create** atomic, not
the **initialisation**. `writeFileSync` is `open()` *then* `write()`, and between those
two syscalls the file **exists and is zero bytes**.

That admits a third participant the exclusive flag cannot see: a writer arriving *inside*
the window finds `existsSync === true`, skips creation, takes the lock **correctly**, and
appends — into a file the creator is about to overwrite from offset 0. When the 479-byte
header lands, that line is simply gone.

Every writer exits 0, and the queue comes out perfectly well-formed and one item shorter.
That is the `kept=29 of 30` `agent-inbox-tests` §7 has been reporting on windows-latest —
a real data-loss bug, not a flake. Full investigation in
santifer/career-ops#2905 (comment).

## Evidence

The window is directly observable — a second process polling `existsSync` and stat-ing
the moment the file appeared saw it at **0 bytes in 303 of 400 rounds** on Windows.

Reproduced end to end by pinning the process tree to 2 cores, so the creator only has to
lose its timeslice between `open()` and `write()`:

```
=== ROUND 15 FAILED — missing=[item-2,item-12,item-16,item-28] nonzeroExits=0
  writers that won the wx create: item-19

  item-2 : existsSync seen=true → preLock size=0 → appended before=0   after=34
  item-16:                                          appended before=104 after=139
           → postCheck mine=FALSE      ← watched its own line vanish

    BREAK item-23: 479 -> 514   [expected before=139]
```

Four writers walked the window, each **correctly serialised by the lock** (every `before`
equals the previous `after`). Then `item-19`'s `write(HEADER)` landed at offset 0 and
replaced all 139 bytes. `479` is `Buffer.byteLength(HEADER)` to the byte.

For completeness: `appendFileSync` is atomic across processes on Windows — 25 rounds ×
30 concurrent writers with **no lock at all**, zero losses. The append and the lock are
both innocent.

## The change

Two lines of behaviour — `ensureFile()` moves inside `withPipelineLock`. It reuses the
lock already taken one line later, adds no second mechanism, and the critical section
stays sub-millisecond. `'wx'` stays as the guard against writers that are not this
function.

This makes the window **unreachable** rather than narrow: no writer can observe the file
until the creator has released, and the creator writes the header before it releases.

A/B at 30 concurrent writers pinned to 2 cores, arms alternated round by round, **400
rounds each**:

|                            | shipped | fixed |
|----------------------------|---------|-------|
| appends into a 0-byte file | 4       | **0** |
| silent loss (all exited 0) | 3       | **0** |

## Test

The regression test is **deterministic, not a race**: it holds the lock itself and
asserts the queue file does not appear while held, so a seed happening before acquisition
is visible without needing a loaded multi-core runner.

- with the fix: 23 passed, 0 failed
- against unfixed `agent-inbox.mjs`: 22 passed, 1 failed — `❌ queue file is NOT created while another process holds the lock`

Full suite on an idle machine: **4866 passed, 0 failed**. Fresh-install path checked
explicitly, since `ensureFile()` no longer pre-creates `data/` — `acquirePipelineLock`
already does `mkdirSync(dirname(lockDir), { recursive: true })`.

## Scope — please read before expecting §7 to go quiet

This removes the **silent** loss. It does **not** address a separate defect in
`pipeline-lock.mjs`: `lockCanRecover()`'s `catch` returns `true` for "vanished" and the
caller acts on it by `rmSync`-ing rather than retrying, which can delete a lock another
writer legitimately created in the meantime. Traced across three processes in a 540 µs
window. §7 can still go red with a **non-zero exit** until that is fixed separately.

Also left alone: a process killed between `open()` and `write()` while holding the lock
still leaves a 0-byte file, after which adds append with no header. Cosmetic, no data
loss, and fixing it means widening `ensureFile()`'s contract from "exists" to "exists and
is initialised" — beyond this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved queue initialization to prevent incomplete or corrupted queue files during concurrent operations.
  * Ensured new queue items are added only after required queue setup is complete.
  * Added safeguards for operations running while another queue process holds the lock.

* **Tests**
  * Added coverage verifying safe queue initialization, header creation, and item placement under locking conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->