### PR TITLE
fix(pipeline-lock): a vanished lock is not a lock you may delete

### DIFF
--- a/pipeline-lock.mjs
+++ b/pipeline-lock.mjs
@@ -170,24 +170,42 @@ function processIsAlive(pid) {
 // OWNERLESS_GRACE_MS is a lower bound on that patience, never a cap: a larger
 // caller staleMs still wins, and a genuinely abandoned directory still ages
 // out, so a crash while holding the guard cannot disable recovery for good.
-function lockCanRecover(lockDir, staleMs) {
+//
+// The answer is a VERDICT, not a boolean, because "recoverable" was two
+// different answers wearing one hat and only one of them licenses a delete:
+//
+//   STALE    — a directory is THERE and its holder is gone. Deleting it IS the
+//              recovery, and it is the only case that should reach rmSync.
+//   VANISHED — there was nothing there when we looked. Also "not blocked", but
+//              emphatically NOT a licence to delete: the caller acts on this
+//              verdict microseconds later, and by then the path may be owned by
+//              a process that legitimately created it in between. Deleting on
+//              this answer is how an acquirer destroys a live lock it never
+//              observed (see the caller).
+//   LIVE     — someone holds it, or we could not establish otherwise. Wait.
+export const RECOVER_STALE = 'stale';
+export const RECOVER_VANISHED = 'vanished';
+export const RECOVER_LIVE = 'live';
+
+export function lockRecoveryVerdict(lockDir, staleMs) {
   const { inspected, owner } = readLockOwner(lockDir);
   // Unreadable is not ownerless. A stamp this process could not read proves
   // nothing about whether its holder is alive, and falling through to the age
   // rule on that basis is how a LIVE lock gets condemned — the same reasoning
   // #2984 applied to the stat below, one step earlier in the same function.
-  if (!inspected) return false;
-  if (owner?.pid) return !processIsAlive(owner.pid);
+  if (!inspected) return RECOVER_LIVE;
+  if (owner?.pid) return processIsAlive(owner.pid) ? RECOVER_LIVE : RECOVER_STALE;
   try {
-    return Date.now() - statSync(lockDir).mtimeMs > Math.max(staleMs, OWNERLESS_GRACE_MS);
+    return Date.now() - statSync(lockDir).mtimeMs > Math.max(staleMs, OWNERLESS_GRACE_MS)
+      ? RECOVER_STALE
+      : RECOVER_LIVE;
   } catch (err) {
-    // Only a genuinely vanished directory is "nothing to recover". Any other
-    // stat failure — Windows EPERM/EBUSY while the directory is mid-flight —
-    // is "could not look", and answering "recoverable" to that hands the
-    // caller an rmSync of a LIVE lock created microseconds ago: its winner
-    // then dies with ENOENT writing owner.json (#2777, third face — measured
-    // after the rm-contention fix exposed it).
-    return err?.code === 'ENOENT';
+    // Any stat failure other than ENOENT — Windows EPERM/EBUSY while the
+    // directory is mid-flight — is "could not look", and answering
+    // "recoverable" to that hands the caller an rmSync of a LIVE lock created
+    // microseconds ago: its winner then dies with ENOENT writing owner.json
+    // (#2777, third face — measured after the rm-contention fix exposed it).
+    return err?.code === 'ENOENT' ? RECOVER_VANISHED : RECOVER_LIVE;
   }
 }
 
@@ -382,14 +400,33 @@ export async function acquirePipelineLock(pipelinePath, options = {}) {
         // A process killed between taking the guard and cleaning it up would
         // otherwise disable stale recovery forever. The guard normally lives
         // for milliseconds, so an old one is judged by the same age rule.
-        if (lockCanRecover(recoverGuardDir, staleMs)) {
+        // STALE only. A guard that was already gone when we looked needs no
+        // eviction, and evicting on that answer would delete the guard a
+        // different caller has just legitimately taken — putting two callers
+        // inside the decide-then-delete window this guard exists to serialize.
+        if (lockRecoveryVerdict(recoverGuardDir, staleMs) === RECOVER_STALE) {
           rmLockArtifactSync(recoverGuardDir);
         }
       }
 
       if (hasRecoverGuard) {
         try {
-          if (lockCanRecover(lockDir, staleMs)) {
+          // Only STALE reaches the rm. VANISHED means the lock was absent when
+          // we looked, and the gap between that observation and this line is
+          // long enough for another acquirer to have won the mkdir and be
+          // partway through writing its owner.json. Deleting on that answer
+          // destroys the fresh, live lock: measured on Windows, the winner's
+          // mkdir landed 472 us after the vanished verdict and the rm 68 us
+          // after that, killing it with `ENOENT ... open '<path>.lock/owner.json'`
+          // and losing its queued item. The rm is the lucky outcome — had the
+          // stamp landed first, both callers would have held the lock with no
+          // error at all.
+          //
+          // So VANISHED falls through to the normal backoff and retries
+          // acquisition, which is what the old comment already claimed this
+          // branch did. It costs one backoff in a rare case; deleting a live
+          // lock costs an item.
+          if (lockRecoveryVerdict(lockDir, staleMs) === RECOVER_STALE) {
             if (rmLockArtifactSync(lockDir)) {
               continue; // retry acquisition immediately, still holding the guard's decision
             }
@@ -447,7 +484,7 @@ export async function acquirePipelineLock(pipelinePath, options = {}) {
         continue;
       }
       // Best-effort: a contended rm here must not mask ownerErr, and an
-      // orphaned owner-less lock ages out via lockCanRecover anyway.
+      // orphaned owner-less lock ages out via lockRecoveryVerdict anyway.
       //
       // The try/catch is what makes that sentence true for EVERY failure, not
       // just a contended one. rmLockArtifactSync deliberately rethrows the

--- a/test/pipeline-lock.test.mjs
+++ b/test/pipeline-lock.test.mjs
@@ -22,7 +22,10 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync, existsSync, mkdirSync, writeFileSync, readFileSync, utimesSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
-import { acquirePipelineLock, LockTimeoutError, OWNERLESS_GRACE_MS } from '../pipeline-lock.mjs';
+import {
+  acquirePipelineLock, LockTimeoutError, OWNERLESS_GRACE_MS,
+  lockRecoveryVerdict, RECOVER_STALE, RECOVER_VANISHED, RECOVER_LIVE,
+} from '../pipeline-lock.mjs';
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
@@ -264,6 +267,64 @@ test('acquirePipelineLock: a recover guard abandoned by a crashed process still 
     const lock = await acquirePipelineLock(p, { timeoutMs: 1000, retryMs: 20, staleMs: 1 });
     lock.release();
     assert.equal(existsSync(guardDir), false, 'the abandoned recover guard should have been cleaned up');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// The verdict itself. A cross-process reproduction of the bug below is
+// inherently a race — it needs a rival acquirer to win the mkdir inside the
+// microseconds between the verdict and the rm — so the decision is asserted
+// directly instead. What the caller does with each verdict is the other half,
+// and it is a two-line branch right at the call site.
+test('lockRecoveryVerdict: an absent directory is VANISHED, never STALE — "gone" is not a licence to delete', () => {
+  const root = fixtureRoot();
+  try {
+    const lockDir = join(root, 'data', 'pipeline.md.lock');
+    // Nothing at the path at all: the exact state that produced
+    // `canRecover:VANISHED->true` in the trace, immediately before a rival
+    // acquirer created a fresh lock there and had it deleted underneath it.
+    assert.equal(lockRecoveryVerdict(lockDir, 1), RECOVER_VANISHED);
+    // The distinction that matters: a caller that deletes on STALE and only on
+    // STALE cannot destroy a lock it never observed.
+    assert.notEqual(lockRecoveryVerdict(lockDir, 1), RECOVER_STALE);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('lockRecoveryVerdict: STALE, LIVE and the grace floor keep their existing meanings', () => {
+  const root = fixtureRoot();
+  try {
+    const dead = join(root, 'data', 'dead.lock');
+    writeCrashedHolder(dead);
+    assert.equal(lockRecoveryVerdict(dead, 1), RECOVER_STALE, 'a crashed holder is still reclaimable');
+
+    const live = join(root, 'data', 'live.lock');
+    mkdirSync(live, { recursive: true });
+    writeFileSync(join(live, 'owner.json'), JSON.stringify({
+      pid: process.pid, token: 'live', started_at: new Date().toISOString(),
+    }), 'utf-8');
+    backdate(live, OWNERLESS_GRACE_MS * 50);
+    assert.equal(lockRecoveryVerdict(live, 1), RECOVER_LIVE, 'a live owner is never stale, however old');
+
+    const fresh = join(root, 'data', 'fresh.lock');
+    mkdirSync(fresh, { recursive: true });
+    assert.equal(lockRecoveryVerdict(fresh, 1), RECOVER_LIVE, 'ownerless but inside the grace floor (#2304)');
+
+    const aged = join(root, 'data', 'aged.lock');
+    mkdirSync(aged, { recursive: true });
+    backdate(aged, OWNERLESS_GRACE_MS * 5);
+    assert.equal(lockRecoveryVerdict(aged, 1), RECOVER_STALE, 'ownerless past the floor still ages out (#2304)');
+
+    // #2984: unreadable is not ownerless, and must not become VANISHED either —
+    // that would hand the caller the same delete by a different route.
+    const opaque = join(root, 'data', 'opaque.lock');
+    mkdirSync(opaque, { recursive: true });
+    mkdirSync(join(opaque, 'owner.json'));
+    backdate(opaque, OWNERLESS_GRACE_MS * 5);
+    assert.equal(lockRecoveryVerdict(opaque, 1), RECOVER_LIVE, 'a stamp we could not read protects the lock');
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/tests/lock-rm-contention.test.mjs
+++ b/tests/lock-rm-contention.test.mjs
@@ -101,17 +101,26 @@ const mkErr = (code) => Object.assign(new Error(code), { code });
 }
 
 // ── 3b. "Could not look" is never "recoverable" ──────────────────────
-// The third face of #2777: lockCanRecover's stat catch answered `true`
+// The third face of #2777: the recovery judgment's stat catch answered `true`
 // (recoverable) to EVERY stat failure, so a Windows EPERM on a mid-flight
 // directory let a caller delete a live lock created microseconds ago — its
 // winner then died with ENOENT writing owner.json. Only ENOENT (genuinely
 // vanished) may answer "nothing to recover"; both locks must carry the guard.
+//
+// The SHAPE of that answer now differs by file, so this asserts the rule rather
+// than one spelling of it. pipeline-lock.mjs — the definition — returns a
+// verdict, because "vanished" and "stale" are different answers and only one of
+// them licenses a delete: acting on "it was gone when I looked" destroys a lock
+// a rival acquirer created in the interim. The copies still return a boolean.
+// What every implementor must do is discriminate on ENOENT and never hand
+// "could not look" to the caller as recoverable.
 {
+  const ENOENT_ONLY = /return err\?\.code === 'ENOENT'(?:;|\s*\?\s*RECOVER_VANISHED\s*:\s*RECOVER_LIVE;)/;
   for (const file of protocolImplementors()) {
     const src = readFileSync(join(ROOT, file), 'utf-8');
     ok(
-      /return err\?\.code === 'ENOENT';/.test(src),
-      `${file}: lockCanRecover's stat catch answers recoverable ONLY on ENOENT`,
+      ENOENT_ONLY.test(src),
+      `${file}: the recovery judgment's stat catch answers recoverable ONLY on ENOENT`,
     );
     ok(
       !/catch\s*\{\s*\n\s*return true;/.test(src),


### PR DESCRIPTION
## The defect

`lockCanRecover()` answers one boolean to two questions that have opposite consequences:

```js
try {
  return Date.now() - statSync(lockDir).mtimeMs > Math.max(staleMs, OWNERLESS_GRACE_MS);
} catch (err) {
  return err?.code === 'ENOENT';   // "vanished — nothing to recover, retry acquisition"
}
```

and the caller acts on that boolean by **deleting**:

```js
if (lockCanRecover(lockDir, staleMs)) {
  if (rmLockArtifactSync(lockDir)) continue;
}
```

"There was nothing there when I looked" is not a licence to delete. The verdict is computed
from an observation, and the caller acts on it microseconds later — by which time another
acquirer may have legitimately won `mkdirSync(lockDir)` and be partway through writing its
`owner.json`. The rm then destroys a live lock that this caller never observed.

The comment already says the intent is *"retry acquisition"*. The control flow does not
retry — it removes.

## Evidence

Traced live, with every lock-directory event from every process time-ordered
(microseconds, one round):

```
t=…368689  pid=2816   canRecover:VANISHED->true  code=ENOENT
t=…369161  pid=24864  MKDIR-OK (acquired; owner.json not yet written)
t=…369229  pid=2816   RMSYNC-RECOVER (deleting lockDir)  existsNow=true
t=…371071  pid=24864  OWNER-WRITE-FAILED  code=ENOENT
```

pid 2816's stat found the lock genuinely absent. **472 µs later** pid 24864 created a fresh
one. **68 µs after that** the stale verdict was acted on and deleted it — `existsNow=true`
is the proof it removed a directory that was present. pid 24864 then died with
`ENOENT … open '<path>.lock/owner.json'` and its queued item was never appended.

The crash is the *lucky* outcome. Had pid 24864's stamp landed 68 µs earlier, it would have
entered the critical section while pid 2816 `continue`d and re-`mkdir`ed the now-free path:
**two holders, no error anywhere.**

### Reproduced on current `main` — and it is not the crash that matters

An earlier revision of this description said I could not reproduce the failure on current
`main` (99 rounds, no crash) and asked you to weigh that. **That was measuring the wrong
thing, and the conclusion was wrong in the safe-sounding direction.** Replacing it.

Two things were off:

**1. The harness was counting process spawns, not acquisitions.** 30 processes per round,
each paying ~50 ms of node startup for a *single* lock acquisition — about 30 contention
events per round. Looping inside each worker instead gives ~6,000 per round, and the defect
appears immediately.

**2. The crash is unreproducible for a known reason, not a mysterious one.** `main` now
catches exactly this ENOENT and retries:

```js
// ENOENT writing owner.json means the just-won lock directory is gone:
// another caller (mis)judged it reclaimable and deleted it. That is a
// lost race, not a failure — re-enter the loop and compete again.
```

So the loud symptom is already absorbed. What is *not* absorbed is the reason it happens:
a caller deleting a lock directory it never observed. The retry rescues a victim that finds
out via ENOENT on its own stamp. A victim whose stamp landed a moment earlier is not
rescued — it holds a lock the deleter is about to re-create and enter, and **nothing
anywhere reports it**.

### Measured

24 workers × 250 acquisitions each, pinned to 2 cores, `pipeline-lock.mjs` as the only
variable. Hold intervals are recorded per process to its own file and the parent looks for
overlapping `[enter, exit]` pairs — the same mutual-exclusion property #2905 §9 measures,
which is the check that would catch this in CI.

| | current `main` | with this PR |
|---|---|---|
| acquisitions | 54,898 (9 rounds) | 180,000 (30 rounds) |
| VANISHED verdicts | 7,986 | 0 reaching an rm |
| deleted a lock that **existed** after judging it absent | **2,307** | **0** |
| …where the victim had already stamped `owner.json` | **110** | **0** |
| **two processes inside the critical section at once** | **298** | **0** |
| rounds with ≥1 double-hold | **9 of 9** | **0 of 30** |
| writers killed outright | 21 | **0** |

```
!! MUTUAL EXCLUSION BROKEN: #11 held until 23739871319900, #5 entered 23739870970400
```

Every round on `main` broke mutual exclusion. Zero violations in 180,000 acquisitions with
the fix — which is also the control that says the overlap detector is measuring real overlap
rather than cross-process clock skew.

The shipped arm was stopped at 9 rounds once every round had fired; the fix arm ran the full
30. The asymmetry is in the conservative direction for both claims — more evidence that the
fix holds, less that the bug is common, and the bug is common anyway.

### Second commit: the same defect on the STALE path

The table above was measured with long-lived workers looping on the lock. In the regime the
CLI actually uses, where each process takes the lock once and exits, it did **not** hold,
and I only found that by running §9's own shape as a control.

`STALE` has the same structure as `VANISHED`. It says the directory we *read* was abandoned,
and the rm acts on whatever is at the path a moment later. Reaching that verdict costs a
`readFileSync` and a `process.kill`, which is room enough to be descheduled, and in that gap
a stale lock can be reclaimed by someone else and replaced by a live one.

Logging the directory's inode either side of the verdict, the one stale reclaim in a
2,400-acquisition run:

```
idBefore=5910974513639709  ownerBefore=39392
idAfter =6192449490350378  ownerAfter =27256  alive=true
```

A different directory, owned by a live process, deleted anyway.

The second commit carries the judged directory's identity to the rm and rechecks it, and
adds a backstop for the symmetric case a caller cannot control: another process doing this
to *us*. That one is silent, because the delete lands after our `owner.json` write succeeds
and nothing in the acquisition path notices. `main` already recovers when the delete lands
*before* the stamp; reading our own stamp back extends the same recovery to just after it.

Measured in that regime, 30 processes each taking the lock once and exiting:

| | overlapping holds | runs affected |
|---|---|---|
| current `main` | 21 | 14 of 60 |
| first commit only | 2 | 2 of 60 |
| both commits | **0** | **0 of 120** (3,600 acquisitions) |

High-turnover regime unchanged at 0 in 60,000 acquisitions.

No unit test covers the second commit. The window is synchronous, so a deterministic test
would have to monkey-patch `fs` rather than drive the lock. I wrote one that did not
discriminate and removed it rather than ship a green tick that proves nothing.


## The change

`lockCanRecover` becomes `lockRecoveryVerdict`, returning a tri-state instead of a boolean:

- `STALE` — a directory is **there** and its holder is gone. Deleting it *is* the recovery,
  and it is now the only verdict that reaches an rm.
- `VANISHED` — nothing was there. Not blocked, but not deletable either: fall through to the
  normal backoff and retry acquisition, which is what the old comment already claimed.
- `LIVE` — held, or we could not establish otherwise. Wait.

Both call sites — the lock and the recover guard — now delete on `STALE` only. The guard site
had the same defect: evicting on "already gone" can delete a guard another caller has just
taken, putting two callers inside the decide-then-delete window the guard exists to serialize.

Behaviour is otherwise unchanged: the `#2984` unreadable-stamp protection, the `#2304` grace
floor, and dead-owner reclamation all keep their existing meanings, and there are assertions
pinning each.

Cost of the fix is one backoff (~40–120 ms) in a rare case. Deleting a live lock costs an item.

## Tests

`node --test test/pipeline-lock.test.mjs` — **21 pass, 0 fail**, including two new cases:

- an absent directory is `VANISHED` and specifically **not** `STALE`
- `STALE` / `LIVE` / the grace floor / the unreadable stamp all keep their meanings

**An honest limitation:** these are unit tests on the verdict. They do not fail-then-pass
across the fix in a meaningful way — the pre-fix module simply lacks the export. A
cross-process behavioural test would need a rival acquirer to win the mkdir inside the
microseconds between verdict and rm, which is a race, not a test. The behavioural half is
covered by the trace above and by the two-line branch being visible at the call site.

## Not in this PR

The **same helper is duplicated** in `followup-seed.mjs` and `portal-health-lock.mjs`, and
both carry the identical `ENOENT → true → rmSync` defect (both are also still on the
pre-`#2984` `readLockOwner`). I have deliberately left them alone rather than widen this into
three subsystems at once — happy to follow up, or to fold them in here if you'd prefer one
sweep.

Related: #3118 (merged) fixes the *silent* item loss in `agent-inbox.mjs` (the `ensureFile()`
initialisation window). This one addresses the *loud* failure. They are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## One guard updated

`tests/lock-rm-contention.test.mjs` pinned the literal source text
`return err?.code === 'ENOENT';` across every file implementing this lock protocol. It now
asserts the **rule** instead of one spelling — the definition returns a verdict, the copies
still return a boolean, and every implementor must discriminate on ENOENT. Confirmed it still
goes red if the catch regresses to a bare `return true`.

Full suite: **4897 passed, 0 failed.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lock recovery decisions to distinguish stale, vanished, and active locks.
  * Prevented cleanup from deleting newly recreated locks or guards after a lock disappears.
  * Preserved safe behavior for crashed, live, ownerless, and unreadable lock states.

* **Tests**
  * Added coverage for missing lock directories and lock recovery edge cases.
  * Updated contention checks to validate the supported recovery outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

