### PR TITLE
fix(add-entry): delegate flag validation to shared validateFlags

### DIFF
--- a/add-entry.mjs
+++ b/add-entry.mjs
@@ -42,6 +42,7 @@ import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { normalizeTextKey } from './tracker-parse.mjs';
+import { validateFlags } from './lib/cli-flags.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 
@@ -216,17 +217,9 @@ async function readStdin() {
 async function main() {
   const args = process.argv.slice(2);
 
-  if (args.includes('--help') || args.includes('-h')) {
-    console.log(USAGE);
-    process.exit(0);
-  }
-
-  const unknownFlags = args.filter(a => a.startsWith('-') && !KNOWN_FLAGS.includes(a));
-  if (unknownFlags.length) {
-    console.error(`add-entry: unrecognized flag(s): ${unknownFlags.join(', ')}. Valid flags: ${KNOWN_FLAGS.join(', ')}`);
-    console.error(USAGE);
-    process.exit(1);
-  }
+  // Migrated to shared validateFlags to reject mistyped flags (#3112).
+  // Inside the main-module guard so importers are unaffected (#3088).
+  validateFlags(args, KNOWN_FLAGS, USAGE);
 
   const dryRun = args.includes('--dry-run');
   const useStdin = args.includes('--stdin');

--- a/test-all.mjs
+++ b/test-all.mjs
@@ -8665,7 +8665,7 @@ try {
 
     const missingPayloadPath = join(cliTmp, 'missing-payload.json');
     const badFlag = spawnSync(NODE, [join(ROOT, 'add-entry.mjs'), missingPayloadPath, '--sumary'], { env, encoding: 'utf-8' });
-    if (badFlag.status === 1 && badFlag.stderr.includes('--sumary') && badFlag.stderr.includes('Usage:') &&
+    if (badFlag.status === 1 && /unrecognized flag/.test(badFlag.stderr) && badFlag.stderr.includes('--sumary') &&
         !badFlag.stderr.includes('could not parse payload') &&
         !readFileSync(cvPath, 'utf-8').includes('CliProj') && !existsSync(adPath)) {
       pass('add-entry CLI rejects an unrecognized flag before reading or writing payload data');

--- a/tests/cli-flag-validation.test.mjs
+++ b/tests/cli-flag-validation.test.mjs
@@ -56,6 +56,7 @@ const SCRIPTS = [
   ['detect-reposts.mjs', '--windo'],
   ['weekly-digest.mjs', '--dri'],
   ['upskill.mjs', '--min-report'],
+  ['add-entry.mjs', '--dry-rum'],
   ['archive-posting.mjs', '--reprot', /USAGE/],
 ];
 


### PR DESCRIPTION
## What does this PR do?

Replaces add-entry.mjs’s manual args.includes(...) flag checking with the shared validateFlags helper, so a mistyped flag (e.g. --dry-rum) is rejected instead of silently ignored. Also updates the pre-existing add-entry unknown-flag assertion in test-all.mjs: it checked for a "Usage:" string in stderr, which matched the old hand-rolled validation but not validateFlags’s actual output (validateFlags only prints Usage: for --help, not for an unrecognized flag). Updated to check for the actual /unrecognized flag/ pattern, matching the same assertion shape already used for reply-watch.mjs’s migration (#2743).


## Related issue

Closes #3112

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)
- [x] I ran `node test-all.mjs` — 4913/4914 passed. The one remaining
      failure (`live archive`) is a pre-existing Playwright/network
      timeout against a live Greenhouse URL, unrelated to this change
      and present before it.

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved command-line option validation for unknown or mistyped flags.
- Help and usage behavior now works consistently when invalid options are provided.
- Invalid options are rejected before any payload data is read or written.
- Added coverage for invalid flags used alone or alongside other options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->