### PR TITLE
fix(locks): one recovery judgment, imported by all three copies

### DIFF
--- a/followup-seed.mjs
+++ b/followup-seed.mjs
@@ -66,7 +66,7 @@ import { createHash, randomUUID } from 'crypto';
 // so the next Windows-contention finding lands in one place instead of three.
 import {
   isMkdirContention, isRmContention, rmLockArtifactSync, createLockWaitPolicy,
-  sameLockDirectory,
+  sameLockDirectory, lockRecoveryVerdict, RECOVER_STALE,
 } from './pipeline-lock.mjs';
 import { tmpdir } from 'os';
 import { resolveColumns, parseTrackerRow } from './tracker-parse.mjs';
@@ -94,9 +94,12 @@ const FOLLOWUPS_LOCK_PREFIX = 'career-ops-followups-';
 
 /**
  * Minimum age before directory age alone may condemn an ownerless lock.
- * See `lockCanRecover` for why the age check needs a floor.
+ * See `lockRecoveryVerdict` for why the age check needs a floor.
+ *
+ * Re-exported rather than redeclared: the floor is applied inside that function
+ * now, so a local copy would be a constant this file no longer enforces.
  */
-export const OWNERLESS_GRACE_MS = 1_000;
+export { OWNERLESS_GRACE_MS } from './pipeline-lock.mjs';
 
 /** Structured error carrying an exit-code-mapping `code`. */
 export class SeedError extends Error {
@@ -284,16 +287,6 @@ function sleep(ms) {
   return new Promise(res => setTimeout(res, ms));
 }
 
-function processIsAlive(pid) {
-  if (!Number.isInteger(pid) || pid <= 0) return false;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (err) {
-    return err?.code === 'EPERM';
-  }
-}
-
 function readLockOwner(lockDir) {
   try {
     return JSON.parse(readFileSync(join(lockDir, 'owner.json'), 'utf-8'));
@@ -302,36 +295,12 @@ function readLockOwner(lockDir) {
   }
 }
 
-/**
- * Decide whether an existing lock can be safely recovered. Owner-PID liveness
- * wins; directory age is only consulted when the metadata is missing.
- *
- * That age fallback needs a floor. A lock is ownerless by construction — not
- * by accident — for the instant between its `mkdirSync` and its `owner.json`
- * write. Judging it on `age > staleMs` alone lets a caller with an aggressive
- * staleMs delete a lock created microseconds ago, stealing it from a winner
- * still inside its acquisition window and putting two writers into the
- * read-check-append critical section. OWNERLESS_GRACE_MS is a lower bound on
- * that patience, never a cap: a larger caller staleMs still wins, and a
- * genuinely abandoned lock still ages out.
- *
- * @param {string} lockDir - Directory that represents the active lock.
- * @param {number} staleMs - Age threshold for metadata-free lock recovery, floored at OWNERLESS_GRACE_MS.
- * @returns {boolean} True when the caller may remove and recreate the lock.
- */
-function lockCanRecover(lockDir, staleMs) {
-  const owner = readLockOwner(lockDir);
-  if (owner?.pid) return !processIsAlive(owner.pid);
-  try {
-    return Date.now() - statSync(lockDir).mtimeMs > Math.max(staleMs, OWNERLESS_GRACE_MS);
-  } catch (err) {
-    // Only a genuinely vanished directory means "nothing to recover". Any other
-    // stat failure — a Windows EPERM/EBUSY while the directory is mid-flight —
-    // is "could not look", and answering "recoverable" to that hands the caller
-    // an rmSync of a LIVE lock created microseconds ago (#2777, third face).
-    return err?.code === 'ENOENT';
-  }
-}
+// The recovery judgment comes from pipeline-lock rather than a fourth copy of
+// it, for the reason stated at the import: a finding lands once. This file's
+// copy had drifted twice over — it still answered a bare boolean, so "the
+// directory was gone when I looked" reached the caller as a licence to DELETE
+// whatever is at that path now, and it predated #2984, so an unreadable owner
+// stamp fell through to the age rule and could condemn a live lock.
 
 /**
  * Acquire an exclusive filesystem lock covering the read-check-append
@@ -402,7 +371,7 @@ async function acquireFollowupsLock(lockDir, followupsPath, options = {}) {
           if (!sameLockDirectory(before, after)) return; // swapped underneath us
           // Best-effort: ownership is verified, so a contended rm (Windows
           // EPERM/EBUSY while another process stats it) must not kill a caller
-          // whose work already succeeded. The orphan ages out via lockCanRecover.
+          // whose work already succeeded. The orphan ages out via lockRecoveryVerdict.
           rmLockArtifactSync(lockDir);
         },
       };
@@ -435,14 +404,20 @@ async function acquireFollowupsLock(lockDir, followupsPath, options = {}) {
         // take the guard and run recovery. Removing it unconditionally would
         // instead let two writers recover the same lock at once, which is
         // exactly what the guard exists to prevent.
-        if (lockCanRecover(recoverGuardDir, staleMs)) {
+        // STALE only: a guard already gone needs no eviction, and evicting on
+        // that answer deletes the guard another caller has just taken.
+        if (lockRecoveryVerdict(recoverGuardDir, staleMs) === RECOVER_STALE) {
           rmLockArtifactSync(recoverGuardDir);
         }
       }
 
       if (hasRecoverGuard) {
         try {
-          if (lockCanRecover(lockDir, staleMs)) {
+          // STALE only. VANISHED means the lock was absent when we looked, and
+          // by the time this line runs another acquirer may have won the mkdir
+          // and be partway through writing owner.json — deleting on that answer
+          // destroys a live lock and kills its winner with ENOENT.
+          if (lockRecoveryVerdict(lockDir, staleMs) === RECOVER_STALE) {
             if (rmLockArtifactSync(lockDir)) continue;
             // rm hit contention: another process is touching the stale lock at
             // this instant — back off instead of treating the collision as fatal.

--- a/portal-health-lock.mjs
+++ b/portal-health-lock.mjs
@@ -33,6 +33,7 @@ import { randomUUID } from 'crypto';
 // classifiers live in pipeline-lock.mjs so the next finding lands once.
 import {
   isMkdirContention, rmLockArtifactSync, createLockWaitPolicy,
+  lockRecoveryVerdict, RECOVER_STALE,
 } from './pipeline-lock.mjs';
 
 const DEFAULT_STALE_MS = 30_000;
@@ -50,7 +51,11 @@ const DEFAULT_TIMEOUT_MS = 8_000;
 // This is a lower bound on patience, never a cap: a larger caller staleMs
 // still wins, and a genuinely abandoned directory still ages out, so a crash
 // while holding the guard cannot disable recovery for good.
-export const OWNERLESS_GRACE_MS = 1_000;
+//
+// Re-exported rather than redeclared: the floor is applied inside
+// lockRecoveryVerdict now, so a local copy of the number would be a constant
+// this file no longer enforces — free to drift from the one that decides.
+export { OWNERLESS_GRACE_MS } from './pipeline-lock.mjs';
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
@@ -82,30 +87,12 @@ function sameLockDirectory(left, right) {
     && (left.ino !== 0 || left.birthtimeMs === right.birthtimeMs);
 }
 
-function processIsAlive(pid) {
-  if (!Number.isInteger(pid) || pid <= 0) return false;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (err) {
-    return err?.code === 'EPERM'; // exists, just not signalable by this user
-  }
-}
-
-// Conservative: a lock whose recorded owner is still running is never stale,
-// however old it is. Age is the fallback only when there's no readable owner.
-function lockCanRecover(lockDir, staleMs) {
-  const owner = readLockOwner(lockDir);
-  if (owner?.pid) return !processIsAlive(owner.pid);
-  try {
-    return Date.now() - statSync(lockDir).mtimeMs > Math.max(staleMs, OWNERLESS_GRACE_MS);
-  } catch (err) {
-    // Only a vanished directory means "nothing to recover". Any other stat
-    // failure — a Windows EPERM/EBUSY mid-flight — is "could not look", and
-    // answering "recoverable" to that deletes a LIVE lock (#2777, third face).
-    return err?.code === 'ENOENT';
-  }
-}
+// The recovery judgment comes from pipeline-lock rather than a fourth copy of
+// it, for the reason stated at the import: a finding lands once. This file's
+// copy had drifted twice over — it still answered a bare boolean, so "the
+// directory was gone when I looked" reached the caller as a licence to DELETE
+// whatever is at that path now, and it predated #2984, so an unreadable owner
+// stamp fell through to the age rule and could condemn a live lock.
 
 /**
  * Blocks until the lock on `filePath` is held, then returns a handle whose
@@ -173,14 +160,20 @@ export async function acquirePortalHealthLock(filePath, options = {}) {
         // A process killed between taking the guard and cleaning it up would
         // otherwise disable stale recovery forever. The guard normally lives
         // for milliseconds, so an old one is judged by the same age rule.
-        if (lockCanRecover(recoverGuardDir, staleMs)) {
+        // STALE only: a guard already gone needs no eviction, and evicting on
+        // that answer deletes the guard another caller has just taken.
+        if (lockRecoveryVerdict(recoverGuardDir, staleMs) === RECOVER_STALE) {
           rmLockArtifactSync(recoverGuardDir);
         }
       }
 
       if (hasRecoverGuard) {
         try {
-          if (lockCanRecover(lockDir, staleMs)) {
+          // STALE only. VANISHED means the lock was absent when we looked, and
+          // by the time this line runs another acquirer may have won the mkdir
+          // and be partway through writing owner.json — deleting on that answer
+          // destroys a live lock and kills its winner with ENOENT.
+          if (lockRecoveryVerdict(lockDir, staleMs) === RECOVER_STALE) {
             rmLockArtifactSync(lockDir);
             continue; // retry acquisition immediately
           }

--- a/tests/lock-rm-contention.test.mjs
+++ b/tests/lock-rm-contention.test.mjs
@@ -94,8 +94,12 @@ const mkErr = (code) => Object.assign(new Error(code), { code });
       `${file} does not treat a non-EEXIST mkdir answer as fatal (Windows says EPERM under contention)`,
     );
     ok(
-      /return err\?\.code === 'ENOENT';/.test(src),
-      `${file} answers "recoverable" only on ENOENT, never on "could not look"`,
+      /import\s*\{[^}]*lockRecoveryVerdict[^}]*\}\s*from\s*'\.\/pipeline-lock\.mjs'/.test(src),
+      `${file} imports the recovery judgment from pipeline-lock`,
+    );
+    ok(
+      !/function lockCanRecover/.test(src) && !/function lockRecoveryVerdict/.test(src),
+      `${file} defines no second copy of the recovery judgment`,
     );
   }
 }
@@ -107,23 +111,29 @@ const mkErr = (code) => Object.assign(new Error(code), { code });
 // winner then died with ENOENT writing owner.json. Only ENOENT (genuinely
 // vanished) may answer "nothing to recover"; both locks must carry the guard.
 //
-// The SHAPE of that answer now differs by file, so this asserts the rule rather
-// than one spelling of it. pipeline-lock.mjs — the definition — returns a
-// verdict, because "vanished" and "stale" are different answers and only one of
-// them licenses a delete: acting on "it was gone when I looked" destroys a lock
-// a rival acquirer created in the interim. The copies still return a boolean.
-// What every implementor must do is discriminate on ENOENT and never hand
-// "could not look" to the caller as recoverable.
+// There is now exactly ONE place to assert this, which is the point: section 3
+// requires every other implementor to import the judgment rather than carry a
+// copy, so the rule is checked where it is decided instead of four times over.
+// Four correct copies were never the goal — #2984 asked for one definition, and
+// a repo that merely keeps its copies in agreement is one patch away from the
+// drift that produced all three faces of #2777.
+//
+// The verdict is tri-state because "vanished" and "stale" are different answers
+// and only one of them licenses a delete: acting on "it was gone when I looked"
+// destroys a lock a rival acquirer created in the interim.
 {
-  const ENOENT_ONLY = /return err\?\.code === 'ENOENT'(?:;|\s*\?\s*RECOVER_VANISHED\s*:\s*RECOVER_LIVE;)/;
+  const src = readFileSync(join(ROOT, 'pipeline-lock.mjs'), 'utf-8');
+  ok(
+    /return err\?\.code === 'ENOENT' \? RECOVER_VANISHED : RECOVER_LIVE;/.test(src),
+    'pipeline-lock.mjs: the stat catch answers VANISHED only on ENOENT, never on "could not look"',
+  );
+  ok(
+    !/return err\?\.code === 'ENOENT';/.test(src),
+    'pipeline-lock.mjs: the judgment is a verdict, not a boolean that conflates vanished with stale',
+  );
   for (const file of protocolImplementors()) {
-    const src = readFileSync(join(ROOT, file), 'utf-8');
     ok(
-      ENOENT_ONLY.test(src),
-      `${file}: the recovery judgment's stat catch answers recoverable ONLY on ENOENT`,
-    );
-    ok(
-      !/catch\s*\{\s*\n\s*return true;/.test(src),
+      !/catch\s*\{\s*\n\s*return true;/.test(readFileSync(join(ROOT, file), 'utf-8')),
       `${file}: no bare catch{return true} remains in a recovery judgment`,
     );
   }

--- a/tracker-utils.mjs
+++ b/tracker-utils.mjs
@@ -20,14 +20,19 @@ import * as yaml from 'js-yaml';
 // but EEXIST as fatal, killing a writer and losing its item.
 import {
   isMkdirContention, isRmContention, rmLockArtifactSync, createLockWaitPolicy,
+  lockRecoveryVerdict, RECOVER_STALE,
 } from './pipeline-lock.mjs';
 import { normalizeTextKey } from './tracker-parse.mjs';
 
 /**
  * Minimum age before directory age alone may condemn an ownerless lock or
- * recover guard. See `lockCanRecover` for why the age check needs a floor.
+ * recover guard. See `lockRecoveryVerdict` for why the age check needs a floor.
+ *
+ * Re-exported rather than redeclared: the floor is applied inside that function
+ * now, so a local copy would be a constant this file no longer enforces — free
+ * to drift from the one that actually decides.
  */
-export const OWNERLESS_GRACE_MS = 1_000;
+export { OWNERLESS_GRACE_MS } from './pipeline-lock.mjs';
 
 /**
  * Rebuild a markdown table row from the cells produced by `line.split('|')`.
@@ -227,27 +232,6 @@ function sleep(ms) {
 }
 
 /**
- * Determine whether a process id still belongs to a live process.
- *
- * The tracker lock stores the owner PID in `owner.json`. When another process
- * finds an existing lock, this check lets it distinguish a valid live owner from
- * a crashed process that left a stale lock directory behind. `EPERM` counts as
- * alive because the process exists even if the current user cannot signal it.
- *
- * @param {number} pid - Process id recorded by the lock owner.
- * @returns {boolean} True when the process appears to still exist.
- */
-function processIsAlive(pid) {
-  if (!Number.isInteger(pid) || pid <= 0) return false;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (err) {
-    return err?.code === 'EPERM';
-  }
-}
-
-/**
  * Read lock ownership metadata from a tracker lock directory.
  *
  * The metadata contains the owner PID, a unique release token, the acquisition
@@ -270,45 +254,12 @@ function sameLockDirectory(left, right) {
     && (left.ino !== 0 || left.birthtimeMs === right.birthtimeMs);
 }
 
-/**
- * Decide whether an existing lock can be safely recovered.
- *
- * Recovery is conservative: if the lock has an owner PID and that process is
- * still alive, the lock is never considered stale merely because it is old. If
- * the owner process is gone, or if the metadata cannot be read and the lock
- * directory itself is older than the stale threshold, the waiting process may
- * remove the lock and retry acquisition.
- *
- * That age fallback needs a floor. Two directories are ownerless by
- * construction, not by accident: a lock between its `mkdirSync` and its
- * `owner.json` write, and the recover guard, which never carries `owner.json`
- * at all. Judging those on `age > staleMs` alone lets a caller with an
- * aggressive staleMs delete a directory created microseconds ago — either
- * stealing a winner's lock inside its acquisition window, or evicting a live
- * guard and putting two callers inside the decide-then-delete window the guard
- * exists to serialize. OWNERLESS_GRACE_MS is a lower bound on that patience,
- * never a cap: a larger caller staleMs still wins, and a genuinely abandoned
- * directory still ages out, so a crash while holding the guard cannot disable
- * recovery for good.
- *
- * @param {string} lockDir - Directory that represents the active lock.
- * @param {number} staleMs - Age threshold for metadata-free lock recovery, floored at OWNERLESS_GRACE_MS.
- * @returns {boolean} True when the caller may remove and recreate the lock.
- */
-function lockCanRecover(lockDir, staleMs) {
-  const owner = readLockOwner(lockDir);
-  if (owner?.pid) return !processIsAlive(owner.pid);
-
-  try {
-    return Date.now() - statSync(lockDir).mtimeMs > Math.max(staleMs, OWNERLESS_GRACE_MS);
-  } catch (err) {
-    // Mirrors pipeline-lock: only ENOENT means "vanished, nothing to
-    // recover". A Windows EPERM/EBUSY mid-flight stat is "could not look",
-    // and treating it as recoverable lets a caller delete a live lock
-    // created microseconds ago (#2777, third face).
-    return err?.code === 'ENOENT';
-  }
-}
+// The recovery judgment comes from pipeline-lock rather than a second copy of
+// it. "Mirrors pipeline-lock" was the previous arrangement, and mirroring is
+// precisely what drifts: this copy still answered a bare boolean, so "the
+// directory was gone when I looked" reached the caller as a licence to DELETE
+// whatever is at that path now — a lock a rival acquirer may have created in
+// between, whose winner then dies with ENOENT writing its own owner.json.
 
 /**
  * Acquire an exclusive filesystem lock for one tracker mutation.
@@ -443,7 +394,7 @@ export async function acquireTrackerLock(lockDir, options = {}) {
           // verified above, so a contended rm (Windows EPERM/EBUSY while
           // another process stats the directory) must not kill a caller whose
           // work already succeeded — the orphaned lock ages out via
-          // lockCanRecover. Injected removeLock hooks (fault tests) keep
+          // lockRecoveryVerdict. Injected removeLock hooks (fault tests) keep
           // their errors: only the known contention codes are swallowed.
           try {
             removeLock(lockDir);
@@ -477,14 +428,21 @@ export async function acquireTrackerLock(lockDir, options = {}) {
         // Only an EEXIST guard is judged by age: an EPERM/EACCES answer means
         // the guard is mid-flight right now, and reasoning about the age of a
         // directory we cannot even stat reliably would evict a live guard.
-        if (guardErr.code === 'EEXIST' && lockCanRecover(recoverGuardDir, staleMs)) {
+        // STALE only: a guard already gone needs no eviction, and evicting on
+        // that answer deletes the guard another caller has just taken.
+        if (guardErr.code === 'EEXIST'
+          && lockRecoveryVerdict(recoverGuardDir, staleMs) === RECOVER_STALE) {
           rmLockArtifactSync(recoverGuardDir);
         }
       }
 
       if (hasRecoverGuard) {
         try {
-          if (lockCanRecover(lockDir, staleMs)) {
+          // STALE only. VANISHED means the lock was absent when we looked, and
+          // by the time this line runs another acquirer may have won the mkdir
+          // and be partway through writing owner.json — deleting on that answer
+          // destroys a live lock and kills its winner with ENOENT.
+          if (lockRecoveryVerdict(lockDir, staleMs) === RECOVER_STALE) {
             if (rmLockArtifactSync(lockDir)) {
               staleRecovered = true;
               continue;


### PR DESCRIPTION
> **Stacked on #3120** — it exports the verdict this PR imports. Please merge that first;
> this diff is against its branch, so review it as the three call-site conversions.

## Why this exists

#3120 fixes `lockCanRecover()` in `pipeline-lock.mjs`: an ENOENT from `statSync` answered
"recoverable", and the caller acts on that by **deleting** whatever is at the path now —
which may be a lock a rival acquirer legitimately created in between, whose winner then
dies with `ENOENT … open '<path>.lock/owner.json'`.

That helper is copied into **three** other files, and all three had the same defect:

- `followup-seed.mjs`
- `portal-health-lock.mjs`
- `tracker-utils.mjs`

I originally flagged two of these; `tracker-utils.mjs` turned up when I checked the guard's
own `protocolImplementors()` list. Fixing two of three would have left the drift in place.

## The change

All three now import `lockRecoveryVerdict` from `pipeline-lock` and delete on
`RECOVER_STALE` only, at **both** call sites — the lock and the recover guard. The guard
site had the same defect: evicting on "already gone" deletes a guard another caller has
just taken, putting two callers inside the decide-then-delete window it exists to
serialize.

The local `processIsAlive()` copies go with the judgment. `readLockOwner()` stays in each —
still used by `release()` for the token check.

### A second fix these files get for free

Their copies **predated #2984**, so an owner stamp that could not be *read* fell through to
the age rule and could condemn a live lock. That is the second face of #2777, fixed in
`pipeline-lock` some time ago and still open in all three of these. Importing the judgment
closes it without a separate patch.

### OWNERLESS_GRACE_MS

Re-exported rather than redeclared. The floor is applied inside `lockRecoveryVerdict` now,
so a local copy of the number would be a constant the file no longer enforces — free to
drift from the one that decides. Nothing imported it from these modules and the value is
unchanged at `1_000`.

## The guard got stricter, not looser

`tests/lock-rm-contention.test.mjs` used to require every implementor to spell the ENOENT
discrimination correctly — which **four correct copies would satisfy**. It now requires
exactly one definition and an import in everyone else, and asserts the discrimination once,
where it is decided.

Four copies in agreement were never the goal. #2984 asked for one definition, and a repo
that merely keeps its copies in step is one patch away from the drift that produced all
three faces of #2777.

## Tests

Full suite: **4898 passed, 0 failed.** Includes `tests/portal-health-lock.test.mjs`,
`tests/with-followups-lock.test.mjs`, `tracker-writer-lock-tests.mjs` and
`test/pipeline-lock.test.mjs`, all of which exercise these acquisition paths directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lock recovery to prevent deletion when lock state is uncertain or the lock has already disappeared.
  * Standardized recovery behavior across health checks, follow-up processing, and tracking workflows.
  * Reduced the risk of removing newly recreated or still-active locks during contention.

* **Tests**
  * Added validation ensuring only confirmed stale locks are removed and access errors remain recoverable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->