### PR TITLE
test: retry cleanup rmSync in the six remaining standalone suites

### DIFF
--- a/tests/application-artifacts.test.mjs
+++ b/tests/application-artifacts.test.mjs
@@ -1,8 +1,9 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { existsSync, mkdtempSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
+import { rmSync } from './helpers.mjs';
 import { applicationArtifactPaths, ensureApplicationArtifactDirs, slugifySegment, writeReuseDecision } from '../application-artifacts.mjs';
 import { repoRelativeManifestPath, workspaceRelativeManifestPath } from '../generate-pdf.mjs';
 

--- a/tests/batch-evaluate.test.mjs
+++ b/tests/batch-evaluate.test.mjs
@@ -1,6 +1,6 @@
-import { pass, fail, ROOT } from './helpers.mjs';
+import { pass, fail, rmSync, ROOT } from './helpers.mjs';
 import { processPipelineBatch, processOffer, PATHS } from '../batch-evaluate-gemini.mjs';
-import { mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync } from 'fs';
+import { mkdtempSync, mkdirSync, readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 

--- a/tests/batch-runner-jd-prefetch.test.mjs
+++ b/tests/batch-runner-jd-prefetch.test.mjs
@@ -17,9 +17,9 @@
 //
 // Tests extract the real bash snippets from batch-runner.sh so the tests and
 // the implementation can never drift apart.
-import { pass, fail, getBash } from './helpers.mjs';
+import { pass, fail, rmSync, getBash } from './helpers.mjs';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { readFileSync, writeFileSync, mkdtempSync, mkdirSync, existsSync, rmSync, mkdtempSync as _mdt } from 'node:fs';
+import { readFileSync, writeFileSync, mkdtempSync, mkdirSync, existsSync, mkdtempSync as _mdt } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';

--- a/tests/batch-runner-score-delimiter.test.mjs
+++ b/tests/batch-runner-score-delimiter.test.mjs
@@ -24,9 +24,9 @@
 //
 // This test extracts the REAL emitter out of batch/batch-runner.sh and runs it,
 // rather than restating it, so the two cannot drift apart.
-import { pass, fail, getBash } from './helpers.mjs';
+import { pass, fail, rmSync, getBash } from './helpers.mjs';
 import { execFileSync } from 'node:child_process';
-import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdtempSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';

--- a/tests/batch-tailor-flags.test.mjs
+++ b/tests/batch-tailor-flags.test.mjs
@@ -17,9 +17,9 @@
 // sandbox instead of the developer's real batch run. Every case below picks a
 // threshold that matches NO job, so the script always exits before spawning a
 // worker.
-import { pass, fail, ROOT } from './helpers.mjs';
+import { pass, fail, rmSync, ROOT } from './helpers.mjs';
 import { execFileSync } from 'child_process';
-import { mkdtempSync, writeFileSync, rmSync, readFileSync } from 'fs';
+import { mkdtempSync, writeFileSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 

--- a/tests/browser-extract.test.mjs
+++ b/tests/browser-extract.test.mjs
@@ -1,10 +1,10 @@
 // tests/browser-extract.test.mjs — unit coverage for the pure logic in
 // browser-extract.mjs (config resolution + result normalizers). The Playwright
 // navigation path is exercised live, not here.
-import { pass, fail, ROOT } from './helpers.mjs';
+import { pass, fail, rmSync, ROOT } from './helpers.mjs';
 import { join } from 'path';
 import { pathToFileURL } from 'url';
-import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { mkdtempSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 
 console.log('\nbrowser-extract.mjs (config + normalizers)');

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -2,7 +2,7 @@
 // Moved verbatim from test-all.mjs (issue #1440); no framework by design:
 // the suite must run on a fresh clone with only Node.
 import { execFileSync } from 'child_process';
-import { existsSync, readdirSync } from 'fs';
+import { existsSync, readdirSync, rmSync as _rmSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -10,6 +10,16 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 export const ROOT = join(__dirname, '..');   // repo root (tests/ lives one level down)
 export const QUICK = process.argv.includes('--quick');
 export const NODE = process.execPath;
+
+// Windows keeps a handle open on a just-exited child's files for a short
+// window (antivirus widens it), so a cleanup rmSync can fail with EPERM even
+// though every assertion passed — `force: true` suppresses ENOENT, not EPERM.
+// Node retries exactly that error class (EBUSY/EMFILE/ENFILE/ENOTEMPTY/EPERM)
+// with linear backoff when given maxRetries, so default it here. An explicit
+// option still wins, and a removal that keeps failing still throws. Same
+// wrapper test-all.mjs applies to its own call sites (#3066), shared so the
+// suites under tests/ cannot drift from it.
+export const rmSync = (target, opts = {}) => _rmSync(target, { maxRetries: 10, retryDelay: 100, ...opts });
 
 /**
  * The per-script budget run() applies when a caller does not override it.


### PR DESCRIPTION
## What does this PR do?

Gives the six remaining standalone suites the same retrying `rmSync` that #3066 gave `test-all.mjs`, so a Windows EPERM during fixture cleanup stops aborting a run whose assertions all passed. The wrapper is exported once from `tests/helpers.mjs` rather than pasted into each file.

## Related issue

Fixes #3114

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [x] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---

### One definition instead of six

The issue says to mirror #3066's wrapper exactly, and the wrapper here is byte-identical to it apart from the `export` keyword:

```
test-all.mjs:52      const rmSync = (target, opts = {}) => _rmSync(target, { maxRetries: 10, retryDelay: 100, ...opts });
tests/helpers.mjs:22 export const rmSync = (target, opts = {}) => _rmSync(target, { maxRetries: 10, retryDelay: 100, ...opts });
```

What I did not do is paste it into all six files. Five of the six already import `pass`/`fail` from `./helpers.mjs`, and six copies of a helper plus its rationale comment is the drift this repo already has an issue class for. Happy to switch to the literal per-file copy if you would rather keep the wrapper local, it is a small change.

One consequence worth naming: `test-all.mjs` keeps its own inline copy, so there are two definitions rather than one. Folding it into the shared export is a two-line change but it touches the core file and is outside what this issue asks, so I left it. Say the word for a follow-up.

### Semantics

`maxRetries`/`retryDelay` are defaults spread before `...opts`, so nothing is swallowed. Verified against the shared helper directly:

```
ok  non-EPERM still throws: ENOENT
ok  explicit opts pass through: force suppressed ENOENT
ok  recursive cleanup removes the tree
```

### Still fails loudly

Injecting a deliberate `fail()` into `browser-extract.test.mjs`:

```
📊 Results: 0 passed, 1 failed, 0 warnings
🔴 TESTS FAILED — do NOT push/merge until fixed
exit=1
```

Reverted, and that suite is back to 21 passed, 0 failed.

### Testing

`node test-all.mjs --quick` on this branch and on `main` at `61f8850`, same base, same flags:

```
branch  📊 Results: 4918 passed, 0 failed, 2 warnings
main    📊 Results: 4918 passed, 0 failed, 2 warnings
```

Full `node test-all.mjs` on the branch is 4919 passed, 0 failed, 2 warnings, exit 0. The extra assertion over the `--quick` run is `✅ Dashboard compiles`, which `--quick` skips.

Both warnings are pre-existing on `main` and unrelated: `cv-sync-check.mjs exited with error (expected without user data)` and `Possible personal data in dashboard/internal/ui/screens/stats.go: "santifer.io"`.

Also green: `cd dashboard && go test ./...` (all packages ok) and `node upgrade-tests.mjs --pr-gate` (GREEN).

### One thing I noticed, not touched here

`tests/batch-evaluate.test.mjs` ends with a bare `run();` on an async function that is never awaited, so in a full run its five assertions land roughly 1300 lines after its own heading, interleaved into whatever suite is running by then. They are counted, so nothing is lost, but `--only batch-evaluate` reports `0 passed, 0 failed` because the summary prints before the promise settles. Unrelated to this change and left alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test cleanup reliability with automatic retries when removing temporary files and directories.
  * Standardized cleanup behavior across multiple test scenarios.
  * No changes to application functionality or test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->