### PR TITLE
fix(update): stop misreading upstream's own content as a local edit (#3094)

### DIFF
--- a/tests/updater-local-system-edits.test.mjs
+++ b/tests/updater-local-system-edits.test.mjs
@@ -55,6 +55,16 @@ function upstreamChange(repo, file, content) {
   repo.g('checkout', '-q', 'main');
 }
 
+/**
+ * Replay what apply() does with an update: check the content out of the
+ * upstream ref and record it with an ordinary commit. NOT a merge — that is
+ * the whole point of case 14, so this must stay a raw checkout.
+ */
+function replayUpdate(repo, version) {
+  repo.g('checkout', 'upstream', '--', ...PATHS);
+  repo.g('commit', '-qm', `chore: auto-update system files to v${version}`);
+}
+
 const PATHS = ['modes/', 'generate-cover-letter.mjs'];
 
 // ── 1. The reported case: a committed local fix upstream has not adopted ──
@@ -362,4 +372,80 @@ const PATHS = ['modes/', 'generate-cover-letter.mjs'];
     fail(`#13 expected ['generate-cover-letter.mjs'], got ${JSON.stringify(atRisk)}`);
   }
   rmSync(dir, { recursive: true, force: true });
+}
+
+// ── 14. The SECOND update: upstream's own last release is not a local edit ──
+//    Every case above models an install at its FIRST update, where the
+//    merge-base is still the commit the install was cloned at and therefore
+//    still describes it. apply() never advances that merge-base: it installs
+//    updates with a raw checkout plus an ordinary commit, neither of which
+//    creates ancestry to the fetched commit. So from the second update on, the
+//    baseline describes a state the install left behind, and every file
+//    upstream changed in between reads as a local edit — preserved, backed up
+//    to `.bak`, and never updated. `VERSION` is a system file too, so it is
+//    preserved along with the rest and the run reports the version it just
+//    failed to install (#3094).
+{
+  const repo = makeRepo();
+  upstreamChange(repo, 'modes/pdf.md', 'shipped pdf v2\n');
+  replayUpdate(repo, '2');
+  upstreamChange(repo, 'modes/pdf.md', 'shipped pdf v3\n');
+
+  const atRisk = locallyModifiedSystemFiles(PATHS, 'upstream', repo.ctx);
+  if (atRisk.length === 0) {
+    pass('content installed by a previous update is not a local edit (#3094)');
+  } else {
+    fail(`#14 expected [], got ${JSON.stringify(atRisk)}`);
+  }
+}
+
+// ── 15. ...and the fix must not cost us the warning it exists for ──
+//    Case 14 removes files from atRisk, so pin that it removes ONLY the ones
+//    upstream itself installed. A genuine local fix in a twice-updated install
+//    is exactly the #2337 case, and it has to survive the second update too.
+{
+  const repo = makeRepo();
+  upstreamChange(repo, 'modes/pdf.md', 'shipped pdf v2\n');
+  replayUpdate(repo, '2');
+  upstreamChange(repo, 'modes/pdf.md', 'shipped pdf v3\n');
+  writeFileSync(join(repo.dir, 'generate-cover-letter.mjs'), 'local linkedin fix\n');
+  repo.g('commit', '-qam', 'local fix');
+
+  const atRisk = locallyModifiedSystemFiles(PATHS, 'upstream', repo.ctx);
+  if (atRisk.length === 1 && atRisk[0] === 'generate-cover-letter.mjs') {
+    pass('a real local fix is still reported after a second update (#2337)');
+  } else {
+    fail(`#15 expected ['generate-cover-letter.mjs'], got ${JSON.stringify(atRisk)}`);
+  }
+}
+
+// ── 16. History we cannot read degrades the warning, never the update ──
+//    Same contract as case 7, one level down: the #3094 filter reads upstream
+//    history, and a shallow clone does not have it. A history query that fails
+//    must leave the detector reporting what it already knew rather than
+//    throwing — a warning we cannot compute must never abort the checkout.
+{
+  const repo = makeRepo();
+  upstreamChange(repo, 'modes/pdf.md', 'shipped pdf v2\n');
+  writeFileSync(join(repo.dir, 'generate-cover-letter.mjs'), 'local linkedin fix\n');
+  const blind = {
+    root: repo.dir,
+    git: (...args) => {
+      if (args[0] === 'log') throw new Error('shallow clone: no history here');
+      return repo.g(...args);
+    },
+  };
+
+  let threw = false;
+  let atRisk = null;
+  try {
+    atRisk = locallyModifiedSystemFiles(PATHS, 'upstream', blind);
+  } catch {
+    threw = true;
+  }
+  if (!threw && Array.isArray(atRisk) && atRisk.includes('generate-cover-letter.mjs')) {
+    pass('unreadable upstream history degrades the filter, not the update');
+  } else {
+    fail(`#16 threw=${threw} atRisk=${JSON.stringify(atRisk)}`);
+  }
 }

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -1038,7 +1038,20 @@ export function prepareMaterializedSkillEntrypointsForStage(paths, root = ROOT) 
  *   2. it differs from the upstream ref. A local fix upstream has since adopted
  *      independently is byte-identical there, so the checkout costs nothing and
  *      warning about it would be noise — the exact case the #2337 reporter
- *      isolated when one of their two fixes survived an update.
+ *      isolated when one of their two fixes survived an update;
+ *   3. its content is not content upstream itself published at that path
+ *      (#3094). Conditions 1 and 2 assume the merge-base still describes this
+ *      install. It does not: apply() installs an update with a raw checkout
+ *      plus an ordinary commit, and neither creates ancestry to the fetched
+ *      commit, so the merge-base stays pinned to the commit the install was
+ *      CLONED at. From the second update on, everything upstream changed since
+ *      then differs from that baseline and reads as a local edit, so the
+ *      update's own payload is preserved into `.bak` files and silently
+ *      dropped — `VERSION` with it, which is why such a run reports the version
+ *      it just failed to install. Content upstream published cannot have been
+ *      authored here, and the question is asked per file because a stuck
+ *      install is a MIXTURE of versions: no single baseline commit describes
+ *      it, which is what rules out recording one.
  *
  * @param {string[]} paths - manifest entries (files or `dir/` prefixes).
  * @param {string} upstreamRef - ref being checked out, normally FETCH_HEAD.
@@ -1123,9 +1136,91 @@ export function locallyModifiedSystemFiles(paths, upstreamRef = 'FETCH_HEAD', ct
   // here also gives the `.bak` failure branch back its single meaning: a backup
   // that genuinely could not be written (permissions, full disk).
   const root = ctx.root || ROOT;
-  return [...new Set(atRisk)]
+  const present = [...new Set(atRisk)]
     .filter((file) => existsSync(join(root, ...file.split('/'))))
     .sort();
+
+  // Condition 3 (#3094). Runs last, on the files that survived everything
+  // above: it needs them to exist on disk to hash them, and on a healthy
+  // install the list is empty by now, so the whole query is skipped.
+  const publishedUpstream = contentPublishedUpstream(present, baseline, upstreamRef, runGit);
+  return present.filter((file) => !publishedUpstream.has(file));
+}
+
+/**
+ * Of `files`, those whose CURRENT content upstream published at that same path
+ * at some point in `baseline..upstreamRef` (#3094).
+ *
+ * Content-addressing does the work: git names a blob by a hash of its bytes, so
+ * "has upstream ever shipped exactly this?" is a set lookup over IDs, never a
+ * text comparison. Two git calls regardless of how many files are checked — the
+ * history walk dominates, not the file count.
+ *
+ * Both the source AND destination ID of each change are collected. The source
+ * ID of the oldest change in the window is the content as of the baseline
+ * itself, which is what an install that never received that file's update is
+ * still holding; taking only destinations would leave a blind spot at the
+ * oldest edge of the window.
+ *
+ * Everything here fails open, returning an empty set so that nothing is
+ * filtered and the caller reports what it already knew. A shallow clone has no
+ * history to read, and unrelated histories give no `baseline` to bound the walk
+ * — the same degradation contract the diffs above follow, for the same reason:
+ * a check we cannot compute must never abort the update.
+ *
+ * @param {string[]} files - existing repo-relative paths, already at risk.
+ * @param {string|null} baseline - merge-base commit, or null if there is none.
+ * @param {string} upstreamRef - ref being checked out, normally FETCH_HEAD.
+ * @param {Function} runGit - git runner bound to the install root.
+ * @returns {Set<string>} subset of `files` whose content came from upstream.
+ */
+function contentPublishedUpstream(files, baseline, upstreamRef, runGit) {
+  const published = new Set();
+  if (files.length === 0 || !baseline) return published;
+
+  let raw = '';
+  try {
+    // `--raw` lines are `:<srcmode> <dstmode> <srcOID> <dstOID> <status>\t<path>`.
+    // `--full-history` keeps commits history simplification would prune, and
+    // `--no-renames` keeps the question about this exact path. A path git has to
+    // C-quote (a space, a quote) simply will not match a `files` entry and stays
+    // reported — the safe direction, and career-ops ships no such path.
+    raw = runGit('log', '--full-history', '--no-renames', '--format=', '--raw',
+      '--no-abbrev', `${baseline}..${upstreamRef}`, '--', ...files);
+  } catch {
+    return published;
+  }
+
+  const idsByPath = new Map();
+  for (const line of raw.split('\n')) {
+    if (!line.startsWith(':')) continue;
+    const [meta, path] = line.split('\t');
+    if (!path) continue;
+    if (!idsByPath.has(path)) idsByPath.set(path, new Set());
+    const fields = meta.split(' ');
+    for (const id of [fields[2], fields[3]]) {
+      // An added file has an all-zero source ID and a deleted one an all-zero
+      // destination; neither names content.
+      if (id && !/^0+$/.test(id)) idsByPath.get(path).add(id);
+    }
+  }
+  if (idsByPath.size === 0) return published;
+
+  // The worktree copy is hashed, not the committed one: an uncommitted edit is
+  // exactly as overwritable, and `hash-object` applies the same filters git
+  // would on the way in, so a CRLF working file still hashes to the LF blob.
+  let hashes = [];
+  try {
+    hashes = runGit('hash-object', '--', ...files).split('\n').map((h) => h.trim());
+  } catch {
+    return published;
+  }
+  if (hashes.length !== files.length) return published;
+
+  files.forEach((file, i) => {
+    if (idsByPath.get(file)?.has(hashes[i])) published.add(file);
+  });
+  return published;
 }
 
 export function revertPaths(paths, protectedPaths = new Set(), ctx = {}) {


### PR DESCRIPTION
## What does this PR do?

`locallyModifiedSystemFiles()` decides a system file was edited locally by diffing it against `merge-base(HEAD, FETCH_HEAD)`, documented as the baseline the install was last synced to. `apply()` never advances that merge-base: it installs an update with a raw checkout plus an ordinary commit, and neither creates ancestry to the fetched commit, so it stays pinned to the commit the install was *cloned* at.

From the second update on, every file upstream changed since the clone differs from that baseline and is reported as a local edit. The update's own payload is preserved into `.bak` files and silently dropped — `VERSION` with it, so the run reports the version it just failed to install and `check()` keeps offering the same update forever.

This adds a third condition to the at-risk test: **a file is not at risk if its current content is content upstream itself published at that path.** Upstream's own bytes cannot have been authored here.

## Related issue

Fixes #3094

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Why per file, and not by recording the sync point

Recording the applied `FETCH_HEAD` (a ref, a file, or a second commit parent) was the first thing I tried to design, and two findings ruled it out:

1. **It cannot repair any install that is already affected.** No install has such a record yet, so the first run after the fix still falls back to the merge-base and stays stuck. The self-re-exec at `:1447-1448` means a fix merged here reaches every install on its next `apply` — but only if it works on that first run, inside an install that is already in the broken state.
2. **A stuck install is a mixture of versions, so no single commit describes it.** Measured in the reproduction after the failed update:

   ```
   system files present in both releases : 786
     content == v1.25.0 only :  83   <- left behind
     content == v1.27.0 only : 122   <- updated
     identical in both       : 574
   ```

   A sync point would also be a lie about exactly the preserved files: they are excluded from the checkout by design, so "this install is now at X" is false for them, and the next update would compare a genuine local edit against a baseline that already holds upstream's newer version — the #2337 loss mode.

Baselining on the last auto-update commit has the same flaw from the other direction: preserved files are excluded from that commit, so a *committed* local edit that survives one update diffs clean against it and is silently overwritten on the next.

## Evidence

Reproduction as described in #3094: an install cloned at 1.24.0, updated to 1.25.0, then updated again. One stuck install, copied, with a genuine local edit to `merge-tracker.mjs` added before the final update. One copy updated to plain `main`, the other to `main` + this patch.

| | flagged as local edits | `VERSION` after | new `.bak` | local fix kept |
|---|---|---|---|---|
| control (`main`) | 122 | 1.25.0 — unchanged | 122 | yes |
| this PR | 1 | 1.28.0 | 1 | yes |

Control reports `Update complete: v1.25.0 → v1.25.0`. With the patch the single flagged file is `merge-tracker.mjs`, the one that was actually edited.

## Cost

Two `git` calls, run only on the files that survive the existing two conditions.

| | flagged | added |
|---|---|---|
| healthy install, nothing edited | 0 | none measurable — the query never runs |
| stuck install, 418 commits in the window | 122 → 1 | +868 ms |

## Behaviour changes worth stating

1. **A file deliberately reverted to an older upstream version is no longer reported**, and receives no `.bak`. Its content is upstream's own by definition, so it remains recoverable from history, and the Data Contract calls the system layer system-owned — but it is a real change and I would rather name it than have it found in review.
2. **The dropped files are silent**, matching the existing rule that a file upstream independently adopted is not worth warning about ("warning about it would be noise").
3. **This compensates for the stale baseline rather than moving it.** The merge-base stays frozen; the fix stops the wrong answer from mattering. The record of what was installed was never written down and cannot be recovered retroactively, so removing the need for one is the only option that helps existing installs. A sync point could be added later as a *speed* improvement — the search window grows slowly as an install ages — but not as the correctness fix.

## Tests

Three cases added to `tests/updater-local-system-edits.test.mjs`, in the existing style:

- **14** — content installed by a previous update is not a local edit. Fails on `main` with `["modes/pdf.md"]`.
- **15** — a genuine local fix is still reported after a second update, so the new condition cannot quietly cost us the warning the detector exists for. Fails on `main` with the false positive alongside the real one.
- **16** — unreadable upstream history (shallow clone) degrades the filter and still reports what was already known, matching the contract case 7 pins for a bad ref.

`node test-all.mjs`: 4921 passed, 0 failed. The 3 warnings are present on unmodified `main` in the same environment (no `cv.md` in a fresh clone, no Go compiler, `santifer.io` in `dashboard/internal/ui/screens/stats.go`).

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes exempt — this is a bug fix, and #3094 exists anyway)
- [x] My PR does not include personal data
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the Data Contract (no user-layer files touched)
- [x] My changes align with the project roadmap


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of locally modified system files during updates.
  * Prevents previously installed upstream content from being incorrectly reported as local edits.
  * Preserves genuine local-change warnings.
  * Updates continue safely when upstream history cannot be read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->