### PR TITLE
fix(providers/lever): fold categories.allLocations into location

### DIFF
--- a/providers/lever.mjs
+++ b/providers/lever.mjs
@@ -43,6 +43,25 @@ function resolveApiUrl(entry) {
   return `https://api.${host[1]}/v0/postings/${slug}`;
 }
 
+/** Fold `categories.location` together with any extra `categories.allLocations`
+ *  into one string. Lever puts a SINGLE primary city in `location`, and exposes
+ *  the full set on multi-location postings in `allLocations` — reading only the
+ *  former silently hides every other eligible location from scan.mjs's
+ *  location_filter (e.g. a req open in Barcelona AND Montevideo looks
+ *  Barcelona-only). Mirrors resolveLocation() in providers/remotli.mjs.
+ *  @param {any} categories */
+function resolveLocation(categories) {
+  const primary = typeof categories?.location === 'string' ? categories.location.trim() : '';
+  const all = Array.isArray(categories?.allLocations)
+    ? categories.allLocations.filter(l => typeof l === 'string' && l.trim()).map(l => l.trim())
+    : [];
+  const merged = [];
+  for (const l of [primary, ...all]) {
+    if (l && !merged.some(m => m.toLowerCase() === l.toLowerCase())) merged.push(l);
+  }
+  return merged.join('; ');
+}
+
 /** @type {Provider} */
 export default {
   id: 'lever',
@@ -66,7 +85,7 @@ export default {
       title: j.text || '',
       url: j.hostedUrl || '',
       company: entry.name,
-      location: j.categories?.location || '',
+      location: resolveLocation(j.categories),
       // Lever's v0 postings list ships the full description for free (same
       // payload, no per-job request) — enables scan.mjs content_filter.
       description: typeof j.descriptionPlain === 'string' ? j.descriptionPlain : '',

--- a/tests/providers/lever.test.mjs
+++ b/tests/providers/lever.test.mjs
@@ -128,6 +128,38 @@ try {
       createdAt: '2026-07-01',
     },
     {},                                                                   // fully empty posting object
+    {
+      // multi-location posting: `location` carries only the primary city,
+      // `allLocations` carries the full set. Both must survive into location.
+      text: 'Technical Lead - Java',
+      hostedUrl: 'https://jobs.lever.co/acme/2222-technical-lead-java',
+      categories: {
+        location: 'Barcelona',
+        allLocations: ['Barcelona', 'Madrid', 'Montevideo (Hybrid)'],
+      },
+    },
+    {
+      // allLocations junk: non-strings, blanks, and a case-variant dupe of the
+      // primary must all be dropped without losing the real extra location.
+      text: 'Cloud Architect',
+      hostedUrl: 'https://jobs.lever.co/acme/3333-cloud-architect',
+      categories: {
+        location: 'Madrid',
+        allLocations: ['  madrid  ', '', null, 42, 'Sao Paulo'],
+      },
+    },
+    {
+      // allLocations present but location absent → still resolves.
+      text: 'DevOps Engineer',
+      hostedUrl: 'https://jobs.lever.co/acme/4444-devops',
+      categories: { allLocations: ['Montevideo'] },
+    },
+    {
+      // allLocations not an array → ignored, primary preserved.
+      text: 'Security Engineer',
+      hostedUrl: 'https://jobs.lever.co/acme/5555-security',
+      categories: { location: 'Lisbon', allLocations: 'Lisbon' },
+    },
   ];
 
   let capturedUrl = null;
@@ -143,9 +175,9 @@ try {
     fail(`lever.fetch() url=${JSON.stringify(capturedUrl)} opts=${JSON.stringify(capturedOpts)}`);
   }
 
-  if (fetched.length === 3)
+  if (fetched.length === 7)
     pass('lever.fetch() returns one normalized row per posting (no silent drops)');
-  else fail(`lever.fetch() returned ${fetched.length} rows (expected 3)`);
+  else fail(`lever.fetch() returned ${fetched.length} rows (expected 7)`);
 
   if (fetched[0]?.title === 'Staff Platform Engineer'
       && fetched[0]?.url === 'https://jobs.lever.co/acme/1111-staff-platform-engineer'
@@ -164,6 +196,26 @@ try {
       && fetched[2]?.company === 'Acme' && fetched[2]?.description === '' && fetched[2]?.postedAt === undefined)
     pass('lever.fetch() maps an empty posting object to empty-string fields without crashing');
   else fail(`lever.fetch() row 2 = ${JSON.stringify(fetched[2])}`);
+
+  // categories.allLocations — the multi-location fix. Lever puts a single
+  // primary city in `location`; reading only that hides every other eligible
+  // location from scan.mjs's location_filter (a Barcelona+Montevideo req looks
+  // Barcelona-only, so a Montevideo-based filter silently drops it).
+  if (fetched[3]?.location === 'Barcelona; Madrid; Montevideo (Hybrid)')
+    pass('lever.fetch() folds categories.allLocations into location (multi-location postings stay visible to location_filter)');
+  else fail(`lever.fetch() row 3 location = ${JSON.stringify(fetched[3]?.location)}`);
+
+  if (fetched[4]?.location === 'Madrid; Sao Paulo')
+    pass('lever.fetch() drops blank/non-string allLocations entries and case-insensitive duplicates of the primary');
+  else fail(`lever.fetch() row 4 location = ${JSON.stringify(fetched[4]?.location)}`);
+
+  if (fetched[5]?.location === 'Montevideo')
+    pass('lever.fetch() resolves allLocations when categories.location is absent');
+  else fail(`lever.fetch() row 5 location = ${JSON.stringify(fetched[5]?.location)}`);
+
+  if (fetched[6]?.location === 'Lisbon')
+    pass('lever.fetch() ignores a non-array allLocations and preserves the primary location');
+  else fail(`lever.fetch() row 6 location = ${JSON.stringify(fetched[6]?.location)}`);
 
   // Non-array response bodies → [], no crash.
   const emptyCases = [null, {}, { postings: [] }, 'nope'];


### PR DESCRIPTION
## What does this PR do?

`providers/lever.mjs` reads only `categories.location`, which Lever populates with a **single primary** city. Multi-location postings expose the full set in `categories.allLocations`, which the provider ignores — so a requisition open in both Barcelona and Montevideo looks Barcelona-only to `scan.mjs`'s `location_filter` and is silently dropped.

This folds `allLocations` into the location string, mirroring the `resolveLocation()` helper that `providers/remotli.mjs` already uses for the same problem.

## Related issue

None — bug fix, sent straight in per CONTRIBUTING.

## Why it matters

The failure mode leaves no trace. A filtered-out posting never surfaces, so there is nothing to notice as missing; the scan just quietly returns fewer roles than the board actually offers.

Measured against one live public Lever board (`api.lever.co/v0/postings/dlocal`, 53 open postings at the time of writing), postings whose location string contains "Montevideo" go from **2 to 29**. Among the ones currently invisible: Staff Engineer - Java, Head of Platform Engineering, Principal Security Engineer, DevOps Engineer CI/CD, Cloud Architect. Every one is LatAm-eligible while appearing to the scanner as Barcelona/Madrid/Spain only.

Reproducible against any Lever board with multi-location requisitions; nothing about it is specific to that company.

## Implementation

```js
function resolveLocation(categories) {
  const primary = typeof categories?.location === 'string' ? categories.location.trim() : '';
  const all = Array.isArray(categories?.allLocations)
    ? categories.allLocations.filter(l => typeof l === 'string' && l.trim()).map(l => l.trim())
    : [];
  const merged = [];
  for (const l of [primary, ...all]) {
    if (l && !merged.some(m => m.toLowerCase() === l.toLowerCase())) merged.push(l);
  }
  return merged.join('; ');
}
```

Same `; ` join, same case-insensitive dedup, and same tolerance for blank/non-string entries as `remotli.mjs` — deliberately copied rather than re-invented, so the two stay comparable.

Backward compatible: a posting with no `allLocations` yields exactly the previous single-location string.

## Tests

Four assertions added to `tests/providers/lever.test.mjs`, extending the existing `fetch()` normalization fixture:

- folds `allLocations` into `location` for a multi-location posting
- drops blank/non-string entries and case-insensitive duplicates of the primary
- resolves `allLocations` when `categories.location` is absent
- ignores a non-array `allLocations` and preserves the primary

`node test-all.mjs` on this branch: **4922 passed, 0 failed**.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Lever job listings now display all available locations, including additional locations provided for a posting.
  - Duplicate and invalid location entries are filtered, and multiple locations are presented in a consistent format.

- **Bug Fixes**
  - Improved location display for postings without a primary location or with incomplete location data.

- **Tests**
  - Added coverage for multi-location, duplicate, invalid, and missing-location scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->