### PR TITLE
fix(templates): keep a project's tech line with the description it belongs to

### DIFF
--- a/templates/cv-template.compact.html
+++ b/templates/cv-template.compact.html
@@ -287,6 +287,13 @@ version: 1.0.0
     page-break-after: avoid;
   }
 
+  /* Keep a project's tech line attached to the description above it, so a bare
+     "Python | github.com/..." line is never stranded atop the next page. */
+  .project-tech {
+    break-before: avoid;
+    page-break-before: avoid;
+  }
+
   /* === RTL (Arabic) support === */
   html[lang="ar"] body {
     direction: rtl;

--- a/templates/cv-template.executive.html
+++ b/templates/cv-template.executive.html
@@ -278,6 +278,13 @@ version: 1.0.0
     page-break-after: avoid;
   }
 
+  /* Keep a project's tech line attached to the description above it, so a bare
+     "Python | github.com/..." line is never stranded atop the next page. */
+  .project-tech {
+    break-before: avoid;
+    page-break-before: avoid;
+  }
+
   /* === RTL (Arabic) support === */
   html[lang="ar"] body {
     direction: rtl;

--- a/templates/cv-template.html
+++ b/templates/cv-template.html
@@ -442,6 +442,15 @@
     page-break-after: avoid;
   }
 
+  /* Keep a project's tech line attached to the description above it.  A project
+     may still split across pages, but not at the one opportunity that strands a
+     bare "Python | github.com/..." line at the top of the next page with no
+     title or description to identify it. */
+  .project-tech {
+    break-before: avoid;
+    page-break-before: avoid;
+  }
+
   /* === RTL (Arabic) Support === */
   html[lang="ar"] body {
     direction: rtl;

--- a/templates/cv-template.jake.html
+++ b/templates/cv-template.jake.html
@@ -271,6 +271,13 @@ version: 1.0.0
     page-break-after: avoid;
   }
 
+  /* Keep a project's tech line attached to the description above it, so a bare
+     "Python | github.com/..." line is never stranded atop the next page. */
+  .project-tech {
+    break-before: avoid;
+    page-break-before: avoid;
+  }
+
   /* === RTL (Arabic) support === */
   html[lang="ar"] body {
     direction: rtl;

--- a/templates/cv-template.leadership.html
+++ b/templates/cv-template.leadership.html
@@ -288,6 +288,13 @@ version: 1.0.0
     page-break-after: avoid;
   }
 
+  /* Keep a project's tech line attached to the description above it, so a bare
+     "Python | github.com/..." line is never stranded atop the next page. */
+  .project-tech {
+    break-before: avoid;
+    page-break-before: avoid;
+  }
+
   /* === RTL (Arabic) support === */
   html[lang="ar"] body {
     direction: rtl;

--- a/templates/cv-template.modern.html
+++ b/templates/cv-template.modern.html
@@ -321,6 +321,13 @@ version: 1.0.0
     page-break-after: avoid;
   }
 
+  /* Keep a project's tech line attached to the description above it, so a bare
+     "Python | github.com/..." line is never stranded atop the next page. */
+  .project-tech {
+    break-before: avoid;
+    page-break-before: avoid;
+  }
+
   /* === RTL (Arabic) support === */
   html[lang="ar"] body {
     direction: rtl;

--- a/templates/cv-template.zh-minimal.html
+++ b/templates/cv-template.zh-minimal.html
@@ -426,6 +426,15 @@ version: 1.0.0
     page-break-after: avoid;
   }
 
+  /* Keep a project's tech line attached to the description above it.  A project
+     may still split across pages, but not at the one opportunity that strands a
+     bare "Python | github.com/..." line at the top of the next page with no
+     title or description to identify it. */
+  .project-tech {
+    break-before: avoid;
+    page-break-before: avoid;
+  }
+
   /* === RTL (Arabic) Support === */
   html[lang="ar"] body {
     direction: rtl;

--- a/tests/template-page-breaks.test.mjs
+++ b/tests/template-page-breaks.test.mjs
@@ -1,0 +1,113 @@
+// tests/template-page-breaks.test.mjs — a project's tech line must never be
+// stranded at the top of a page.
+//
+// Every CV template deliberately lets a `.project` split across a page boundary
+// ("content packs tight instead of jumping wholesale and leaving large bottom
+// gaps", as cv-template.html's own comment puts it). That choice is only safe
+// while the *worst* split is forbidden. `.project-desc` and `.project-tech` are
+// sibling blocks, so the gap between them is a legal break opportunity, and
+// Chromium takes it whenever a description happens to end near the bottom of a
+// page: the next page opens with a bare "TypeScript | github.com/user/repo" and
+// nothing above it to say which project that describes.
+//
+// The symmetric case was already guarded — `.project-title` carries
+// `break-after: avoid` so a title is never orphaned at the bottom. This file
+// pins the other half, and pins it as an *invariant over every discovered
+// template* rather than as seven copies of one assertion, because the failure is
+// invisible until a CV happens to be the wrong length. Six of the seven
+// templates shipped without it; a new variant copied from any of them would
+// have shipped without it too.
+//
+// Deliberately a CSS assertion, not a render: suites here must run on a bare
+// clone with only Node (#1440), and reproducing the orphan needs Chromium plus a
+// payload tuned to one template's exact geometry. The rule is the contract; the
+// render is how the rule was arrived at.
+import { readFileSync } from 'fs';
+import { relative } from 'path';
+import { pass, fail, ROOT } from './helpers.mjs';
+import { listTemplates } from '../cv-templates.mjs';
+
+console.log('\nCV template page-break control — no orphaned project tech line');
+
+/**
+ * Innermost CSS rules as {selectors, declarations} pairs.
+ *
+ * Declarations never contain braces, so matching the innermost `… { … }` also
+ * reaches rules nested inside `@media print` without needing to track at-rule
+ * depth. Comments are stripped first so a commented-out rule can never satisfy
+ * an assertion.
+ *
+ * @param {string} css - Stylesheet text (a full template file is fine).
+ * @returns {Array<{selectors: string[], decls: string}>}
+ */
+function rules(css) {
+  const clean = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  const out = [];
+  for (const m of clean.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+    out.push({
+      selectors: m[1].split(',').map((s) => s.trim()).filter(Boolean),
+      decls: m[2],
+    });
+  }
+  return out;
+}
+
+/** Whether any rule targeting `selector` declares `prop: value`. */
+function declares(parsed, selector, prop, value) {
+  const exact = new RegExp(`(^|\\s|>|\\+|~)${selector.replace('.', '\\.')}(\\s|$|:)`);
+  const decl = new RegExp(`(^|[;{\\s])${prop}\\s*:\\s*${value}\\s*(;|$)`);
+  return parsed.some((r) => r.selectors.some((s) => exact.test(s)) && decl.test(r.decls));
+}
+
+const templates = listTemplates('cv').filter((t) => t.format === 'html');
+
+if (templates.length === 0) {
+  fail('no HTML CV templates discovered — listTemplates("cv") returned nothing');
+} else {
+  pass(`discovered ${templates.length} HTML CV templates to check`);
+}
+
+for (const t of templates) {
+  const rel = relative(ROOT, t.path).replace(/\\/g, '/');
+  const css = readFileSync(t.path, 'utf-8');
+  const parsed = rules(css);
+
+  // A template that styles no tech line cannot orphan one.
+  if (!parsed.some((r) => r.selectors.some((s) => /(^|\s)\.project-tech(\s|$|:)/.test(s)))) {
+    pass(`${rel}: no .project-tech rule — nothing to orphan`);
+    continue;
+  }
+
+  // Templates that keep a whole .project atomic move the block as a unit, so the
+  // break opportunity this file is about never exists for them.
+  const atomicProject = declares(parsed, '.project', 'break-inside', 'avoid');
+
+  const guarded = declares(parsed, '.project-tech', 'break-before', 'avoid')
+    || declares(parsed, '.project-desc', 'break-after', 'avoid');
+
+  if (atomicProject) {
+    pass(`${rel}: .project is atomic (break-inside: avoid) — cannot split before the tech line`);
+  } else if (guarded) {
+    pass(`${rel}: forbids a break immediately before .project-tech`);
+  } else {
+    fail(`${rel}: .project may split across pages but nothing forbids a break before `
+      + `.project-tech — a bare tech line can land alone atop the next page. Add `
+      + `\`.project-tech { break-before: avoid; page-break-before: avoid; }\``);
+  }
+
+  // The templates pair every modern break property with its legacy alias. Losing
+  // half the pair is the kind of edit that looks like a tidy-up and quietly drops
+  // support for whatever engine still needs the prefix-era name.
+  if (declares(parsed, '.project-tech', 'break-before', 'avoid')
+    && !declares(parsed, '.project-tech', 'page-break-before', 'avoid')) {
+    fail(`${rel}: .project-tech has break-before: avoid without the paired page-break-before: avoid`);
+  }
+
+  // Regression guard on the protection that already existed: a project title must
+  // still not be the last thing on a page.
+  if (declares(parsed, '.project-title', 'break-after', 'avoid')) {
+    pass(`${rel}: .project-title still carries break-after: avoid`);
+  } else if (!atomicProject) {
+    fail(`${rel}: .project-title lost break-after: avoid — a title can be orphaned at the bottom of a page`);
+  }
+}

--- a/tests/template-page-breaks.test.mjs
+++ b/tests/template-page-breaks.test.mjs
@@ -32,16 +32,21 @@ console.log('\nCV template page-break control — no orphaned project tech line'
 /**
  * Innermost CSS rules as {selectors, declarations} pairs.
  *
- * Declarations never contain braces, so matching the innermost `… { … }` also
- * reaches rules nested inside `@media print` without needing to track at-rule
- * depth. Comments are stripped first so a commented-out rule can never satisfy
- * an assertion.
+ * Matching the innermost `… { … }` also reaches rules nested inside
+ * `@media print` without tracking at-rule depth — but only once two things that
+ * do put braces inside a declaration block are removed first. Comments go so a
+ * commented-out rule can never satisfy an assertion, and `{{PLACEHOLDER}}`
+ * interpolations go because templates use them inside declarations
+ * (`max-width: {{PAGE_WIDTH}};`), which would otherwise skip the rule holding
+ * one and absorb its text into the next rule's selector list.
  *
  * @param {string} css - Stylesheet text (a full template file is fine).
  * @returns {Array<{selectors: string[], decls: string}>}
  */
 function rules(css) {
-  const clean = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  const clean = css
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\{\{[^{}]*\}\}/g, 'PLACEHOLDER');
   const out = [];
   for (const m of clean.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
     out.push({
@@ -72,16 +77,19 @@ for (const t of templates) {
   const css = readFileSync(t.path, 'utf-8');
   const parsed = rules(css);
 
-  // A template that styles no tech line cannot orphan one.
-  if (!parsed.some((r) => r.selectors.some((s) => /(^|\s)\.project-tech(\s|$|:)/.test(s)))) {
-    pass(`${rel}: no .project-tech rule — nothing to orphan`);
-    continue;
-  }
+  // Every template is held to this, including one that styles no .project-tech.
+  // The markup is not the template's to opt out of: it comes from the shared
+  // templates/sections/projects.html, so a template emits that div whenever the
+  // payload carries `tech`, styled or not — and an unstyled block is still a
+  // block-level sibling that a page break can land in front of. Skipping on "no
+  // .project-tech rule" would pass such a template vacuously.
 
-  // Templates that keep a whole .project atomic move the block as a unit, so the
-  // break opportunity this file is about never exists for them.
+  // Keeping a whole .project atomic is the other valid way to satisfy the
+  // invariant: the block moves as a unit, so the opportunity never exists.
   const atomicProject = declares(parsed, '.project', 'break-inside', 'avoid');
 
+  // Either side of the break opportunity may declare it — the CSS fragmentation
+  // rules forbid the break if either does.
   const guarded = declares(parsed, '.project-tech', 'break-before', 'avoid')
     || declares(parsed, '.project-desc', 'break-after', 'avoid');
 


### PR DESCRIPTION
## What does this PR do?

Every CV template deliberately lets a `.project` block split across a page boundary — cv-template.html says so in its own comment: *"Sections and multi-bullet roles are allowed to flow across a page boundary so content packs tight instead of jumping wholesale and leaving large bottom gaps."* That's the right default, but it's only safe while the worst split is forbidden, and one wasn't.

`.project-desc` and `.project-tech` are sibling blocks, so the gap between them is a legal break opportunity. When a project's description happens to end near the bottom of a page, Chromium takes it — and page 2 opens with a bare `TypeScript | github.com/user/repo` with no title or description above it to say which project it belongs to.

The symmetric case was already handled: `.project-title` carries `break-after: avoid` so a title is never orphaned at the *bottom* of a page. This adds the other half.

## Related issue

None — bug fix, sending it straight in per CONTRIBUTING.md.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## The fix

```css
/* Keep a project's tech line attached to the description above it. */
.project-tech {
  break-before: avoid;
  page-break-before: avoid;
}
```

Applied to the seven templates `listTemplates('cv')` discovers. `resume-template.html` is **not** touched: it sets `break-inside: avoid` on `.project`, so that block already moves as a unit and the break opportunity never exists there.

### Why `break-before` on the tech line rather than `break-after` on the description

`break-after: avoid` on `.project-desc` fixes the same symptom, and I started there — but `<!--TECH_BLOCK-->` is conditional. For a project with a description and no tech line, a trailing `break-after: avoid` propagates to the end edge of the whole `.project`, gluing it to the next project's title. That over-constrains a case that was never broken. `break-before: avoid` on `.project-tech` forbids exactly the one offending opportunity and is inert when there is no tech line.

## Before / after

Reproduced with a synthetic payload (no personal data) tuned so the last project's description ends just at the page-1 boundary — first non-empty line of page 2, via `pdftotext -f 2 -l 2`:

| template | before | after |
|---|---|---|
| `cv-template.html` | `TypeScript \| github.com/janesmith/project-five` | `than.` → then the tech line |
| `cv-template.zh-minimal.html` | `TypeScript \| github.com/janesmith/project-five` | `than.` → then the tech line |

Chromium now breaks *inside* the description instead, so the tech line arrives with the tail of the prose it describes. **The page count does not change** (2 before, 2 after) — the templates' documented preference for packing content tight over relocating whole blocks is preserved. The other five render clean with no regression.

The orphan window is narrow: it took growing the final description one word at a time to land on it. That is exactly why it went unnoticed — it depends on a CV being an unlucky length, so it shows up on a real person's PDF and not on any fixture.

## Regression test

`tests/template-page-breaks.test.mjs` asserts the invariant over `listTemplates('cv')` rather than per file, so a template added later is covered without touching the suite. Six of the seven shipped without the guard; a new variant copied from any of them would have shipped without it too.

The invariant, not the diff: *if a template lets `.project` split, it must forbid a break immediately before `.project-tech`.* A template that keeps `.project` atomic passes without needing the rule, which is why `resume-template.html` staying unchanged is a pass and not an exemption.

Verified in both directions — against the templates as they were, `test-all.mjs` reports **7 failed, exit 1**; with the fix, **4923 passed, 0 failed**.

It's a CSS assertion rather than a render, because suites under `tests/` must run on a bare clone with only Node (#1440) and reproducing the orphan needs Chromium plus a payload tuned to one template's exact geometry. It also guards the two adjacent things an edit here could quietly undo: the paired legacy `page-break-*` alias, and the `break-after: avoid` on `.project-title`.

I left the `version:` in the template metadata headers alone — nothing in the repo's history bumps it, so I didn't want to invent a convention.

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved printed CV pagination so project technology details stay with their preceding descriptions instead of appearing alone at the top of a new page.
  * Applied the pagination improvement consistently across all CV templates.

* **Tests**
  * Added regression coverage to verify page-break behavior across every HTML CV template.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->