### PR TITLE
fix(tests): assert the echoed flag as a substring, not an unescaped RegExp

### DIFF
--- a/tests/cli-flag-validation.test.mjs
+++ b/tests/cli-flag-validation.test.mjs
@@ -64,7 +64,11 @@ for (const [script, typo, usage = /Usage:/i] of SCRIPTS) {
     const r = runScript(script, typo, 'some-value');
     assert.equal(r.status, 1, `${script} ${typo} exited ${r.status}, want 1`);
     assert.match(r.all, /unrecognized flag/i, `${script} did not name the unrecognized flag`);
-    assert.match(r.all, new RegExp(typo.replace(/^--/, '--')), `${script} did not echo ${typo} back`);
+    // Substring, not a regex. The flag is data, and `typo.replace(/^--/, '--')`
+    // replaced `--` with itself, so nothing was ever escaped: the RegExp only
+    // worked because none of today's flags carry a metacharacter. Add one that
+    // does and the assertion stops asking the question it is named after.
+    assert.ok(r.all.includes(typo), `${script} did not echo ${typo} back`);
   });
 
   test(`${script} --help exits 0 and prints usage`, () => {


### PR DESCRIPTION
## What this fixes

CodeQL alert #131 (`js/identity-replacement`, open since 15-ago) on `tests/cli-flag-validation.test.mjs:67`:

```js
assert.match(r.all, new RegExp(typo.replace(/^--/, '--')), `${script} did not echo ${typo} back`);
```

`typo.replace(/^--/, '--')` replaces `--` with itself. Nothing is escaped, so this builds a RegExp straight out of the flag string.

## Why it matters beyond the alert

Today every flag under test is metacharacter-free (`--windo`, `--fiel`, `--reprot`), so the RegExp happens to behave like a substring match and the suite is green for the right reason by luck. The first flag containing a `.`, `+`, `(` or `[` changes that: the assertion either matches something it shouldn't or throws while compiling, and either way the failure reads as *the script misbehaved* rather than *the test asked the wrong question*. That is the expensive kind of test failure, because it sends the reader to the wrong file.

## The change

The assertion's own name says what it means: *did the script echo this flag back*. That is a substring check, so it is now written as one, with a comment recording why the old line looked deliberate.

```js
assert.ok(r.all.includes(typo), `${script} did not echo ${typo} back`);
```

## Verification

- `node --test tests/cli-flag-validation.test.mjs` → **28 passed, 0 failed**.
- Checked for siblings: this was the only `new RegExp()` in `tests/` built from a variable rather than a literal, so it is an isolated case and not a family.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated command-line flag validation checks to reliably recognize literal typo text in reported output.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->