### PR TITLE
fix(pipeline-lock): carry the judged directory's identity to the rm

### DIFF
--- a/pipeline-lock.mjs
+++ b/pipeline-lock.mjs
@@ -89,6 +89,17 @@ function readLockOwner(lockDir) {
   }
 }
 
+// stat, or null when the path is gone or unreadable. Callers that are deciding
+// whether to DELETE something need "I could not establish this" and "it is not
+// there" to arrive as the same cautious answer.
+function statOrNull(dir) {
+  try {
+    return statSync(dir);
+  } catch {
+    return null;
+  }
+}
+
 // Identity of a directory, so a lock that was removed and recreated by another
 // process is never mistaken for the one this caller created.
 function sameLockDirectory(left, right) {
@@ -426,7 +437,25 @@ export async function acquirePipelineLock(pipelinePath, options = {}) {
           // acquisition, which is what the old comment already claimed this
           // branch did. It costs one backoff in a rare case; deleting a live
           // lock costs an item.
-          if (lockRecoveryVerdict(lockDir, staleMs) === RECOVER_STALE) {
+          // STALE is not enough on its own either: it says the directory we
+          // READ was abandoned, and the rm acts on whatever is at the path a
+          // moment later. Reaching the verdict costs a readFileSync and a
+          // process.kill, which is ample room to be descheduled, and in that
+          // gap the stale lock can be reclaimed by someone else and replaced by
+          // a live one. Deleting then destroys a lock this caller never judged.
+          //
+          // Not hypothetical. Logging the directory's inode either side of the
+          // verdict, the ONE stale reclaim in a 2,400-acquisition run came back
+          //   idBefore=5910974513639709 ownerBefore=39392
+          //   idAfter =6192449490350378 ownerAfter =27256 alive=true
+          // — a different directory, owned by a live process, deleted anyway.
+          //
+          // So the identity of the judged directory is carried to the rm and
+          // rechecked. A path that changed underneath us is left alone; we go
+          // back and compete for it normally.
+          const judged = statOrNull(lockDir);
+          if (judged && lockRecoveryVerdict(lockDir, staleMs) === RECOVER_STALE
+            && sameLockDirectory(judged, statOrNull(lockDir) ?? {})) {
             if (rmLockArtifactSync(lockDir)) {
               continue; // retry acquisition immediately, still holding the guard's decision
             }
@@ -499,6 +528,25 @@ export async function acquirePipelineLock(pipelinePath, options = {}) {
         /* cleanup must never outrank the reason we are here */
       }
       throw ownerErr;
+    }
+
+    // Read our own stamp back before handing the caller a lock handle.
+    //
+    // The identity recheck above stops this caller from deleting a directory it
+    // did not judge, but it cannot stop another caller from doing so to US, and
+    // that failure has no error attached to it: the delete lands after our
+    // owner.json write succeeds, so nothing in the acquisition path notices and
+    // two processes enter the critical section believing they hold it.
+    //
+    // main already recovers the case where the delete lands BEFORE the stamp —
+    // the write fails ENOENT and the loop competes again. This is the same
+    // recovery for the case where it lands just after. A stamp that is missing,
+    // or that carries someone else's token, means we no longer hold what we
+    // took, so we compete again rather than proceed.
+    const confirmed = readLockOwner(lockDir);
+    if (confirmed.owner?.token !== token) {
+      if (holderStillWedged()) throw buildTimeoutError();
+      continue;
     }
 
     let released = false;


### PR DESCRIPTION
Follow-up to #3120, which merged before I finished measuring it. This is the second half.

## What #3120 left open

#3120 stopped a caller acting on a `VANISHED` verdict, where the directory was *absent*
when it looked. `STALE` has the same structure and was untouched: it says the directory we
**read** was abandoned, and the rm acts on whatever is at the path a moment later. Reaching
that verdict costs a `readFileSync` and a `process.kill`, which is room enough to be
descheduled, and in that gap a stale lock can be reclaimed by someone else and replaced by a
live one.

I found this by running #2905's §9 as a control on the merged fix, which is the one check in
the repo that measures mutual exclusion. It was not clean.

## Measured

Logging the lock directory's inode either side of the verdict, the single stale reclaim in a
2,400-acquisition run:

```
idBefore=5910974513639709  ownerBefore=39392
idAfter =6192449490350378  ownerAfter =27256  alive=true
```

A different directory, owned by a live process, deleted anyway.

30 processes each taking the lock once and exiting, which is what every career-ops CLI does.
Hold intervals recorded per process to its own file, parent looks for overlapping
`[enter, exit]` pairs:

| | overlapping holds | runs affected |
|---|---|---|
| before #3120 | 21 | 14 of 60 |
| #3120 as merged | 2 | 2 of 60 |
| with this PR | **0** | **0 of 120** (3,600 acquisitions) |

The high-turnover regime is unchanged at 0 in 60,000 acquisitions, so this does not trade one
regime for another.

## The change

The identity of the judged directory is carried to the rm and rechecked. A path that changed
underneath us is left alone and we compete for it normally.

The second half is a backstop for the symmetric case a caller cannot control: another process
doing this to *us*. That one is silent, because the delete lands after our `owner.json` write
succeeds and nothing in the acquisition path notices. `main` already recovers when the delete
lands *before* the stamp (the write fails ENOENT and the loop competes again); reading our own
stamp back extends the same recovery to a delete landing just after it.

## No test, and why

The window is synchronous. The replacement has to land between two statements, so a
deterministic test would have to monkey-patch `fs` rather than drive the lock. I wrote one
that did not discriminate — it failed identically with and without the fix, because a crashed
holder with `staleMs: 1` is legitimately reclaimed — and removed it rather than ship a green
tick that proves nothing. The evidence is the measurement above.

Suite: 4980 passed, 0 failed.

Related: #3123 converts the three copies of this lock to import the judgment, and will pick
this up when it rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lock handling in concurrent operations.
  * Prevented stale or replaced locks from being incorrectly reclaimed.
  * Reduced the risk of multiple processes entering protected operations simultaneously.
  * Added safer recovery when lock state changes during acquisition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->