### PR TITLE
fix(plugins): discover a plugin directory that is symlinked into a plugin root

### DIFF
--- a/plugins/_engine.mjs
+++ b/plugins/_engine.mjs
@@ -24,7 +24,7 @@
  * all reuse it with no prod-vs-test drift.
  */
 
-import { existsSync, readdirSync, readFileSync, realpathSync } from 'fs';
+import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from 'fs';
 import path from 'path';
 import { pathToFileURL } from 'url';
 import { resolveAndValidate } from './_net.mjs';
@@ -253,8 +253,24 @@ export function discoverPlugins(roots, overrideIds = new Set()) {
       warnSkip(root, `unreadable — ${err.message}`);
       continue;
     }
+    // A symlink to a plugin repo is a directory for our purposes: plugins.local/
+    // exists so a developer can work on a plugin from its own checkout, and
+    // linking it in is the natural way to do that. Dirent.isDirectory() is false
+    // for a symlink, so those were silently skipped -- no warning, the plugin
+    // simply never appeared in `plugins.mjs list`. statSync resolves the link;
+    // a broken one throws and is treated as not-a-directory rather than crashing
+    // discovery for every other plugin.
+    const isDirLike = (e) => {
+      if (e.isDirectory()) return true;
+      if (!e.isSymbolicLink()) return false;
+      try {
+        return statSync(path.join(root, e.name)).isDirectory();
+      } catch {
+        return false;
+      }
+    };
     const dirs = entries
-      .filter(e => e.isDirectory() && !e.name.startsWith('_') && !e.name.startsWith('.'))
+      .filter(e => isDirLike(e) && !e.name.startsWith('_') && !e.name.startsWith('.'))
       .map(e => e.name)
       .sort();
     for (const name of dirs) {

--- a/tests/plugin-symlink-discovery.test.mjs
+++ b/tests/plugin-symlink-discovery.test.mjs
@@ -1,0 +1,107 @@
+// tests/plugin-symlink-discovery.test.mjs — discoverPlugins() must treat a
+// symlinked plugin directory as a plugin directory (#3140).
+//
+// plugins.local/ exists so a developer can work on a plugin from its own
+// checkout, and linking that checkout in is the natural way to do it.
+// readdirSync does not follow links, so a symlinked entry reports
+// isDirectory() === false and a bare isDirectory() filter drops it with no
+// warning at all: the plugin never appears in `plugins.mjs list` even though
+// config/plugins.yml enables it.
+import { pass, fail, ROOT } from './helpers.mjs';
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { pathToFileURL } from 'url';
+
+const { discoverPlugins, pluginRoots } = await import(pathToFileURL(join(ROOT, 'plugins/_engine.mjs')).href);
+
+console.log('\nplugins/_engine.mjs — symlinked plugin discovery (#3140)');
+
+const check = (desc, condition, details = '') => {
+  if (condition) pass(desc);
+  else fail(`${desc}${details ? ` (${details})` : ''}`);
+};
+
+const manifest = (id) => JSON.stringify({
+  id,
+  apiVersion: 1,
+  description: `${id} test plugin`,
+  hooks: ['ingest'],
+  requiredEnv: [],
+  allowedHosts: [],
+  humanInTheLoop: true,
+});
+
+/** Write a complete, valid plugin into `dir`, with the manifest id `id`. */
+function writePlugin(dir, id) {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'manifest.json'), manifest(id));
+  writeFileSync(join(dir, 'index.mjs'), 'export default {};\n');
+  return dir;
+}
+
+const tmp = mkdtempSync(join(tmpdir(), 'cops-plugin-symlink-'));
+
+try {
+  const local = join(tmp, 'plugins.local');
+  mkdirSync(local, { recursive: true });
+
+  // A plugin living in its own checkout, linked into plugins.local/ under the
+  // id it declares. The manifest id must match the LINK name, not the target
+  // directory name, which is what a developer linking `career-ops-plugin-demo`
+  // in as `demo` actually gets.
+  const externalCheckout = writePlugin(join(tmp, 'checkouts', 'career-ops-plugin-demo'), 'demo');
+  symlinkSync(externalCheckout, join(local, 'demo'));
+
+  // A plain directory plugin alongside it — the sibling that must keep working.
+  writePlugin(join(local, 'regular'), 'regular');
+
+  const ids = () => discoverPlugins(pluginRoots(tmp)).map(p => p.id).sort();
+
+  const found = ids();
+  check(
+    'a symlinked plugin directory is discovered',
+    found.includes('demo'),
+    `discovered: ${JSON.stringify(found)}`,
+  );
+  check(
+    'the symlinked plugin resolves to its real checkout directory',
+    discoverPlugins(pluginRoots(tmp)).find(p => p.id === 'demo')?.dir === join(local, 'demo'),
+  );
+  check(
+    'a plain directory plugin is still discovered alongside a symlinked one',
+    found.includes('regular'),
+    `discovered: ${JSON.stringify(found)}`,
+  );
+
+  // A dangling symlink (the checkout was moved or deleted) must be skipped
+  // quietly. Resolving it throws, and an unguarded resolve takes down
+  // discovery for every other plugin in the root, not just the dead link.
+  symlinkSync(join(tmp, 'checkouts', 'gone-away'), join(local, 'dangling'));
+
+  let afterDangling;
+  let threw = null;
+  try {
+    afterDangling = ids();
+  } catch (err) {
+    threw = err;
+  }
+
+  check(
+    'a dangling symlink in a plugin root does not throw',
+    threw === null,
+    threw ? `${threw.constructor.name}: ${threw.message}` : '',
+  );
+  check(
+    'a dangling symlink does not suppress the other plugins in its root',
+    Array.isArray(afterDangling) && afterDangling.includes('demo') && afterDangling.includes('regular'),
+    `discovered: ${JSON.stringify(afterDangling)}`,
+  );
+  check(
+    'a dangling symlink is not itself reported as a plugin',
+    Array.isArray(afterDangling) && !afterDangling.includes('dangling'),
+    `discovered: ${JSON.stringify(afterDangling)}`,
+  );
+} finally {
+  rmSync(tmp, { recursive: true, force: true });
+}

--- a/tests/plugin-symlink-discovery.test.mjs
+++ b/tests/plugin-symlink-discovery.test.mjs
@@ -7,13 +7,20 @@
 // isDirectory() === false and a bare isDirectory() filter drops it with no
 // warning at all: the plugin never appears in `plugins.mjs list` even though
 // config/plugins.yml enables it.
+//
+// Discovery is only the first gate. An enabled plugin still has to survive
+// pluginStatus(), lockGate() -- which derives its trust source from
+// manifest.dir and hashes that whole tree -- and the entry import, and every
+// one of those sees the LINK path rather than the resolved checkout. So the
+// second half of this file drives loadPlugins() end to end on a symlinked
+// plugin and calls the hook it returns.
 import { pass, fail, ROOT } from './helpers.mjs';
-import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync } from 'fs';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, symlinkSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { pathToFileURL } from 'url';
 
-const { discoverPlugins, pluginRoots } = await import(pathToFileURL(join(ROOT, 'plugins/_engine.mjs')).href);
+const { discoverPlugins, pluginRoots, loadPlugins } = await import(pathToFileURL(join(ROOT, 'plugins/_engine.mjs')).href);
 
 console.log('\nplugins/_engine.mjs — symlinked plugin discovery (#3140)');
 
@@ -33,14 +40,21 @@ const manifest = (id) => JSON.stringify({
 });
 
 /** Write a complete, valid plugin into `dir`, with the manifest id `id`. */
-function writePlugin(dir, id) {
+function writePlugin(dir, id, entryBody = 'export default {};\n') {
   mkdirSync(dir, { recursive: true });
   writeFileSync(join(dir, 'manifest.json'), manifest(id));
-  writeFileSync(join(dir, 'index.mjs'), 'export default {};\n');
+  writeFileSync(join(dir, 'index.mjs'), entryBody);
   return dir;
 }
 
+/** Write config/plugins.yml under `root` enabling (or disabling) `id`. */
+function writePluginConfig(root, id, enabled) {
+  mkdirSync(join(root, 'config'), { recursive: true });
+  writeFileSync(join(root, 'config', 'plugins.yml'), `plugins:\n  ${id}:\n    enabled: ${enabled}\n`);
+}
+
 const tmp = mkdtempSync(join(tmpdir(), 'cops-plugin-symlink-'));
+const tmpEnabled = mkdtempSync(join(tmpdir(), 'cops-plugin-symlink-load-'));
 
 try {
   const local = join(tmp, 'plugins.local');
@@ -102,6 +116,77 @@ try {
     Array.isArray(afterDangling) && !afterDangling.includes('dangling'),
     `discovered: ${JSON.stringify(afterDangling)}`,
   );
+
+  // --- the enabled load path -------------------------------------------------
+  // Its own root, so the only plugin in play is the symlinked one and an empty
+  // result cannot be mistaken for a pass. The hook records that it really ran.
+  const loadLocal = join(tmpEnabled, 'plugins.local');
+  mkdirSync(loadLocal, { recursive: true });
+  const linkedCheckout = writePlugin(
+    join(tmpEnabled, 'checkouts', 'career-ops-plugin-linked'),
+    'linked',
+    'export default { ingest: async (ctx) => ({ ran: true, dryRun: ctx.dryRun }) };\n',
+  );
+  symlinkSync(linkedCheckout, join(loadLocal, 'linked'));
+  writePluginConfig(tmpEnabled, 'linked', true);
+
+  const firstLoad = await loadPlugins('ingest', { root: tmpEnabled, dryRun: true });
+  check(
+    'an enabled symlinked plugin is returned by loadPlugins',
+    firstLoad.length === 1 && firstLoad[0].id === 'linked',
+    `loaded: ${JSON.stringify(firstLoad.map(p => p.id))}`,
+  );
+
+  // The hook has to be genuinely importable and callable from the link path:
+  // importHook() resolves manifest.entry against manifest.dir, which is the link.
+  let hookResult = null;
+  if (firstLoad.length === 1) hookResult = await firstLoad[0].hook(firstLoad[0].ctx);
+  check(
+    'the ingest hook of a symlinked plugin imports and runs',
+    hookResult?.ran === true && hookResult?.dryRun === true,
+    `hook returned: ${JSON.stringify(hookResult)}`,
+  );
+
+  // lockGate() pins an unpinned plugin on first load, which means it hashed the
+  // tree behind the link and classified the source from the link path. A silent
+  // failure in either leaves no entry at all, so assert the entry, not the load.
+  let lock = null;
+  try { lock = JSON.parse(readFileSync(join(tmpEnabled, 'plugins.lock'), 'utf8')); } catch { /* asserted below */ }
+  const pinned = lock?.plugins?.linked;
+  check(
+    'lockGate pins the tree behind the symlink on first load',
+    typeof pinned?.integrity === 'string' && pinned.integrity.startsWith('sha256-')
+      && Object.keys(pinned.files || {}).sort().join(',') === 'index.mjs,manifest.json',
+    `lock entry: ${JSON.stringify(pinned)}`,
+  );
+  check(
+    'a symlinked plugin under plugins.local is pinned as a local, not bundled, source',
+    pinned?.source === 'local',
+    `source: ${JSON.stringify(pinned?.source)}`,
+  );
+
+  // Second load hits the pinned branch instead of the unpinned one: the tree
+  // must re-hash through the link to the SAME integrity or the gate rejects it.
+  const secondLoad = await loadPlugins('ingest', { root: tmpEnabled, dryRun: true });
+  let relock = null;
+  try { relock = JSON.parse(readFileSync(join(tmpEnabled, 'plugins.lock'), 'utf8')); } catch { /* asserted below */ }
+  check(
+    'a symlinked plugin still loads once its tree is pinned in plugins.lock',
+    secondLoad.length === 1 && secondLoad[0].id === 'linked'
+      && relock?.plugins?.linked?.integrity === pinned?.integrity,
+    `loaded: ${JSON.stringify(secondLoad.map(p => p.id))}, integrity stable: ${relock?.plugins?.linked?.integrity === pinned?.integrity}`,
+  );
+
+  // Same fixture, config flipped: proves the assertions above are reading the
+  // enabled path and not an empty array that happens to satisfy them.
+  writePluginConfig(tmpEnabled, 'linked', false);
+  const disabledLoad = await loadPlugins('ingest', { root: tmpEnabled, dryRun: true });
+  check(
+    'a discovered symlinked plugin is not loaded while config/plugins.yml disables it',
+    disabledLoad.length === 0,
+    `loaded: ${JSON.stringify(disabledLoad.map(p => p.id))}`,
+  );
 } finally {
   rmSync(tmp, { recursive: true, force: true });
+  rmSync(tmpEnabled, { recursive: true, force: true });
 }


### PR DESCRIPTION
## What does this PR do?

`discoverPlugins()` dropped any plugin directory that was a symlink, because `readdirSync` does not follow links and `Dirent.isDirectory()` therefore reports `false` for one. The entry was filtered out before its manifest was read, and because `warnSkip()` was never reached the skip was completely silent: the plugin never appeared in `plugins.mjs list` even with `config/plugins.yml` enabling it. This resolves the link with `statSync` instead, and adds a regression test.

## Related issue

Closes #3140

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---

### Why it matters

`plugins.local/` exists so a developer can work on a plugin from its own checkout. Symlinking that checkout in is the natural way to do it, and it was the one arrangement that silently did not work. From the user's side there is no signal at all: no warning, no error, `doctor.mjs` clean, and the plugin's hooks simply never fire. It reads as the plugin config being ignored.

### On the dangling-link guard

`statSync` throws on a broken symlink. That resolve is wrapped because an unguarded throw propagates out of the `for` loop over the root's entries, so a single dead link would take down discovery for **every** plugin in that root, not just itself. A dangling link is treated as not-a-directory and skipped, which is what the old filter did with it anyway.

### Test

`tests/plugin-symlink-discovery.test.mjs`, 6 assertions, auto-discovered under `tests/` so no `test-all.mjs` section was needed.

Mutation-checked in both directions rather than assumed:

- Reverting the filter to bare `e.isDirectory()` reddens 3 named assertions: `a symlinked plugin directory is discovered`, `the symlinked plugin resolves to its real checkout directory`, and `a dangling symlink does not suppress the other plugins in its root`.
- Removing the `try`/`catch` reddens `a dangling symlink in a plugin root does not throw` with `ENOENT: no such file or directory, stat '.../plugins.local/dangling'`, plus the two assertions that depend on discovery surviving the dead link.

The manifest id in the fixture matches the **link** name rather than the target directory name, which is what a developer linking `career-ops-plugin-demo` in as `demo` actually gets.

`node test-all.mjs`: 4996 passed, 0 failed, 2 warnings (both pre-existing and environmental, unrelated to this branch).

One note for Windows CI: `symlinkSync` needs the privilege, and the test creates real symlinks rather than junctions. If the runner rejects it I will convert the fixture to a skip-with-warning in the same shape as the existing symlink-privilege handling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin directories linked via symbolic links are now discovered correctly.
  * Broken symbolic links are safely ignored without preventing other plugins from loading.

* **Tests**
  * Added coverage for valid and dangling symbolic links during plugin discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->