### PR TITLE
fix(providers): validate the resolved address before connecting (DNS rebinding)

### DIFF
--- a/providers/_dns-cache.mjs
+++ b/providers/_dns-cache.mjs
@@ -50,6 +50,7 @@
  */
 
 import dns from 'node:dns';
+import { inProviderFetch, isBlockedAddress, blockedAddressError } from './_ip-guard.mjs';
 
 /**
  * DNS failures that mean *the resolver itself refused or failed*, as opposed
@@ -244,11 +245,40 @@ export function createCachedLookup(realLookup, options = {}) {
   /** @type {Map<string, Function[]>} */
   const inflight = new Map();
 
+  /**
+   * Wrap a lookup callback so a non-public address never reaches the connector
+   * (#3096).
+   *
+   * Applied at ENTRY, so it covers all three ways a result is delivered: a
+   * fresh resolver answer, a cache HIT, and a coalesced waiter. Validating
+   * only the resolver path would leave the cache as the hole — a hostname
+   * resolved outside a provider fetch is cached unvalidated, and the next
+   * provider fetch for that name would be served the private address from
+   * memory without ever reaching the check.
+   *
+   * Only inside a provider request: this lookup is patched process-wide, and
+   * loopback has to keep working for everything else (see _ip-guard.mjs).
+   */
+  function guarded(hostname, callback) {
+    if (!inProviderFetch()) return callback;
+    return (err, ...rest) => {
+      if (err) return callback(err, ...rest);
+      // all:true yields one array of {address, family}; otherwise (address, family).
+      const addresses = Array.isArray(rest[0])
+        ? rest[0].map((entry) => entry && entry.address)
+        : [rest[0]];
+      const bad = addresses.find((address) => isBlockedAddress(address));
+      if (bad !== undefined) return callback(blockedAddressError(hostname, bad));
+      return callback(err, ...rest);
+    };
+  }
+
   function cachedLookup(hostname, options, callback) {
     if (typeof options === 'function') {
       callback = options;
       options = {};
     }
+    callback = guarded(hostname, callback);
     // dns.lookup accepts a bare family number in place of an options object.
     const opts = typeof options === 'number' ? { family: options } : (options ?? {});
     const key = `${hostname}|${opts.family ?? 0}|${opts.all ? 1 : 0}|${opts.hints ?? 0}|${opts.verbatim ?? ''}`;

--- a/providers/_http.mjs
+++ b/providers/_http.mjs
@@ -3,12 +3,27 @@
 
 import './_dns-cache.mjs'; // memoize dns.lookup process-wide (see that file)
 import { DEFAULT_USER_AGENT, BROWSER_LIKE_USER_AGENT } from '../user-agent.mjs';
+import { providerFetchContext } from './_ip-guard.mjs';
 
 export { BROWSER_LIKE_USER_AGENT };
 
 const DEFAULT_TIMEOUT_MS = 10_000;
 
-async function fetchWithTimeout(url, { timeoutMs = DEFAULT_TIMEOUT_MS, headers = {}, method = 'GET', body = null, redirect = 'follow' } = {}, consume) {
+async function fetchWithTimeout(url, opts = {}, consume) {
+  // Mark this request as provider traffic for the whole of its async life, so
+  // the patched dns.lookup validates the addresses it resolves (#3096). The
+  // guard is scoped rather than global because _dns-cache.mjs patches
+  // node:dns process-wide, and loopback has to keep working for everything
+  // that is not a provider fetch — see providers/_ip-guard.mjs.
+  //
+  // AsyncLocalStorage.run wraps the ENTIRE fetch, not just the call that
+  // starts it: the DNS lookup happens inside connect, well after the
+  // synchronous part of fetch() has returned, and the context has to still be
+  // entered when it does.
+  return providerFetchContext.run({ url: String(url) }, () => fetchInContext(url, opts, consume));
+}
+
+async function fetchInContext(url, { timeoutMs = DEFAULT_TIMEOUT_MS, headers = {}, method = 'GET', body = null, redirect = 'follow' } = {}, consume) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {

--- a/providers/_ip-guard.mjs
+++ b/providers/_ip-guard.mjs
@@ -1,0 +1,150 @@
+// Reject a connection whose resolved address is not a public one (#3096).
+//
+// Every provider's host guard pins the HOSTNAME to a public registrable
+// domain, but nothing checked where that name RESOLVES. A hostname with an A
+// record pointing at 127.0.0.1, 169.254.169.254 (cloud metadata) or an RFC1918
+// range was connected to normally. `redirect: 'error'` blocks redirect-based
+// hops; it does not block a direct malicious record.
+//
+// WHY THE CHECK IS SCOPED, NOT GLOBAL. _dns-cache.mjs patches `dns.lookup` on
+// the node:dns module object, which is process-wide. Rejecting private ranges
+// there unconditionally would reject every loopback connection anything in the
+// process makes — measured, Node calls dns.lookup even for a numeric host:
+//
+//     fetch('http://127.0.0.1:PORT')  -> dns.lookup calls: 1
+//     fetch('http://localhost:PORT')  -> dns.lookup calls: 2
+//
+// In this repo that is already 10+ test files that stand up a local HTTP
+// server and fetch it. An env opt-out would have fixed the suite by disabling
+// the guard exactly where it is most likely to regress, so instead
+// providers/_http.mjs marks its own requests with the AsyncLocalStorage below
+// and the patched lookup validates only inside that context.
+//
+// WHY AT LOOKUP TIME. The address validated has to be the address dialled, or
+// a name that answers public-then-private (DNS rebinding) slips through a
+// pre-flight check. `net.connect` reads `dns.lookup` at call time and connects
+// to what it returns, so validating in the lookup closes that window without
+// an undici Agent — and undici is not a dependency of this project.
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+/**
+ * Set while a provider HTTP request is in flight. The patched dns.lookup
+ * validates resolved addresses only when this is entered, so loopback stays
+ * usable everywhere else in the process.
+ *
+ * @type {AsyncLocalStorage<{ url: string }>}
+ */
+export const providerFetchContext = new AsyncLocalStorage();
+
+/** Is a provider request in flight on this async path? */
+export function inProviderFetch() {
+  return providerFetchContext.getStore() !== undefined;
+}
+
+/**
+ * IPv4 ranges that must never be dialled by a provider.
+ *
+ * 169.254.0.0/16 is the one with teeth: 169.254.169.254 is the cloud instance
+ * metadata endpoint on AWS/GCP/Azure, so it is the address an SSRF is usually
+ * aimed at. The rest are the ordinary private/loopback/reserved space.
+ *
+ * @type {[number, number][]} [network, prefixLength]
+ */
+const V4_BLOCKED = [
+  [0x00000000, 8],   // 0.0.0.0/8      "this network"
+  [0x0A000000, 8],   // 10.0.0.0/8     RFC1918
+  [0x64400000, 10],  // 100.64.0.0/10  CGNAT
+  [0x7F000000, 8],   // 127.0.0.0/8    loopback
+  [0xA9FE0000, 16],  // 169.254.0.0/16 link-local + cloud metadata
+  [0xAC100000, 12],  // 172.16.0.0/12  RFC1918
+  [0xC0000000, 24],  // 192.0.0.0/24   IETF protocol assignments
+  [0xC0A80000, 16],  // 192.168.0.0/16 RFC1918
+  [0xC6120000, 15],  // 198.18.0.0/15  benchmarking
+  [0xE0000000, 4],   // 224.0.0.0/4    multicast
+  [0xF0000000, 4],   // 240.0.0.0/4    reserved (includes 255.255.255.255)
+];
+
+/** Dotted-quad -> uint32, or null when it is not a well-formed IPv4 literal. */
+function v4ToInt(address) {
+  const parts = String(address).split('.');
+  if (parts.length !== 4) return null;
+  let value = 0;
+  for (const part of parts) {
+    // Canonical decimal octets only. A leading zero is rejected because
+    // `0177.0.0.1` is octal for 127.0.0.1 in some parsers, and a form this
+    // function reads as public while a connector reads as loopback is the
+    // whole bypass. dns.lookup never emits a non-canonical quad, so this is
+    // defence in depth rather than a live path — which is the right default
+    // for a function whose job is to say "safe".
+    if (!/^(0|[1-9]\d{0,2})$/.test(part)) return null;
+    const octet = Number(part);
+    if (octet > 255) return null;
+    value = value * 256 + octet;
+  }
+  return value >>> 0;
+}
+
+/**
+ * Does this address belong to a range a provider must never connect to?
+ *
+ * Accepts both families. An IPv4-mapped or IPv4-compatible IPv6 address is
+ * unwrapped and judged as IPv4 — `::ffff:127.0.0.1` is loopback however it is
+ * spelled, and treating the two spellings differently is the bypass.
+ *
+ * @param {string} address - Resolved IP literal, as dns.lookup returns it.
+ * @returns {boolean} True when the address is private/loopback/reserved.
+ */
+export function isBlockedAddress(address) {
+  const raw = String(address ?? '').trim();
+  if (!raw) return true; // nothing to validate is not the same as safe
+
+  // Strip an RFC 4007 zone id (fe80::1%eth0) before parsing.
+  const addr = raw.split('%')[0].toLowerCase();
+
+  const asV4 = v4ToInt(addr);
+  if (asV4 !== null) {
+    return V4_BLOCKED.some(([net, bits]) => {
+      const mask = bits === 0 ? 0 : (0xFFFFFFFF << (32 - bits)) >>> 0;
+      return (asV4 & mask) >>> 0 === net;
+    });
+  }
+
+  if (!addr.includes(':')) return true; // neither v4 nor v6 — refuse to guess
+
+  // IPv4-mapped (::ffff:a.b.c.d) and IPv4-compatible (::a.b.c.d).
+  const tail = addr.slice(addr.lastIndexOf(':') + 1);
+  if (tail.includes('.')) {
+    const embedded = v4ToInt(tail);
+    return embedded === null ? true : isBlockedAddress(tail);
+  }
+
+  if (addr === '::' || addr === '::1') return true;      // unspecified, loopback
+  if (/^f[cd]/.test(addr)) return true;                   // fc00::/7 unique local
+  if (/^fe[89ab]/.test(addr)) return true;                // fe80::/10 link-local
+  if (/^ff/.test(addr)) return true;                      // ff00::/8 multicast
+  return false;
+}
+
+/**
+ * The error a blocked lookup fails with.
+ *
+ * Carries a `code` so it reads like any other DNS failure to callers that
+ * branch on one, and is deliberately NOT in RESOLVER_FAILURE_CODES — this is a
+ * verdict about one hostname, not a sick resolver, so it must not be
+ * negative-cached as resolver health nor counted toward a resolver-outage
+ * signal.
+ *
+ * @param {string} hostname - The name that resolved.
+ * @param {string} address - The address it resolved to.
+ * @returns {Error}
+ */
+export function blockedAddressError(hostname, address) {
+  const err = new Error(
+    `Refusing to connect to ${hostname}: resolves to non-public address ${address}`,
+  );
+  /** @type {any} */ (err).code = 'ECAREEROPS_BLOCKED_ADDRESS';
+  /** @type {any} */ (err).hostname = hostname;
+  /** @type {any} */ (err).address = address;
+  return err;
+}

--- a/tests/providers/private-address-guard.test.mjs
+++ b/tests/providers/private-address-guard.test.mjs
@@ -1,0 +1,136 @@
+// tests/providers/private-address-guard.test.mjs — a provider must not connect
+// to a host that resolves to a non-public address (#3096).
+//
+// Every provider's host guard pins the HOSTNAME to a public registrable
+// domain; nothing checked where that name RESOLVES. `redirect: 'error'` blocks
+// redirect hops, not a direct malicious A record.
+//
+// OFFLINE: the end-to-end cases use `localhost` against a local server, which
+// is a real name resolving to a real loopback address — no DNS stubbing, and
+// no network. Stubbing dns.lookup here would be worse than useless: a stub
+// that answers directly never reaches the patched lookup, so the guard would
+// appear to fail while working correctly (which is exactly what happened to me
+// while writing this).
+//
+// Run:  node --test tests/providers/private-address-guard.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import dnsModule from 'node:dns';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const ROOT = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+const spec = (rel) => pathToFileURL(join(ROOT, rel)).href;
+
+const { isBlockedAddress, blockedAddressError, providerFetchContext } = await import(spec('providers/_ip-guard.mjs'));
+const { fetchText } = await import(spec('providers/_http.mjs'));
+const { RESOLVER_FAILURE_CODES } = await import(spec('providers/_dns-cache.mjs'));
+
+/** Start a loopback server; returns its port and a close(). */
+async function localServer(body = 'SECRET-LOCAL-DATA') {
+  const srv = http.createServer((_q, s) => s.end(body)).listen(0, '127.0.0.1');
+  await new Promise((r) => srv.once('listening', r));
+  return { port: srv.address().port, close: () => srv.close() };
+}
+
+const codeOf = (err) => (err?.cause ?? err)?.code;
+
+// ── classification ─────────────────────────────────────────────────────────
+
+test('blocks loopback, private, link-local and reserved ranges', () => {
+  for (const address of [
+    '127.0.0.1', '127.1.2.3', '0.0.0.0',
+    '10.1.2.3', '172.16.0.1', '172.31.255.255', '192.168.1.1',
+    '169.254.169.254',      // cloud instance metadata — the usual SSRF target
+    '100.64.0.1',           // CGNAT
+    '224.0.0.1', '255.255.255.255',
+    '::1', '::', 'fc00::1', 'fd12::3', 'fe80::1', 'fe80::1%eth0', 'ff02::1',
+    '::ffff:127.0.0.1',     // IPv4-mapped loopback
+    '::ffff:169.254.169.254',
+  ]) {
+    assert.equal(isBlockedAddress(address), true, `${address} should be blocked`);
+  }
+});
+
+test('allows ordinary public addresses, including the range boundaries', () => {
+  for (const address of [
+    '8.8.8.8', '1.1.1.1', '13.107.42.14',
+    '172.15.255.255', '172.32.0.1',   // either side of 172.16.0.0/12
+    '100.63.255.255',                  // just below 100.64.0.0/10
+    '192.169.0.1',                     // just above 192.168.0.0/16
+    '2606:4700::1111', '2001:4860:4860::8888', '::ffff:8.8.8.8',
+  ]) {
+    assert.equal(isBlockedAddress(address), false, `${address} should be allowed`);
+  }
+});
+
+test('unparseable input is blocked, not guessed', () => {
+  // A permissive parse is a bypass: the string is attacker-influenced.
+  for (const address of ['', '   ', 'garbage', '1.2.3', '1.2.3.4.5', '01.2.3.4', '999.1.1.1', null, undefined]) {
+    assert.equal(isBlockedAddress(address), true, `${JSON.stringify(address)} should be blocked`);
+  }
+});
+
+// ── the guard, end to end ──────────────────────────────────────────────────
+
+test('a provider fetch to a name resolving to loopback is refused', async () => {
+  const srv = await localServer();
+  try {
+    await assert.rejects(
+      () => fetchText(`http://localhost:${srv.port}/`, { timeoutMs: 4000 }),
+      (err) => codeOf(err) === 'ECAREEROPS_BLOCKED_ADDRESS',
+      'localhost resolved to loopback and was connected to anyway',
+    );
+  } finally { srv.close(); }
+});
+
+test('a NON-provider fetch to loopback still works', async () => {
+  // The scoping guarantee. dns.lookup is patched process-wide, so an
+  // unscoped check would break every local-server test in the repo — and
+  // would most likely be "fixed" by an env opt-out that disables the guard
+  // exactly where it is most likely to regress.
+  const srv = await localServer();
+  try {
+    const res = await fetch(`http://localhost:${srv.port}/`);
+    assert.equal(await res.text(), 'SECRET-LOCAL-DATA');
+  } finally { srv.close(); }
+});
+
+test('a cached lookup is guarded too, not just a fresh one', async () => {
+  // The hole this closes: resolve the name OUTSIDE a provider fetch so it is
+  // memoized unvalidated, then fetch it as a provider. Guarding only the
+  // resolver path would serve the private address straight from cache.
+  const srv = await localServer();
+  try {
+    await new Promise((resolve, reject) =>
+      dnsModule.lookup('localhost', (err, addr) => (err ? reject(err) : resolve(addr))));
+    await assert.rejects(
+      () => fetchText(`http://localhost:${srv.port}/`, { timeoutMs: 4000 }),
+      (err) => codeOf(err) === 'ECAREEROPS_BLOCKED_ADDRESS',
+      'a pre-warmed cache entry bypassed the guard',
+    );
+  } finally { srv.close(); }
+});
+
+// ── the error must not be mistaken for a sick resolver ─────────────────────
+
+test('the block code is not a resolver-failure code', () => {
+  // RESOLVER_FAILURE_CODES drives negative caching and the resolver-outage
+  // signal (#2229). This is a verdict about ONE hostname, not resolver health;
+  // counting it as the latter would negative-cache a refusal and could trip an
+  // outage path over a config the user should be told about instead.
+  const err = blockedAddressError('evil.example', '127.0.0.1');
+  assert.equal(err.code, 'ECAREEROPS_BLOCKED_ADDRESS');
+  assert.equal(RESOLVER_FAILURE_CODES.has(err.code), false);
+  assert.match(err.message, /evil\.example/);
+  assert.match(err.message, /127\.0\.0\.1/);
+});
+
+test('the context is entered only for provider requests', async () => {
+  const { inProviderFetch } = await import(spec('providers/_ip-guard.mjs'));
+  assert.equal(inProviderFetch(), false);
+  providerFetchContext.run({ url: 'x' }, () => assert.equal(inProviderFetch(), true));
+  assert.equal(inProviderFetch(), false);
+});


### PR DESCRIPTION
Fixes #3096. Design posted in-thread before writing this, because the obvious placement turned out to be ruled out.

## The constraint that shaped it

`_dns-cache.mjs` is the natural home — its header explains it patches `dns.lookup` on the `node:dns` module object specifically to avoid a dependency, and `net.connect` reads it at call time, which is exactly the connect-time property this needs.

But that patch is **process-global**, and Node calls `dns.lookup` even for a numeric host. Measured:

```
fetch('http://127.0.0.1:PORT')  -> dns.lookup calls: 1
fetch('http://localhost:PORT')  -> dns.lookup calls: 2
```

So an unconditional private-range rejection there rejects every loopback connection anything in the process makes — already 10+ test files in this repo stand up a local server and fetch it. An env opt-out would have "fixed" the suite by disabling the guard precisely where it is most likely to regress.

`undici` is also not a dependency (`package.json` carries four), and `_dns-cache.mjs` exists in its current shape to keep it that way, so the Agent route would have added one for this.

**So the guard is scoped, not global:** `_http.mjs` marks its own requests with an `AsyncLocalStorage`, and the patched lookup validates only inside that context. Connect-time validation is preserved, loopback keeps working everywhere else, no new dependency.

## Measured end to end, no DNS stubbing

```
provider fetch     -> localhost   blocked (ECAREEROPS_BLOCKED_ADDRESS)
NON-provider fetch -> localhost   still works
cache pre-warmed outside, then
provider fetch     -> localhost   blocked
```

That third line is the hole I went looking for after writing the first two. The guard is applied at callback **entry**, so it covers a fresh resolver answer, a **cache hit**, and a coalesced waiter alike. Guarding only the resolver path would leave the cache as the bypass: a hostname resolved outside a provider fetch is memoized unvalidated, and the next provider fetch is served the private address from memory. There's a test for exactly that sequence.

## Scope

A literal private IP in a URL is untouched, and doesn't need to be — the per-provider host guards reject it before any fetch happens:

```
ashby.detect({careers_url:'http://169.254.169.254/acme'})  -> null
ashby.detect({careers_url:'http://127.0.0.1/acme'})        -> null
```

This closes the remaining path: a **permitted** hostname that resolves somewhere private.

## Details worth a look

- **IPv4-mapped IPv6 is unwrapped and judged as IPv4.** `::ffff:127.0.0.1` is loopback however it's spelled; treating the spellings differently is the bypass.
- **Octets must be canonical decimal.** `0177.0.0.1` is octal for 127.0.0.1 in some parsers, and a form this function reads as public while a connector reads as loopback defeats the point. `dns.lookup` never emits a non-canonical quad, so it's defence in depth — but I had it wrong first (`/^\d{1,3}$/` accepted `01.2.3.4`) and the test caught it.
- **The error is deliberately NOT in `RESOLVER_FAILURE_CODES`.** This is a verdict about one hostname, not resolver health — counting it as the latter would negative-cache it and could feed the resolver-outage signal from #2229 over a config problem the user should be told about instead.

## A wrong turn worth recording

My first test stubbed `dns.lookup` to make `evil.example` resolve to loopback, and reported a leak. The guard was fine — a stub that answers directly never reaches the patched lookup, so it tests nothing and looks like a failure. The committed tests use `localhost` against a local server instead: a real name, a real loopback address, still fully offline.

## Verification

Checked for discrimination: with the two wiring changes reverted, **exactly the two end-to-end assertions fail** and the six classification/scoping ones pass.

Classification covers both families, IPv4-mapped, the cloud-metadata address, and the boundaries either side of `172.16/12`, `100.64/10` and `192.168/16`, so a mask off by one bit fails rather than passing quietly.

`node test-all.mjs --quick`: 4402 pass / 0 fail (3 warnings pre-existing and environmental). The SYSTEM_PATHS coverage guard is satisfied — `providers/` is covered by a directory rule, so no manifest entry was needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Provider requests now block connections to private, loopback, link-local, cloud metadata, multicast, and other reserved IP addresses.
  * Protection applies to fresh DNS lookups, cached results, and concurrent requests.
  * DNS rebinding attempts and malformed addresses are rejected.
* **Bug Fixes**
  * Non-provider requests to local addresses continue to work as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->