### PR TITLE
fix(plugins): discoverPlugins() silently skips a symlinked plugin directory

### DIFF
--- a/plugins/_engine.mjs
+++ b/plugins/_engine.mjs
@@ -24,7 +24,7 @@
  * all reuse it with no prod-vs-test drift.
  */
 
-import { existsSync, readdirSync, readFileSync, realpathSync } from 'fs';
+import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from 'fs';
 import path from 'path';
 import { pathToFileURL } from 'url';
 import { resolveAndValidate } from './_net.mjs';
@@ -254,7 +254,27 @@ export function discoverPlugins(roots, overrideIds = new Set()) {
       continue;
     }
     const dirs = entries
-      .filter(e => e.isDirectory() && !e.name.startsWith('_') && !e.name.startsWith('.'))
+      .filter(e => !e.name.startsWith('_') && !e.name.startsWith('.'))
+      // readdirSync(withFileTypes) does NOT follow links, so a symlinked
+      // plugin directory reports isDirectory() === false and was dropped here
+      // — before the manifest was read and before warnSkip() could fire, so
+      // the plugin simply never appeared and nothing said why (#3140).
+      // plugins.local/ exists so a developer can work from their own checkout,
+      // and symlinking it in is the natural way to do that.
+      //
+      // statSync FOLLOWS the link, which is the question being asked: does
+      // this entry lead to a directory? Wrapped, because it throws on a
+      // dangling link — unguarded, one dead symlink would abort discovery for
+      // EVERY plugin in the root rather than skipping the one that is broken.
+      .filter((e) => {
+        if (e.isDirectory()) return true;
+        if (!e.isSymbolicLink()) return false;
+        try {
+          return statSync(path.join(root, e.name)).isDirectory();
+        } catch {
+          return false; // dangling or unreadable link — skip it, keep the rest
+        }
+      })
       .map(e => e.name)
       .sort();
     for (const name of dirs) {

--- a/tests/plugins-symlink-discovery.test.mjs
+++ b/tests/plugins-symlink-discovery.test.mjs
@@ -1,0 +1,102 @@
+// tests/plugins-symlink-discovery.test.mjs — a symlinked plugin directory must
+// be discovered (#3140).
+//
+// readdirSync(withFileTypes) does NOT follow links, so a symlinked plugin dir
+// reports isDirectory() === false and was filtered out before the manifest was
+// read — and before warnSkip() could fire, so the plugin never appeared and
+// nothing said why. plugins.local/ exists so a developer can work from their
+// own checkout, and symlinking it in is the natural way to do that, so the one
+// arrangement the directory is for was the one that did not work.
+//
+// The dangling-link case is the reason the resolve is guarded: statSync throws
+// on a broken link, and unguarded that would abort discovery for EVERY plugin
+// in the root rather than skipping the one dead entry.
+//
+// Run:  node --test tests/plugins-symlink-discovery.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const { discoverPlugins, pluginRoots } = await import(pathToFileURL(join(ROOT, 'plugins/_engine.mjs')).href);
+
+/** Write a minimal valid plugin at `dir` whose id matches the directory name. */
+function writePlugin(dir, id) {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'manifest.json'), JSON.stringify({
+    id, apiVersion: 1, description: id, hooks: ['ingest'],
+    requiredEnv: [], allowedHosts: [], humanInTheLoop: true,
+  }));
+  writeFileSync(join(dir, 'index.mjs'), 'export default {};\n');
+}
+
+function withRoot(fn) {
+  const base = mkdtempSync(join(tmpdir(), 'cops-plugins-'));
+  try {
+    mkdirSync(join(base, 'plugins.local'), { recursive: true });
+    return fn(base);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+}
+
+const ids = (base) => discoverPlugins(pluginRoots(base)).map((p) => p.id).sort();
+
+test('a symlinked plugin directory is discovered', () => {
+  withRoot((base) => {
+    const checkout = join(base, 'checkouts', 'demo');
+    writePlugin(checkout, 'demo');
+    symlinkSync(checkout, join(base, 'plugins.local', 'demo'));
+    assert.deepEqual(ids(base), ['demo'], 'the symlinked plugin was skipped');
+  });
+});
+
+test('a real directory still works — the filter did not invert', () => {
+  withRoot((base) => {
+    writePlugin(join(base, 'plugins.local', 'demo'), 'demo');
+    assert.deepEqual(ids(base), ['demo']);
+  });
+});
+
+test('a dangling symlink is skipped quietly and the rest still load', () => {
+  // The guard's whole purpose: unguarded, statSync on the broken link throws
+  // and takes every other plugin in the root with it.
+  withRoot((base) => {
+    const checkout = join(base, 'checkouts', 'demo');
+    writePlugin(checkout, 'demo');
+    symlinkSync(checkout, join(base, 'plugins.local', 'demo'));
+    writePlugin(join(base, 'plugins.local', 'second'), 'second');
+    symlinkSync(join(base, 'nowhere-at-all'), join(base, 'plugins.local', 'dead'));
+    assert.deepEqual(ids(base), ['demo', 'second'], 'a dangling link disrupted discovery');
+  });
+});
+
+test('a symlink to a FILE is not treated as a plugin directory', () => {
+  // isSymbolicLink() alone is not the question — "does it lead to a directory"
+  // is, which is why the resolve is statSync().isDirectory() and not a bare
+  // "links are fine" pass.
+  withRoot((base) => {
+    const file = join(base, 'not-a-dir.txt');
+    writeFileSync(file, 'x');
+    symlinkSync(file, join(base, 'plugins.local', 'bogus'));
+    writePlugin(join(base, 'plugins.local', 'second'), 'second');
+    assert.deepEqual(ids(base), ['second']);
+  });
+});
+
+test('underscore and dot entries are still excluded, symlinked or not', () => {
+  // _engine.mjs / _net.mjs live alongside plugins; the prefix filter must keep
+  // applying after the link resolve was added.
+  withRoot((base) => {
+    const checkout = join(base, 'checkouts', 'hidden');
+    writePlugin(checkout, 'hidden');
+    symlinkSync(checkout, join(base, 'plugins.local', '_hidden'));
+    symlinkSync(checkout, join(base, 'plugins.local', '.hidden'));
+    writePlugin(join(base, 'plugins.local', 'second'), 'second');
+    assert.deepEqual(ids(base), ['second']);
+  });
+});


### PR DESCRIPTION
Fixes #3140. Reported and diagnosed by @rubicon; I commented offering to drop it if they were already on it.

Reproduced on main with their fixture — same two files, same call, only the symlink differs:

```
symlinked plugin dir -> []
real plugin dir      -> ["demo"]
```

`readdirSync(withFileTypes)` does not follow links, so a symlinked plugin directory reports `isDirectory() === false` and was filtered out **before** the manifest was read and before `warnSkip()` could fire. The plugin never appeared in `plugins.mjs list`, its hooks never ran, and nothing said why — with `config/plugins.yml` enabling it and `doctor.mjs` clean.

`plugins.local/` exists so a developer can work on a plugin from its own checkout, and symlinking that checkout in is the natural way to do it. The one arrangement the directory is *for* was the one that didn't work.

## The resolve, and the two ways to get it wrong

`statSync` is the right call because it **follows** the link, which is the question actually being asked: *does this entry lead to a directory?*

- A bare "symlinks are fine" pass would be wrong — a link to a **file** is not a plugin directory. Pinned by a test.
- The `try/catch` is load-bearing rather than defensive habit: `statSync` throws on a dangling link, and unguarded that would abort discovery for **every** plugin in the root rather than skipping the one dead entry. That's your expected-behaviour note, and it's the assertion I care most about:

```
symlink + real + DANGLING link -> ["demo","second"]
```

The `_`/`.` prefix filter still runs first and is unchanged, so `_engine.mjs` and friends stay excluded whether or not they're links.

## Verification

Three of the five assertions guard against over-correcting, since "treat symlinks as directories" has a wrong shape on either side of the right one: the file-symlink case, the dangling-link case, and the prefix-exclusion case. Plus the bug itself and a plain real directory, so an inverted filter can't pass.

Hermetic — every root is a tmpdir built in-test, so nothing depends on the repo's own `plugins/` or on `plugins.local/` existing.

Checked for discrimination: with `plugins/_engine.mjs` reverted, **exactly the symlink and dangling-link assertions fail** and the three guards pass.

`node test-all.mjs --quick`: 4988 pass / 0 fail (3 warnings pre-existing and environmental).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin discovery now supports valid symlinked directories.
  * Invalid, dangling, unreadable, and file-targeting symlinks are safely skipped without interrupting discovery.
  * Existing filtering and manifest validation continue to work for discovered plugins.

* **Tests**
  * Added coverage for valid directories, symlinked directories, dangling symlinks, file symlinks, and excluded entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->