### PR TITLE
fix: honor custom font family for CJK templates

### DIFF
--- a/templates/cv-template.html
+++ b/templates/cv-template.html
@@ -502,9 +502,9 @@
      browser's per-glyph fallback picks the first installed CJK face for kana
      and kanji. Mirrors the lang="ar" precedent above. */
   html[lang="ja"] body {
-    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'Hiragino Sans', 'Hiragino Kaku Gothic ProN',
-      'Yu Gothic', 'YuGothic', 'Noto Sans CJK JP', 'Noto Sans JP',
-      Meiryo, 'MS PGothic', sans-serif;
+    font-family: var(--font-family, 'Liberation Sans', 'Helvetica Neue', Arial, 'Hiragino Sans',
+      'Hiragino Kaku Gothic ProN', 'Yu Gothic', 'YuGothic', 'Noto Sans CJK JP',
+      'Noto Sans JP', Meiryo, 'MS PGothic', sans-serif);
   }
 
   html[lang="ja"] .header h1,
@@ -513,9 +513,9 @@
   html[lang="ja"] .project-title,
   html[lang="ja"] .competency-tag,
   html[lang="ja"] .skill-category {
-    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'Hiragino Sans', 'Hiragino Kaku Gothic ProN',
+   font-family: var(--font-family, 'Liberation Sans', 'Helvetica Neue', Arial, 'Hiragino Sans', 'Hiragino Kaku Gothic ProN',
       'Yu Gothic', 'YuGothic', 'Noto Sans CJK JP', 'Noto Sans JP',
-      Meiryo, 'MS PGothic', sans-serif;
+      Meiryo, 'MS PGothic', sans-serif);
   }
 
   /* === Simplified Chinese typography ===
@@ -525,9 +525,9 @@
      punctuation from producing clipped or awkward PDF lines. */
   html[lang="zh-CN"] body,
   html[lang="zh"] body {
-    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'PingFang SC',
+    font-family: var(--font-family, 'Liberation Sans', 'Helvetica Neue', Arial, 'PingFang SC',
       'Hiragino Sans GB', 'Microsoft YaHei', 'Noto Sans CJK SC',
-      'Noto Sans SC', 'Source Han Sans SC', sans-serif;
+      'Noto Sans SC', 'Source Han Sans SC', sans-serif);
     line-break: strict;
     word-break: normal;
     overflow-wrap: break-word;
@@ -547,9 +547,9 @@
   html[lang="zh"] .contact-row,
   html[lang="zh"] .competency-tag,
   html[lang="zh"] .skill-category {
-    font-family: 'Liberation Sans', 'Helvetica Neue', Arial, 'PingFang SC',
+    font-family: var(--font-family, 'Liberation Sans', 'Helvetica Neue', Arial, 'PingFang SC',
       'Hiragino Sans GB', 'Microsoft YaHei', 'Noto Sans CJK SC',
-      'Noto Sans SC', 'Source Han Sans SC', sans-serif;
+      'Noto Sans SC', 'Source Han Sans SC', sans-serif);
   }
 
   /* === Korean typography ===

--- a/tests/theme-style.test.mjs
+++ b/tests/theme-style.test.mjs
@@ -86,6 +86,24 @@ try {
     if (hasRoot && usesVars && !circular) pass(`${tpl} declares :root theme defaults and reads them via var() (no circular refs)`);
     else fail(`${tpl}: hasRoot=${hasRoot} usesVars=${usesVars} circular=${circular}`);
   }
+  // Regression: localized CJK body font stacks must honor the profile
+  // --font-family override while keeping their curated fallback stacks.
+  {
+    const tplSrc = readFileSync(join(ROOT, 'templates/cv-template.html'), 'utf-8');
+
+    const jaBody = /html\[lang="ja"\]\s+body\s*\{[^}]*font-family:\s*var\(--font-family,\s*'Liberation Sans'/s.test(tplSrc);
+    const zhBody = /html\[lang="zh-CN"\]\s+body,\s*html\[lang="zh"\]\s+body\s*\{[^}]*font-family:\s*var\(--font-family,\s*'Liberation Sans'/s.test(tplSrc);
+
+    const jaBodyCount = (tplSrc.match(/html\[lang="ja"\]\s+body\s*\{/g) || []).length;
+    const zhCnBodyCount = (tplSrc.match(/html\[lang="zh-CN"\]\s+body/g) || []).length;
+    const zhBodyCount = (tplSrc.match(/html\[lang="zh"\]\s+body/g) || []).length;
+
+    if (jaBody && zhBody && jaBodyCount === 1 && zhCnBodyCount === 1 && zhBodyCount === 1) {
+      pass('CJK body font stacks honor --font-family overrides without duplicate body selectors');
+    } else {
+      fail(`CJK body font regression: ja=${jaBody} zh=${zhBody} jaCount=${jaBodyCount} zhCNCount=${zhCnBodyCount} zhCount=${zhBodyCount}`);
+    }
+  }
 
   // Regression: the Korean locale must honor profile.style.font_family on the
   // body and the prominent heading/contact surfaces. A duplicate selector or a


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change in 1-3 sentences -->

## Related issue

<!-- Link the issue this PR addresses, if it has one. Format: Fixes #123 / Closes #123 -->
<!-- Issue-first is asked for NEW FEATURES, new modes/commands, and architecture changes — it saves you from building something we'd have to redirect. -->
<!-- No issue needed, send the PR straight in: bug fixes, new zero-auth scanner providers, docs, and translations. We don't want to slow these down. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [ ] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [ ] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [ ] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [ ] I ran `node test-all.mjs` and all tests pass
- [ ] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [ ] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---
Questions? [Join the Discord](https://discord.gg/8pRpHETxa4) for faster feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Japanese and Simplified Chinese CV templates now honor custom font settings.
  * Preserved appropriate locale-specific fallback fonts for consistent typography.

* **Tests**
  * Added regression coverage for localized font overrides, fallback behavior, and duplicate selector prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->