### PR TITLE
fix(cli): validate browser-extract flags and honour both value forms

### DIFF
--- a/browser-extract.mjs
+++ b/browser-extract.mjs
@@ -36,6 +36,7 @@ import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import * as yaml from 'js-yaml';
 import { LIVENESS_CONTEXT_OPTIONS, rejectPrivateOrInvalid } from './liveness-browser.mjs';
+import { flagValue, hasFlag, validateFlags } from './lib/cli-flags.mjs';
 
 const CAREER_OPS = dirname(fileURLToPath(import.meta.url));
 
@@ -122,34 +123,76 @@ export function normalizeListing(anchors, finalUrl, max = DEFAULT_LISTING_MAX) {
   return { url: finalUrl, jobs };
 }
 
+const VALUE_FLAGS = ['--mode', '--max', '--max-chars', '--timeout'];
+const KNOWN_FLAGS = [...VALUE_FLAGS, '--help', '-h'];
+
+// One synopsis, used by both --help and the no_url error, so the two cannot
+// drift apart: the error's own copy already omitted --timeout.
+const USAGE_SYNOPSIS = 'browser-extract.mjs <url> [--mode jd|listing] [--max N] [--max-chars N] [--timeout MS]';
+
+const USAGE = `Usage:
+  node ${USAGE_SYNOPSIS}
+
+  --mode jd|listing   jd (default) returns { url, title, text }; listing returns { url, jobs }
+  --max N             listing: maximum postings to return (default ${DEFAULT_LISTING_MAX})
+  --max-chars N       jd: text cap (default ${JD_TEXT_CAP}); raise it for a long JD
+  --timeout MS        navigation timeout (default ${DEFAULT_TIMEOUT_MS})
+  --help, -h          Show this help`;
+
 /**
- * Parse CLI args into { url, mode, max, timeout }. Index-based so a flag value
- * (e.g. the `listing` in `--mode listing`) is never mistaken for the URL, and an
- * explicit `0` is honored instead of being silently replaced by the default.
- * Exported for tests.
+ * Parse CLI args into { url, mode, max, maxChars, timeout }.
+ *
+ * Value reads go through lib/cli-flags.mjs so BOTH accepted forms reach the
+ * extractor. The hand-rolled loop this replaces matched tokens exactly against
+ * its own `FLAGS` set, so `--max-chars=50000` was never recognized as a flag:
+ * it fell to the `!tok.startsWith('--')` branch, was not the URL either, and
+ * the run silently proceeded at the 12000 default — a JD truncated at the tail
+ * for a caller who explicitly asked for more. Same silent-wrong-answer shape as
+ * the `--from=…` class in #2401/#2402 that lib/cli-flags.mjs exists to end.
+ *
+ * The URL is still found positionally, and an explicit `0` is still honored
+ * rather than silently replaced by the default.
+ *
  * @param {string[]} argv - process.argv.slice(2)
  */
 export function parseArgs(argv) {
-  const FLAGS = new Set(['--mode', '--max', '--max-chars', '--timeout']);
-  let url;
-  let mode = 'jd';
-  let max = DEFAULT_LISTING_MAX;
-  let maxChars = JD_TEXT_CAP;
-  let timeout = DEFAULT_TIMEOUT_MS;
-  for (let i = 0; i < argv.length; i++) {
-    const tok = argv[i];
-    if (FLAGS.has(tok)) {
-      const val = argv[++i]; // consume the next token as this flag's value
-      const n = Number(val);
-      if (tok === '--mode' && val != null) mode = val;
-      else if (tok === '--max' && Number.isInteger(n) && n >= 0) max = n;
-      else if (tok === '--max-chars' && Number.isInteger(n) && n > 0) maxChars = n;
-      else if (tok === '--timeout' && Number.isInteger(n) && n > 0) timeout = n;
-    } else if (!tok.startsWith('--') && url === undefined) {
-      url = tok;
+  const args = Array.isArray(argv) ? argv : [];
+
+  // A value token consumed by a space-separated flag is not the URL. Mirrors
+  // validateFlags' own adjacency rule: only a token that does not itself start
+  // with `--` is treated as a value, so `--mode --max 5` leaves `--max` to be
+  // reported rather than swallowed as the mode.
+  const consumed = new Set();
+  args.forEach((a, i) => {
+    if (VALUE_FLAGS.includes(a) && args[i + 1] !== undefined && !args[i + 1].startsWith('--')) {
+      consumed.add(i + 1);
     }
+  });
+
+  let url;
+  for (let i = 0; i < args.length; i++) {
+    const tok = args[i];
+    if (typeof tok !== 'string' || consumed.has(i)) continue;
+    if (!tok.startsWith('-') && url === undefined) url = tok;
   }
-  return { url, mode, max, maxChars, timeout };
+
+  // Each numeric read keeps its own range rule: `--max` admits 0 (a listing
+  // capped at nothing is a meaningful request), the other two do not.
+  const num = (flag, ok, fallback) => {
+    if (!hasFlag(args, flag)) return fallback;
+    const n = Number(flagValue(args, flag));
+    return Number.isInteger(n) && ok(n) ? n : fallback;
+  };
+
+  const modeVal = hasFlag(args, '--mode') ? flagValue(args, '--mode') : undefined;
+
+  return {
+    url,
+    mode: modeVal == null ? 'jd' : modeVal,
+    max: num('--max', (n) => n >= 0, DEFAULT_LISTING_MAX),
+    maxChars: num('--max-chars', (n) => n > 0, JD_TEXT_CAP),
+    timeout: num('--timeout', (n) => n > 0, DEFAULT_TIMEOUT_MS),
+  };
 }
 
 // Read the raw DOM inside the page: title, main visible text, and visible
@@ -182,10 +225,26 @@ async function readDom(page) {
 }
 
 async function main() {
-  const { url, mode, max, maxChars, timeout } = parseArgs(process.argv.slice(2));
+  const args = process.argv.slice(2);
+
+  // Before anything launches a browser, because each of these used to fail in a
+  // way that named the wrong thing (measured on 764f20f8):
+  //   `--max-char 5000 <url>`  the typo was skipped, `5000` became the URL and
+  //                            the real one was discarded — reported as
+  //                            `invalid URL`, which is not what was wrong.
+  //   `<url> --bogus`          skipped entirely; the scan ran and exited 0.
+  //   `--help`                 exit 1 with a `no_url` error, never usage.
+  //   `-h`                     one dash, so it was read AS the URL: `invalid URL`.
+  // requireOperand: this script has nothing more specific to say about a missing
+  // operand than the shared message, and without it `--max-chars --help` prints
+  // usage and exits 0 with the malformed flag never reported (the ordering
+  // CodeRabbit caught on #2961).
+  validateFlags(args, KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS, requireOperand: true });
+
+  const { url, mode, max, maxChars, timeout } = parseArgs(args);
 
   if (!url) {
-    console.error(JSON.stringify({ error: 'usage: browser-extract.mjs <url> [--mode jd|listing] [--max N] [--max-chars N]', code: 'no_url' }));
+    console.error(JSON.stringify({ error: `usage: ${USAGE_SYNOPSIS}`, code: 'no_url' }));
     process.exit(1);
   }
   if (mode !== 'jd' && mode !== 'listing') {

--- a/tests/browser-extract-flags.test.mjs
+++ b/tests/browser-extract-flags.test.mjs
@@ -1,0 +1,161 @@
+// tests/browser-extract-flags.test.mjs — browser-extract.mjs's CLI contract.
+//
+// The script hand-rolled its argv parsing and matched tokens EXACTLY against a
+// local `FLAGS` set, which left three distinct failures on `main` (#3004). All
+// three are the class lib/cli-flags.mjs exists to end (#2401/#2402, #2775):
+//
+//   --max-chars=50000        → not in FLAGS, not the URL either: dropped, and
+//                              the run returned a JD truncated at the 12000
+//                              default with exit 0. Silently wrong.
+//   --max-char 5000 <url>    → the typo was skipped, then `5000` became the URL
+//                              and the real one was discarded — reported as
+//                              `invalid URL`, naming nothing the caller typed.
+//   <url> --bogus            → skipped entirely, run proceeded. Fully silent.
+//   --help / -h              → exit 1 with a `no_url` error, never usage; `-h`
+//                              does not start with `--`, so it was read AS the
+//                              URL and failed with `invalid URL`.
+//
+// Every case below runs the real binary as a subprocess, because the defect is
+// in what the CLI does end to end, not only in what parseArgs returns. The
+// error paths must all exit BEFORE Playwright launches, so none of them needs a
+// browser or a network — a case that hung would be a regression in itself.
+import { pass, fail, ROOT } from './helpers.mjs';
+import { execFileSync } from 'child_process';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+import { tmpdir } from 'os';
+
+console.log('\nbrowser-extract.mjs — flag validation and value forms');
+
+const NODE = process.execPath;
+const SCRIPT = join(ROOT, 'browser-extract.mjs');
+
+// cwd is deliberately not the project root: the script resolves its own paths
+// through import.meta.url, and a cwd-relative read would show up here.
+function run(args) {
+  try {
+    const out = execFileSync(NODE, [SCRIPT, ...args], { cwd: tmpdir(), encoding: 'utf-8', timeout: 30000 });
+    return { code: 0, out };
+  } catch (e) {
+    return { code: e.status ?? 1, out: `${e.stdout || ''}${e.stderr || ''}` };
+  }
+}
+
+const { parseArgs } = await import(pathToFileURL(SCRIPT).href);
+
+// ── 1. A mistyped flag is refused, and the message names it ──────────────
+// Before: `5000` became the URL and the caller was told the URL was invalid.
+{
+  const r = run(['--max-char', '5000', 'https://example.com/job']);
+  if (r.code !== 0 && /--max-char\b/.test(r.out) && !/invalid URL/.test(r.out)) {
+    pass('--max-char is refused by name, not misreported as an invalid URL');
+  } else {
+    fail(`typo not named: code=${r.code} out=${r.out.trim().slice(0, 160)}`);
+  }
+}
+
+// A typo that is not adjacent to a value was the fully silent case: it left the
+// URL intact and the run proceeded as if nothing had been asked for.
+{
+  const r = run(['https://example.com/job', '--bogus']);
+  if (r.code !== 0 && /--bogus/.test(r.out)) {
+    pass('an unrecognized flag after the URL is refused instead of ignored');
+  } else {
+    fail(`--bogus silently accepted: code=${r.code} out=${r.out.trim().slice(0, 160)}`);
+  }
+}
+
+// ── 2. --help and -h print usage and exit 0, without launching a browser ──
+// Before: --help exited 1 with a no_url error, and -h was read as the URL.
+for (const flag of ['--help', '-h']) {
+  const r = run([flag]);
+  if (r.code === 0 && /--max-chars/.test(r.out) && !/error|invalid URL/i.test(r.out)) {
+    pass(`${flag} prints the usage block and exits 0`);
+  } else {
+    fail(`${flag}: code=${r.code} out=${r.out.trim().slice(0, 160)}`);
+  }
+}
+
+// The unrecognized-flag check must run BEFORE --help, or `--help --bogus`
+// exits 0 having never looked at --bogus (the ordering CodeRabbit caught on
+// #2745/#2746).
+{
+  const r = run(['--help', '--bogus']);
+  if (r.code !== 0 && /--bogus/.test(r.out)) {
+    pass('--help --bogus still reports the unrecognized flag');
+  } else {
+    fail(`ordering regression: code=${r.code} out=${r.out.trim().slice(0, 160)}`);
+  }
+}
+
+// A value flag with no operand must not be swallowed by --help either (#2961).
+{
+  const r = run(['--max-chars', '--help']);
+  if (r.code !== 0 && /--max-chars requires a value/.test(r.out)) {
+    pass('--max-chars --help reports the missing operand instead of showing help');
+  } else {
+    fail(`missing operand: code=${r.code} out=${r.out.trim().slice(0, 160)}`);
+  }
+}
+
+// ── 3. Both value forms actually reach the extractor ─────────────────────
+// This is the half the gate alone does not fix: `--max-chars=50000` passed
+// validation and was then dropped by parseArgs, so the JD came back capped at
+// 12000 for a caller who explicitly asked for more.
+{
+  const eq = parseArgs(['--max-chars=50000', 'https://example.com/job']);
+  const sp = parseArgs(['--max-chars', '50000', 'https://example.com/job']);
+  if (eq.maxChars === 50000 && sp.maxChars === 50000) {
+    pass('--max-chars reaches the extractor in both the equals and space forms');
+  } else {
+    fail(`--max-chars dropped: equals=${eq.maxChars} space=${sp.maxChars}`);
+  }
+}
+
+{
+  const r = parseArgs(['--mode=listing', '--max=7', '--timeout=999', 'https://example.com/careers']);
+  if (r.mode === 'listing' && r.max === 7 && r.timeout === 999 && r.url === 'https://example.com/careers') {
+    pass('--mode, --max and --timeout all honour the equals form');
+  } else {
+    fail(`equals form dropped: ${JSON.stringify(r)}`);
+  }
+}
+
+// ── 4. Regressions the rewrite could have introduced ─────────────────────
+// The URL is still found positionally, whichever side of the flags it is on,
+// and a flag's space-separated value is never mistaken for it.
+{
+  const before = parseArgs(['--mode', 'listing', 'https://example.com/careers']);
+  const after = parseArgs(['https://example.com/careers', '--mode', 'listing']);
+  if (before.url === 'https://example.com/careers' && after.url === 'https://example.com/careers') {
+    pass('the URL is still found on either side of the flags');
+  } else {
+    fail(`url positioning: before=${before.url} after=${after.url}`);
+  }
+}
+
+// `--max 0` is a meaningful request (cap the listing at nothing) and must not
+// be replaced by the default, while an out-of-range or non-integer value still
+// falls back rather than propagating NaN into the extractor.
+{
+  const zero = parseArgs(['--max', '0', 'https://example.com/careers']);
+  const neg = parseArgs(['--max-chars', '-5', 'https://example.com/job']);
+  const junk = parseArgs(['--timeout', 'soon', 'https://example.com/job']);
+  if (zero.max === 0 && neg.maxChars === 12000 && junk.timeout === 15000) {
+    pass('--max 0 is honoured, and out-of-range or non-numeric values fall back');
+  } else {
+    fail(`range rules: max=${zero.max} maxChars=${neg.maxChars} timeout=${junk.timeout}`);
+  }
+}
+
+// A bad --mode value is still the extractor's error to report, not the gate's:
+// validateFlags only knows flag NAMES, so `--mode nonsense` must reach the
+// existing bad_mode check rather than being refused as an unrecognized flag.
+{
+  const r = run(['--mode', 'nonsense', 'https://example.com/job']);
+  if (r.code !== 0 && /bad_mode/.test(r.out)) {
+    pass('an unknown --mode value still reaches the extractor\'s own bad_mode error');
+  } else {
+    fail(`bad_mode bypassed: code=${r.code} out=${r.out.trim().slice(0, 160)}`);
+  }
+}


### PR DESCRIPTION
Closes #3004.

## What does this PR do?

Routes `browser-extract.mjs`'s argv handling through `lib/cli-flags.mjs`: `validateFlags` in front of any browser work, and `flagValue`/`hasFlag` for the value reads, so a mistyped flag is refused by name and both accepted flag forms actually reach the extractor.

## Problem

The script hand-rolled its parsing and matched tokens **_exactly_** against a local `FLAGS` set. Measured on `764f20f8`, that left three separate failures, not one:

1. **`--max-chars=50000` was dropped.** It is not in `FLAGS`, and it starts with `--`, so it was not taken as the URL either. The run proceeded at the 12000 default and returned a JD truncated at the tail, exit 0. This is the `--from=…` class from #2401/#2402, and it is the half a validation gate alone cannot fix - the flag clears the gate and is then discarded anyway.

2. **A typo adjacent to a value stole the URL.** `--max-char 5000 https://example.com/job` skipped the unknown token, took `5000` as the URL and discarded the real one:

   ```
   {"error":"invalid URL","code":"invalid_url"}
   ```

   The one thing the caller got right is the thing it names.

3. **A typo away from a value was fully silent.** `<url> --bogus` was skipped entirely and the scan ran to completion, exit 0. `--help` exited 1 with a `no_url` error instead of printing usage, and `-h` has a single dash, so it was read as the URL and failed with `invalid URL`.

## Change

- **`validateFlags(args, KNOWN_FLAGS, USAGE, { valueFlags: VALUE_FLAGS, requireOperand: true })`**, before the URL check and before Playwright loads. `requireOperand` because this script has nothing more specific to say about a missing operand than the shared message, and without it `--max-chars --help` prints usage and exits 0 with the malformed flag never reported - the ordering CodeRabbit caught on #2745/#2746 and #2961.
- **`parseArgs` reads values via `flagValue`/`hasFlag`**, so `--max-chars=50000` and `--max-chars 50000` are the same request. The URL is still found positionally, with an adjacency rule mirroring `validateFlags`' own so a flag's space-separated value is never mistaken for it.
- **One `USAGE_SYNOPSIS` constant** behind both `--help` and the `no_url` error. Those had already drifted: the error's copy omitted `--timeout`.

## Compatibility

Behaviour deliberately preserved, each asserted:

- the URL is found on either side of the flags;
- `--max 0` is honoured rather than replaced by the default, and out-of-range or non-numeric values still fall back instead of propagating `NaN`;
- an unknown `--mode` **_value_** still reaches the extractor's own `bad_mode` error rather than being refused by the gate, since `validateFlags` only knows flag names;
- the module's exports are unchanged, so `doctor.mjs`'s `resolveExtractorMode` read is untouched.

The one intended behaviour change beyond the fixes: previously-ignored garbage now exits 1. That is the point of the issue, and it is the same break every prior adopter of this helper took (#1635, #2745, #2746, #2961).

## Tests

`tests/browser-extract-flags.test.mjs`, 11 assertions, run against the real binary as a subprocess because the defect is in what the CLI does end to end. Every error path exits before Playwright launches, so none of them needs a browser or a network.

Seen red on `764f20f8`: **8 of the 11 fail** there, including `--bogus` actually launching a browser and fetching the page. The 3 that pass on both sides are the regression guards above, which is what they are for.

`node test-all.mjs`: 5076 passed, 0 failed, 3 warnings. All 3 are pre-existing and environmental - `cv-sync-check` without user data, no Go compiler for the dashboard build, and a `santifer.io` string in `dashboard/internal/ui/screens/stats.go`. Same 3 on an unpatched checkout, which reports 5065 passed.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for both `--flag=value` and space-separated CLI option formats.
  * Improved URL detection regardless of argument position.
  * Added clearer help and usage guidance.

* **Bug Fixes**
  * Added validation for unknown flags, missing values, and numeric option ranges.
  * Improved handling of invalid command-line input before browser launch.

* **Tests**
  * Added end-to-end coverage for CLI parsing, validation, help behavior, and option handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->