### PR TITLE
fix(pdf): name canonicalization failure separately from a real workspace escape

### DIFF
--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -81,11 +81,17 @@ function assertInsideWorkspace(absPath, label) {
   let canonical;
   try {
     canonical = existsSync(probe) ? resolve(realpathSync(probe), ...tail) : absPath;
-  } catch {
+  } catch (err) {
     // Canonicalization failed (realpath raced away, permission error): containment
     // is unprovable, so fail closed rather than fall back to a lexical form that a
-    // symlinked ancestor could slip past.
-    throw new Error(`${label} escapes the tracker workspace: ${absPath}`);
+    // symlinked ancestor could slip past. Named as its own failure, not as an
+    // escape: an intermittent CI-only hit of this guard (#3162) was undiagnosable
+    // while both branches threw the same message — "escapes" points a reader at
+    // the path, when the actual event was realpath failing underneath it.
+    throw new Error(
+      `${label} could not be canonicalized against the tracker workspace`
+      + ` (${/** @type {any} */ (err)?.code || 'realpath failed'} on ${probe}): ${absPath}`,
+    );
   }
   const rel = relative(__workspaceRoot, canonical);
   if (rel === '' || rel.startsWith('..') || isAbsolute(rel)) {


### PR DESCRIPTION
Part of #3162's diagnosis path.

`assertInsideWorkspace`'s catch threw the same *escapes the tracker workspace* message as the lexical containment check, so the intermittent macOS CI failure in #3162 could not be attributed: was it a real escape or a failed `realpathSync`? The catch now says which event fired and carries `err.code` plus the probe path.

- Fail-closed semantics unchanged: any canonicalization failure still throws.
- The only test asserting the message (`generate-pdf-batch.test.mjs:312`) exercises the lexical branch, which keeps its wording.
- Both generate-pdf suites green locally (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for PDF generation failures by identifying the specific failure code and affected paths.
  * Prevented canonicalization errors from being incorrectly reported as workspace path violations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->