### PR TITLE
fix(tests): guard the web/ mirror import behind existsSync

### DIFF
--- a/tests/profile-keywords-parity.test.mjs
+++ b/tests/profile-keywords-parity.test.mjs
@@ -22,67 +22,83 @@
 // strings for its caller's cleanChips to handle. The contract under test is
 // "the same keywords", not "the same post-processing".
 
-import { pass, fail, ROOT } from './helpers.mjs';
-import { readFileSync } from 'fs';
+import { pass, fail, warn, ROOT } from './helpers.mjs';
+import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
+import { pathToFileURL } from 'url';
 import * as yaml from 'js-yaml';
 import { profileTargetKeywords as core } from '../providers/_profile-keywords.mjs';
-import { profileTargetKeywords as web } from '../web/src/lib/profile-keywords.mjs';
 
 console.log('\nprofile-keywords — web mirror vs core helper');
 
-// A true set comparison, not a length check: the core de-dupes and the mirror
-// does not, so a keyword appearing in both `primary` and an archetype name
-// legitimately yields 2 entries on one side and 1 on the other.
-const sameSet = (a, b) => {
-  const A = new Set(a), B = new Set(b);
-  return A.size === B.size && [...A].every((k) => B.has(k));
-};
+// web/ is NOT in update-system.mjs's SYSTEM_PATHS but tests/ is, so this file
+// ships to installs whose checkout has no web/ at all — and a static import
+// cannot be skipped, so it turns a core-only install into a permanent failure
+// (#1675 / #1677). Three branches, as in test-all.mjs's #2666 mirror-parity
+// freeze: an absent web/ is a real absence, but a mirror missing under a
+// present web/ is a move, and a skip is how a parity freeze quietly stops
+// guarding.
+const WEB_MIRROR = join(ROOT, 'web', 'src', 'lib', 'profile-keywords.mjs');
+if (!existsSync(join(ROOT, 'web', 'src'))) {
+  warn('web/ not present in this checkout — skipping the profile-keywords parity check');
+} else if (!existsSync(WEB_MIRROR)) {
+  fail('web/ exists but web/src/lib/profile-keywords.mjs is missing — the parity check cannot verify (moved?)');
+} else {
+  const { profileTargetKeywords: web } = await import(pathToFileURL(WEB_MIRROR).href);
 
-// The shipped example is the shape that actually exists on disk, so it is the
-// case that matters most — and it must not be empty, or parity is vacuous.
-const example = yaml.load(readFileSync(join(ROOT, 'config', 'profile.example.yml'), 'utf-8'));
-const fromExample = web(example);
-if (fromExample.length >= 2) pass(`config/profile.example.yml yields ${fromExample.length} keywords (parity is not vacuous)`);
-else fail(`config/profile.example.yml yielded ${fromExample.length} keywords — the mirror is returning nothing`);
-if (sameSet(fromExample, core(example))) pass('web mirror matches core on config/profile.example.yml');
-else fail(`drift on profile.example.yml: web=${JSON.stringify(fromExample)} core=${JSON.stringify(core(example))}`);
+  // A true set comparison, not a length check: the core de-dupes and the mirror
+  // does not, so a keyword appearing in both `primary` and an archetype name
+  // legitimately yields 2 entries on one side and 1 on the other.
+  const sameSet = (a, b) => {
+    const A = new Set(a), B = new Set(b);
+    return A.size === B.size && [...A].every((k) => B.has(k));
+  };
 
-// Shapes the two have disagreed on, or could. Each is a documented field form,
-// not a synthetic edge case: `primary` as a list is what api/profile/route.ts
-// writes; `archetypes` entries are {name, level, fit} objects.
-const cases = [
-  ['primary as a list', { target_roles: { primary: ['ML Engineer', 'Inference Engineer'] } }],
-  ['archetypes contribute .name', { target_roles: { archetypes: [{ name: 'Edge AI Engineer', level: 'Senior', fit: 'primary' }] } }],
-  ['both together', { target_roles: { primary: ['A'], archetypes: [{ name: 'B' }] } }],
-  ['archetype with no name', { target_roles: { archetypes: [{ level: 'Senior' }] } }],
-  ['primary as a bare scalar', { target_roles: { primary: 'Senior AI Engineer' } }],
-  ['target_roles absent', {}],
-  ['target_roles null', { target_roles: null }],
-  ['target_roles is an array', { target_roles: [] }],
-];
+  // The shipped example is the shape that actually exists on disk, so it is the
+  // case that matters most — and it must not be empty, or parity is vacuous.
+  const example = yaml.load(readFileSync(join(ROOT, 'config', 'profile.example.yml'), 'utf-8'));
+  const fromExample = web(example);
+  if (fromExample.length >= 2) pass(`config/profile.example.yml yields ${fromExample.length} keywords (parity is not vacuous)`);
+  else fail(`config/profile.example.yml yielded ${fromExample.length} keywords — the mirror is returning nothing`);
+  if (sameSet(fromExample, core(example))) pass('web mirror matches core on config/profile.example.yml');
+  else fail(`drift on profile.example.yml: web=${JSON.stringify(fromExample)} core=${JSON.stringify(core(example))}`);
 
-for (const [label, doc] of cases) {
-  let w, c;
-  try {
-    w = web(doc);
-    c = core(doc);
-  } catch (e) {
-    fail(`${label}: threw — ${e.message}`);
-    continue;
+  // Shapes the two have disagreed on, or could. Each is a documented field form,
+  // not a synthetic edge case: `primary` as a list is what api/profile/route.ts
+  // writes; `archetypes` entries are {name, level, fit} objects.
+  const cases = [
+    ['primary as a list', { target_roles: { primary: ['ML Engineer', 'Inference Engineer'] } }],
+    ['archetypes contribute .name', { target_roles: { archetypes: [{ name: 'Edge AI Engineer', level: 'Senior', fit: 'primary' }] } }],
+    ['both together', { target_roles: { primary: ['A'], archetypes: [{ name: 'B' }] } }],
+    ['archetype with no name', { target_roles: { archetypes: [{ level: 'Senior' }] } }],
+    ['primary as a bare scalar', { target_roles: { primary: 'Senior AI Engineer' } }],
+    ['target_roles absent', {}],
+    ['target_roles null', { target_roles: null }],
+    ['target_roles is an array', { target_roles: [] }],
+  ];
+
+  for (const [label, doc] of cases) {
+    let w, c;
+    try {
+      w = web(doc);
+      c = core(doc);
+    } catch (e) {
+      fail(`${label}: threw — ${e.message}`);
+      continue;
+    }
+    if (sameSet(w, c)) pass(`parity: ${label}`);
+    else fail(`parity: ${label} — web=${JSON.stringify(w)} core=${JSON.stringify(c)}`);
   }
-  if (sameSet(w, c)) pass(`parity: ${label}`);
-  else fail(`parity: ${label} — web=${JSON.stringify(w)} core=${JSON.stringify(c)}`);
-}
 
-// Neither side may throw on junk: both are tolerant readers on a seeding path,
-// never validators.
-for (const junk of [null, undefined, 'a string', 42, []]) {
-  try {
-    web(junk);
-    core(junk);
-    pass(`both tolerate ${JSON.stringify(junk) ?? 'undefined'}`);
-  } catch (e) {
-    fail(`threw on ${JSON.stringify(junk) ?? 'undefined'}: ${e.message}`);
+  // Neither side may throw on junk: both are tolerant readers on a seeding path,
+  // never validators.
+  for (const junk of [null, undefined, 'a string', 42, []]) {
+    try {
+      web(junk);
+      core(junk);
+      pass(`both tolerate ${JSON.stringify(junk) ?? 'undefined'}`);
+    } catch (e) {
+      fail(`threw on ${JSON.stringify(junk) ?? 'undefined'}: ${e.message}`);
+    }
   }
 }


### PR DESCRIPTION
## What does this PR do?

`tests/profile-keywords-parity.test.mjs` imported `../web/src/lib/profile-keywords.mjs` statically.
`tests/` ships to end users through `update-system.mjs`'s `SYSTEM_PATHS`; `web/` deliberately does not
(`validate-system-paths-coverage.mjs`'s `EXCLUDE_PREFIXES`). So on a core-only install the suite threw
`ERR_MODULE_NOT_FOUND` and `node test-all.mjs` exited 1 — permanently, on the command users are told to
run. This replaces the static import with an `existsSync`-guarded dynamic one.

The guard has **three** branches, following the `#2666` mirror-parity freeze in `test-all.mjs` rather
than the two-branch snippet I wrote in the issue:

- `web/src` absent → `warn`, exit 0 (a core-only install; the parity check is not applicable)
- `web/src` present but the mirror missing → `fail` (that is a move, not an absence)
- otherwise → dynamic import, all 15 assertions run unchanged

Two reasons for the extra branch and for `warn` over `pass`. CI always checks out `web/`, so a *move*
is the only way this guard can fire there — with a two-branch `existsSync(WEB_MIRROR)` that would print
"web/ is not present", silently drop the parity assertion, and stay green forever; the sibling mirror
already sits one directory deeper at `web/src/lib/core/normalize-text-key.mjs`. And `pass` would report
15 assertions that never ran as one green assertion, where `helpers.mjs`'s `warn` is documented for
exactly this case and still exits 0.

Most of the diff is re-indentation of the existing assertions into the `else` block — `?w=1` shows the
two real changes.

## Related issue

Fixes #3055 — confirmed by @santifer, who scoped this one file ahead of the wider sweep:
https://github.com/santifer/career-ops/issues/3055#issuecomment-5367433438

Scope note: I checked every `.mjs` outside `web/` on `main`, and line 30 of this file was the only
static `web/` import left — `tracker-columns-tests.mjs` and `test-all.mjs` §55.7 are already guarded.
So this PR touches nothing else. If the sweep introduces a shared `hasWeb()`/`skipWeb()` primitive in
`tests/helpers.mjs`, happy to fold this inline guard behind it.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

## Verification

Run on Windows against a clean worktree of `2e4458ed` with `npm install --ignore-scripts`.

| state | command | result |
|---|---|---|
| `web/` present (as shipped) | `node test-all.mjs --only profile-keywords-parity` | 15 passed, 0 failed, exit 0 |
| `web/` absent, **before** this patch | same, in a `git archive` export with `web/` removed | `ERR_MODULE_NOT_FOUND`, 1 failed, exit 1 — the reported bug |
| `web/` absent, **after** this patch | same | `⚠️ web/ not present in this checkout — skipping the profile-keywords parity check`, 0 failed, exit 0 |
| `web/src` present, mirror missing | same, with an empty `web/src` | `❌ web/ exists but web/src/lib/profile-keywords.mjs is missing — the parity check cannot verify (moved?)`, exit 1 |
| full suite, before vs after | `node test-all.mjs` | identical both ways: `5086 passed, 0 failed, 3 warnings`, exit 0 |

`npm run lint` clean (509 files) before and after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved profile keyword parity checks for environments without the optional web components.
  * Tests now skip with a warning when the web source is unavailable, while still detecting missing mirror files when the web components are present.
  * Existing parity and tolerance validations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->