### PR TITLE
fix(ashby): surface remote work model in the location string

### DIFF
--- a/providers/ashby.mjs
+++ b/providers/ashby.mjs
@@ -123,6 +123,24 @@ function toEpochMs(value) {
 // Canada-only and gets wrongly removed by scan.mjs's location_filter. We fold
 // in each secondary's region, locality, and country so the filter can match
 // (e.g. "Europe", "Berlin", "Germany"). Deduped, joined with " · ".
+// Remote work model: Ashby's posting-api exposes `workplaceType`
+// ("Remote" | "Hybrid" | "Onsite") and `isRemote` (boolean) as fields SEPARATE
+// from `location`, which keeps naming the office/HQ city even for a fully
+// remote role. Folding only the location strings therefore renders a remote
+// posting as e.g. "San Francisco", and a `location_filter` that blocks that
+// city drops a role the candidate could actually take. Appending "Remote"
+// makes the work model visible to scan.mjs's string matching without
+// discarding the city, so both `allow: ["Remote"]` and city-based filters keep
+// working.
+//
+// `workplaceType` wins whenever it is present: the two fields can disagree, and
+// boards in the wild carry `isRemote: true` together with
+// `workplaceType: "Hybrid"` for office-anchored roles. Trusting `isRemote`
+// alone would label those "Remote" and defeat a remote-only filter. `isRemote`
+// remains the fallback for payloads that omit `workplaceType`.
+//
+// Mirrors existing behavior in bamboohr.mjs, gem.mjs, and thehub.mjs, which
+// already append "Remote" from their own providers' remote flags.
 /** @param {any} j */
 function formatLocation(j) {
   const parts = [];
@@ -139,6 +157,9 @@ function formatLocation(j) {
       }
     }
   }
+  const wt = typeof j.workplaceType === 'string' ? j.workplaceType.trim().toLowerCase() : '';
+  const isRemote = wt ? wt === 'remote' : j.isRemote === true;
+  if (isRemote && !parts.some((p) => /remote/i.test(p))) parts.push('Remote');
   return [...new Set(parts)].join(' · ');
 }
 

--- a/tests/providers/ashby.test.mjs
+++ b/tests/providers/ashby.test.mjs
@@ -188,6 +188,42 @@ try {
     pass('ashby.fetch() folds secondaryLocations (region/locality/country) into location, deduped, " · "-joined');
   else fail(`ashby.fetch() row 0 location = ${JSON.stringify(fetched[0]?.location)}`);
 
+  // Remote work model — `workplaceType` / `isRemote` live outside `location`,
+  // which keeps naming the office city on a fully remote posting. Without
+  // folding them in, a location_filter blocking that city silently drops a
+  // remote role. `workplaceType` is authoritative when present; `isRemote` is
+  // the fallback. See formatLocation() in providers/ashby.mjs.
+  const workModel = await ashby.fetch(
+    { name: 'Acme', careers_url: 'https://jobs.ashbyhq.com/acme' },
+    {
+      fetchJson: async () => ({
+        jobs: [
+          { title: 'Remote via workplaceType', location: 'San Francisco', isRemote: true, workplaceType: 'Remote' },
+          { title: 'Hybrid despite isRemote', location: 'New York', isRemote: true, workplaceType: 'Hybrid' },
+          { title: 'Onsite', location: 'Austin', isRemote: false, workplaceType: 'Onsite' },
+          { title: 'isRemote fallback, no workplaceType', location: 'Seattle', isRemote: true },
+          { title: 'Already says remote', location: 'Remote - US', isRemote: true, workplaceType: 'Remote' },
+          { title: 'Blank workplaceType falls back', location: 'Denver', isRemote: true, workplaceType: '   ' },
+        ],
+      }),
+    },
+  );
+
+  const workModelExpected = [
+    'San Francisco · Remote',
+    'New York',
+    'Austin',
+    'Seattle · Remote',
+    'Remote - US',
+    'Denver · Remote',
+  ];
+  const workModelActual = workModel.map((r) => r.location);
+  if (JSON.stringify(workModelActual) === JSON.stringify(workModelExpected)) {
+    pass('ashby.fetch() appends "Remote" from workplaceType/isRemote; workplaceType wins over isRemote; no duplicate "Remote"');
+  } else {
+    fail(`ashby.fetch() work-model locations = ${JSON.stringify(workModelActual)} (expected ${JSON.stringify(workModelExpected)})`);
+  }
+
   if (fetched[1]?.title === '' && fetched[1]?.url === '' && fetched[1]?.location === ''
       && fetched[1]?.salary === null && fetched[1]?.postedAt === undefined)
     pass('ashby.fetch() tolerates a sparse job (empty strings, null salary, undefined postedAt for a bad date)');


### PR DESCRIPTION
## Problem

Ashby's posting-api returns `workplaceType` (`"Remote"` | `"Hybrid"` | `"Onsite"`) and `isRemote` as fields **separate from** `location` — and `location` keeps naming the office/HQ city even when a posting is fully remote.

`formatLocation()` folds only `location` + `secondaryLocations`, so a remote role renders as e.g. `"San Francisco"`. Any `location_filter` blocking that city silently drops a posting the candidate could actually take.

I hit this with a real posting: a fully remote **VP of Engineering** role (`location: "San Francisco"`, `workplaceType: "Remote"`, `isRemote: true`) never reached triage under a filter blocking US metros.

Sampling 40 tracked Ashby boards (2,243 postings) found **263 US-city postings flagged remote** that a metro block list discards. The failure is silent — nothing in the scan summary indicates a remote role was dropped for its office city.

## Fix

Append `"Remote"` to the location string when the posting is remote, unless a location part already says so. The city is preserved, so city-based filters keep working while `allow` / `always_allow: ["Remote"]` now matches.

```js
const wt = typeof j.workplaceType === 'string' ? j.workplaceType.trim().toLowerCase() : '';
const isRemote = wt ? wt === 'remote' : j.isRemote === true;
if (isRemote && !parts.some((p) => /remote/i.test(p))) parts.push('Remote');
```

**`workplaceType` is authoritative when present; `isRemote` is the fallback.** The two disagree in the wild — boards carry `isRemote: true` alongside `workplaceType: "Hybrid"` for office-anchored roles. Trusting `isRemote` alone labels those "Remote" and defeats a remote-only filter, so this deliberately does *not* OR the two flags together.

## Consistency with other providers

This mirrors behavior that already exists elsewhere in `providers/`:

- `bamboohr.mjs` — `const remote = j.isRemote ? 'Remote' : '';`
- `gem.mjs` — `if (loc?.isRemote) parts.push('Remote');`
- `thehub.mjs` — appends `'Remote'` when `isRemote === true`

Ashby was the outlier.

## Tests

Adds one case to `tests/providers/ashby.test.mjs` covering six scenarios:

| Input | Expected |
|---|---|
| `location: "San Francisco"`, `workplaceType: "Remote"` | `San Francisco · Remote` |
| `location: "New York"`, `isRemote: true`, `workplaceType: "Hybrid"` | `New York` (workplaceType wins) |
| `location: "Austin"`, `workplaceType: "Onsite"` | `Austin` |
| `location: "Seattle"`, `isRemote: true`, no `workplaceType` | `Seattle · Remote` (fallback) |
| `location: "Remote - US"`, `workplaceType: "Remote"` | `Remote - US` (no duplicate) |
| `location: "Denver"`, `isRemote: true`, `workplaceType: "   "` | `Denver · Remote` (blank falls back) |

`node test-all.mjs` → **4992 passed, 0 failed**.

## Notes

- Additive only: 57 insertions, 0 deletions. Existing `secondaryLocations` folding and dedup are untouched.
- Boards that omit both fields are unaffected.
- `providers/greenhouse.mjs` may have a similar gap — its comment references the Ashby `secondaryLocations` issue — but I haven't verified Greenhouse's payload shape, so it's out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved remote-work location formatting for Ashby job listings.
  * Remote roles are now labeled consistently while preserving office and additional location details.
  * Enhanced support for filtering listings by remote status.

* **Bug Fixes**
  * Prevented duplicate “Remote” labels.
  * Corrected handling of remote, onsite, hybrid, and unspecified workplace types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->