### PR TITLE
fix(greenhouse): populate job.description via content=true (#3175)

### DIFF
--- a/providers/greenhouse.mjs
+++ b/providers/greenhouse.mjs
@@ -3,6 +3,12 @@
 
 // Greenhouse provider — hits the public boards-api JSON endpoint.
 // Handles both explicit `api:` URLs and auto-detection from `careers_url`.
+// Requests the board with `content=true` (#3175) so each posting carries its
+// full body as plain-text `description`; scan.mjs's content_filter,
+// country_eligibility filter and visa_filter all read that field, and without
+// it every Greenhouse board passed those filters blind.
+
+import { decodeEntities } from './_html-entities.mjs';
 
 const ALLOWED_GREENHOUSE_HOSTS = new Set([
   'boards-api.greenhouse.io',
@@ -114,6 +120,31 @@ export function buildOfficeMap(json) {
   return map;
 }
 
+// ── Posting body → plain text ────────────────────────────────────────
+// With content=true the list response embeds each posting's body as
+// DOUBLE-encoded HTML: the JSON string carries entity-escaped markup
+// (`&lt;p&gt;`), so the first decode pass reveals the real tags, and
+// text-level entities (`&amp;`, `&#39;`) only become decodable once those
+// tags are gone. Plain text is what the description-consuming filters match
+// against — substring matching over raw HTML misses keywords split by a tag
+// and pads matches into attribute soup.
+//
+// The result is capped like alibaba's full-text JDs to keep scan payloads
+// sane: a 10 KB/posting body is normal for Greenhouse, not an outlier.
+
+const DESCRIPTION_CAP = 4000;
+
+/**
+ * Entity-decoded markup → stripped plain text. Exported for tests.
+ * @param {unknown} content
+ */
+export function contentToText(content) {
+  if (typeof content !== 'string' || !content) return '';
+  const html = decodeEntities(content);
+  const noMedia = html.replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, ' ');
+  return decodeEntities(noMedia.replace(/<[^>]+>/g, ' ')).replace(/\s+/g, ' ').trim().slice(0, DESCRIPTION_CAP);
+}
+
 /** @type {Provider} */
 export default {
   id: 'greenhouse',
@@ -131,9 +162,17 @@ export default {
     const apiUrl = resolveApiUrl(entry);
     if (!apiUrl) throw new Error(`greenhouse: cannot derive API URL for ${entry.name}`);
     assertGreenhouseUrl(apiUrl);
+    // content=true embeds each posting's body in the list response (one
+    // request, no per-job detail fetches). searchParams.set is idempotent, so
+    // an entry.api that already pins the param can't end up with a duplicate.
+    const listUrl = new URL(apiUrl);
+    listUrl.searchParams.set('content', 'true');
+    // Re-validate the final href: the guard chain runs on the exact string
+    // that goes over the wire, not just the pre-param base.
+    const listHref = assertGreenhouseUrl(listUrl.href);
     // redirect:'error' prevents SSRF via server-side redirects; combined with
     // assertGreenhouseUrl above it guarantees the final hostname stays in the allowlist.
-    const json = /** @type {any} */ (await ctx.fetchJson(apiUrl, { redirect: 'error' }));
+    const json = /** @type {any} */ (await ctx.fetchJson(listHref, { redirect: 'error' }));
     const jobs = Array.isArray(json?.jobs) ? json.jobs : [];
     const usable = jobs.filter(/** @param {any} j */ j => j.absolute_url);
 
@@ -167,11 +206,16 @@ export default {
         const offices = officeMap.get(j.id);
         if (offices && offices.size > 0) location = [location, ...offices].join(' · ');
       }
+      const description = contentToText(j.content);
       return {
         title: j.title || '',
         url: j.absolute_url,
         company: entry.name,
         location,
+        // Omitted entirely when the board ships no body — same shape as
+        // cryptocurrencyjobs/remotli, so "no signal" stays distinguishable
+        // from an empty string downstream.
+        ...(description ? { description } : {}),
         postedAt: toEpochMs(j.first_published),
       };
     });

--- a/tests/providers/greenhouse.test.mjs
+++ b/tests/providers/greenhouse.test.mjs
@@ -13,7 +13,7 @@ console.log('\nProvider — greenhouse');
 try {
   const greenhouseModule = await import(pathToFileURL(join(ROOT, 'providers/greenhouse.mjs')).href);
   const greenhouse = greenhouseModule.default;
-  const { isWorkModelOnly, officesUrlFor, buildOfficeMap } = greenhouseModule;
+  const { isWorkModelOnly, officesUrlFor, buildOfficeMap, contentToText } = greenhouseModule;
 
   if (greenhouse.id === 'greenhouse') pass('greenhouse.id is "greenhouse"');
   else fail(`greenhouse.id is ${JSON.stringify(greenhouse.id)}`);
@@ -110,11 +110,21 @@ try {
     { fetchJson: async (url, opts) => { capturedUrl = url; capturedOpts = opts; return sample; } },
   );
 
-  if (capturedUrl === 'https://boards-api.greenhouse.io/v1/boards/acme/jobs' && capturedOpts?.redirect === 'error') {
-    pass('greenhouse.fetch() hits the derived boards-api URL with redirect:"error" (SSRF guard)');
+  if (capturedUrl === 'https://boards-api.greenhouse.io/v1/boards/acme/jobs?content=true' && capturedOpts?.redirect === 'error') {
+    pass('greenhouse.fetch() hits the derived boards-api URL with content=true and redirect:"error" (SSRF guard)');
   } else {
     fail(`greenhouse.fetch() url=${JSON.stringify(capturedUrl)} opts=${JSON.stringify(capturedOpts)}`);
   }
+
+  // content=true must be set idempotently on an entry.api that already pins it.
+  let pinnedUrl = null;
+  await greenhouse.fetch(
+    { name: 'Pinned', api: 'https://boards-api.greenhouse.io/v1/boards/pinned/jobs?content=true' },
+    { fetchJson: async (url) => { pinnedUrl = url; return { jobs: [] }; } },
+  );
+  if (pinnedUrl === 'https://boards-api.greenhouse.io/v1/boards/pinned/jobs?content=true')
+    pass('greenhouse.fetch() does not duplicate an entry.api that already carries content=true');
+  else fail(`greenhouse.fetch() pinned url=${JSON.stringify(pinnedUrl)}`);
 
   if (fetched.length === 3)
     pass('greenhouse.fetch() drops rows without absolute_url (3 of 4 kept)');
@@ -135,6 +145,68 @@ try {
   if (fetched[2]?.postedAt === undefined)
     pass('greenhouse.fetch() yields undefined postedAt for an unparseable first_published (NaN-safe)');
   else fail(`greenhouse.fetch() row 2 postedAt = ${JSON.stringify(fetched[2]?.postedAt)}`);
+
+  // ── content=true → description (#3175) ──────────────────────────────
+  // The boards API embeds posting bodies as DOUBLE-encoded HTML: one decode
+  // pass reveals the tags, the second (after stripping) resolves text-level
+  // entities. script/style bodies must never leak into the plain text, since
+  // visa_filter/content_filter match by substring.
+  const contentSample = {
+    jobs: [
+      {
+        id: 301,
+        title: 'Sponsor',
+        absolute_url: 'https://job-boards.greenhouse.io/acme/jobs/301',
+        // &lt;script&gt;tracking()&lt;/script&gt; + &lt;style&gt; must vanish;
+        // "&amp;amp;" proves the second decode pass; "&#39;" proves numeric
+        // entities inside visible text survive to the end.
+        content: '&lt;div&gt;&lt;script&gt;tracking()&lt;/script&gt;&lt;style&gt;.x{}&lt;/style&gt;&lt;h2&gt;About &amp;amp; Us&lt;/h2&gt;&lt;p&gt;We offer &#39;visa sponsorship&#39; for &lt;b&gt;H-1B&lt;/b&gt; roles.&lt;/p&gt;&lt;/div&gt;',
+      },
+      {
+        id: 302,
+        title: 'No Body',
+        absolute_url: 'https://job-boards.greenhouse.io/acme/jobs/302',
+        // no content field — description key must be absent entirely
+      },
+      {
+        id: 303,
+        title: 'Empty Body',
+        absolute_url: 'https://job-boards.greenhouse.io/acme/jobs/303',
+        content: '',
+      },
+    ],
+  };
+  const withBodies = await greenhouse.fetch(
+    { name: 'Acme', careers_url: 'https://job-boards.greenhouse.io/acme' },
+    { fetchJson: async () => contentSample },
+  );
+
+  if (withBodies[0]?.description === "About & Us We offer 'visa sponsorship' for H-1B roles.")
+    pass('greenhouse.fetch() double-decodes the posting body into clean plain-text description');
+  else fail(`greenhouse.fetch() row 0 description = ${JSON.stringify(withBodies[0]?.description)}`);
+
+  if (!('description' in (withBodies[1] || {})) && !('description' in (withBodies[2] || {})))
+    pass('greenhouse.fetch() omits the description key when the board ships no body');
+  else fail(`greenhouse.fetch() description keys = ${JSON.stringify(withBodies.map(j => 'description' in j))}`);
+
+  if (withBodies[0] && !('content' in withBodies[0]))
+    pass('greenhouse.fetch() does not leak the raw content field into the normalized job');
+  else fail('greenhouse.fetch() leaked raw content');
+
+  // Cap: a full JD body is ~10 KB of HTML; the stripped text is sliced so scan
+  // payloads stay sane (same rationale as alibaba's 4000-char cap).
+  const longBody = await greenhouse.fetch(
+    { name: 'Acme', careers_url: 'https://job-boards.greenhouse.io/acme' },
+    { fetchJson: async () => ({ jobs: [{ id: 9, title: 'Long', absolute_url: 'https://job-boards.greenhouse.io/acme/jobs/9', content: '&lt;p&gt;' + 'x'.repeat(5000) + '&lt;/p&gt;' }] }) },
+  );
+  if (longBody[0]?.description?.length === 4000 && /^x+$/.test(longBody[0].description))
+    pass('greenhouse.fetch() caps the stripped description at 4000 chars');
+  else fail(`greenhouse.fetch() capped length = ${longBody[0]?.description?.length}`);
+
+  // Unit: contentToText contract on the shapes the API can produce.
+  if (contentToText(null) === '' && contentToText(undefined) === '' && contentToText(42) === '' && contentToText('') === '')
+    pass('contentToText() returns "" for missing / non-string / empty content');
+  else fail('contentToText() should return "" for non-string and empty input');
 
   // Epoch-0 first_published must survive (the `|| undefined` trap toEpochMs avoids).
   const epochZero = await greenhouse.fetch(


### PR DESCRIPTION
## What does this PR do?

Greenhouse boards now ship each posting's full body as plain-text `job.description`, fetched in the same single list request via the boards API's `content=true` param. Until now `providers/greenhouse.mjs` requested titles only, so `visa_filter`, `content_filter`, and the country-eligibility filter all passed every Greenhouse board blind, including postings that explicitly refuse sponsorship.

## Related issue

Part of #3175 (Phase 1: Greenhouse; the detail-fetch tier for Recruitee/SmartRecruiters/Ashby is Phase 2, discussed there).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in) — issue #3175 was opened anyway for the multi-phase coordination
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass — 5100 passed; 1 contained failure is `tests/plugin-symlink-discovery.test.mjs` dying on `symlinkSync` EPERM, a Windows symlink-privilege limitation of this machine (no Developer Mode), unrelated to this change and pre-existing here. The greenhouse suite (40 assertions) and the shared-decoder guard suite both pass.
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

## Implementation notes

- **Double-decoded HTML:** with `content=true`, bodies arrive entity-escaped (`&lt;p&gt;`), so one pass reveals tags and a second pass after stripping resolves text-level entities (`&amp;`, `&#39;`). Verified against the live API.
- **Payload cost, measured:** `content=true` grew a public board's response from ~57 KB to ~829 KB across 83 jobs (~10 KB/posting). Mitigated the same way alibaba caps its full-text JDs: stripped text is sliced at 4000 chars. Happy to switch to opt-in per board entry if the maintainer prefers that tradeoff — one-line change at the `searchParams.set` call site.
- **Shape discipline:** the `description` key is omitted entirely when a posting has no body (same convention as cryptocurrencyjobs/remotli), so downstream "no signal" stays distinguishable from empty string. The raw `content` field never leaks into the normalized job.
- **Guard chain:** the final URL (with params) is re-validated through `assertGreenhouseUrl` before the request; `searchParams.set` is idempotent so an `entry.api` already pinning `content=true` can't be duplicated.
- Live smoke test against a public 83-job board: 83/83 jobs carry clean text descriptions, cap enforced, no HTML residue.

## How to test

1. `node tests/providers/greenhouse.test.mjs` — 40 pass, including the new double-decode, omission, idempotent-param, and 4000-char-cap cases
2. `node tests/providers/rss-entity-decoding.test.mjs` — confirms no private decoder re-entered alongside the shared one
3. Optional live check: any Greenhouse board now yields descriptions where it previously yielded none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Job listings now include an optional plain-text description when posting content is available.
  * Descriptions are cleaned for readability, with scripts and styles removed and content limited to 4,000 characters.
  * Greenhouse content is fetched more reliably, including support for existing content parameters.

* **Bug Fixes**
  * Prevented duplicate content parameters in Greenhouse requests.
  * Excluded empty descriptions and raw HTML from normalized job listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->