### PR TITLE
fix(liveness): add a LinkedIn rung so LinkedIn postings get a real verdict

### DIFF
--- a/check-liveness.mjs
+++ b/check-liveness.mjs
@@ -5,8 +5,8 @@
  *
  * Tests whether job posting URLs are still active or have expired.
  * Uses the same detection logic as scan.md step 7.5.
- * Zero Claude API tokens. Two rungs: a free ATS API check first
- * (Greenhouse/Lever — no browser), then Playwright for everything else.
+ * Zero Claude API tokens. Two rungs: a free public-API check first
+ * (liveness-api.mjs, no browser), then Playwright for everything else.
  *
  * Usage:
  *   node check-liveness.mjs <url1> [url2] ...

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -526,7 +526,9 @@ npm run rollback
 
 ## liveness
 
-Tests whether job posting URLs are still live. Two rungs: a zero-token ATS API check first (`liveness-api.mjs` — Greenhouse, Lever, Ashby, Workday), falling back to headless Chromium (`liveness-browser.mjs`) for non-ATS pages or when the API is inconclusive. The browser rung detects expired patterns (e.g. "job no longer available"), HTTP 404/410, ATS redirect patterns, and apply-button presence, and supports multi-language expired patterns (English, German, French).
+Tests whether job posting URLs are still live. Two rungs: a zero-token API check first (`liveness-api.mjs` — Greenhouse, Lever, Ashby, Workday, LinkedIn), falling back to headless Chromium (`liveness-browser.mjs`) for everything else or when the API is inconclusive. The browser rung detects expired patterns (e.g. "job no longer available"), HTTP 404/410, ATS redirect patterns, and apply-button presence, and supports multi-language expired patterns (English, German, French).
+
+The LinkedIn rung reads the guest posting endpoint, which returns the rendered posting as HTML and answers HTTP 200 for closed postings as well as live ones. Liveness therefore comes from two independent signals in the body — the "No longer accepting applications" banner and the apply control — and the rung only concludes when they agree: banner without apply control is expired, apply control without banner is live, a body carrying both or neither is `uncertain`. That `uncertain` is final rather than a fall-through, because a headless fetch of `linkedin.com/jobs/view/{id}` lands on a generic search page rather than the posting, so the browser rung has nothing better to offer. The endpoint is unauthenticated and rate-limited, so the rung spaces its own requests.
 
 Per-job ATS endpoints (Greenhouse, Lever, Workday) treat a 200 as proof the posting is live; Ashby's public API is org-level (the whole job board), so that rung parses the board and confirms the specific job id is still listed. A definitive 404/410 from any ATS API is authoritative and short-circuits the browser check entirely — zero tokens, no browser launch.
 

--- a/liveness-api.mjs
+++ b/liveness-api.mjs
@@ -13,7 +13,7 @@
  * anything ambiguous (unknown ATS, redirect, 429/5xx, network/timeout) we return
  * `null` (→ caller falls back to Playwright).
  *
- * Two endpoint shapes:
+ * Three endpoint shapes:
  *   - Per-job (Greenhouse, Lever, Workday): the URL maps to a single-job endpoint,
  *     so a 200 is itself proof the posting is live.
  *   - Org-level (Ashby): the URL maps to the org's whole job board. A 200 only
@@ -21,6 +21,9 @@
  *     and confirms THIS posting is still listed before returning active/expired.
  *     (Ashby pages are JS-rendered, so the browser/static rung sees only nav/footer
  *     and false-reports live postings as expired — this API rung is authoritative.)
+ *   - Per-job HTML (LinkedIn): the guest endpoint returns the rendered posting as
+ *     HTML and answers 200 for closed postings too, so `interpret` reads two
+ *     independent signals out of the body and only concludes when they agree.
  *
  * SSRF-safe by construction: the request URL is built from a FIXED, hard-coded API
  * host plus path segments extracted from the posting URL with a strict charset
@@ -54,8 +57,11 @@ function isSafeValue(v) {
 // `match` returns the extracted path params (or null); `api` builds the FIXED-host URL.
 // Optional per-provider fields:
 //   `timeoutMs`  — override the default fetch timeout (slow/rate-limited APIs).
+//   `throttleMs` — minimum interval between our requests to this provider.
+//   `accept`     — override the Accept header (providers that answer in HTML).
 //   `interpret`  — read the 200 response body to decide liveness (org-level APIs
-//                  where a 200 alone doesn't prove THIS posting is live).
+//                  where a 200 alone doesn't prove THIS posting is live, and
+//                  per-job APIs that answer 200 for a closed posting).
 //   `api404Authoritative` — defaults to true (a 404/410 means gone). Set to
 //                  false when the provider's public API can 404 a posting that
 //                  is still genuinely live elsewhere (see the `lever` entry).
@@ -141,7 +147,118 @@ const ATS_PROVIDERS = [
     api: ({ tenant, shard, site, jobPath }) =>
       `https://${tenant}.${shard}.myworkdayjobs.com/wday/cxs/${tenant}/${site}/job/${jobPath}`,
   },
+  {
+    id: 'linkedin',
+    // linkedin.com/jobs/view/{id} · .../jobs/view/{title-slug}-{id} · any page that
+    // carries the posting in ?currentJobId= (search and collection views).
+    //
+    // LinkedIn had no rung here, so every LinkedIn URL fell through to Playwright —
+    // where /jobs/view/{id} redirects to a generic search page and no verdict can be
+    // trusted. The guest endpoint below returns the rendered posting as HTML with no
+    // auth and no browser, and it answers 200 for closed postings as well as live
+    // ones, so liveness has to come from the body (`interpret`), never from the
+    // status code alone.
+    match(u) {
+      if (!/(^|\.)linkedin\.com$/.test(u.hostname)) return null;
+      const path = u.pathname.match(/^\/jobs\/view\/(?:.*-)?(\d+)\/?$/);
+      if (path) return { id: path[1] };
+      const current = u.searchParams.get('currentJobId');
+      return current && /^\d+$/.test(current) ? { id: current } : null;
+    },
+    api: ({ id }) => `https://www.linkedin.com/jobs-guest/jobs/api/jobPosting/${id}`,
+    // The endpoint is unauthenticated and rate-limited. Space our calls; the
+    // interval sits on the provider so it holds for every caller rather than only
+    // the loop in check-liveness.mjs.
+    throttleMs: 3_500,
+    // We parse HTML here, so ask for it. The endpoint also serves HTML under an
+    // application/json Accept, but a request that misdescribes what it wants is one
+    // content-negotiation change away from breaking silently.
+    accept: 'text/html',
+    async interpret(res) {
+      let html;
+      try {
+        html = await res.text();
+      } catch {
+        return null; // unreadable body → inconclusive, let the browser decide
+      }
+      return classifyLinkedInPosting(html);
+    },
+  },
 ];
+
+// LinkedIn renders a closed posting with an explicit banner
+// (`<figcaption class="closed-job__flavor--closed">No longer accepting
+// applications</figcaption>`) and drops the apply control. A live posting shows one
+// of two apply controls: the on-site button, or the off-site sign-in modal.
+const LINKEDIN_CLOSED_MARKER = /No longer accepting applications/i;
+const LINKEDIN_APPLY_CONTROL = /public_jobs_apply-link-onsite|job-details-topcard-apply-modal/;
+
+/**
+ * Decide liveness for one LinkedIn posting from its guest-endpoint HTML.
+ * Pure + deterministic (no I/O), mirroring classifyLiveness in liveness-core.mjs.
+ *
+ * The two signals are read independently and must agree before this concludes
+ * anything. A body carrying the closed banner AND an apply control, or neither, is
+ * a page we do not recognise — a layout change, a partial render, an interstitial —
+ * and it returns `uncertain` rather than picking the likelier answer.
+ *
+ * The asymmetry is deliberate and is the whole reason for the two-signal rule, and
+ * it is this module's CONSERVATIVE BY DESIGN rule applied to a body read rather than
+ * a status code: a wrong `expired` costs the user a real job they never see again,
+ * while a wrong `uncertain` costs one re-check on the next sweep.
+ *
+ * @param {any} html - the guest endpoint's response body
+ * @returns {{ result: 'active' | 'expired' | 'uncertain', code: string, reason: string } | null}
+ *   null = nothing to read (empty or non-string body) → caller falls back.
+ */
+export function classifyLinkedInPosting(html) {
+  if (typeof html !== 'string' || html.length === 0) return null;
+  const closed = LINKEDIN_CLOSED_MARKER.test(html);
+  const apply = LINKEDIN_APPLY_CONTROL.test(html);
+  if (closed && !apply) {
+    return {
+      result: 'expired',
+      code: 'linkedin_closed_marker',
+      reason: 'LinkedIn shows "No longer accepting applications" and no apply control',
+    };
+  }
+  if (apply && !closed) {
+    return {
+      result: 'active',
+      code: 'linkedin_apply_control',
+      reason: 'LinkedIn shows an apply control and no closure banner (live)',
+    };
+  }
+  return {
+    result: 'uncertain',
+    code: 'linkedin_signals_disagree',
+    reason: closed
+      ? 'LinkedIn shows both a closure banner and an apply control — unrecognised page'
+      : 'LinkedIn shows neither a closure banner nor an apply control — unrecognised page',
+  };
+}
+
+// Reserved send times per provider, so back-to-back callers queue behind each
+// other instead of all reading the same "last request" timestamp and firing
+// together.
+const nextRequestAt = new Map();
+
+/**
+ * Wait until this provider's next request slot, then reserve the one after it.
+ *
+ * @param {string} providerId
+ * @param {number} [intervalMs] - minimum spacing; falsy means no throttling
+ * @returns {Promise<number>} milliseconds actually waited
+ */
+export async function throttleProviderRequest(providerId, intervalMs) {
+  if (!intervalMs) return 0;
+  const now = Date.now();
+  const earliest = Math.max(now, nextRequestAt.get(providerId) ?? 0);
+  nextRequestAt.set(providerId, earliest + intervalMs);
+  const wait = earliest - now;
+  if (wait > 0) await new Promise((resolve) => setTimeout(resolve, wait));
+  return wait;
+}
 
 /**
  * Decide liveness for one Ashby posting from its org's job-board API payload.
@@ -171,7 +288,7 @@ export function classifyAshbyBoard(json, jobId) {
  * Map a posting URL to its ATS API URL, or null if it isn't a known ATS posting
  * (or any extracted segment fails the strict charset). Pure + deterministic.
  * @param {string} rawUrl
- * @returns {{ ats: string, apiUrl: string, parts: Record<string, string>, timeoutMs?: number, interpret?: (res: Response, parts: Record<string, string>) => Promise<{ result: 'active' | 'expired', code: string, reason: string } | null>, api404Authoritative: boolean } | null}
+ * @returns {{ ats: string, apiUrl: string, parts: Record<string, string>, timeoutMs?: number, throttleMs?: number, accept?: string, interpret?: (res: Response, parts: Record<string, string>) => Promise<{ result: 'active' | 'expired' | 'uncertain', code: string, reason: string } | null>, api404Authoritative: boolean } | null}
  */
 export function resolveAtsApi(rawUrl) {
   let u;
@@ -193,6 +310,8 @@ export function resolveAtsApi(rawUrl) {
       apiUrl: provider.api(parts),
       parts,
       timeoutMs: provider.timeoutMs,
+      throttleMs: provider.throttleMs,
+      accept: provider.accept,
       interpret: provider.interpret,
       api404Authoritative: provider.api404Authoritative !== false,
     };
@@ -208,13 +327,19 @@ export function isAtsPosting(url) {
 /**
  * Zero-token liveness check via the posting's ATS API.
  * @param {string} url
- * @returns {Promise<{ result: 'active' | 'expired', code: string, reason: string } | null>}
+ * @returns {Promise<{ result: 'active' | 'expired' | 'uncertain', code: string, reason: string } | null>}
  *   null = not a known ATS posting, or inconclusive → caller should fall back to Playwright.
+ *   `uncertain` is a conclusion in its own right: the provider reached the posting
+ *   and could not read it, and no other rung would do better.
  */
 export async function checkLivenessViaApi(url) {
   const resolved = resolveAtsApi(url);
   if (!resolved) return null;
-  const { ats, apiUrl, parts, interpret, timeoutMs, api404Authoritative } = resolved;
+  const { ats, apiUrl, parts, interpret, timeoutMs, throttleMs, accept, api404Authoritative } = resolved;
+
+  // Wait out any provider rate limit BEFORE arming the timeout, so the spacing
+  // does not eat the budget the request itself needs.
+  await throttleProviderRequest(ats, throttleMs);
 
   // The timeout guards the whole classification (fetch + any `interpret` body read),
   // since aborting the shared signal also tears down an in-flight res.json().
@@ -225,7 +350,7 @@ export async function checkLivenessViaApi(url) {
     try {
       res = await fetch(apiUrl, {
         method: 'GET',
-        headers: { 'user-agent': DEFAULT_USER_AGENT, accept: 'application/json' },
+        headers: { 'user-agent': DEFAULT_USER_AGENT, accept: accept || 'application/json' },
         redirect: 'error', // refuse server-side redirects (SSRF + ambiguity guard)
         signal: controller.signal,
       });

--- a/tests/fixtures/linkedin-guest-closed.html
+++ b/tests/fixtures/linkedin-guest-closed.html
@@ -1,0 +1,20 @@
+<!-- Trimmed capture of https://www.linkedin.com/jobs-guest/jobs/api/jobPosting/{id}
+     for a posting LinkedIn has closed. The full response is ~19-60KB of the same
+     shell; everything kept here is byte-identical to the live markup around the
+     signals the checker reads. Company, title and location are synthetic. -->
+<section class="core-rail">
+  <div class="top-card-layout">
+    <h1 class="top-card-layout__title">Staff Software Engineer</h1>
+    <h4 class="top-card-layout__second-subline">
+      <span class="topcard__flavor">Acme Corporation</span>
+      <span class="topcard__flavor topcard__flavor--bullet">New York, NY</span>
+      <figure class="closed-job closed-job__flavor topcard__flavor-row">
+        <span class="closed-job__icon closed-job__icon--error-pebble lazy-load"></span>
+        <figcaption class="closed-job__flavor--closed">No longer accepting applications</figcaption>
+      </figure>
+    </h4>
+  </div>
+  <div class="description__text">
+    <p>Acme is hiring a Staff Software Engineer to lead work on its platform services.</p>
+  </div>
+</section>

--- a/tests/fixtures/linkedin-guest-live-modal.html
+++ b/tests/fixtures/linkedin-guest-live-modal.html
@@ -1,0 +1,21 @@
+<!-- Trimmed capture of the same endpoint for a live posting whose apply control is
+     the off-site sign-in modal. Both apply shapes occur on live postings, which is
+     why the checker accepts either. Company, title and location are synthetic. -->
+<section class="core-rail">
+  <div class="top-card-layout">
+    <h1 class="top-card-layout__title">Director of Product</h1>
+    <h4 class="top-card-layout__second-subline">
+      <span class="topcard__flavor">Acme Corporation</span>
+      <span class="topcard__flavor topcard__flavor--bullet">Greater Boston</span>
+    </h4>
+    <button class="sign-up-modal__outlet top-card-layout__cta btn-md btn-primary"
+            data-tracking-control-name="public_jobs_contextual-sign-in-modal_ssr-ui-lib-outlet-button"
+            data-modal="job-details-topcard-apply-modal">
+      Apply
+      <icon data-svg-class-name="apply-button__offsite-apply-icon-svg"></icon>
+    </button>
+  </div>
+  <div class="description__text">
+    <p>Own the roadmap for a platform product line, reporting to the VP of Product.</p>
+  </div>
+</section>

--- a/tests/fixtures/linkedin-guest-live-onsite.html
+++ b/tests/fixtures/linkedin-guest-live-onsite.html
@@ -1,0 +1,20 @@
+<!-- Trimmed capture of the same endpoint for a live posting whose apply control is
+     the on-site button. Company, title and location are synthetic. -->
+<section class="core-rail">
+  <div class="top-card-layout">
+    <h1 class="top-card-layout__title">Senior Data Analyst</h1>
+    <h4 class="top-card-layout__second-subline">
+      <span class="topcard__flavor">Acme Corporation</span>
+      <span class="topcard__flavor topcard__flavor--bullet">Remote</span>
+    </h4>
+    <button class="top-card-layout__cta top-card-layout__cta--primary btn-md btn-primary"
+            data-reference-id="0WabHVI4QSy3qsP9168h/w=="
+            data-tracking-id="heLsH1TLTiyHZguU6EIn6Q=="
+            data-tracking-control-name="public_jobs_apply-link-onsite">
+      Apply
+    </button>
+  </div>
+  <div class="description__text">
+    <p>Own reporting end to end, from ingestion through the executive dashboards.</p>
+  </div>
+</section>

--- a/tests/liveness-api-linkedin.test.mjs
+++ b/tests/liveness-api-linkedin.test.mjs
@@ -1,0 +1,222 @@
+// tests/liveness-api-linkedin.test.mjs — the LinkedIn rung of the liveness ladder.
+//
+// LinkedIn had no API rung, so every LinkedIn URL fell through to Playwright. A
+// headless fetch of linkedin.com/jobs/view/{id} lands on a generic search page, so
+// that rung never produced a verdict worth trusting and dead LinkedIn postings kept
+// reading as live.
+//
+// The rung reads the guest endpoint, which returns rendered HTML with no auth and
+// no browser. Two independent signals, and BOTH have to agree:
+//
+//   closed marker present + no apply control -> expired
+//   no closed marker      + apply control    -> active
+//   anything else                            -> uncertain
+//
+// The asymmetry that matters: a false `expired` costs the user a real job they
+// never see again, while a false `uncertain` costs one re-check. So a checker that
+// can only ever answer "expired" is worse than no checker at all. Every assertion
+// below that names a `live` fixture is the negative control for that failure mode:
+// delete the apply-control signal from the implementation and they redden; delete
+// the closed-marker signal and the expired assertions redden. Neither direction can
+// go green on its own.
+import { pass, fail, ROOT } from './helpers.mjs';
+import { join } from 'path';
+import { readFileSync } from 'fs';
+import { pathToFileURL } from 'url';
+
+const { resolveAtsApi, classifyLinkedInPosting, checkLivenessViaApi, throttleProviderRequest } =
+  await import(pathToFileURL(join(ROOT, 'liveness-api.mjs')).href);
+
+console.log('\nLinkedIn liveness rung');
+
+function check(desc, condition, details = '') {
+  if (condition) pass(desc);
+  else fail(`${desc}${details ? ` (${details})` : ''}`);
+}
+
+const fixture = (name) => readFileSync(join(ROOT, 'tests', 'fixtures', `linkedin-guest-${name}.html`), 'utf-8');
+const CLOSED = fixture('closed');
+const LIVE_ONSITE = fixture('live-onsite');
+const LIVE_MODAL = fixture('live-modal');
+
+const ID = '4402976479';
+const API = `https://www.linkedin.com/jobs-guest/jobs/api/jobPosting/${ID}`;
+
+// -- 1. URL -> guest API resolution -----------------------------------------
+{
+  const bare = resolveAtsApi(`https://www.linkedin.com/jobs/view/${ID}/`);
+  check('a bare /jobs/view/{id} URL resolves to the guest posting endpoint',
+    bare?.ats === 'linkedin' && bare.apiUrl === API, JSON.stringify(bare));
+
+  // The URL people actually copy out of LinkedIn carries a title slug in front
+  // of the id.
+  const slug = resolveAtsApi(`https://www.linkedin.com/jobs/view/staff-software-engineer-at-acme-${ID}`);
+  check('a slugged /jobs/view/{slug}-{id} URL resolves to the same endpoint',
+    slug?.ats === 'linkedin' && slug.apiUrl === API, JSON.stringify(slug));
+
+  // Search and collection pages keep the posting id in the query string; a URL
+  // pasted from that view is still a specific posting.
+  const search = resolveAtsApi(`https://www.linkedin.com/jobs/search/?currentJobId=${ID}&keywords=engineer`);
+  check('a ?currentJobId= search URL resolves to the same endpoint',
+    search?.ats === 'linkedin' && search.apiUrl === API, JSON.stringify(search));
+
+  const collection = resolveAtsApi(`https://www.linkedin.com/jobs/collections/recommended/?currentJobId=${ID}`);
+  check('a ?currentJobId= collections URL resolves to the same endpoint',
+    collection?.ats === 'linkedin' && collection.apiUrl === API, JSON.stringify(collection));
+
+  check('the rung declares an interpret step, so a 200 alone never means live',
+    typeof bare?.interpret === 'function', JSON.stringify(bare));
+}
+
+// -- 2. what must NOT resolve ------------------------------------------------
+// Every one of these would either point the fixed-host URL template at something
+// that is not a posting, or hand a non-posting page to the classifier.
+{
+  const rejects = [
+    ['a LinkedIn profile URL', 'https://www.linkedin.com/in/example-person'],
+    ['a company page', 'https://www.linkedin.com/company/acme/jobs/'],
+    ['a job search page with no posting id', 'https://www.linkedin.com/jobs/search/?keywords=engineer'],
+    ['a non-numeric job id', 'https://www.linkedin.com/jobs/view/not-a-number/'],
+    ['a non-numeric currentJobId', 'https://www.linkedin.com/jobs/search/?currentJobId=abc'],
+    ['a lookalike host', 'https://notlinkedin.com/jobs/view/4402976479'],
+    ['a subdomain-suffix lookalike host', 'https://linkedin.com.example.org/jobs/view/4402976479'],
+    ['plain http', 'http://www.linkedin.com/jobs/view/4402976479'],
+  ];
+  for (const [desc, url] of rejects) {
+    check(`${desc} does not resolve to the LinkedIn rung`, resolveAtsApi(url) === null, url);
+  }
+
+  // Regional subdomains are real LinkedIn posting hosts and must still resolve.
+  const regional = resolveAtsApi(`https://uk.linkedin.com/jobs/view/${ID}`);
+  check('a regional LinkedIn subdomain still resolves', regional?.ats === 'linkedin', JSON.stringify(regional));
+}
+
+// -- 3. the two-signal classifier, on real captured markup -------------------
+{
+  const closed = classifyLinkedInPosting(CLOSED);
+  check('a posting carrying the closed marker and no apply control is expired',
+    closed?.result === 'expired', JSON.stringify(closed));
+  check('and the expired verdict carries a LinkedIn-specific code',
+    closed?.code === 'linkedin_closed_marker', JSON.stringify(closed));
+
+  // NEGATIVE CONTROL. If the apply-control signal stops being read, these two go
+  // red and nothing else does — which is the whole point of asserting them by
+  // name. A rung that answers "expired" for every posting passes every assertion
+  // above and fails exactly here.
+  const onsite = classifyLinkedInPosting(LIVE_ONSITE);
+  check('a posting with the on-site apply button and no closed marker is live',
+    onsite?.result === 'active', JSON.stringify(onsite));
+  check('and it is specifically NOT reported expired',
+    onsite?.result !== 'expired', JSON.stringify(onsite));
+
+  const modal = classifyLinkedInPosting(LIVE_MODAL);
+  check('a posting with the off-site apply modal and no closed marker is live',
+    modal?.result === 'active', JSON.stringify(modal));
+  check('and it is specifically NOT reported expired',
+    modal?.result !== 'expired', JSON.stringify(modal));
+
+  check('the live verdict carries a LinkedIn-specific code',
+    onsite?.code === 'linkedin_apply_control' && modal?.code === 'linkedin_apply_control',
+    `${JSON.stringify(onsite)} ${JSON.stringify(modal)}`);
+}
+
+// -- 4. one signal is never enough -------------------------------------------
+// Both halves have to agree. These are the cases where the page is telling us two
+// things at once, or nothing at all, and a guess in either direction is wrong.
+{
+  const both = classifyLinkedInPosting(`${CLOSED}\n${LIVE_ONSITE}`);
+  check('closed marker AND apply control together is uncertain, not a guess',
+    both?.result === 'uncertain', JSON.stringify(both));
+
+  const neither = classifyLinkedInPosting(
+    '<section class="core-rail"><h1 class="top-card-layout__title">Staff Software Engineer</h1></section>'
+  );
+  check('neither signal present is uncertain, not expired',
+    neither?.result === 'uncertain', JSON.stringify(neither));
+
+  // The signals must be read independently rather than one being derived from the
+  // other: apply control alone, with no closed marker, is the live case above;
+  // closed marker alone, with no apply control, is the expired case above. This
+  // pins that a body carrying only the marker never reads as live.
+  const markerOnly = classifyLinkedInPosting(
+    '<figcaption class="closed-job__flavor--closed">No longer accepting applications</figcaption>'
+  );
+  check('the closed marker on its own never reads as live',
+    markerOnly?.result === 'expired', JSON.stringify(markerOnly));
+
+  check('an empty body is inconclusive rather than expired',
+    classifyLinkedInPosting('') === null, JSON.stringify(classifyLinkedInPosting('')));
+  check('a non-string body is inconclusive rather than expired',
+    classifyLinkedInPosting(null) === null && classifyLinkedInPosting(undefined) === null);
+}
+
+// -- 5. the interpret step is wired to the classifier -------------------------
+// The classifier being right is worth nothing if the rung never calls it. This
+// runs the real interpret over a real Response, so the body read is exercised too.
+{
+  const resolved = resolveAtsApi(`https://www.linkedin.com/jobs/view/${ID}/`);
+  const verdict = await resolved.interpret(new Response(CLOSED, { status: 200 }), resolved.parts);
+  check('interpret runs the classifier over the response body',
+    verdict?.result === 'expired' && verdict.code === 'linkedin_closed_marker', JSON.stringify(verdict));
+
+  const live = await resolved.interpret(new Response(LIVE_MODAL, { status: 200 }), resolved.parts);
+  check('and returns live for a live body, through the same path',
+    live?.result === 'active', JSON.stringify(live));
+}
+
+// -- 6. end to end through checkLivenessViaApi --------------------------------
+// One call only: the rung throttles itself, so a second would sleep for seconds.
+{
+  const realFetch = globalThis.fetch;
+  let requested = null;
+  let sentHeaders = null;
+  globalThis.fetch = async (url, init) => {
+    requested = String(url);
+    sentHeaders = init?.headers ?? null;
+    return new Response(LIVE_ONSITE, { status: 200, headers: { 'content-type': 'text/html' } });
+  };
+  try {
+    const verdict = await checkLivenessViaApi(`https://www.linkedin.com/jobs/view/${ID}/`);
+    check('checkLivenessViaApi returns the live verdict for a LinkedIn posting',
+      verdict?.result === 'active' && verdict.code === 'linkedin_apply_control', JSON.stringify(verdict));
+    check('and it asked the guest endpoint, not the posting page',
+      requested === API, String(requested));
+    check('and asked for HTML, which is what the rung parses',
+      /text\/html/.test(String(sentHeaders?.accept ?? '')), JSON.stringify(sentHeaders));
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+}
+
+// -- 7. throttling ------------------------------------------------------------
+// The guest endpoint is unauthenticated and rate-limited; a manual sweep of it has
+// to space calls 3-4s apart. The interval lives on the provider so it applies to
+// every caller, not just the one loop in check-liveness.mjs.
+{
+  const resolved = resolveAtsApi(`https://www.linkedin.com/jobs/view/${ID}/`);
+  check('the LinkedIn rung declares a throttle interval of at least 3s',
+    typeof resolved?.throttleMs === 'number' && resolved.throttleMs >= 3000, JSON.stringify(resolved?.throttleMs));
+
+  // Reserve-then-wait, so back-to-back callers queue instead of all reading the
+  // same "last request" timestamp and firing together.
+  const started = Date.now();
+  const first = await throttleProviderRequest('test-provider-linkedin-rung', 60);
+  const second = await throttleProviderRequest('test-provider-linkedin-rung', 60);
+  const elapsed = Date.now() - started;
+  check('the first request through a throttled provider does not wait', first === 0, String(first));
+  check('the second waits out the interval', second >= 55 && elapsed >= 55, `waited=${second} elapsed=${elapsed}`);
+  check('a provider with no declared interval never waits',
+    (await throttleProviderRequest('test-provider-linkedin-rung-unthrottled', 0)) === 0);
+}
+
+// -- 8. the ladder still prefers this rung over the browser -------------------
+// Structural: a rung nothing routes to is indistinguishable from no rung. The
+// browser rung is the thing being avoided here, so assert the caller checks the
+// API first rather than trusting the ordering to stay put.
+{
+  const src = readFileSync(join(ROOT, 'check-liveness.mjs'), 'utf-8');
+  const apiAt = src.indexOf('checkLivenessViaApi(');
+  const browserAt = src.indexOf('checkUrlLivenessWithFallback(');
+  check('check-liveness.mjs consults the API rung before the browser rung',
+    apiAt > -1 && browserAt > -1 && apiAt < browserAt, `api=${apiAt} browser=${browserAt}`);
+}


### PR DESCRIPTION
## What does this PR do?

Adds a LinkedIn rung to `liveness-api.mjs` using the public guest endpoint, so a LinkedIn posting gets a real verdict instead of being left `uncertain` or judged from the redirect the browser rung lands on.

## Related issue

Closes #3179

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

---

### The rule, and why both signals are required

`https://www.linkedin.com/jobs-guest/jobs/api/jobPosting/{id}`, no auth and no browser.

- **expired** iff the body carries `No longer accepting applications` (`<figcaption class="closed-job__flavor--closed">`)
- **live** iff that marker is absent **and** an apply control is present (`public_jobs_apply-link-onsite` or `job-details-topcard-apply-modal`)
- anything else -> `uncertain`

Either signal alone can emit a confident wrong answer. A marker check on its own cannot tell "open" from "page did not render"; an apply check on its own cannot tell "closed" from "apply control moved". This follows the module's own stated invariant that a false `expired` is the worse failure, so ambiguity resolves to `uncertain` rather than to a guess.

Ids are parsed from `/jobs/view/{id}`, the slugged `/jobs/view/{title-slug}-{id}`, and `?currentJobId=` on search and collections pages.

### Two small pieces of provider plumbing

`throttleMs` (LinkedIn: 3500ms) and `accept` (LinkedIn: `text/html`), both threaded through `resolveAtsApi` and `checkLivenessViaApi`. The throttle is awaited **before** the timeout is armed, so waiting out the interval cannot consume the request's own budget. `api404Authoritative` is untouched and still flows through; LinkedIn does not set it and keeps the default behavior.

The `accept` override is semantic correctness rather than load-bearing: the endpoint serves the same HTML under the project's existing `DEFAULT_USER_AGENT`. I am not claiming it as a fix.

### Test

`tests/liveness-api-linkedin.test.mjs`, 36 assertions, auto-discovered under `tests/`, no `test-all.mjs` section and no `update-system.mjs` registration needed. Fixtures are synthetic.

Mutation-checked in three directions, and the third is the one that matters:

- **closed-marker signal forced off** reddens 5 named assertions, incl. `the closed marker on its own never reads as live`
- **apply-control signal forced off** reddens 6, incl. `checkLivenessViaApi returns the live verdict for a LinkedIn posting`
- **classifier forced to always answer `expired`** — the harmful checker — reddens 9, including the negative control `neither signal present is uncertain, not expired`

That last one is deliberate. A rung that can only say "expired" would pass a suite full of expired fixtures while being the worst possible outcome, so the suite is built so it cannot.

Also pinned: a lookalike host does not resolve to the rung (loosening the host guard to a substring match reddens two assertions), and a non-numeric job id does not resolve either.

`node test-all.mjs`: 5171 passed, 0 failed, 2 warnings (both pre-existing and unrelated).

### Docs

`docs/SCRIPTS.md` and `check-liveness.mjs`'s header both listed the rungs as Greenhouse/Lever and were already stale before this change; corrected to match.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LinkedIn posting checks using guest API responses.
  * Detects active, expired, and uncertain postings using multiple signals.
  * Supports regional LinkedIn hosts, request pacing, and appropriate response handling.
* **Bug Fixes**
  * Improved liveness checks with a generic public API check before browser-based fallback.
* **Documentation**
  * Updated liveness documentation to describe LinkedIn checks, outcomes, and request pacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->