### PR TITLE
fix(classify-tier): Associate + an academic rank is not entry-level

### DIFF
--- a/classify-tier.mjs
+++ b/classify-tier.mjs
@@ -96,17 +96,49 @@ export function classifyTier(title) {
     }
   ];
 
-  // Guard (a): "Associate [*] Director/VP/Chief/Principal/Partner/Head-of" resolves
-  // to senior. The `associate` prefix qualifies the seniority band of a senior role;
-  // it does not demote it to entry-level. Works for both a direct compound
-  // ("Associate Director") and a broad one ("Associate Creative Director"). Checked
-  // before the position loop because `associate` always precedes the senior noun,
-  // so the leftmost-marker rule would fire on `associate` at index 0 and return entry.
+  // Guard (a): "Associate <senior noun>" resolves to senior. The `associate`
+  // prefix qualifies the seniority band of a senior role; it does not demote it
+  // to entry-level. Checked before the position loop because `associate` always
+  // precedes the senior noun, so the leftmost-marker rule would fire on
+  // `associate` at index 0 and return entry.
+  //
+  // The noun list is CLOSED, and has to stay that way: in plenty of fields
+  // `associate` genuinely does mark the junior variant, and those must keep
+  // resolving to entry — Associate Attorney, Associate Editor, Associate
+  // Producer, Associate Manager, Associate Consultant. A generic "associate
+  // never demotes" rule breaks every one of them.
+  //
+  // The academic ranks are on the list because `associate` names a RANK there
+  // rather than a junior variant: Associate Professor is the rung above
+  // Assistant Professor, and Dean/Provost/Chancellor/Superintendent head an
+  // institution (#3178). The criterion is institution-level head, not
+  // office-level deputy — which is why Registrar, Bursar and Librarian stay
+  // off, along with Rector (a parish `associate rector` IS the junior one).
   const associateAt = cleanTitle.search(/\bassociate\b/i);
   if (associateAt >= 0) {
-    const afterAssociate = cleanTitle.slice(associateAt + 'associate'.length);
-    if (/\b(director|vice\s+president|vp|principal|partner|chief|head\s+of)\b/i.test(afterAssociate)) {
-      return 'senior';
+    // A junior marker that LEADS the title still decides it. "Intern, Associate
+    // Dean of Student Life" is an internship in a dean's office, not a
+    // deanship — the same doctrine the position loop below applies to
+    // "Summer Intern, Director of Product". Without this the guard returns
+    // early and inverts the very harm #3178 is about, on the same board.
+    const juniorAt = cleanTitle.search(/\b(?:intern(?:ship)?|trainee|co-op|graduate|junior|entry(?:-level)?)\b/i);
+    if (juniorAt < 0 || juniorAt > associateAt) {
+      const afterAssociate = cleanTitle.slice(associateAt + 'associate'.length);
+      // WHITESPACE only, and at most two words of gap. Both bounds carry
+      // weight. Any comma or dash after `associate` means `associate` is the
+      // role and what follows is a separate clause: "Research Associate -
+      // Professor Smith Laboratory" and "Administrative Associate, Office of
+      // the Dean" are junior roles that a to-end-of-string search reads as
+      // senior. The two-word cap then stops "Office of the Dean" and real
+      // employers named for a noun on this list — Dean & Company (whose entry
+      // title is literally "Associate Consultant"), Dean Foods, Dean Witter,
+      // Provost Umphrey. It also keeps the legal pair honest: bare `counsel`
+      // is off the list because a firm's associate IS the junior lawyer, and
+      // without the bound "Associate Counsel, Office of the General Counsel"
+      // would match `general counsel` from the department name.
+      if (/^\s+(?:[a-z]+\s+){0,2}(director|vice\s+president|vp|principal|partner|chief|head\s+of|professor|dean|provost|chancellor|superintendent|general\s+counsel)\b/i.test(afterAssociate)) {
+        return 'senior';
+      }
     }
   }
 

--- a/tests/classify-tier-position.test.mjs
+++ b/tests/classify-tier-position.test.mjs
@@ -108,6 +108,74 @@ try {
   check('Intern Program Coordinator', 'intern');
   check('Graduate Scheme Analyst', 'intern');
   check('Trainee Program Engineer', 'intern');
+
+  // ── Guard (a): `associate` names a RANK, not a junior variant (#3178) ──
+  // These fell through the closed noun list to the `associate` matcher at
+  // classify-tier.mjs:72 and classified `entry`. scan.mjs drops a posting whose
+  // tier is in `skip_tiers` and never names it (it prints a "Filtered by tier: N
+  // removed" count, not the title), so an academic candidate running the
+  // documented example config — templates/portals.example.yml suggests
+  // `skip_tiers: [intern, entry]` and ships a HigherEdJobs board, both commented
+  // out — lost every Associate Professor posting without seeing which.
+  check('Associate Professor', 'senior');
+  check('Associate Research Professor', 'senior');
+  check('Associate Dean', 'senior');
+  check('Associate Dean of Students', 'senior');
+  check('Associate Provost', 'senior');
+  check('Associate Chancellor', 'senior');
+  check('Associate Vice Chancellor', 'senior');
+  check('Associate Superintendent', 'senior');
+  // Legal: the COMPOUND is on the list, the bare noun deliberately is not.
+  check('Associate General Counsel', 'senior');
+  // Pinned because the widened list must keep them (both new to this file).
+  check('Associate Vice President', 'senior');
+  check('Associate Partner', 'senior');
+
+  // ── The counterexamples that keep the noun list closed ──
+  // In these fields `associate` really is the junior variant, so guard (a)
+  // cannot become a generic "associate never demotes" rule. `Associate Rector`
+  // (a parish curate) and `Associate Registrar` (an office-level deputy) are why
+  // the criterion is "institution-level head", not "sounds academic".
+  check('Associate Counsel', 'entry');
+  check('Associate Attorney', 'entry');
+  check('Associate Editor', 'entry');
+  check('Associate Producer', 'entry');
+  check('Associate Manager', 'entry');
+  check('Associate Consultant', 'entry');
+  check('Associate Rector', 'entry');
+  check('Associate Registrar', 'entry');
+
+  // ── Guard (a) is skipped when a junior marker LEADS the title ──
+  // Same doctrine as the position loop: "Summer Intern, Director of Product" is
+  // an internship. Without this, guard (a) returns early and inverts #3178's own
+  // harm on the same board — a junior candidate skipping `senior` would lose the
+  // dean's-office internships they were scanning for.
+  check('Intern, Associate Dean of Student Life', 'intern');
+  check('Student Intern, Office of the Associate Provost', 'intern');
+  check('Summer Intern, Associate Professor Research Group', 'intern');
+  check('Graduate Trainee, Office of the Associate Dean', 'intern');
+  check('Entry-Level Associate, Dean of Admissions Office', 'entry');
+  check('Junior Associate Professor Support Specialist', 'entry');
+
+  // ── Guard (a)'s window is whitespace-only and at most two words ──
+  // A comma or dash after `associate` means `associate` is the ROLE and what
+  // follows is a separate clause; an unbounded search to end-of-string reads all
+  // of these as senior. The two-word cap additionally stops "Office of the X"
+  // and employers named for a noun on the list — Dean & Company, whose entry
+  // title is literally "Associate Consultant", plus Dean Foods, Dean Witter and
+  // Provost Umphrey. The counsel pair is the sharpest: identical junior in-house
+  // lawyer, tier decided by the department name.
+  check('Administrative Associate, Office of the Dean', 'entry');
+  check('Program Associate, Office of the Provost', 'entry');
+  check('Research Associate - Professor Smith Laboratory', 'entry');
+  check('Postdoctoral Research Associate, Lab of Professor Jane Doe', 'entry');
+  check('Associate Consultant - Dean & Company', 'entry');
+  check('Associate Attorney - Provost Umphrey Law Firm', 'entry');
+  check('Associate Manager, Dean Foods', 'entry');
+  check('Junior Associate, Dean Witter', 'entry');
+  check('Associate Counsel, Office of the General Counsel', 'entry');
+  check('Associate Counsel - Office of General Counsel', 'entry');
+
 } catch (error) {
   fail(`classify-tier.mjs tests could not run: ${error.message}`);
 }


### PR DESCRIPTION
Fixes #3178

## The bug

`classify-tier.mjs` guard (a) already resolves `associate` + a senior noun to `senior` — the `associate` prefix qualifies a senior role's band rather than demoting it. The noun list just never covered the academic ladder, so these fell through to the `associate` → `entry` matcher at `:72`:

```
entry   Associate Professor        entry   Associate Chancellor
entry   Associate Dean             entry   Associate General Counsel
entry   Associate Provost

senior  Associate Director         ← the existing guard, working
senior  Associate Creative Director
```

`scan.mjs` drops a posting whose tier is in `skip_tiers` and never names it — it prints a `Filtered by tier: N removed` count, not the title. So an academic candidate running the documented example config (`templates/portals.example.yml` suggests `skip_tiers: [intern, entry]` and ships a HigherEdJobs board, both commented out) lost every Associate Professor posting without seeing which.

## The change

Adds `professor` / `dean` / `provost` / `chancellor` / `superintendent` and the `general counsel` compound.

The criterion is **institution-level head, not office-level deputy** — which is why `Registrar`, `Bursar` and `Librarian` stay off, and `Rector` too, since a parish's associate rector genuinely *is* the junior one. The list has to stay closed: in plenty of fields `associate` really does mark the junior variant, and `Associate Attorney` / `Editor` / `Producer` / `Manager` / `Consultant` must keep resolving `entry`.

**Two bounds come with it, because widening the list alone made the guard worse than it was.** An adversarial pass over the first draft found both, and both are reachable from ordinary higher-ed titles:

**1. Guard (a) is skipped when an intern/entry marker leads the title.** It returns before the position loop, so:

```
Intern, Associate Dean of Student Life           →  senior   (before)
Student Intern, Office of the Associate Provost  →  senior   (before)
```

That inverts this fix's own harm on the same board — the junior candidate loses the dean's-office internships instead. It's the same doctrine the position loop already applies to "Summer Intern, Director of Product".

**2. The window is whitespace-only and at most two words.** It used to slice to end-of-string, so any senior noun anywhere to the right matched:

```
Administrative Associate, Office of the Dean     →  senior   (before)
Research Associate - Professor Smith Laboratory  →  senior   (before)
Associate Consultant - Dean & Company            →  senior   (before)
Associate Manager, Dean Foods                    →  senior   (before)
```

A comma or dash after `associate` means `associate` is the *role* and what follows is a separate clause. The two-word cap then stops "Office of the X" and real employers named for a noun on the list — Dean & Company (whose entry title is literally "Associate Consultant"), Dean Foods, Dean Witter, Provost Umphrey.

That second bound is also what makes the counsel split **real rather than asserted**. Bare `counsel` is deliberately off the list, but unbounded:

```
Associate Counsel                                 →  entry
Associate Counsel, Office of the General Counsel  →  senior   (before)
```

Same junior in-house lawyer, opposite tier, decided by the department name.

Both bounds are pre-existing in `director` — this change surfaces them because the academic nouns land in titles where they fire constantly.

## Test

Extends `tests/classify-tier-position.test.mjs` (79 assertions, 0 failed). Reverting `classify-tier.mjs` fails exactly 9 of them.

The counterexample blocks are the load-bearing half: they pin the titles where `associate` really is junior, so the noun list can't quietly become a generic "associate never demotes" rule.

## Scoped out, deliberately

- **The top of each ladder sits at `mid`.** `Professor`, `Dean`, `Provost`, `General Counsel` with no prefix hit no matcher and fall to the `mid` default, so `Associate Professor` now outranks `Professor`. That's odd, but fixing it means bare `dean`/`professor` matchers, which need the same windowing (otherwise every "Dean & Company" title goes senior) and would flip `Assistant Professor` too. Separate change, happy to take it if you want it.
- **`Staff Associate` → `senior`**, pre-existing and unrelated: the `staff` matcher fires at index 0. Narrowing that risks `Staff Engineer`, so I left it alone.
- **`senior` vs `mid` for `Associate Professor`.** #3178 asked; either fixes the harm, since the documented config skips `intern` and `entry`. This uses `senior` because it needs no new machinery — flipping it is a one-line change if you'd rather.

## Verification

- `node test-all.mjs --quick` → **5152 passed, 0 failed** (2 pre-existing warnings)
- `node validate-system-paths-coverage.mjs` → clean; `classify-tier.mjs` already in `SYSTEM_PATHS`, no new files
- Blast radius is exactly `skip_tiers` — `scan.mjs:2606` is the only caller; `role-matcher.mjs`, `web/src/lib/inbox.ts` and `dashboard/internal/data/stats.go` do their own string matching and never call `classifyTier`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved classification of associate-level titles, including academic and institutional senior roles.
  * Preserved junior classification when intern or entry-level markers appear first.
  * Prevented incorrect matches caused by punctuation, unrelated organization names, or overly broad title text.

* **Tests**
  * Added coverage for senior, junior, punctuation, spacing, and employer-name classification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->