### PR TITLE
fix(pdf): name both sides when the lexical containment check fires

### DIFF
--- a/generate-pdf.mjs
+++ b/generate-pdf.mjs
@@ -95,7 +95,14 @@ function assertInsideWorkspace(absPath, label) {
   }
   const rel = relative(__workspaceRoot, canonical);
   if (rel === '' || rel.startsWith('..') || isAbsolute(rel)) {
-    throw new Error(`${label} escapes the tracker workspace: ${absPath}`);
+    // #3162: an intermittent macOS-CI-only hit of this branch happens on paths
+    // that are lexically inside the sandbox, and canonicalization SUCCEEDS
+    // before it. Print both sides so the next occurrence names the disagreeing
+    // ancestor outright instead of asking a reader to reconstruct it.
+    throw new Error(
+      `${label} escapes the tracker workspace: ${absPath}`
+      + ` (workspaceRoot=${__workspaceRoot} canonical=${canonical} rel=${rel})`,
+    );
   }
   return absPath;
 }


### PR DESCRIPTION
Part of #3162. Occurrence 5 (logged by @FReptar0 on #3181's run) reproduced on a tree that **carries** the #3172 canonicalization fix: `20ca092` is a descendant of `7d97d14` (verified with `git merge-base --is-ancestor`), so that hypothesis is ruled out as the cure.

Since #3163 split the two failure paths, the surviving `escapes the tracker workspace` message can only come from the **lexical branch after a successful `realpathSync`**. This PR makes that branch print `workspaceRoot`, the canonicalized path and their `relative()` form, so the next occurrence names the disagreeing ancestor outright (both are runner-local temp paths, fine to surface in a test failure).

Verified: the only assertion pinning this message (`tests/generate-pdf-batch.test.mjs:326`) is a prefix regex, unaffected by the appended detail. Full `test-all.mjs --quick` on this branch: 5,183 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace escape error messages by including the workspace root, canonical path, and relative path for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->