### PR TITLE
fix(tests): assert the flag echo with includes instead of an unescaped RegExp

### DIFF
--- a/tests/cli-flag-validation.test.mjs
+++ b/tests/cli-flag-validation.test.mjs
@@ -41,7 +41,7 @@ for (const [script, typo] of SCRIPTS) {
     const r = runScript(script, typo, 'some-value');
     assert.equal(r.status, 1, `${script} ${typo} exited ${r.status}, want 1`);
     assert.match(r.all, /unrecognized flag/i, `${script} did not name the unrecognized flag`);
-    assert.match(r.all, new RegExp(typo.replace(/^--/, '--')), `${script} did not echo ${typo} back`);
+    assert.ok(r.all.includes(typo), `${script} did not echo ${typo} back`);
   });
 }
 


### PR DESCRIPTION
Fixes CodeQL alert #135 (`js/identity-replacement`, medium): `typo.replace(/^--/, '--')` replaces `--` with `--`, a no-op. The intent was to keep the RegExp safe for the flag text, and it worked only because the current fixtures carry no regex metacharacters. `String.prototype.includes` states the intent directly and removes the footgun for future fixtures.

Behavior-neutral for the existing table: all fixtures still pass, `test-all.mjs --quick` 5,183 / 0 on a tree carrying this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation of command-line typo error messages by checking for the exact reported text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->