### PR TITLE
feat(providers): job.description for recruitee, ashby, and opt-in smartrecruiters (#3175)

### DIFF
--- a/providers/README.md
+++ b/providers/README.md
@@ -70,7 +70,8 @@ There is no index file — discovery is filesystem-convention-based
 
 Underscore-prefixed files are shared helpers, never loaded as providers:
 `_types.js` (contract typedefs), `_registry.mjs` (loader/router),
-`_http.mjs` (HTTP transport), `_html-entities.mjs`, `_trust-validator.mjs`.
+`_http.mjs` (HTTP transport), `_html-entities.mjs`, `_html-to-text.mjs`
+(description HTML → plain text), `_config-utils.mjs`, `_trust-validator.mjs`.
 
 ## Security conventions
 

--- a/providers/README.md
+++ b/providers/README.md
@@ -44,7 +44,11 @@ export default {
 - `url` — required, absolute; used as the dedup key.
 - `company`, `location` — strings, may be empty.
 - `description` — optional; populate ONLY when the list payload carries it
-  for free (no extra per-job request — the scanner is zero-token).
+  for free (no extra per-job request — the scanner is zero-token). The one
+  exception is opt-in, bounded detail enrichment: `fetchDetails: true` plus
+  `detailLimit` in the portals entry (currently vdab and smartrecruiters)
+  fetches per-posting detail JSON to populate `description`, capped at
+  `detailLimit` calls and skipped entirely while a health probe is running.
 - `postedAt` — optional epoch ms; omit when the source has no usable date.
 
 ### Context (`ctx`)

--- a/providers/_html-to-text.mjs
+++ b/providers/_html-to-text.mjs
@@ -1,0 +1,33 @@
+// @ts-check
+// Shared HTML → plain-text pipeline for providers whose payloads embed
+// description markup. Greenhouse's contentToText was the first instance;
+// this is the extracted form so later providers cannot grow a divergent
+// copy — same rationale that produced _html-entities when entity decoders
+// drifted across four files (#1555/#1639/#2623).
+import { decodeEntities } from './_html-entities.mjs';
+
+// Capped like greenhouse/alibaba full-text JDs: a 10 KB/posting body is
+// normal on these boards, and scan payloads must stay sane.
+export const DESCRIPTION_CAP = 4000;
+
+/**
+ * Entity-decoded markup → stripped plain text.
+ *
+ * Double-decode: the payload often carries entity-escaped tags (`&lt;p&gt;`),
+ * so the first pass reveals real tags, and text-level entities (`&amp;`,
+ * `&#39;`) only become decodable once those tags are gone. Plain text is what
+ * the description-consuming filters match against — substring matching over
+ * raw HTML misses keywords split by a tag and pads matches into attribute
+ * soup.
+ *
+ * Exported for tests.
+ *
+ * @param {unknown} content
+ * @returns {string}
+ */
+export function htmlToText(content) {
+  if (typeof content !== 'string' || !content) return '';
+  const html = decodeEntities(content);
+  const noMedia = html.replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, ' ');
+  return decodeEntities(noMedia.replace(/<[^>]+>/g, ' ')).replace(/\s+/g, ' ').trim().slice(0, DESCRIPTION_CAP);
+}

--- a/providers/_types.js
+++ b/providers/_types.js
@@ -20,11 +20,13 @@
  * @property {string} location May be empty.
  * @property {string} [description] Job description text, populated ONLY when the
  *                               provider's list payload carries it for free (no
- *                               extra per-job request — the scanner is zero-token).
- *                               Lever supplies it via `descriptionPlain`; most
- *                               providers omit it. Consumed by scan.mjs's
- *                               content_filter; an empty/absent value always
- *                               passes the filter.
+ *                               extra per-job request — the scanner is zero-token),
+ *                               or when a board opts into vdab/smartrecruiters-style
+ *                               `fetchDetails` (bounded per-job enrichment, skipped
+ *                               while probing). Lever/Ashby supply it via
+ *                               `descriptionPlain`; most providers omit it.
+ *                               Consumed by scan.mjs's content_filter; an
+ *                               empty/absent value always passes the filter.
  * @property {number} [postedAt] Epoch ms when the posting was published.
  *                               Omitted when the source doesn't expose a
  *                               usable date. scan.mjs ignores it; consumers

--- a/providers/ashby.mjs
+++ b/providers/ashby.mjs
@@ -212,6 +212,10 @@ export default {
       url: j.jobUrl || '',
       company: entry.name,
       location: formatLocation(j),
+      // Ashby's posting-api list ships `descriptionPlain` for free (same
+      // payload, no per-job request) — mirrors lever. Enables scan.mjs's
+      // content_filter / visa_filter.
+      description: typeof j.descriptionPlain === 'string' ? j.descriptionPlain : '',
       salary: parseCompensation(j),
       postedAt: toEpochMs(j.publishedAt),
     }));

--- a/providers/greenhouse.mjs
+++ b/providers/greenhouse.mjs
@@ -8,7 +8,7 @@
 // country_eligibility filter and visa_filter all read that field, and without
 // it every Greenhouse board passed those filters blind.
 
-import { decodeEntities } from './_html-entities.mjs';
+import { htmlToText } from './_html-to-text.mjs';
 
 const ALLOWED_GREENHOUSE_HOSTS = new Set([
   'boards-api.greenhouse.io',
@@ -125,24 +125,16 @@ export function buildOfficeMap(json) {
 // DOUBLE-encoded HTML: the JSON string carries entity-escaped markup
 // (`&lt;p&gt;`), so the first decode pass reveals the real tags, and
 // text-level entities (`&amp;`, `&#39;`) only become decodable once those
-// tags are gone. Plain text is what the description-consuming filters match
-// against — substring matching over raw HTML misses keywords split by a tag
-// and pads matches into attribute soup.
-//
-// The result is capped like alibaba's full-text JDs to keep scan payloads
-// sane: a 10 KB/posting body is normal for Greenhouse, not an outlier.
-
-const DESCRIPTION_CAP = 4000;
+// tags are gone. That pipeline (and its rationale) now lives in
+// _html-to-text.mjs, shared with the providers added in #3175's phase 2;
+// this wrapper keeps greenhouse's tested export name.
 
 /**
  * Entity-decoded markup → stripped plain text. Exported for tests.
  * @param {unknown} content
  */
 export function contentToText(content) {
-  if (typeof content !== 'string' || !content) return '';
-  const html = decodeEntities(content);
-  const noMedia = html.replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, ' ');
-  return decodeEntities(noMedia.replace(/<[^>]+>/g, ' ')).replace(/\s+/g, ' ').trim().slice(0, DESCRIPTION_CAP);
+  return htmlToText(content);
 }
 
 /** @type {Provider} */

--- a/providers/recruitee.mjs
+++ b/providers/recruitee.mjs
@@ -7,6 +7,8 @@
 // regex match on `<safe-slug>.recruitee.com` rather than a static
 // allowlist.
 
+import { htmlToText } from './_html-to-text.mjs';
+
 const RECRUITEE_HOST_RE = /^[a-z0-9][a-z0-9-]*\.recruitee\.com$/;
 
 function assertRecruiteeUrl(url) {
@@ -71,10 +73,14 @@ export default {
  *   dropped (empty string returned per the Job contract).
  * - location: prefer the explicit `location` field; else assemble from
  *   city/country, appending "Remote" when `remote` is true.
+ * - description: Recruitee's list payload embeds each offer's full HTML body
+ *   for free (same request — verified against a live board), so it is
+ *   stripped to plain text here and feeds scan.mjs's content_filter /
+ *   visa_filter. Omitted when the offer carries no usable body.
  *
  * @param {any} json
  * @param {string} companyName
- * @returns {Array<{title: string, url: string, company: string, location: string}>}
+ * @returns {Array<{title: string, url: string, company: string, location: string, description?: string}>}
  */
 export function parseRecruiteeResponse(json, companyName) {
   const offers = json?.offers;
@@ -84,6 +90,7 @@ export function parseRecruiteeResponse(json, companyName) {
     const country = j.country || '';
     const remote = j.remote ? 'Remote' : '';
     const location = j.location || [city, country, remote].filter(Boolean).join(', ');
+    const description = htmlToText(j.description);
 
     // Resolve offer URL. Recruitee tenants commonly publish postings on their
     // own custom domain (e.g. careers.hostaway.com), so the per-offer URL is
@@ -109,6 +116,7 @@ export function parseRecruiteeResponse(json, companyName) {
       url,
       location,
       company: companyName,
+      ...(description ? { description } : {}),
     };
   });
 }

--- a/providers/smartrecruiters.mjs
+++ b/providers/smartrecruiters.mjs
@@ -6,11 +6,61 @@
 // `https://(careers|jobs).smartrecruiters.com/<slug>`. A tracked_companies
 // entry can also set `provider: smartrecruiters` explicitly to bypass
 // detection (useful when the public careers URL is a branded custom domain).
+//
+// The list payload carries NO description body. Boards that need it opt in
+// via tracked_companies config (mirrors vdab):
+//
+//   smartrecruiters:
+//     fetchDetails: true   # fetch each posting's detail JSON for descriptions
+//     detailLimit: 25      # max detail calls per sweep when fetchDetails=true
+//
+// Detail enrichment answers "what does this job say", not "is this endpoint
+// alive" — it is skipped entirely while verify-portals is probing, and runs
+// in small batches so a 400-posting board cannot hammer the shared API host.
+
+import { intInRange } from './_config-utils.mjs';
+import { htmlToText } from './_html-to-text.mjs';
 
 const ALLOWED_SMARTRECRUITERS_HOSTS = new Set(['api.smartrecruiters.com']);
 const SR_CAREERS_HOSTS = new Set(['careers.smartrecruiters.com', 'jobs.smartrecruiters.com']);
 const SR_PAGE_SIZE = 100;
 const SR_MAX_PAGES = 50;  // safety cap (5000 postings @ 100/page)
+const SR_DETAIL_BATCH = 5;
+
+/**
+ * @param {any} entry
+ * @returns {{ fetchDetails: boolean, detailLimit: number }}
+ */
+function parseSmartRecruitersConfig(entry) {
+  const cfg = (entry && entry.smartrecruiters) || {};
+  return {
+    fetchDetails: cfg.fetchDetails === true,
+    detailLimit: intInRange(cfg.detailLimit, 25, 1, 100),
+  };
+}
+
+/**
+ * Extracts the best plain-text description from a posting-detail response.
+ *
+ * The detail payload nests HTML bodies under `jobAd.sections`, keyed by a
+ * fixed section set (companyDescription, jobDescription, qualifications,
+ * additionalInformation). Joined in that order — company context first,
+ * call-to-action last — then stripped by the shared pipeline.
+ *
+ * @param {any} detail
+ * @returns {string}
+ */
+export function extractDescription(detail) {
+  const sections = detail?.jobAd?.sections;
+  if (!sections || typeof sections !== 'object') return '';
+  const parts = [];
+  for (const key of ['companyDescription', 'jobDescription', 'qualifications', 'additionalInformation']) {
+    const text = sections[key]?.text;
+    if (typeof text === 'string' && text.trim()) parts.push(text);
+  }
+  if (parts.length === 0) return '';
+  return htmlToText(parts.join('\n'));
+}
 
 function assertSmartRecruitersUrl(url) {
   let parsed;
@@ -51,6 +101,10 @@ function buildPostingsUrl(slug, offset = 0) {
   return `https://api.smartrecruiters.com/v1/companies/${slug}/postings?limit=${SR_PAGE_SIZE}&offset=${offset}&status=PUBLIC`;
 }
 
+function buildPostingDetailUrl(slug, id) {
+  return `https://api.smartrecruiters.com/v1/companies/${slug}/postings/${encodeURIComponent(id)}`;
+}
+
 function resolveApiUrl(entry) {
   const slug = resolveSlug(entry);
   return slug ? buildPostingsUrl(slug, 0) : null;
@@ -79,7 +133,34 @@ export default {
       all.push(...parsed);
       if (parsed.length < SR_PAGE_SIZE) break;  // last page (short)
     }
-    return all;
+
+    // Detail enrichment answers "what does this job say", not "is this
+    // endpoint alive" — skip it entirely while probing so it never spends
+    // budget a liveness check has no use for (same rule as vdab).
+    const { fetchDetails, detailLimit } = parseSmartRecruitersConfig(entry);
+    const probing = Number.isInteger(ctx?.maxPages) && ctx.maxPages > 0;
+    if (fetchDetails && !probing) {
+      const jobs = all.filter((job) => job.id).slice(0, detailLimit);
+      for (let i = 0; i < jobs.length; i += SR_DETAIL_BATCH) {
+        const batch = jobs.slice(i, i + SR_DETAIL_BATCH);
+        await Promise.all(batch.map(async (job) => {
+          try {
+            const detailUrl = buildPostingDetailUrl(slug, job.id);
+            assertSmartRecruitersUrl(detailUrl);
+            const detail = await ctx.fetchJson(detailUrl, { redirect: 'error' });
+            const description = extractDescription(detail);
+            if (description) job.description = description;
+          } catch {
+            // Detail fetch is an enrichment only. Keep the listing result.
+          }
+        }));
+      }
+    }
+
+    // The numeric posting id drove the detail calls above; it is internal
+    // plumbing and must not leak into the pipeline's Job rows (vdab strips
+    // its id the same way).
+    return all.map(({ id, ...job }) => job);
   },
 };
 
@@ -101,7 +182,7 @@ export default {
  *
  * @param {any} json
  * @param {string} companyName
- * @returns {Array<{title: string, url: string, company: string, location: string}>}
+ * @returns {Array<{title: string, url: string, company: string, location: string, id?: string}>}
  */
 export function parseSmartRecruitersResponse(json, companyName) {
   const items = json?.content;
@@ -136,6 +217,6 @@ export function parseSmartRecruitersResponse(json, companyName) {
         url = `https://jobs.smartrecruiters.com/${companySlug}/${j.id}${slugified ? `-${slugified}` : ''}`;
       }
     }
-    return { title: j.name || '', url, location, company: companyName };
+    return { title: j.name || '', url, location, company: companyName, id: typeof j.id === 'string' || typeof j.id === 'number' ? String(j.id) : undefined };
   });
 }

--- a/providers/smartrecruiters.mjs
+++ b/providers/smartrecruiters.mjs
@@ -123,8 +123,15 @@ export default {
     const slug = resolveSlug(entry);
     if (!slug) throw new Error(`smartrecruiters: cannot derive API URL for ${entry.name}`);
 
+    // Honor the ctx.maxPages pagination hint (the portal health probe passes 1);
+    // a real sweep keeps the SR_MAX_PAGES safety cap.
+    const pageLimit = Math.min(
+      SR_MAX_PAGES,
+      Number.isInteger(ctx?.maxPages) && ctx.maxPages > 0 ? ctx.maxPages : Infinity,
+    );
+
     const all = [];
-    for (let page = 0; page < SR_MAX_PAGES; page++) {
+    for (let page = 0; page < pageLimit; page++) {
       const apiUrl = buildPostingsUrl(slug, page * SR_PAGE_SIZE);
       assertSmartRecruitersUrl(apiUrl);
       const json = await ctx.fetchJson(apiUrl, { redirect: 'error' });

--- a/tests/providers/_html-to-text.test.mjs
+++ b/tests/providers/_html-to-text.test.mjs
@@ -1,0 +1,81 @@
+// tests/providers/_html-to-text.test.mjs — shared description pipeline.
+// _html-to-text.mjs is the extracted form of greenhouse's contentToText
+// (#3175 phase 2): providers whose payloads embed HTML bodies must all strip
+// through this one pipeline so a divergent private copy cannot grow the way
+// entity decoders once did.
+import { pass, fail, ROOT } from '../helpers.mjs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+console.log('\nShared — _html-to-text');
+
+try {
+  const mod = await import(pathToFileURL(join(ROOT, 'providers/_html-to-text.mjs')).href);
+  const { htmlToText, DESCRIPTION_CAP } = mod;
+
+  if (DESCRIPTION_CAP === 4000) pass('DESCRIPTION_CAP is 4000 (greenhouse/alibaba precedent)');
+  else fail(`DESCRIPTION_CAP = ${JSON.stringify(DESCRIPTION_CAP)}, expected 4000`);
+
+  // Non-string and empty inputs degrade to "" — never a thrown error.
+  if (htmlToText(null) === '' && htmlToText(undefined) === '' && htmlToText(42) === '' && htmlToText('') === '') {
+    pass('htmlToText() returns "" for missing / non-string / empty input');
+  } else {
+    fail('htmlToText() should return "" for non-string and empty input');
+  }
+
+  if (htmlToText('Already plain text') === 'Already plain text') {
+    pass('htmlToText() passes plain text through unchanged');
+  } else {
+    fail(`plain passthrough = ${JSON.stringify(htmlToText('Already plain text'))}`);
+  }
+
+  if (htmlToText('<p>Hello <b>world</b></p>') === 'Hello world') {
+    pass('htmlToText() strips tags');
+  } else {
+    fail(`tag stripping = ${JSON.stringify(htmlToText('<p>Hello <b>world</b></p>'))}`);
+  }
+
+  if (htmlToText('<style>.x{color:red}</style><script>evil()</script><p>Body</p>') === 'Body') {
+    pass("htmlToText() drops <script>/<style> WITH their contents");
+  } else {
+    fail(`media strip = ${JSON.stringify(htmlToText('<style>.x{color:red}</style><script>evil()</script><p>Body</p>'))}`);
+  }
+
+  // The double-decode case that motivated greenhouse's pipeline: entity-
+  // escaped markup first reveals real tags, and only after those are gone
+  // can the text-level entities decode. A single-pass decoder leaves "&amp;"
+  // behind or turns attribute soup into noise.
+  const doubled = htmlToText('&lt;p&gt;C++ &amp;amp; Rust&amp;rsquo;s runtime&lt;/p&gt;');
+  if (doubled === "C++ & Rust\u2019s runtime") {
+    pass('htmlToText() double-decodes entity-escaped markup to readable text');
+  } else {
+    fail(`double decode = ${JSON.stringify(doubled)}`);
+  }
+
+  // A keyword split across a tag boundary must survive stripping, since
+  // visa/content filters substring-match over the result.
+  const split = htmlToText('<p>No sponsorship is <span>provided</span> for this role</p>');
+  if (split === 'No sponsorship is provided for this role') {
+    pass('htmlToText() re-joins text split across tag boundaries');
+  } else {
+    fail(`split keyword = ${JSON.stringify(split)}`);
+  }
+
+  if (htmlToText('<p>a</p>\t\n <p>b</p>') === 'a b') {
+    pass('htmlToText() collapses whitespace runs to single spaces and trims');
+  } else {
+    fail(`collapse = ${JSON.stringify(htmlToText('<p>a</p>\t\n <p>b</p>'))}`);
+  }
+
+  const longBody = `<p>${'word '.repeat(1200)}</p>`;
+  // The cap slices after trim+collapse, so the cut can land mid-pattern
+  // (greenhouse behaves identically) — assert only the budget, not the tail.
+  const capped = htmlToText(longBody);
+  if (capped.length === 4000 && capped.startsWith('word')) {
+    pass('htmlToText() caps output at DESCRIPTION_CAP characters');
+  } else {
+    fail(`cap: length=${capped.length}, tail=${JSON.stringify(capped.slice(-10))}`);
+  }
+} catch (e) {
+  fail(`_html-to-text tests crashed: ${e.message}`);
+}

--- a/tests/providers/ashby.test.mjs
+++ b/tests/providers/ashby.test.mjs
@@ -324,6 +324,33 @@ try {
     }
   }
 
+  // ── Description (#3175 phase 2) ──
+  // Ashby's posting-api list ships descriptionPlain for free (same payload,
+  // no per-job request) — mapped verbatim, mirroring lever. A non-string
+  // value degrades to '' rather than leaking a wrong type into the pipeline.
+  const withDesc = await ashby.fetch(
+    { name: 'Acme', careers_url: 'https://jobs.ashbyhq.com/acme' },
+    {
+      fetchJson: async () => ({
+        jobs: [
+          { title: 'Writer', jobUrl: 'https://jobs.ashbyhq.com/acme/w1', descriptionPlain: 'Own the blog.\nShip weekly.' },
+          { title: 'No body' },
+          { title: 'Bad body', descriptionPlain: 42 },
+        ],
+      }),
+    },
+  );
+  if (withDesc[0]?.description === 'Own the blog.\nShip weekly.') {
+    pass('ashby.fetch() carries descriptionPlain through untouched when it is a string');
+  } else {
+    fail(`row 0 description = ${JSON.stringify(withDesc[0]?.description)}`);
+  }
+  if (withDesc[1]?.description === '' && withDesc[2]?.description === '') {
+    pass('ashby.fetch() emits "" for a missing / non-string descriptionPlain');
+  } else {
+    fail(`descriptions = ${JSON.stringify([withDesc[1]?.description, withDesc[2]?.description])}`);
+  }
+
 } catch (e) {
   fail(`ashby provider tests crashed: ${e.message}`);
 }

--- a/tests/providers/recruitee.test.mjs
+++ b/tests/providers/recruitee.test.mjs
@@ -131,6 +131,35 @@ try {
     }
   }
 
+  // ── Description (#3175 phase 2) ──
+  // Recruitee's list payload embeds each offer's HTML body for free — same
+  // request, no per-job fetch. It must arrive as plain text (tags stripped,
+  // entities decoded), and offers without a body omit the key entirely.
+  const descOffers = parseRecruiteeResponse(
+    {
+      offers: [
+        {
+          title: 'With body',
+          careers_url: 'https://channable.recruitee.com/o/with-body',
+          description: '&lt;p&gt;Build &lt;strong&gt;pipelines&lt;/strong&gt; at Hostaway&amp;rsquo;s HQ&lt;/p&gt;&lt;script&gt;evil()&lt;/script&gt;',
+        },
+        { title: 'Without body', careers_url: 'https://channable.recruitee.com/o/no-body' },
+        { title: 'Empty body', description: '   ' },
+      ],
+    },
+    'Channable',
+  );
+  if (descOffers[0]?.description === "Build pipelines at Hostaway\u2019s HQ") {
+    pass('parseRecruiteeResponse double-decodes the offer body to plain text (tags + script gone)');
+  } else {
+    fail(`row 0 description = ${JSON.stringify(descOffers[0]?.description)}`);
+  }
+  if (!('description' in descOffers[1]) && !('description' in descOffers[2])) {
+    pass('parseRecruiteeResponse omits the description key when the offer has no usable body');
+  } else {
+    fail(`rows 1-2 = ${JSON.stringify(descOffers.slice(1))}`);
+  }
+
 } catch (e) {
   fail(`recruitee provider tests crashed: ${e.message}`);
 }

--- a/tests/providers/smartrecruiters.test.mjs
+++ b/tests/providers/smartrecruiters.test.mjs
@@ -8,7 +8,7 @@ console.log('\nProvider — smartrecruiters');
 try {
   const smartrecruitersModule = await import(pathToFileURL(join(ROOT, 'providers/smartrecruiters.mjs')).href);
   const sr = smartrecruitersModule.default;
-  const { parseSmartRecruitersResponse } = smartrecruitersModule;
+  const { parseSmartRecruitersResponse, extractDescription } = smartrecruitersModule;
 
   if (sr.id === 'smartrecruiters') pass('smartrecruiters.id is "smartrecruiters"');
   else fail(`smartrecruiters.id is ${JSON.stringify(sr.id)}`);
@@ -236,6 +236,194 @@ try {
     pass('smartrecruiters.fetch() stops on the first empty page');
   } else {
     fail(`empty pagination: requests=${emptyPageRequests}, total=${emptyJobs.length}`);
+  }
+
+  // ── Description enrichment (#3175 phase 2) ──
+  // The list payload carries no body; opted-in boards fetch one detail JSON
+  // per posting. extractDescription() joins the four known jobAd sections in
+  // a fixed order (company context first, call-to-action last), then strips
+  // via the shared _html-to-text pipeline.
+  if (extractDescription(null) === '' && extractDescription({}) === ''
+      && extractDescription({ jobAd: {} }) === '' && extractDescription({ jobAd: { sections: 'nope' } }) === '') {
+    pass('extractDescription() returns "" for missing / malformed payloads');
+  } else {
+    fail('extractDescription() should return "" for missing or malformed payloads');
+  }
+
+  const joined = extractDescription({
+    jobAd: {
+      sections: {
+        additionalInformation: { text: '<p>Sponsorship: <strong>no</strong></p>' },
+        companyDescription: { text: '<p>Acme builds &amp; ships widgets</p>' },
+        someUnknownSection: { text: '<p>must be ignored</p>' },
+        qualifications: { text: '<ul><li>5+ years</li></ul>' },
+        jobDescription: { text: '<p>You will&nbsp;build robots</p>' },
+      },
+    },
+  });
+  if (joined === "Acme builds & ships widgets You will build robots 5+ years Sponsorship: no") {
+    pass('extractDescription() joins the four known sections in order, strips HTML, decodes entities');
+  } else {
+    fail(`extractDescription() = ${JSON.stringify(joined)}`);
+  }
+
+  if (extractDescription({ jobAd: { sections: { jobDescription: { text: '   ' } } } }) === '') {
+    pass('extractDescription() returns "" when every section is blank');
+  } else {
+    fail('extractDescription() should return "" for blank-only sections');
+  }
+
+  // fetch(): opt-in detail enrichment — hits the detail endpoint per posting,
+  // attaches the plain-text description, and strips the internal id.
+  {
+    const detailCalls = [];
+    const enriched = await sr.fetch(
+      {
+        name: 'DescCo',
+        careers_url: 'https://careers.smartrecruiters.com/desco',
+        smartrecruiters: { fetchDetails: true, detailLimit: 25 },
+      },
+      {
+        fetchJson: async (url) => {
+          detailCalls.push(url);
+          if (detailCalls.length === 1) {
+            return {
+              content: [
+                { id: 'A1', name: 'Role A' },
+                { id: 'B2', name: 'Role B' },
+              ],
+            };
+          }
+          const id = new URL(url).pathname.split('/').pop();
+          return {
+            jobAd: {
+              sections: id === 'A1'
+                ? { jobDescription: { text: '<p>Body of A1</p>' } }
+                : {},  // B2 has no usable sections → no description key
+            },
+          };
+        },
+      },
+    );
+    const listCallsOnly = detailCalls.filter((u) => u.includes('/postings?'));
+    const detailUrls = detailCalls.filter((u) => !u.includes('/postings?'));
+    if (listCallsOnly.length === 1
+        && detailUrls.length === 2
+        && detailUrls[0] === 'https://api.smartrecruiters.com/v1/companies/desco/postings/A1'
+        && detailUrls[1] === 'https://api.smartrecruiters.com/v1/companies/desco/postings/B2') {
+      pass('fetch(fetchDetails:true) requests one detail URL per posting, in list order');
+    } else {
+      fail(`detail calls: ${JSON.stringify(detailCalls)}`);
+    }
+    if (enriched[0]?.description === 'Body of A1' && !('id' in enriched[0])) {
+      pass("fetch(fetchDetails:true) attaches the description and strips the internal id");
+    } else {
+      fail(`row 0 = ${JSON.stringify(enriched[0])}`);
+    }
+    if (!('description' in enriched[1]) && !('id' in enriched[1])) {
+      pass('fetch(fetchDetails:true) omits the description key when the board ships no sections');
+    } else {
+      fail(`row 1 = ${JSON.stringify(enriched[1])}`);
+    }
+  }
+
+  // Default (no config): zero detail calls — the scanner stays zero-token.
+  {
+    let defaultModeDetailCalls = 0;
+    await sr.fetch(
+      { name: 'PlainCo', careers_url: 'https://careers.smartrecruiters.com/plainco' },
+      {
+        fetchJson: async (url) => {
+          if (!url.includes('/postings?')) defaultModeDetailCalls++;
+          return { content: [{ id: 'X1', name: 'Role X' }] };
+        },
+      },
+    );
+    if (defaultModeDetailCalls === 0) {
+      pass('fetch() without smartrecruiters.fetchDetails makes no per-posting requests');
+    } else {
+      fail(`expected 0 detail calls by default, saw ${defaultModeDetailCalls}`);
+    }
+  }
+
+  // Probing (verify-portals passes ctx.maxPages=1): enrichment must never
+  // spend budget a liveness check has no use for (same rule as vdab).
+  {
+    let probeDetailCalls = 0;
+    await sr.fetch(
+      {
+        name: 'ProbeCo',
+        careers_url: 'https://careers.smartrecruiters.com/probeco',
+        smartrecruiters: { fetchDetails: true },
+      },
+      {
+        maxPages: 1,
+        fetchJson: async (url) => {
+          if (!url.includes('/postings?')) probeDetailCalls++;
+          return { content: [{ id: 'Y1', name: 'Role Y' }] };
+        },
+      },
+    );
+    if (probeDetailCalls === 0) {
+      pass('fetch() skips detail enrichment while probing (ctx.maxPages set)');
+    } else {
+      fail(`expected 0 detail calls while probing, saw ${probeDetailCalls}`);
+    }
+  }
+
+  // detailLimit caps the per-sweep detail budget on a large board.
+  {
+    const bigBoardIds = Array.from({ length: 40 }, (_, i) => `ID-${i}`);
+    let bigBoardDetailCalls = 0;
+    await sr.fetch(
+      {
+        name: 'BigCo',
+        careers_url: 'https://careers.smartrecruiters.com/bigco',
+        smartrecruiters: { fetchDetails: true, detailLimit: 10 },
+      },
+      {
+        fetchJson: async (url) => {
+          if (url.includes('/postings?')) return { content: bigBoardIds.map((id) => ({ id, name: `Role ${id}` })) };
+          bigBoardDetailCalls++;
+          return { jobAd: { sections: { jobDescription: { text: `<p>body ${bigBoardDetailCalls}</p>` } } } };
+        },
+      },
+    );
+    if (bigBoardDetailCalls === 10) {
+      pass('fetch() caps detail calls at smartrecruiters.detailLimit (40 postings → 10 details)');
+    } else {
+      fail(`expected 10 detail calls (detailLimit=10), saw ${bigBoardDetailCalls}`);
+    }
+  }
+
+  // A failing detail fetch is an enrichment only — the listing result survives.
+  {
+    let resilientCalls = 0;
+    const survived = await sr.fetch(
+      {
+        name: 'FlakyCo',
+        careers_url: 'https://careers.smartrecruiters.com/flakyco',
+        smartrecruiters: { fetchDetails: true },
+      },
+      {
+        fetchJson: async (url) => {
+          if (url.includes('/postings?')) {
+            return { content: [{ id: 'OK-1', name: 'Fine Role' }, { id: 'BAD-2', name: 'Doomed Role' }] };
+          }
+          resilientCalls++;
+          if (new URL(url).pathname.endsWith('BAD-2')) throw new Error('HTTP 500');
+          return { jobAd: { sections: { jobDescription: { text: '<p>fine body</p>' } } } };
+        },
+      },
+    );
+    if (resilientCalls === 2 && survived.length === 2
+        && survived[0]?.description === 'fine body'
+        && !('description' in survived[1])
+        && survived[1]?.title === 'Doomed Role') {
+      pass('fetch() keeps the listing row and the rest of the batch when one detail request fails');
+    } else {
+      fail(`resilience: calls=${resilientCalls}, rows=${JSON.stringify(survived)}`);
+    }
   }
 
 } catch (e) {

--- a/tests/providers/smartrecruiters.test.mjs
+++ b/tests/providers/smartrecruiters.test.mjs
@@ -371,6 +371,30 @@ try {
     }
   }
 
+  // ctx.maxPages also caps the listing walk itself, not just enrichment:
+  // a health probe reads one page even when the board keeps serving full pages.
+  {
+    const fullPage = {
+      content: Array.from({ length: 100 }, (_, i) => ({ id: `P${i}`, name: `Role ${i}` })),
+    };
+    let probeListCalls = 0;
+    await sr.fetch(
+      { name: 'CappedCo', careers_url: 'https://careers.smartrecruiters.com/cappedco' },
+      {
+        maxPages: 1,
+        fetchJson: async (url) => {
+          if (url.includes('/postings?')) probeListCalls++;
+          return fullPage;
+        },
+      },
+    );
+    if (probeListCalls === 1) {
+      pass('fetch() honors the ctx.maxPages hint and stops after one list page');
+    } else {
+      fail(`ctx.maxPages=1: ${probeListCalls} list calls (expected 1)`);
+    }
+  }
+
   // detailLimit caps the per-sweep detail budget on a large board.
   {
     const bigBoardIds = Array.from({ length: 40 }, (_, i) => `ID-${i}`);


### PR DESCRIPTION
Phase 2 of #3175: extends `job.description` coverage past greenhouse to the three providers whose boards still pass content_filter/visa_filter blind.

## What changed

**Recruitee + Ashby needed no new requests at all.** Verified against live boards before writing code:

- Recruitee's `/api/offers/` list payload already embeds each offer's full HTML body. It now runs through a plain-text strip (`htmlToText`), so descriptions arrive with zero extra requests.
- Ashby's posting-api list already ships `descriptionPlain` — mapped verbatim, mirroring lever.

**SmartRecruiters is the one true N+1**: its list payload carries no body. Rather than taxing every SR board by default, detail enrichment is opt-in per tracked_companies entry (mirrors vdab):

```yaml
smartrecruiters:
  fetchDetails: true   # fetch each posting's detail JSON for descriptions
  detailLimit: 25      # max detail calls per sweep (default 25, range 1-100)
```

Details run in batches of 5, are skipped entirely while verify-portals probes (`ctx.maxPages`, same rule as vdab), tolerate per-job failures silently, join the four known `jobAd.sections` in fixed order, and the internal posting id is stripped before rows reach the pipeline.

## Shared pipeline

The stripping logic is extracted from greenhouse into `providers/_html-to-text.mjs` (`htmlToText`, cap 4000 like alibaba); greenhouse's tested `contentToText` export now delegates to it instead of keeping a private copy — the same consolidation rationale that produced `_html-entities`.

## Verification

- New/extended suites green: `providers/_html-to-text` (9), `providers/recruitee` (16), `providers/smartrecruiters` (32), `providers/ashby` (31)
- `npm run lint`: clean, 518 files
- `node test-all.mjs`: **5184 passed, 1 failed** — the failure is `tests/plugin-symlink-discovery.test.mjs` dying on `symlinkSync` EPERM (Windows without Developer Mode). Pre-existing/environmental, unrelated to this change; happy to re-run on CI where symlinks are available.
- Live smoke through the actual provider code:
  - Hostaway (Recruitee): 13/13 jobs with clean plain-text descriptions
  - Linear (Ashby): 32/32 with `descriptionPlain`
  - Wise (SmartRecruiters): 426 listed, exactly 5 enriched at `detailLimit=5`, id stripped, and one enriched body surfaced a real sponsorship statement ("unable to sponsor OR transfer Visa's...") — precisely what visa_filter was missing

Closes #3175 (phases 1-2; Workday/SuccessFactors were declared out of scope in the issue).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Job listings from Ashby, Recruitee, Greenhouse, and SmartRecruiters now include cleaner plain-text descriptions.
  * SmartRecruiters listings can optionally fetch enriched descriptions, with configurable request limits.
  * Descriptions are safely cleaned, normalized, and capped at 4,000 characters.

* **Documentation**
  * Updated provider documentation to describe description sources and enrichment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->