### PR TITLE
feat(cv): add optional url support for projects in HTML and LaTeX CVs

### DIFF
--- a/build-cv-html.mjs
+++ b/build-cv-html.mjs
@@ -384,6 +384,11 @@ function buildProjects(entries, partial) {
       const badge = e.badge
         ? `<span class="project-badge">${escapeHtml(e.badge)}</span>`
         : '';
+      const nameText = escapeHtml(e.name || '');
+      const url = sanitizeUrl(e.url);
+      const nameHtml = url
+        ? `<a href="${url}">${nameText}</a>`
+        : nameText;
       // Prefer a single description; fall back to joining bullets into one line so
       // a bullets-shaped payload still renders inside the .project-desc block.
       const descText = e.description
@@ -395,7 +400,7 @@ function buildProjects(entries, partial) {
         ? `\n    <div class="project-tech">${escapeHtml(e.tech)}</div>`
         : '';
       return `<div class="project">
-    <div class="project-title">${escapeHtml(e.name)}${badge}</div>${desc}${tech}
+    <div class="project-title">${nameHtml}${badge}</div>${desc}${tech}
   </div>`;
     }).join('\n  ');
   }
@@ -409,8 +414,13 @@ function buildProjects(entries, partial) {
       ['DESC_BLOCK',  { value: escapeHtml(descText),      present: Boolean(descText) }],
       ['TECH_BLOCK',  { value: escapeHtml(e.tech || ''),  present: Boolean(e.tech) }],
     ]);
+    const nameText = escapeHtml(e.name || '');
+    const url = sanitizeUrl(e.url);
+    const nameHtml = url
+      ? `<a href="${url}">${nameText}</a>`
+      : nameText;
     return fillEntry(entryTemplate, blocks, {
-      NAME:  escapeHtml(e.name || ''),
+      NAME:  nameHtml,
       BADGE: escapeHtml(e.badge || ''),
       DESC:  escapeHtml(descText),
       TECH:  escapeHtml(e.tech || ''),

--- a/build-cv-latex.mjs
+++ b/build-cv-latex.mjs
@@ -45,8 +45,12 @@ function buildProjects(entries) {
   for (const e of entries) {
     if (!e) continue;
     const context = e.context ? ` \\emph{$|$ ${escapeLatex(e.context)}}` : '';
+    const url = sanitizeUrl(e.url);
+    const nameFormatted = url
+      ? `\\href{${escapeLatex(url, 'url')}}{\\textbf{${escapeLatex(e.name)}}}`
+      : `\\textbf{${escapeLatex(e.name)}}`;
     const bullets = Array.isArray(e.bullets) ? e.bullets.map(b => `            \\resumeItem{${escapeLatex(b)}}`).join('\n') : '';
-    blocks.push(`    \\resumeProjectHeading\n      {\\textbf{${escapeLatex(e.name)}}${context}}{${escapeLatex(e.dates)}}\n      \\resumeItemListStart\n${bullets}\n      \\resumeItemListEnd`);
+    blocks.push(`    \\resumeProjectHeading\n      {${nameFormatted}${context}}{${escapeLatex(e.dates || '')}}\n      \\resumeItemListStart\n${bullets}\n      \\resumeItemListEnd`);
   }
   return blocks.join('\n\n');
 }

--- a/modes/pdf.md
+++ b/modes/pdf.md
@@ -166,7 +166,7 @@ Write a JSON file with this structure, then run `node build-cv-html.mjs <input.j
     }
   ],
   "projects": [
-    { "name": "Project Name", "badge": "Open Source", "tech": "Python, FastAPI", "description": "What it does." }
+    { "name": "Project Name", "url": "https://github.com/...", "badge": "Open Source", "tech": "Python, FastAPI", "description": "What it does." }
   ],
   "education": [
     { "title": "B.S. Computer Science", "org": "University Name", "year": "2022", "description": "Optional line." }
@@ -203,7 +203,7 @@ Write a JSON file with this structure, then run `node build-cv-html.mjs <input.j
 | `summary` | string | Personalized summary with keywords. |
 | `competencies` | string[] | 6-8 keyword phrases → competency tags. |
 | `experience[]` | object | `company`, `role`, `location` (optional), `dates`, `bullets` (reordered, keyword-injected). Optional section — omit the key or pass `[]` and the whole block is dropped, header included. Only for candidates with no professional history to list (students, new graduates, career changers); never drop it to hide a gap. |
-| `projects[]` | object | `name`, `badge` (optional), `tech` (optional), `description` (a `bullets` array is also accepted and joined into the description line). |
+| `projects[]` | object | `name`, `url` (optional project/repo link), `badge` (optional), `tech` (optional), `description` (a `bullets` array is also accepted and joined into the description line). |
 | `education[]` | object | `title` (degree), `org` (institution), `year`, `description` (optional). |
 | `certifications[]` | object | `title`, `org`, `year`. |
 | `awards[]` | object | `title` (award name), `org` (issuing body, optional), `year` (optional). Optional section — omit the key or pass `[]` and the whole block is dropped, header included. Use it for competitive or academic distinctions (olympiad medals, hackathon wins, dean's list) that carry more signal than a thin experience section. |

--- a/templates/cv-template.html
+++ b/templates/cv-template.html
@@ -248,6 +248,15 @@
     color: hsl(270, 70%, 45%);
   }
 
+  .project-title a {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  .project-title a:hover {
+    text-decoration: underline;
+  }
+
   .project-badge {
     font-size: 9px;
     font-weight: 500;


### PR DESCRIPTION
## What does this PR do?

Adds support for an optional `url` property on project entries in the CV generation pipeline (`build-cv-html.mjs`, `build-cv-latex.mjs`, and `templates/cv-template.html`). When provided, project titles render as clean, ATS-safe clickable hyperlinks in HTML, PDF, and LaTeX exports; when omitted, titles continue to render as plain text.

## Related issue

<!-- Enhancement to existing CV builder schema -->

## Type of change

- [x] New feature
- [ ] Bug fix
- [x] Documentation / translation
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/santifer/career-ops/blob/main/CONTRIBUTING.md)
- [x] If this is a new feature or architecture change, I opened an issue first (bug fixes, providers, docs & translations are exempt — send those straight in)
- [x] My PR does not include personal data (CV, email, real names, scan results, or pipeline data)
- [x] I ran `node test-all.mjs` and all tests pass
- [x] My changes respect the [Data Contract](https://github.com/santifer/career-ops/blob/main/DATA_CONTRACT.md) (no modifications to user-layer files)
- [x] My changes align with the [project roadmap](https://github.com/santifer/career-ops/discussions/156)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project names can now link to repositories or project pages when a URL is provided.
  * Links are supported in both HTML and PDF CV outputs.
  * Projects without URLs continue to display as plain text.

* **Style**
  * Project links match the title styling and are underlined when hovered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->